### PR TITLE
Service Module

### DIFF
--- a/sprint-docs/service.md
+++ b/sprint-docs/service.md
@@ -1,0 +1,69 @@
+# Service structure
+## service spawning
+A service is created using service.spawn() which will follow the general form
+- Publish service active under `<service_name>/health`
+- Run service start function with arguments of bus connection and context (start function should be non-blocking)
+- Create a shutdown fiber
+- Shutdown fiber will 
+    - wait for a shutdown message on `<service_name>/control/shutdown`
+    - check all fibers' state on `<service_name>/health/fibers/+`
+    - track which fibers are not showing 'disabled' state yet
+    - once all fibers are showing disabled it will publish service state disabled and close
+
+## fiber spawning
+A service fiber is a fiber that is spawned with tracking features, spawning follows the steps
+- Publish 'fiber init' under `<service_name>/health/fibers/<fiber_name>`
+- create fiber and pass context with cancel and values fiber_name and service_name
+- when fiber spins up 
+    - publish 'fiber active'
+    - run the given function with ctx as argument (this function should be blocking)
+    - when given function returns, publish 'fiber disabled'
+
+# How to use
+## Spawn a service
+```lua
+service.spawn(service_obj, bus_connection, context)
+```
+
+## Spawn a service fiber
+```lua
+service.spawn(name, bus_connection, context, function (fiber_context)
+    -- do stuff
+end
+)
+```
+
+# Example
+```lua
+local service = require "service"
+local bus_mod = require "bus"
+local context = require "fibers.context"
+local op = require "fibers.op"
+local sleep = require "fibers.sleep"
+
+-- This is a dummy service
+local dummy_service = {}
+dummy_service.__index = dummy_service
+dummy_service.name = 'dummy_service'
+
+-- The start function should be non-blocking
+function dummy_service:start(bus_conn, ctx)
+    service.spawn_fiber('log-fiber', bus_conn, ctx, function (fib_ctx)
+        while not fib_ctx:err() do
+            print('fiber active')
+            op.choice(
+                sleep.sleep_op(1),
+                fib_ctx:done_op()
+            ):perform()
+        end
+    end)
+end
+
+local ctx = context.with_cancel(context.background)
+local bus = bus_mod.new({q_len=10, m_wild='#', s_wild='+', sep="/"})
+
+service.spawn(dummy_service, bus, ctx)
+
+sleep.sleep(5)
+ctx:cancel('shutdown')
+```

