### PR TITLE
service module PR fixes

### DIFF
--- a/src/service.lua
+++ b/src/service.lua
@@ -1,5 +1,10 @@
 local context = require "fibers.context"
 local fiber = require 'fibers.fiber'
+local sleep           = require 'fibers.sleep'
+local log             = require 'log'
+
+local STATE           = { INITIALISING = 1, ACTIVE = 2, DISABLED = 3 }
+local STR_STATE       = { "INITIALISING", "ACTIVE", "DISABLED" }
 
 local FiberRegister = {}
 FiberRegister.__index = FiberRegister
@@ -8,14 +13,14 @@ function FiberRegister.new()
     return setmetatable({size = 0, fibers = {}}, FiberRegister)
 end
 
-function FiberRegister:push(name, status)
+function FiberRegister:add(name, status)
     if self.fibers[name] == nil then
         self.size = self.size + 1
     end
     self.fibers[name] = status
 end
 
-function FiberRegister:pop(name)
+function FiberRegister:remove(name)
     if self.fibers[name] ~= nil then
         self.size = self.size - 1
         self.fibers[name] = nil
@@ -30,51 +35,82 @@ end
 -- bus connection and a shutdown fiber
 -- (which should be adapted for update, reboot etc when system service is more built out)
 local function spawn(service, bus, ctx)
-    local bus_connection = bus:connect()
+    local bus_connection, conn_err = bus:connect()
+    if conn_err then return conn_err end
     local child_ctx = context.with_cancel(ctx)
+    if service.name == nil then return 'Service does not contain a name attribute' end
     child_ctx.values.service_name = service.name
 
-    local health_topic = child_ctx.values.service_name..'/health'
+    local health_topic = string.format("%s/health", child_ctx:value("service_name"))
 
     -- Non-blocking start function
-    service:start(bus_connection, child_ctx)
+    if (service.start == nil) then
+        return string.format('%s: Service does not contain a start method', child_ctx:value('service_name'))
+    end
     bus_connection:publish({
         topic = health_topic,
         payload = {
-            name = child_ctx.values.service_name,
-            state = 'active'
+            name = child_ctx:value("service_name"),
+            state = STATE.ACTIVE
         },
         retained = true
     })
+    service:start(bus_connection, child_ctx)
 
     -- Creates a shutdown fiber to handle any shutdown messages from the system service
     -- Tracks all long running fibers under the current service before reporting an end to the service
     fiber.spawn(function ()
-        local system_events_sub = bus_connection:subscribe(child_ctx.values.service_name..'/control/shutdown')
+        local function send_disabled()
+            bus_connection:publish({
+                topic = health_topic,
+                payload = {
+                    name = child_ctx:value("service_name"),
+                    state = STATE.DISABLED
+                },
+                retained = true
+            })
+        end
+
+        local system_events_sub, sub_err = bus_connection:subscribe(string.format(
+            "%s/control/shutdown",
+            child_ctx:value('service_name')
+        ))
+        if sub_err then
+            log.error(string.format(
+                "%s: shutdown fiber failed to subscribe to shutdown topic (%s)",
+                ctx:value("service_name"),
+                sub_err
+            ))
+            send_disabled()
+            return
+        end
         local shutdown_event = system_events_sub:next_msg()
         system_events_sub:unsubscribe()
 
-        local service_fibers_status_sub = bus_connection:subscribe(child_ctx.values.service_name..'/health/fibers/+')
+        local service_fibers_status_topic = string.format("%s/health/fibers/+", child_ctx:value('service_name'))
+        local service_fibers_status_sub, status_sub_err = bus_connection:subscribe(service_fibers_status_topic)
+        if status_sub_err then
+            log.error(string.format(
+                "%s : shutdown fiber failed to subscribe to fiber health topic (%s)",
+                ctx:value('service_name'),
+                status_sub_err
+            ))
+            send_disabled()
+            return
+        end
         local active_fibers = FiberRegister.new()
 
         local fibers_checked = false
-
-        -- is there a better way to do this? should be one loop or two for better readability?:
-        -- 1. No fibers
-        -- 2. All fibers already completed
-        -- 3. Some fibers finished
-        -- 4. All fibers finished
-        -- 5. (opt) Could a fiber spin up during the shutdown and not be detected as ongoing?
 
         -- collect what fibers are active or initialising
         while true do
             local message = service_fibers_status_sub:next_msg_op():perform_alt(function () fibers_checked = true end)
             if fibers_checked then break end
             if message.payload ~= '' then
-                if message.payload.state == 'disabled' then
-                    active_fibers:pop(message.payload.name)
+                if message.payload.state == STATE.DISABLED then
+                    active_fibers:remove(message.payload.name)
                 else
-                    active_fibers:push(message.payload.name, message.payload.state)
+                    active_fibers:add(message.payload.name, message.payload.state)
                 end
             end
         end
@@ -86,36 +122,36 @@ local function spawn(service, bus, ctx)
         while not active_fibers:is_empty() do
             local message = service_fibers_status_sub:next_msg()
             if message.payload ~= '' then
-                if message.payload.state == 'disabled' then
-                    active_fibers:pop(message.payload.name)
+                if message.payload.state == STATE.DISABLED then
+                    active_fibers:remove(message.payload.name)
                 else
-                    active_fibers:push(message.payload.name, message.payload.state)
+                    active_fibers:add(message.payload.name, message.payload.state)
                 end
             end
         end
 
-        bus_connection:publish({
-            topic = health_topic,
-            payload = {
-                name = child_ctx.values.service_name,
-                state = 'disabled'
-            },
-            retained = true
-        })
+        send_disabled()
     end)
 end
 
 local function spawn_fiber(name, bus_connection, ctx, fn)
