### PR TITLE
Update how server handles messages

### DIFF
--- a/src/services/dummy.lua
+++ b/src/services/dummy.lua
@@ -77,7 +77,7 @@ function dummy_service:start(rootctx, bus_connection)
     local function send_message(message)
         self.bus_connection:publish({
             topic = message.topic,
-            payload = json.encode(message),
+            payload = json.encode(message.payload),
             retained = true
         })
     end

--- a/src/services/server.lua
+++ b/src/services/server.lua
@@ -123,16 +123,13 @@ local function reply(self, stream) -- luacheck: ignore 212
 
 			while true do
 				local msg, _ = sub:next_msg()
-				-- print("MESSAGE RECEIVED!")
-				local config, _, err = json.decode(msg.payload)
-				if err then
-					log.error(err)
-				else
-					local msg = "data: "..json.encode(config).."\n\n"
-					local write_succesful = stream:write_chunk(msg, false)
-					if not write_succesful then
-						break
-					end
+				local payload, _, _ = json.decode(msg.payload)
+				msg.payload = payload
+
+				local resp = "data: " .. json.encode(msg) .. "\n\n"
+				local write_succesful = stream:write_chunk(resp, false)
+				if not write_succesful then
+					break
 				end
 			end
 		end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] 🍕 Feature
- [X] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description
Issue, we were sending the entire message as the payload in the dummy service causing us to handle the data in a different manner.
<img width="477" alt="Screenshot 2024-06-13 at 08 53 40" src="https://github.com/jangala-dev/devicecode-lua/assets/38012621/8f86dbc1-2291-4db0-9998-c9ffb2675817">

Fix, is to recreate message in server service re-adding the decoded payload.
<img width="490" alt="Screenshot 2024-06-13 at 09 12 18" src="https://github.com/jangala-dev/devicecode-lua/assets/38012621/f06f6dec-7960-4673-894f-87699cd186df">

## Related Issues, Tickets & Documents

## Screenshots/Recordings

## Manual test
- [X] 👍 yes
- [ ] 🙅 no

## Added tests?
- [ ] 👍 yes
- [X] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?
- [ ] 📜 README.md
- [X] 🙅 no documentation needed