--- a/src/service.lua
+++ b/src/service.lua
@@ -1,0 +1,147 @@
+local context = require "fibers.context"
+local fiber = require 'fibers.fiber'
+
+local FiberRegister = {}
+FiberRegister.__index = FiberRegister
+
+function FiberRegister.new()
+    return setmetatable({size = 0, fibers = {}}, FiberRegister)
+end
+
+function FiberRegister:push(name, status)
+    if self.fibers[name] == nil then
+        self.size = self.size + 1
+    end
+    self.fibers[name] = status
+end
+
+function FiberRegister:pop(name)
+    if self.fibers[name] ~= nil then
+        self.size = self.size - 1
+        self.fibers[name] = nil
+    end
+end
+
+function FiberRegister:is_empty()
+    return self.size == 0
+end
+
+-- spawns a service, which involves creation of a child context,
+-- bus connection and a shutdown fiber
+-- (which should be adapted for update, reboot etc when system service is more built out)
+local function spawn(service, bus, ctx)
+    local bus_connection = bus:connect()
+    local child_ctx = context.with_cancel(ctx)
+    child_ctx.values.service_name = service.name
+
+    local health_topic = child_ctx.values.service_name..'/health'
+
+    -- Non-blocking start function
+    service:start(bus_connection, child_ctx)
+    bus_connection:publish({
+        topic = health_topic,
+        payload = {
+            name = child_ctx.values.service_name,
+            state = 'active'
+        },
+        retained = true
+    })
+
+    -- Creates a shutdown fiber to handle any shutdown messages from the system service
+    -- Tracks all long running fibers under the current service before reporting an end to the service
+    fiber.spawn(function ()
+        local system_events_sub = bus_connection:subscribe(child_ctx.values.service_name..'/control/shutdown')
+        local shutdown_event = system_events_sub:next_msg()
+        system_events_sub:unsubscribe()
+
+        local service_fibers_status_sub = bus_connection:subscribe(child_ctx.values.service_name..'/health/fibers/+')
+        local active_fibers = FiberRegister.new()
+
+        local fibers_checked = false
+
+        -- is there a better way to do this? should be one loop or two for better readability?:
+        -- 1. No fibers
+        -- 2. All fibers already completed
+        -- 3. Some fibers finished
+        -- 4. All fibers finished
+        -- 5. (opt) Could a fiber spin up during the shutdown and not be detected as ongoing?
+
+        -- collect what fibers are active or initialising
+        while true do
+            local message = service_fibers_status_sub:next_msg_op():perform_alt(function () fibers_checked = true end)
+            if fibers_checked then break end
+            if message.payload ~= '' then
+                if message.payload.state == 'disabled' then
+                    active_fibers:pop(message.payload.name)
+                else
+                    active_fibers:push(message.payload.name, message.payload.state)
+                end
+            end
+        end
+
+        -- let every fiber know to end
+        child_ctx:cancel(shutdown_event.payload.cause)
+
+        -- wait for fibers to close
+        while not active_fibers:is_empty() do
+            local message = service_fibers_status_sub:next_msg()
+            if message.payload ~= '' then
+                if message.payload.state == 'disabled' then
+                    active_fibers:pop(message.payload.name)
+                else
+                    active_fibers:push(message.payload.name, message.payload.state)
+                end
+            end
+        end
+
+        bus_connection:publish({
+            topic = health_topic,
+            payload = {
+                name = child_ctx.values.service_name,
+                state = 'disabled'
+            },
+            retained = true
+        })
+    end)
+end
+
+local function spawn_fiber(name, bus_connection, ctx, fn)
+    local child_ctx = context.with_cancel(ctx)
+    child_ctx.values.fiber_name = name
+
+    local fiber_topic = child_ctx.values.service_name..'/health/fibers/'..child_ctx.values.fiber_name
+
+    bus_connection:publish({
+        topic = fiber_topic,
+        payload = {
+            name = child_ctx.values.fiber_name,
+            state = 'initialising'
+        },
+        retained = true
+    })
+
+    fiber.spawn(function ()
+        bus_connection:publish({
+            topic = fiber_topic,
+            payload = {
+                name = child_ctx.values.fiber_name,
+                state = 'active'
+            },
+            retained = true
+        })
+        fn(child_ctx)
+        bus_connection:publish({
+            topic = fiber_topic,
+            payload = {
+                name = child_ctx.values.fiber_name,
+                state = 'disabled'
+            },
+            retained = true
+        })
+    end)
+end
+
+return {
+    spawn = spawn,
+    spawn_fiber = spawn_fiber
+}