+    if ctx.cancel == nil then return "provided context does not have cancellation ability" end
+    if ctx:value('service_name') == nil then
+        return "provided context does not have a service name, please make this context is owned by a service"
+    end
     local child_ctx = context.with_cancel(ctx)
     child_ctx.values.fiber_name = name
 
-    local fiber_topic = child_ctx.values.service_name..'/health/fibers/'..child_ctx.values.fiber_name
+    local fiber_topic = string.format(
+        "%s/health/fibers/%s",
+        child_ctx:value('service_name'),
+        child_ctx:value('fiber_name'))
 
     bus_connection:publish({
         topic = fiber_topic,
         payload = {
-            name = child_ctx.values.fiber_name,
-            state = 'initialising'
+            name = child_ctx:value("fiber_name"),
+            state = STATE.INITIALISING
         },
         retained = true
     })
@@ -124,8 +160,8 @@ local function spawn_fiber(name, bus_connection, ctx, fn)
         bus_connection:publish({
             topic = fiber_topic,
             payload = {
-                name = child_ctx.values.fiber_name,
-                state = 'active'
+                name = child_ctx:value("fiber_name"),
+                state = STATE.ACTIVE
             },
             retained = true
         })
@@ -133,8 +169,8 @@ local function spawn_fiber(name, bus_connection, ctx, fn)
         bus_connection:publish({
             topic = fiber_topic,
             payload = {
-                name = child_ctx.values.fiber_name,
-                state = 'disabled'
+                name = child_ctx:value("fiber_name"),
+                state = STATE.DISABLED
             },
             retained = true
         })
@@ -143,5 +179,7 @@ end
 
 return {
     spawn = spawn,
-    spawn_fiber = spawn_fiber
+    spawn_fiber = spawn_fiber,
+    STATE = STATE,
+    STR_STATE = STR_STATE
 }

--- a/tests/test_service.lua
+++ b/tests/test_service.lua
@@ -4,6 +4,7 @@ local fiber = require "fibers.fiber"
 local bus_pkg = require "bus"
 local context = require "fibers.context"
 
+-- check service states, also checks no fibers case
 local function test_service_states()
     -- make a fake service
     local dummy_service = {}
@@ -11,7 +12,7 @@ local function test_service_states()
 
     dummy_service.name = 'dummy-service'
 
-    function dummy_service:start(bus_conn, ctx)
+    function dummy_service:start()
         --nothing
     end
 