--- a/tests/test_service.lua
+++ b/tests/test_service.lua
@@ -1,0 +1,299 @@
+package.path = "../src/?.lua;" .. package.path .. ";/usr/lib/lua/?.lua;/usr/lib/lua/?/init.lua"
+
+local service = require "service"
+local sleep = require "fibers.sleep"
+local fiber = require "fibers.fiber"
+local bus_pkg = require "bus"
+local context = require "fibers.context"
+
+local function test_service_states()
+    -- make a fake service
+    local dummy_service = {}
+    dummy_service.__index = dummy_service
+
+    dummy_service.name = 'dummy-service'
+
+    function dummy_service:start(bus_conn, ctx)
+        --nothing
+    end
+
+    local bus = bus_pkg.new({q_len=10, m_wild='#', s_wild='+', sep="/"})
+    local bus_connection = bus:connect()
+
+    local bg_ctx = context.background()
+    local ctx = context.with_cancel(bg_ctx)
+
+    local expected_states = {'active', 'disabled'}
+    local states = {}
+
+    -- fiber to listen for service health updates
+    fiber.spawn(function ()
+        local service_health_sub = bus_connection:subscribe('dummy-service/health')
+        while not ctx:err() do
+            local msg = service_health_sub:next_msg()
+            if msg.payload ~= '' then
+                table.insert(states, msg.payload.state)
+            end
+        end
+    end)
+
+    service.spawn(dummy_service, bus, ctx)
+
+    -- send shutdown signal to service
+    bus_connection:publish({
+        topic = 'dummy-service/control/shutdown',
+        payload = {
+            cause = "shutdown-service"
+        },
+        retained = true
+    })
+
+    -- a little time for messages to propagate
+    sleep.sleep(0.1)
+
+    ctx:cancel('shutdown')
+
+    -- check service states
+    for i=1, 2 do
+        assert(states[i] == expected_states[i], "service states was "..(states[i] or 'nil').." expected "..expected_states[i])
+    end
+
+    assert(#states == 2, 'service should have gone through 2 states, '..#states..' detected')
+end
+
+local function test_fiber_states()
+    local dummy_service = {}
+    dummy_service.__index = dummy_service
+
+    dummy_service.name = 'dummy-service'
+
+    -- service spins up a fiber that waits for 0.1 seconds before exiting
+    function dummy_service:start(bus_conn, ctx)
+        service.spawn_fiber('sleep-fiber', bus_conn, ctx, function (fctx)
+            sleep.sleep(0.1)
+        end)
+    end
+
+    local bus = bus_pkg.new({q_len=10, m_wild='#', s_wild='+', sep="/"})
+    local bus_connection = bus:connect()
+
+    local bg_ctx = context.background()
+    local ctx = context.with_cancel(bg_ctx)
+
+    local expected_states = {'initialising', 'active', 'disabled'}
+    local states = {}
+
+    -- fiber to listen for fiber health updates
+    fiber.spawn(function ()
+        local fiber_health_sub = bus_connection:subscribe('dummy-service/health/fibers/sleep-fiber')
+        while not ctx:err() do
+            local msg = fiber_health_sub:next_msg()
+            if msg.payload ~= '' then
+                table.insert(states, msg.payload.state)
+            end
+        end
+    end)
+
+    -- let listening fiber spin up
+    fiber.yield()
+
+    service.spawn(dummy_service, bus, ctx)
+
+    -- send shutdown signal to service
+    bus_connection:publish({
+        topic = 'dummy-service/control/shutdown',
+        payload = {
+            cause = "shutdown-service"
+        },
+        retained = true
+    })
+
+    -- let shutdown signal propagate
+    sleep.sleep(0.2)
+
+    ctx:cancel('shutdown')
+
+    -- check fiber states
+    for i=1, 3 do
+        assert(states[i] == expected_states[i], "service states was "..(states[i] or 'nil').." expected "..expected_states[i])
+    end
+
+    assert(#states == 3, 'service should have gone through 3 states, '..#states..' detected')
+end
+
+local function check_fiber_state(bus_conn, service_name, fiber_name)
+    local sub = bus_conn:subscribe(service_name..'/health/fibers/'..fiber_name)
+    local state_msg = sub:next_msg()
+    sub:unsubscribe()
+    return state_msg.payload.state
+end
+
+local function check_service_state(bus_conn, service_name)
+    local sub = bus_conn:subscribe(service_name..'/health')
+    local state_msg = sub:next_msg()
+    sub:unsubscribe()
+    return state_msg.payload.state
+end
+
+local function test_blocked_shutdown()
+    local dummy_service = {}
+    dummy_service.__index = dummy_service
+
+    dummy_service.name = 'dummy-service'
+
+    -- service will create a fiber that will run endlessly, therefore
+    -- blocking the shutdown of the service
+    function dummy_service:start(bus_conn, ctx)
+        service.spawn_fiber('stuck-loop', bus_conn, ctx, function (fctx)
+            local i = 0
+            while true do
+                i = i + 1
+                fiber.yield()
+            end
+        end)
+    end
+
+    local bus = bus_pkg.new({q_len=10, m_wild='#', s_wild='+', sep="/"})
+    local bus_connection = bus:connect()
+
+    local bg_ctx = context.background()
+    local ctx = context.with_cancel(bg_ctx)
+
+    service.spawn(dummy_service, bus, ctx)
+
+    -- send shutdown signal to service
+    bus_connection:publish({
+        topic = 'dummy-service/control/shutdown',
+        payload = {
+            cause = "shutdown-service"
+        },
+        retained = true
+    })
+
+    -- wait for messages to propegate
+    sleep.sleep(0.1)
+
+    local fiber_state = check_fiber_state(bus_connection, 'dummy-service', 'stuck-loop')
+    assert(fiber_state == 'active', 'stuck-loop should be active but is '..fiber_state)
+
+    local service_state = check_service_state(bus_connection, 'dummy-service')
+    assert(service_state == 'active', 'dummy-service should be active but is '..service_state)
+end
+
+local function test_timed_shutdown()
+    local dummy_service = {}
+    dummy_service.__index = dummy_service
+
+    dummy_service.name = 'dummy-service'
+
+    -- service will spin up
+    function dummy_service:start(bus_conn, ctx)
+        service.spawn_fiber('time-dependant', bus_conn, ctx, function (fctx)
+            sleep.sleep(0.2)
+        end)
+    end
+
+    local bus = bus_pkg.new({q_len=10, m_wild='#', s_wild='+', sep="/"})
+    local bus_connection = bus:connect()
+
+    local bg_ctx = context.background()
+    local ctx = context.with_cancel(bg_ctx)
+
+    service.spawn(dummy_service, bus, ctx)
+
+    -- send shutdown signal to service
+    bus_connection:publish({
+        topic = 'dummy-service/control/shutdown',
+        payload = {
+            cause = "shutdown-service"
+        },
+        retained = true
+    })
+
+    -- wait for service and fiber to spin up
+    sleep.sleep(0.1)
+
+    local fiber_state = check_fiber_state(bus_connection, 'dummy-service', 'time-dependant')
+    assert(fiber_state == 'active', 'time-dependant should be active but is '..fiber_state)
+
+    local service_state = check_service_state(bus_connection, 'dummy-service')
+    assert(service_state == 'active', 'dummy-service should be active but is '..service_state)
+
+    -- wait for fiber to finish
+    sleep.sleep(0.3)
+
+    fiber_state = check_fiber_state(bus_connection, 'dummy-service', 'time-dependant')
+    assert(fiber_state == 'disabled', 'time-dependant should be disabled but is '..fiber_state)
+
+    service_state = check_service_state(bus_connection, 'dummy-service')
+    assert(service_state == 'disabled', 'dummy-service should be disabled but is '..service_state)
+end
+
+local function test_context_shutdown()
+    local dummy_service = {}
+    dummy_service.__index = dummy_service
+
+    dummy_service.name = 'dummy-service'
+
+    -- service creates a fiber that requires a context cancellation in order to exit
+    function dummy_service:start(bus_conn, sctx)
+        service.spawn_fiber('ctx-dependant', bus_conn, sctx, function (fctx)
+            local i = 0
+            while not fctx:err() do
+                i = i + 1
+                fiber.yield()
+            end
+        end)
+    end
+
+    local bus = bus_pkg.new({q_len=10, m_wild='#', s_wild='+', sep="/"})
+    local bus_connection = bus:connect()
+
+    local bg_ctx = context.background()
+    local ctx = context.with_cancel(bg_ctx)
+
+    service.spawn(dummy_service, bus, ctx)
+
+    local fiber_state = check_fiber_state(bus_connection, 'dummy-service', 'ctx-dependant')
+    assert(fiber_state == 'initialising', 'ctx-dependant should be initialising but is '..fiber_state)
+
+    -- let fiber spin up
+    sleep.sleep(0.1)
+
+    fiber_state = check_fiber_state(bus_connection, 'dummy-service', 'ctx-dependant')
+    assert(fiber_state == 'active', 'ctx-dependant should be active but is '..fiber_state)
+
+    local service_state = check_service_state(bus_connection, 'dummy-service')
+    assert(service_state == 'active', 'dummy-service should be active but is '..service_state)
+
+    -- send shutdown signal to service
+    bus_connection:publish({
+        topic = 'dummy-service/control/shutdown',
+        payload = {
+            cause = "shutdown-service"
+        },
+        retained = true
+    })
+
+    -- wait for messages to propegate
+    sleep.sleep(0.1)
+
+    fiber_state = check_fiber_state(bus_connection, 'dummy-service', 'ctx-dependant')
+    assert(fiber_state == 'disabled', 'ctx-dependant should be disabled but is '..fiber_state)
+
+    service_state = check_service_state(bus_connection, 'dummy-service')
+    assert(service_state == 'disabled', 'dummy-service should be disabled but is '..service_state)
+end
+
+fiber.spawn(function ()
+    test_service_states()
+    test_fiber_states()
+    test_blocked_shutdown()
+    test_timed_shutdown()
+    test_context_shutdown()
+    fiber.stop()
+end)
+
+print("starting service tests")
+fiber.main()
+print("tests complete")


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [x] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description
Adds a service module to handle the boilerplate of:
- Creating a child context,
- Communicating service status on bus
- Handling shutdown commands from future system service
- creation of identifiable long running fibers
- tracking of long running fibers

This pull request also includes tests for the following scenarios:
- Expected broadcasting of service states (active and disabled)
- Expected broadcasting of fiber states (initialising, active and disabled)
- Blocked service shutdown when a service fiber is hanging
- Service shutdown when a fiber hangs for a set amount of time
- Service shutdown when a fiber is dependent on a cancellation signal via context object

## Manual test
<!-- Have you manually tested this code and confirmed it is working? -->
- [ ] 👍 yes
- [x] 🙅 no

## Added tests?
- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

The service module can be tested completely through a devcontainer, no need for devkit hardware

## Added to documentation?
- [x] 📜 README.md
- [ ] 🙅 no documentation needed