@@ -21,7 +22,7 @@ local function test_service_states()
     local bg_ctx = context.background()
     local ctx = context.with_cancel(bg_ctx)
 
-    local expected_states = {'active', 'disabled'}
+    local expected_states = { service.STATE.ACTIVE, service.STATE.DISABLED }
     local states = {}
 
     -- fiber to listen for service health updates
@@ -53,7 +54,11 @@ local function test_service_states()
 
     -- check service states
     for i=1, 2 do
-        assert(states[i] == expected_states[i], "service states was "..(states[i] or 'nil').." expected "..expected_states[i])
+        assert(states[i] == expected_states[i],
+            "service states was "
+            .. (service.STR_STATE[states[i]] or 'nil')
+            .. " expected "
+            .. service.STR_STATE[expected_states[i]])
     end
 
     assert(#states == 2, 'service should have gone through 2 states, '..#states..' detected')
@@ -67,7 +72,7 @@ local function test_fiber_states()
 
     -- service spins up a fiber that waits for 0.1 seconds before exiting
     function dummy_service:start(bus_conn, ctx)
-        service.spawn_fiber('sleep-fiber', bus_conn, ctx, function (fctx)
+        service.spawn_fiber('sleep-fiber', bus_conn, ctx, function()
             sleep.sleep(0.1)
         end)
     end
@@ -78,7 +83,7 @@ local function test_fiber_states()
     local bg_ctx = context.background()
     local ctx = context.with_cancel(bg_ctx)
 
-    local expected_states = {'initialising', 'active', 'disabled'}
+    local expected_states = { service.STATE.INITIALISING, service.STATE.ACTIVE, service.STATE.DISABLED }
     local states = {}
 
     -- fiber to listen for fiber health updates
@@ -113,7 +118,11 @@ local function test_fiber_states()
 
     -- check fiber states
     for i=1, 3 do
-        assert(states[i] == expected_states[i], "service states was "..(states[i] or 'nil').." expected "..expected_states[i])
+        assert(states[i] == expected_states[i],
+            "service states was "
+            .. (service.STR_STATE[states[i]] or 'nil')
+            .. " expected "
+            .. service.STR_STATE[expected_states[i]])
     end
 
     assert(#states == 3, 'service should have gone through 3 states, '..#states..' detected')
@@ -142,7 +151,7 @@ local function test_blocked_shutdown()
     -- service will create a fiber that will run endlessly, therefore
     -- blocking the shutdown of the service
     function dummy_service:start(bus_conn, ctx)
-        service.spawn_fiber('stuck-loop', bus_conn, ctx, function (fctx)
+        service.spawn_fiber('stuck-loop', bus_conn, ctx, function()
             local i = 0
             while true do
                 i = i + 1
@@ -172,10 +181,12 @@ local function test_blocked_shutdown()
     sleep.sleep(0.1)
 
     local fiber_state = check_fiber_state(bus_connection, 'dummy-service', 'stuck-loop')
-    assert(fiber_state == 'active', 'stuck-loop should be active but is '..fiber_state)
+    assert(fiber_state == service.STATE.ACTIVE, 'stuck-loop should be active but is ' .. service.STR_STATE[fiber_state])
 
     local service_state = check_service_state(bus_connection, 'dummy-service')
-    assert(service_state == 'active', 'dummy-service should be active but is '..service_state)
+    assert(service_state == service.STATE.ACTIVE,
+        'dummy-service should be active but is '
+        .. service.STR_STATE[service_state])
 end
 
 local function test_timed_shutdown()
@@ -186,7 +197,7 @@ local function test_timed_shutdown()
 
     -- service will spin up
     function dummy_service:start(bus_conn, ctx)
-        service.spawn_fiber('time-dependant', bus_conn, ctx, function (fctx)
+        service.spawn_fiber('time-dependant', bus_conn, ctx, function()
             sleep.sleep(0.2)
         end)
     end
@@ -212,19 +223,27 @@ local function test_timed_shutdown()
     sleep.sleep(0.1)
 
     local fiber_state = check_fiber_state(bus_connection, 'dummy-service', 'time-dependant')
-    assert(fiber_state == 'active', 'time-dependant should be active but is '..fiber_state)
+    assert(fiber_state == service.STATE.ACTIVE,
+        'time-dependant should be active but is '
+        .. service.STR_STATE[fiber_state])
 
     local service_state = check_service_state(bus_connection, 'dummy-service')
-    assert(service_state == 'active', 'dummy-service should be active but is '..service_state)
+    assert(service_state == service.STATE.ACTIVE,
+        'dummy-service should be active but is '
+        .. service.STR_STATE[service_state])
 
     -- wait for fiber to finish
     sleep.sleep(0.3)
 
     fiber_state = check_fiber_state(bus_connection, 'dummy-service', 'time-dependant')
-    assert(fiber_state == 'disabled', 'time-dependant should be disabled but is '..fiber_state)
+    assert(fiber_state == service.STATE.DISABLED,
+        'time-dependant should be disabled but is '
+        .. service.STR_STATE[fiber_state])
 
     service_state = check_service_state(bus_connection, 'dummy-service')
-    assert(service_state == 'disabled', 'dummy-service should be disabled but is '..service_state)
+    assert(service_state == service.STATE.DISABLED,
+        'dummy-service should be disabled but is '
+        .. service.STR_STATE[service_state])
 end
 
 local function test_context_shutdown()
@@ -253,16 +272,22 @@ local function test_context_shutdown()
     service.spawn(dummy_service, bus, ctx)
 
     local fiber_state = check_fiber_state(bus_connection, 'dummy-service', 'ctx-dependant')
-    assert(fiber_state == 'initialising', 'ctx-dependant should be initialising but is '..fiber_state)
+    assert(fiber_state == service.STATE.INITIALISING,
+        'ctx-dependant should be initialising but is '
+        .. service.STR_STATE[fiber_state])
 
     -- let fiber spin up
     sleep.sleep(0.1)
 
     fiber_state = check_fiber_state(bus_connection, 'dummy-service', 'ctx-dependant')
-    assert(fiber_state == 'active', 'ctx-dependant should be active but is '..fiber_state)
+    assert(fiber_state == service.STATE.ACTIVE,
+        'ctx-dependant should be active but is '
+        .. service.STR_STATE[fiber_state])
 
     local service_state = check_service_state(bus_connection, 'dummy-service')
-    assert(service_state == 'active', 'dummy-service should be active but is '..service_state)
+    assert(service_state == service.STATE.ACTIVE,
+        'dummy-service should be active but is '
+        .. service.STR_STATE[service_state])
 
     -- send shutdown signal to service
     bus_connection:publish({
@@ -277,10 +302,213 @@ local function test_context_shutdown()
     sleep.sleep(0.1)
 
     fiber_state = check_fiber_state(bus_connection, 'dummy-service', 'ctx-dependant')
-    assert(fiber_state == 'disabled', 'ctx-dependant should be disabled but is '..fiber_state)
+    assert(fiber_state == service.STATE.DISABLED,
+        'ctx-dependant should be disabled but is '
+        .. service.STR_STATE[fiber_state])
 
     service_state = check_service_state(bus_connection, 'dummy-service')
-    assert(service_state == 'disabled', 'dummy-service should be disabled but is '..service_state)
+    assert(service_state == service.STATE.DISABLED,
+        'dummy-service should be disabled but is '
+        .. service.STR_STATE[service_state])
+end
+
+local function test_all_fibers_completed_before_shutdown()
+    local dummy_service = {}
+    dummy_service.__index = dummy_service
+
+    dummy_service.name = 'dummy-service'
+
+    function dummy_service:start(bus_conn, sctx)
+        service.spawn_fiber('sleep-fiber-1', bus_conn, sctx, function()
+            sleep.sleep(0.001)
+        end)
+        service.spawn_fiber('sleep-fiber-2', bus_conn, sctx, function()
+            sleep.sleep(0.001)
+        end)
+    end
+
+    local bus = bus_pkg.new({ q_len = 10, m_wild = '#', s_wild = '+', sep = "/" })
+    local bus_connection = bus:connect()
+
+    local bg_ctx = context.background()
+    local ctx = context.with_cancel(bg_ctx)
+
+    service.spawn(dummy_service, bus, ctx)
+
+    sleep.sleep(0.1)
+
+    local fiber_state = check_fiber_state(bus_connection, 'dummy-service', 'sleep-fiber-1')
+    assert(fiber_state == service.STATE.DISABLED,
+        'ctx-dependant should be disabled but is '
+        .. service.STR_STATE[fiber_state])
+
+    fiber_state = check_fiber_state(bus_connection, 'dummy-service', 'sleep-fiber-2')
+    assert(fiber_state == service.STATE.DISABLED,
+        'ctx-dependant should be disabled but is '
+        .. service.STR_STATE[fiber_state])
+
+    local service_state = check_service_state(bus_connection, 'dummy-service')
+    assert(service_state == service.STATE.ACTIVE,
+        'dummy-service should be disabled but is '
+        .. service.STR_STATE[service_state])
+
+    -- send shutdown signal to service
+    bus_connection:publish({
+        topic = 'dummy-service/control/shutdown',
+        payload = {
+            cause = "shutdown-service"
+        },
+        retained = true
+    })
+
+    sleep.sleep(0.1)
+
+    service_state = check_service_state(bus_connection, 'dummy-service')
+    assert(service_state == service.STATE.DISABLED,
+        'dummy-service should be disabled but is '
+        .. service.STR_STATE[service_state])
+end
+
+local function test_fiber_spawn_during_shutdown()
+    -- service:start
+    -- ctx cancel
+    -- service.spawn_fiber
+
+    local dummy_service = {}
+    dummy_service.__index = dummy_service
+
+    dummy_service.name = 'dummy-service'
+
+    function dummy_service:start(bus_conn, sctx)
+        service.spawn_fiber('sleep-fiber-1', bus_conn, sctx, function(cctx)
+            sleep.sleep(0.1)
+            service.spawn_fiber('sleep-fiber-2', bus_conn, cctx, function()
+                sleep.sleep(0.2)
+            end)
+        end)
+    end
+
+    local bus = bus_pkg.new({ q_len = 10, m_wild = '#', s_wild = '+', sep = "/" })
+    local bus_connection = bus:connect()
+
+    local bg_ctx = context.background()
+    local ctx = context.with_cancel(bg_ctx)
+
+    service.spawn(dummy_service, bus, ctx)
+
+    -- let first fiber spin up
+    sleep.sleep(0.05)
+
+    -- send shutdown signal to service
+    bus_connection:publish({
+        topic = 'dummy-service/control/shutdown',
+        payload = {
+            cause = "shutdown-service"
+        },
+        retained = true
+    })
+
+    -- shutdown will begin then the second fiber will spin up
+    sleep.sleep(0.15)
+
+    -- first fiber should have shutdown correctly
+    local fiber_state = check_fiber_state(bus_connection, 'dummy-service', 'sleep-fiber-1')
+    assert(fiber_state == service.STATE.DISABLED,
+        'sleep-fiber-1 should be disabled but is '
+        .. service.STR_STATE[fiber_state])
+
+    -- second fiber is still running
+    fiber_state = check_fiber_state(bus_connection, 'dummy-service', 'sleep-fiber-2')
+    assert(fiber_state == service.STATE.ACTIVE,
+        'sleep-fiber-2 should be active but is '
+        .. service.STR_STATE[fiber_state])
+
+    -- service must not disable until all fibers have shutdown
+    local service_state = check_service_state(bus_connection, 'dummy-service')
+    assert(service_state == service.STATE.ACTIVE,
+        'dummy-service should be active but is '
+        .. service.STR_STATE[service_state])
+
+    -- second fiber will now shutdown
+    sleep.sleep(0.1)
+
+    fiber_state = check_fiber_state(bus_connection, 'dummy-service', 'sleep-fiber-2')
+    assert(fiber_state == service.STATE.DISABLED,
+        'sleep-fiber-2 should be disabled but is '
+        .. service.STR_STATE[fiber_state])
+
+    -- all fibers have shutdown so the service has also shutdown
+    local service_state = check_service_state(bus_connection, 'dummy-service')
+    assert(service_state == service.STATE.DISABLED,
+        'dummy-service should be disabled but is '
+        .. service.STR_STATE[service_state])
+end
+
+local function test_no_start()
+    local dummy_service = {}
+    dummy_service.__index = dummy_service
+
+    dummy_service.name = 'dummy-service'
+
+    local bus = bus_pkg.new({ q_len = 10, m_wild = '#', s_wild = '+', sep = "/" })
+    local bus_connection = bus:connect()
+
+    local bg_ctx = context.background()
+    local ctx = context.with_cancel(bg_ctx)
+
+    local expected_err = "dummy-service: Service does not contain a start method"
+    local err = service.spawn(dummy_service, bus, ctx)
+    assert(err == expected_err,
+        string.format("expected error = '%s' but got '%s'", expected_err, err))
+end
+
+local function test_no_name()
+    local dummy_service = {}
+    dummy_service.__index = dummy_service
+
+    function dummy_service:start()
+        -- nothing
+    end
+
+    local bus = bus_pkg.new({ q_len = 10, m_wild = '#', s_wild = '+', sep = "/" })
+    local bus_connection = bus:connect()
+
+    local bg_ctx = context.background()
+    local ctx = context.with_cancel(bg_ctx)
+
+    local expected_err = "Service does not contain a name attribute"
+    local err = service.spawn(dummy_service, bus, ctx)
+    assert(err == expected_err,
+        string.format("expected error = '%s' but got '%s'", expected_err, err))
+end
+
+local function test_no_cancel()
+    local bus = bus_pkg.new({ q_len = 10, m_wild = '#', s_wild = '+', sep = "/" })
+    local bus_connection = bus:connect()
+
+    local bg_ctx = context.background()
+
+    local expected_err = "provided context does not have cancellation ability"
+    local err = service.spawn_fiber('nothing-fiber', bus_connection, bg_ctx, function()
+    end)
+
+    assert(err == expected_err,
+        string.format("expected error = '%s' but got '%s'", expected_err, err))
+end
+
+local function test_no_service_name()
+    local bus = bus_pkg.new({ q_len = 10, m_wild = '#', s_wild = '+', sep = "/" })
+    local bus_connection = bus:connect()
+
+    local bg_ctx = context.background()
+    local ctx = context.with_cancel(bg_ctx)
+
+    local expected_err = "provided context does not have a service name, please make this context is owned by a service"
+    local err = service.spawn_fiber('nothing-fiber', bus_connection, ctx, function()
+    end)
+
+    assert(err == expected_err,
+        string.format("expected error = '%s' but got '%s'", expected_err, err))
 end
 
 fiber.spawn(function ()
@@ -289,6 +517,12 @@ fiber.spawn(function ()
     test_blocked_shutdown()
     test_timed_shutdown()
     test_context_shutdown()
+    test_all_fibers_completed_before_shutdown()
+    test_no_start()
+    test_no_name()
+    test_fiber_spawn_during_shutdown()
+    test_no_cancel()
+    test_no_service_name()
     fiber.stop()
 end)
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [x] 🎨 Style
- [x] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description
This PR is in relation to the reviews put forward in #12. Changes made:
- States have change from a string to an "enum"
- FiberRegister method naming changed to reflect map style
- Error checking for bus interactions
- Consistent string formatting
- Error messages contain more information where possible (service name)
- Using context object to retrieve values properly
- New tests for cases:
  - all fibers finish before shutdown signal
  - a fiber spins up after the shutdown signal is activated
  - a service with no name is passed into spawn
  - a service with no start method is passed into spawn
  - a service context with no service_name is passed into spawn_fiber
  - a service context with no cancel method is passed into spawn_fiber

## Related Issues, Tickets & Documents
Fixes #12 

## Manual test
<!-- Have you manually tested this code and confirmed it is working? -->
- [] 👍 yes
- [x] 🙅 no

## Manual test description
<!-- If you selected "Yes" for manual testing, please provide a brief description of the test steps and results here. -->

## Added tests?
- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?
- [ ] 📜 README.md
- [x] 🙅 no documentation needed

