### PR TITLE
Modem Card Manager

### DIFF
--- a/sprint-docs/modemcard_manager.md
+++ b/sprint-docs/modemcard_manager.md
@@ -1,0 +1,112 @@
+# Modem Card Manager Documentation
+
+## Table of Contents
+1. [Overview](#overview)
+2. [Features](#features)
+3. [Architecture](#architecture)
+6. [API Reference](#api-reference)
+   - [Initialization](#initialization)
+   - [Modem Detection](#modem-detection)
+   - [Modem Manager](#modem-manager)
+7. [Usage Examples](#usage-examples)
+8. [Testing](#testing)
+9. [Known Limitations](#known-limitations)
+
+---
+
+## Overview
+### Key Objectives
+- Monitor and manage connected modems dynamically.
+- Send modem events to HAL for integration with other services.
+- Allow for configuration of modems.
+
+---
+
+## Features
+- **Dynamic Modem Detection**: Detects when modems are connected or disconnected.
+- **Events**: Sends modem events (e.g., detection, removal) to HAL with device and capability control interfaces.
+- **Configuration Management**: Applies configurations to modems.
+- **Asynchronous Design**: Uses `fibers` for non-blocking, concurrent operations.
+
+---
+
+## Architecture
+### Core Components
+1. **Modem Manager**:
+   - Handles the lifecycle of modems (detection, configuration, removal).
+
+2. **Modem Detector**:
+   -  Monitors modem state through `mmcli`
+   -  Sends modem card events to the manager for handling
+
+2. **Communication**:
+   - **Detection Channel**: Connection between detector and manager to signal a detection event.
+   - **Removal Channel**: Connection between detector and manager to signal a removale event.
+   - **Configuration Channel**: Modem configs sent from top-level HAL.
+   - **Device Event Queue**: output to top-level HAL to signal modemcard connected/disconnected.
+
+3. **Message Bus**:
+   - This is used to send the modem driver state monitor and command fibers' data
+
+4. **Test Shims**:
+   - Mocked dependencies for testing modules which typically interact with hardware components (e.g., `mmcli` shim).
+
+---
+
+## API Reference
+
+### Initialisation
+```lua
+local modem_manager = require("services.hal.modemcard_manager")
+local instance = modem_manager.new()
+```
+- **Description**: Initialises a new instance of the modem card manager.
+- **Parameters**: None.
+- **Returns**: A new `ModemManagement` instance.
+
+---
+
+### Modem Detection
+```lua
+instance:detector(context, detect_channel, remove_channel)
+```
+- **Description**: Starts monitoring for modem detection and removal.
+- **Parameters**:
+  - `context`: The parent context for managing the detector's lifecycle.
+  - `detect_channel`: Channel for notifying detected modems.
+  - `remove_channel`: Channel for notifying removed modems.
+- **Returns**: None.
+
+---
+
+### Modem Manager
+```lua
+instance:manager(context, bus_connection, device_event_q, config_channel, detect_channel, remove_channel)
+```
+- **Description**: Manages modem configuration and state transitions.
+- **Parameters**:
+  - `context`: The parent context for managing the manager's lifecycle.
+  - `bus_connection`: Connection to the message bus for publishing events.
+  - `device_event_q`: Queue for device events.
+  - `config_channel`: Channel for receiving configuration changes.
+  - `detect_channel`: Channel for notifying detected modems.
+  - `remove_channel`: Channel for notifying removed modems.
+- **Returns**: None.
+
+---
+
+## Testing
+1. Run the test suite:
+   ```bash
+   make test
+   ```
+2. Verify output:
+   - Some error messages may be logged but the script will not crash, ignore these messages
+   - All tests should pass with a "Tests completed" message.
+
+---
+
+## Known Limitations/Futures
+- Requires `mmcli` for full functionality; limited without it.
+- Device control is not yet fully implemented (will be built out as other services are made)
+- Full modem configs may be changed as GSM develops

--- a/src/services/hal/hal_capabilities.lua
+++ b/src/services/hal/hal_capabilities.lua
@@ -1,0 +1,59 @@
+local channel = require "fibers.channel"
+
+local function do_command(driver_q, cmd)
+    cmd.return_channel = channel.new()
+    driver_q:put(cmd)
+    return cmd.return_channel:get()
+end
+
+local ModemCapability = {}
+ModemCapability.__index = ModemCapability
+
+local function new_modem_capability(driver_q)
+    return setmetatable({driver_q = driver_q}, ModemCapability)
+end
+
+function ModemCapability:enable()
+    local cmd = {command = "enable"}
+    return do_command(cmd, self.driver_q)
+end
+
+function ModemCapability:disable()
+    local cmd = {command = "disable"}
+    return do_command(cmd, self.driver_q)
+end
+
+function ModemCapability:restart()
+    local cmd = {command = "restart"}
+    return do_command(cmd, self.driver_q)
+end
+
+function ModemCapability:connect()
+    local cmd = {command = "connect"}
+    return do_command(cmd, self.driver_q)
+end
+
+function ModemCapability:disconnect()
+    local cmd = {command = "disconnect"}
+    return do_command(cmd, self.driver_q)
+end
+
+local GeoCapability = {}
+GeoCapability.__index = GeoCapability
+
+local function new_geo_capability(driver_q)
+    return setmetatable({driver_q = driver_q}, GeoCapability)
+end
+
+local TimeCapability = {}
+TimeCapability.__index = TimeCapability
+
+local function new_time_capability(driver_q)
+    return setmetatable({driver_q = driver_q}, GeoCapability)
+end
+
+return {
+    new_modem_capability = new_modem_capability,
+    new_geo_capability = new_geo_capability,
+    new_time_capability = new_time_capability
+}

--- a/src/services/hal/modemcard_manager.lua
+++ b/src/services/hal/modemcard_manager.lua
@@ -1,0 +1,278 @@
+local fiber = require "fibers.fiber"
+local channel = require "fibers.channel"
+local sleep = require "fibers.sleep"
+local context = require "fibers.context"
+local op = require "fibers.op"
+local service = require "service"
+local utils = require "services.hal.utils"
+local hal_capabilities = require "services.hal.hal_capabilities"
+local modem_driver = require "services.hal.modem_driver"
+local mmcli = require "services.hal.mmcli"
+local log = require "log"
+
+local ModemManagement = {}
+ModemManagement.__index = ModemManagement
+
+local function new()
+    local modem_management = {}
+    return setmetatable(modem_management, ModemManagement)
+end
+
+local ModemCard = {}
+ModemCard.__index = ModemCard
+
+function ModemCard.new(name, config, driver)
+    return setmetatable({name=name, config=config, driver=driver}, ModemCard)
+end
+
+function ModemCard:update_driver(driver)
+    self.driver = driver
+    self.device = driver:device()
+end
+
+function ModemCard:update_config(config)
+    self.config = config
+end
+
+local modems = {
+    -- for short term mmcli level tracking
+    address = {},
+    -- for semi-perminant tracking
+    device = {},
+    imei = {},
+    name = {}
+}
+
+function ModemManagement:detector(ctx, modem_detect_channel, modem_remove_channel)
+    log.trace("Modem Detector: starting...")
+
+    while not ctx:err() do
+        -- First, we start the modem detector
+        local cmd = mmcli.monitor_modems()
+        local stdout = assert(cmd:stdout_pipe())
+        local err = cmd:start()
+
+        if err then
+            log.error("Failed to start modem detection:", err)
+            sleep.sleep(5)
+        else
+            -- Now we loop over every line of output
+            for line in stdout:lines() do
+                local is_added, address, parse_err = utils.parse_monitor(line)
+
+                if is_added==true then
+                    log.trace("Modem Detector: detected at:", address)
+                    modem_detect_channel:put(address)
+                elseif is_added==false then
+                    log.trace("Modem Detector: removed at:", address)
+                    modem_remove_channel:put(address)
+                end
+                if parse_err then
+                    log.debug(string.format("%s - %s: %s",
+                        ctx:value('service_name'),
+                        ctx:value('fiber_name'),
+                        parse_err))
+                end
+            end
+            cmd:wait()
+        end
+        stdout:close()
+    end
+end
+
+local function get_device_index(ctx, bus_conn, imei, device)
+    local device_sub, err
+    local tries = 0
+    repeat
+        device_sub, err = bus_conn:subscribe('/hal/device/usb/+')
+        if err then sleep.sleep(1) end
+        tries = tries + 1
+    until err == nil or tries == 5
+
+    if err then return nil, err end
+
+    local device_event
+    local device_found = false
+
+    repeat
+        device_event = op.choice(
+            device_sub:next_msg_op(),
+            ctx:done_op()
+        ):perform()
+        if device_event ~= nil
+            and device_event.identity.device == 'modemcard'
+            and device_event.payload.identity.imei == imei
+            and device_event.payload.identity.port == device then
+            device_found = true
+        end
+    until device_found or ctx:err()
+
+    device_sub:unsubscribe()
+    if ctx:err() then return nil, string.format("Index not found before: %s", ctx:err()) end
+    return device_event.payload.index
+end
+
+function ModemManagement:manager(
+    ctx,
+    bus_conn,
+    device_event_q,
+    modem_config_channel,
+    modem_detect_channel,
+    modem_remove_channel)
+    log.trace("Modem Manager: starting")
+
+    local modem_config = {}
+
+    local driver_channel = channel.new()
+
+    local function handle_removal(address)
+        local instance = modems.address[address]
+        if not instance then return end
+        instance.driver.ctx:cancel('removed')
+
+        modems.address[address] = nil
+
+        -- Get stale driver information by setting stale flag to true
+        local device = instance.driver:get("device", true)
+        local imei = instance.driver:get("imei", true)
+
+        local device_event = {
+            connected = false,
+            type = 'usb',
+            identifier = device,
+            identity = {
+                device = 'modemcard',
+                name = instance.name or 'unknown',
+                imei = imei,
+                port = device
+            }
+        }
+
+        op.choice(
+            device_event_q:put_op(device_event),
+            ctx:done_op()
+        ):perform()
+    end
+
+    local function handle_detection(address)
+        local driver = modem_driver.new(context.with_cancel(ctx), address)
+        fiber.spawn(function ()
+            local err = driver:init()
+            if err then
+                log.error("HAL: Modem: Handle Detection: modem initialisation failed, removing modem")
+                handle_removal(address)
+            else
+                driver_channel:put(driver)
+            end
+        end)
+    end
+
+    local function handle_driver(driver)
+        if driver.ctx:err() then return end
+
+        -- Extract fingerprinting info
+        local imei = driver:imei()
+        local device = driver:device()
+
+        -- Check if an existing instance for that modem exists
+        local instance = modems.imei[imei] or modems.device[device]
+        if instance then
+            log.trace("HAL: Modem: Handle Driver: driver detected for modem:", instance.name)
+            instance:update_driver(driver)
+            modems.address[driver.address] = instance
+        else
+            log.trace("HAL: Modem: Handle Driver: driver detected for unknown modem:", driver.address)
+            instance = ModemCard.new(nil, nil, driver)
+            -- Modem is unknown, insert it into the tables with the relevant keys
+            modems.address[driver.address] = instance
+            modems.imei[imei] = instance
+            modems.device[device] = instance
+        end
+
+        local device_event = {
+            connected = true,
+            type = 'usb',
+            capabilities = {},
+            device_control = {},
+            identifier = device,
+            identity = {
+                device = 'modemcard',
+                name = instance.name or 'unknown',
+                imei = imei,
+                port = device
+            }
+        }
+
+        device_event.capabilities.modem = hal_capabilities.new_modem_capability(driver.command_q)
+        if instance.config and instance.config.capabilities then
+            if instance.config.capabilities.geo then
+                device_event.capabilities.geo = hal_capabilities.new_geo_capability(driver.command_q)
+            end
+            if instance.config.capabilities.time then
+                device_event.capabilities.time = hal_capabilities.new_time_capability(driver.command_q)
+            end
+        end
+
+        device_event_q:put(device_event)
+
+        fiber.spawn(function()
+            local index, err = get_device_index(context.with_timeout(ctx, 5), bus_conn, imei, device)
+            if err then
+                log.error(string.format("%s - %s: %s", ctx:value("service_name"),
+                    ctx:value("fiber_name"), err))
+                return
+            end
+
+            service.spawn_fiber('State Monitor - ' .. imei, bus_conn, ctx, function()
+                driver:monitor_manager(bus_conn, index)
+            end)
+        end)
+
+        service.spawn_fiber('Command Manger - '..imei, bus_conn, ctx, function ()
+            driver:command_manager()
+        end)
+    end
+
+    local function handle_config(config)
+        if config == nil then return end
+        if config.known == nil or config.defaults == nil then return end
+        modem_config = config
+
+        -- Handling known configs
+        for name, mod_config in pairs(config.known) do
+            local id_field = mod_config.id_field
+            local id_value = mod_config[id_field]
+            local instance = modems[id_field] and modems[id_field][id_value]
+            if instance then
+                instance.name = name
+                instance:update_config(mod_config)
+            else
+                -- Create a new instance and update the modems table
+                instance = ModemCard.new(name, mod_config, nil) -- Driver to be associated later
+                modems.name[name] = instance
+                modems[id_field][id_value] = instance
+            end
+        end
+
+        -- Apply default configuration to all modems without specific configs
+        if modem_config.defaults then
+            for _, modem in pairs(modems.address) do
+                if not modem.name then
+                    log.trace("applying default config to:", modem.address)
+                    modem:update_config(modem_config.defaults)
+                end
+            end
+        end
+    end
+
+    while true do
+        op.choice(
+            modem_config_channel:get_op():wrap(handle_config),
+            modem_detect_channel:get_op():wrap(handle_detection),
+            modem_remove_channel:get_op():wrap(handle_removal),
+            driver_channel:get_op():wrap(handle_driver)
+        ):perform()
+    end
+end
+
+return {new = new}

--- a/src/services/hal/utils.lua
+++ b/src/services/hal/utils.lua
@@ -1,5 +1,13 @@
 local utils = {}
 
+function utils.parse_monitor(line)
+    local status, address = line:match("^(.-)(/org%S+)")
+    if address then
+        return not status:match("-"), address, nil
+    else
+        return nil, nil, 'line could not be parsed'
+    end
+end
 function utils.parse_modem_monitor(line)
     if line == nil then return nil, "Modem monitor message is nil" end
     local result = {}

--- a/tests/test.lua
+++ b/tests/test.lua
@@ -2,6 +2,7 @@ package.path = "../src/lua-fibers/?.lua;" -- fibers submodule src
     .. "../src/lua-trie/src/?.lua;"       -- trie submodule src
     .. "../src/lua-bus/src/?.lua;"        -- bus submodule src
     .. "../src/?.lua;"
+    .. "./test_utils/?.lua;"
     .. package.path
     .. ";/usr/lib/lua/?.lua;/usr/lib/lua/?/init.lua"
 
@@ -12,9 +13,11 @@ local tests = {
     "service",
     "hal_utils",
     "modem_driver",
+    "modemcard_manager",
 }
 
 for _, test in ipairs(tests) do
     dofile("test_" .. test .. ".lua")
     package.path = base_pkg_path
+    -- package.loaded = nil
 end

--- a/tests/test_modemcard_manager.lua
+++ b/tests/test_modemcard_manager.lua
@@ -1,0 +1,336 @@
+local assertions = require "assertions"
+local fiber = require "fibers.fiber"
+local context = require "fibers.context"
+local channel = require "fibers.channel"
+local op = require "fibers.op"
+local sleep = require "fibers.sleep"
+local queue = require "fibers.queue"
+local bus_pkg = require "bus"
+local test_utils = require "test_utils.utils"
+
+local shim_dir = "./test_modemcard_manager/shims/"
+
+-- set module loading to mot cache driver or mmcli for shims
+local module_loader = test_utils.new_module_loader()
+module_loader:add_uncacheable("services.hal.modem_driver")
+module_loader:add_uncacheable("services.hal.mmcli")
+
+local function setup_test_contexts()
+    local bg_context = context.background()
+    local test_context = context.with_cancel(bg_context)
+    local fiber_context = context.with_cancel(test_context)
+    fiber_context.values.service_name = 'dummy-service'
+
+    return test_context, fiber_context
+end
+
+local function make_communication()
+    return
+        channel.new(), -- detect
+        channel.new(), -- remove
+        channel.new(), -- config
+        queue.new()    -- device events
+end
+
+-- Detects 5 Modem events:
+--      No modems connected (also invalid parse case),
+--      modem detected,
+--      modem detected (diff identitiy),
+--      modem disconnected,
+--      modem disconnected (diff identitiy)
+local function test_monitor_modems()
+    test_utils.update_shim_path(shim_dir, "monitor_modems")
+
+    local modem_manager = module_loader:require("services.hal.modemcard_manager")
+    local modem_manager_instance = modem_manager.new()
+
+    local test_context, fiber_context = setup_test_contexts()
+    local detect_channel, remove_channel, _, _ = make_communication()
+
+    local channel_outputs = {}
+
+    -- modem event listening fiber
+    fiber.spawn(function ()
+        while not fiber_context:err() do
+            op.choice(
+                detect_channel:get_op():wrap(function (address)
+                    table.insert(channel_outputs, {state="detect", address = address})
+                end),
+                remove_channel:get_op():wrap(function (address)
+                    table.insert(channel_outputs, {state="remove", address = address})
+                end),
+                fiber_context:done_op()
+            ):perform()
+        end
+    end)
+
+    -- spinning up the detector with a mmcli.lua shim
+    fiber.spawn(function ()
+        modem_manager_instance:detector(fiber_context, detect_channel, remove_channel)
+    end)
+
+    sleep.sleep(1)
+
+    test_context:cancel('test over')
+
+    local expected_modem_events = {
+        {state = "detect", address = '/org/freedesktop/ModemManager1/Modem/0'},
+        {state = "detect", address = '/org/freedesktop/ModemManager1/Modem/1'},
+        {state = "remove", address = '/org/freedesktop/ModemManager1/Modem/0'},
+        {state = "remove", address = '/org/freedesktop/ModemManager1/Modem/1'}
+    }
+
+    assertions.assert_table(expected_modem_events, channel_outputs, "modem_events")
+    test_context:cancel('test-end')
+end
+
+local function test_handle_detection()
+    test_utils.update_shim_path(shim_dir, "monitor_modems")
+
+    local modem_manager = module_loader:require("services.hal.modemcard_manager")
+    local modem_manager_instance = modem_manager.new()
+
+    local test_context, fiber_context = setup_test_contexts()
+
+    local detect_channel, remove_channel, config_channel, device_event_q = make_communication()
+    local bus = bus_pkg.new({ q_len = 10, m_wild = '#', s_wild = '+', sep = "/" })
+
+    -- emulate the connection of a modem
+    fiber.spawn(function()
+        detect_channel:put("address/0")
+    end)
+
+    local expected_event = {
+        connected = true,
+        type = 'usb',
+        identifier = "/sys/devices/platform/axi/1000120000.pcie/1f00300000.usb/xhci-hcd.1/usb3/3-1",
+        identity = {
+            device = 'modemcard',
+            name = 'unknown',
+            imei = '867929068986654',
+            port = "/sys/devices/platform/axi/1000120000.pcie/1f00300000.usb/xhci-hcd.1/usb3/3-1"
+        }
+    }
+
+    -- spinning up the manager
+    fiber.spawn(function()
+        modem_manager_instance:manager(fiber_context, bus:connect(), device_event_q, config_channel, detect_channel,
+            remove_channel)
+    end)
+
+    -- listen for device events
+    local event = device_event_q:get()
+
+    -- check all fields apart from capabilities
+    assertions.assert_table(expected_event, event, "device_event")
+    test_context:cancel('test-end')
+end
+
+local function test_handle_detection_no_exist()
+    test_utils.update_shim_path(shim_dir, "no_device")
+
+    local modem_manager = module_loader:require("services.hal.modemcard_manager")
+    local modem_manager_instance = modem_manager.new()
+
+    local test_context, fiber_context = setup_test_contexts()
+
+    local detect_channel, remove_channel, config_channel, device_event_q = make_communication()
+    local bus = bus_pkg.new({ q_len = 10, m_wild = '#', s_wild = '+', sep = "/" })
+
+    -- emulate the connection of a modem
+    fiber.spawn(function()
+        detect_channel:put("address/0")
+    end)
+
+    -- spinning up the manager
+    fiber.spawn(function()
+        modem_manager_instance:manager(fiber_context, bus:connect(), device_event_q, config_channel, detect_channel,
+            remove_channel)
+    end)
+
+    -- listen for device events for specific amount of time
+    local event = op.choice(
+        device_event_q:get_op(),
+        sleep.sleep_op(0.5)
+    ):perform()
+
+    -- check that nothing was received in time frame
+    assert(event == nil, string.format("expected event to be nil but got %s", assertions.to_str(event)))
+    test_context:cancel('test-end')
+end
+
+local function test_handle_removal()
+    test_utils.update_shim_path(shim_dir, "monitor_modems")
+
+    local modem_manager = module_loader:require("services.hal.modemcard_manager")
+    local modem_manager_instance = modem_manager.new()
+
+    local test_context, fiber_context = setup_test_contexts()
+
+    local detect_channel, remove_channel, config_channel, device_event_q = make_communication()
+    local bus = bus_pkg.new({ q_len = 10, m_wild = '#', s_wild = '+', sep = "/" })
+
+    -- emulate the connection and disconnection of a modem
+    fiber.spawn(function()
+        detect_channel:put('address/0')
+        sleep.sleep(0.1)
+        remove_channel:put('address/0')
+    end)
+
+    local expected_event = {
+        connected = false,
+        type = 'usb',
+        identifier = "/sys/devices/platform/axi/1000120000.pcie/1f00300000.usb/xhci-hcd.1/usb3/3-1",
+        identity = {
+            device = 'modemcard',
+            name = 'unknown',
+            imei = '867929068986654',
+            port = "/sys/devices/platform/axi/1000120000.pcie/1f00300000.usb/xhci-hcd.1/usb3/3-1"
+        }
+    }
+
+    -- spinning up the manager
+    fiber.spawn(function()
+        modem_manager_instance:manager(fiber_context, bus:connect(), device_event_q, config_channel, detect_channel,
+            remove_channel)
+    end)
+
+    -- listen for device events
+
+    local event = device_event_q:get()
+    -- We only care about removals
+    while event.connected == true do
+        event = device_event_q:get()
+    end
+
+    -- check all fields apart from capabilities
+    assertions.assert_table(expected_event, event, "device_event")
+    test_context:cancel('test-end')
+end
+
+-- test what happens if we remove a modem which never connected
+local function test_handle_removal_no_exist()
+    test_utils.update_shim_path(shim_dir, "monitor_modems")
+
+    local modem_manager = module_loader:require("services.hal.modemcard_manager")
+    local modem_manager_instance = modem_manager.new()
+
+    local test_context, fiber_context = setup_test_contexts()
+
+    local detect_channel, remove_channel, config_channel, device_event_q = make_communication()
+
+    local bus = bus_pkg.new({ q_len = 10, m_wild = '#', s_wild = '+', sep = "/" })
+
+    -- emulate the connection and disconnection of a modem
+    fiber.spawn(function()
+        remove_channel:put('address/0')
+    end)
+
+    -- spinning up the manager
+    fiber.spawn(function()
+        modem_manager_instance:manager(fiber_context, bus:connect(), device_event_q, config_channel, detect_channel,
+            remove_channel)
+    end)
+
+    -- listen for device events, expect nothing
+    local event = op.choice(
+        device_event_q:get_op(),
+        sleep.sleep_op(0.5)
+    ):perform()
+
+    -- check that nothing was recieved
+    assert(event == nil, string.format("expected event to be nil but got %s", assertions.to_str(event)))
+    test_context:cancel('test-end')
+end
+
+local function test_handle_config()
+    test_utils.update_shim_path(shim_dir, "monitor_modems")
+
+    local modem_manager = module_loader:require("services.hal.modemcard_manager")
+    local modem_manager_instance = modem_manager.new()
+
+    local test_context, fiber_context = setup_test_contexts()
+
+    local detect_channel, remove_channel, config_channel, device_event_q = make_communication()
+
+    local bus = bus_pkg.new({ q_len = 10, m_wild = '#', s_wild = '+', sep = "/" })
+
+    local expected_name = 'primary'
+
+    -- send a config to modem manager
+    fiber.spawn(function()
+        config_channel:put({
+            defaults = {
+                enabled = true
+            },
+            known = {
+                primary = {
+                    id_field = "device",
+                    device = "/sys/devices/platform/axi/1000120000.pcie/1f00300000.usb/xhci-hcd.1/usb3/3-1",
+                    enabled = true,
+                    autoconnect = true
+                }
+            }
+        })
+        detect_channel:put("address/0")
+    end)
+
+    -- spinning up the manager
+    fiber.spawn(function()
+        modem_manager_instance:manager(fiber_context, bus:connect(), device_event_q, config_channel, detect_channel,
+            remove_channel)
+    end)
+
+    local event = device_event_q:get()
+
+    -- check that config was applied by using name
+    assert(event.identity.name == expected_name, string.format("device name expected %s but got %s",
+        expected_name,
+        assertions.to_str(event.identity.name)))
+    test_context:cancel('test-end')
+end
+
+-- handles the nil cases: nil config, nil known, nil defaults
+local function test_handle_config_nil()
+    test_utils.update_shim_path(shim_dir, "monitor_modems")
+
+    local modem_manager = module_loader:require("services.hal.modemcard_manager")
+    local modem_manager_instance = modem_manager.new()
+
+    local test_context, fiber_context = setup_test_contexts()
+
+    local detect_channel, remove_channel, config_channel, device_event_q = make_communication()
+
+    local bus = bus_pkg.new({ q_len = 10, m_wild = '#', s_wild = '+', sep = "/" })
+
+    -- send a config to modem manager
+    fiber.spawn(function()
+        config_channel:put(nil)
+        config_channel:put({ defaults = {} })
+        config_channel:put({ known = {} })
+    end)
+
+    -- spinning up the manager
+    fiber.spawn(function()
+        modem_manager_instance:manager(fiber_context, bus:connect(), device_event_q, config_channel, detect_channel,
+            remove_channel)
+    end)
+
+    sleep.sleep(0.5)
+    -- if the test makes it past sleep without crashing then the nil value was handled
+    test_context:cancel('test-end')
+end
+fiber.spawn(function ()
+    test_monitor_modems()
+    test_handle_detection()
+    test_handle_detection_no_exist()
+    test_handle_removal()
+    test_handle_removal_no_exist()
+    test_handle_config()
+    test_handle_config_nil()
+    fiber.stop()
+end)
+
+print("running modem card manager tests")
+fiber.main()
+print("passed")

--- a/tests/test_modemcard_manager/shims/monitor_modems/services/hal/mmcli.lua
+++ b/tests/test_modemcard_manager/shims/monitor_modems/services/hal/mmcli.lua
@@ -1,0 +1,29 @@
+local sleep = require "fibers.sleep"
+local file = require "fibers.stream.file"
+local simu_commands = require "SimuCommands"
+
+-- Goes through a set of modem monitor connection/disconnection messages
+-- with time delays to simulate cards being added and removed
+local function monitor_modems()
+    local cmd, _ = simu_commands.new('./test_modemcard_manager/shims/monitor_modems/services/hal/modem_states.json')
+    return cmd
+end
+
+-- Preset modem card info in the format of an mmcli -m <addr> request
+local function information(ctx, device)
+    return {
+        combined_output = function ()
+            sleep.sleep(0.05)
+            local cardfile, err = file.open(
+            "test_modemcard_manager/shims/monitor_modems/services/hal/modemcard_info.json", "r")
+            if err then return nil end
+            local carddata = cardfile:read_all_chars()
+            return carddata
+        end
+    }
+end
+
+return {
+    monitor_modems = monitor_modems,
+    information = information
+}

--- a/tests/test_modemcard_manager/shims/monitor_modems/services/hal/modem_states.json
+++ b/tests/test_modemcard_manager/shims/monitor_modems/services/hal/modem_states.json
@@ -1,0 +1,24 @@
+{
+    "events": [
+        {
+            "out": "No modems were found",
+            "wait": 0.1
+        },
+        {
+            "out": "(+) /org/freedesktop/ModemManager1/Modem/0 [QUALCOMM INCORPORATED] QUECTEL Mobile Broadband Module",
+            "wait": 0.1
+        },
+        {
+            "out": "(+) /org/freedesktop/ModemManager1/Modem/1 [QUALCOMM INCORPORATED] QUECTEL Mobile Broadband Module",
+            "wait": 0.1
+        },
+        {
+            "out": "(-) /org/freedesktop/ModemManager1/Modem/0 [QUALCOMM INCORPORATED] QUECTEL Mobile Broadband Module",
+            "wait": 0.1
+        },
+        {
+            "out": "(-) /org/freedesktop/ModemManager1/Modem/1 [QUALCOMM INCORPORATED] QUECTEL Mobile Broadband Module",
+            "wait": 0.1
+        }
+    ]
+}

--- a/tests/test_modemcard_manager/shims/monitor_modems/services/hal/modemcard_info.json
+++ b/tests/test_modemcard_manager/shims/monitor_modems/services/hal/modemcard_info.json
@@ -1,0 +1,182 @@
+{
+  "modem": {
+    "3gpp": {
+      "5gnr": {
+        "registration-settings": {
+          "drx-cycle": "--",
+          "mico-mode": "--"
+        }
+      },
+      "enabled-locks": [
+        "fixed-dialing"
+      ],
+      "eps": {
+        "initial-bearer": {
+          "dbus-path": "--",
+          "settings": {
+            "apn": "",
+            "ip-type": "ipv4v6",
+            "password": "--",
+            "user": "--"
+          }
+        },
+        "ue-mode-operation": "csps-2"
+      },
+      "imei": "867929068986654",
+      "operator-code": "--",
+      "operator-name": "--",
+      "packet-service-state": "--",
+      "pco": "--",
+      "registration-state": "--"
+    },
+    "cdma": {
+      "activation-state": "--",
+      "cdma1x-registration-state": "--",
+      "esn": "--",
+      "evdo-registration-state": "--",
+      "meid": "--",
+      "nid": "--",
+      "sid": "--"
+    },
+    "dbus-path": "/org/freedesktop/ModemManager1/Modem/14",
+    "generic": {
+      "access-technologies": [],
+      "bearers": [],
+      "carrier-configuration": "ROW_Generic_3GPP",
+      "carrier-configuration-revision": "0501081F",
+      "current-bands": [
+        "egsm",
+        "dcs",
+        "pcs",
+        "g850",
+        "utran-1",
+        "utran-4",
+        "utran-6",
+        "utran-5",
+        "utran-8",
+        "utran-2",
+        "eutran-1",
+        "eutran-2",
+        "eutran-3",
+        "eutran-4",
+        "eutran-5",
+        "eutran-7",
+        "eutran-8",
+        "eutran-12",
+        "eutran-13",
+        "eutran-18",
+        "eutran-19",
+        "eutran-20",
+        "eutran-25",
+        "eutran-26",
+        "eutran-28",
+        "eutran-38",
+        "eutran-39",
+        "eutran-40",
+        "eutran-41",
+        "utran-19"
+      ],
+      "current-capabilities": [
+        "gsm-umts, lte"
+      ],
+      "current-modes": "allowed: 2g, 3g, 4g; preferred: 4g",
+      "device": "/sys/devices/platform/axi/1000120000.pcie/1f00300000.usb/xhci-hcd.1/usb3/3-1",
+      "device-identifier": "a7591502473ae9ffc14e992ff1621f18cc4dd408",
+      "drivers": [
+        "option1",
+        "qmi_wwan"
+      ],
+      "equipment-identifier": "867929068986654",
+      "hardware-revision": "10000",
+      "manufacturer": "QUALCOMM INCORPORATED",
+      "model": "QUECTEL Mobile Broadband Module",
+      "own-numbers": [],
+      "physdev": "/sys/devices/platform/axi/1000120000.pcie/1f00300000.usb/xhci-hcd.1/usb3/3-1",
+      "plugin": "quectel",
+      "ports": [
+        "cdc-wdm0 (qmi)",
+        "ttyUSB0 (ignored)",
+        "ttyUSB1 (gps)",
+        "ttyUSB2 (at)",
+        "ttyUSB3 (at)",
+        "wwan0 (net)"
+      ],
+      "power-state": "on",
+      "primary-port": "cdc-wdm0",
+      "primary-sim-slot": "1",
+      "revision": "EG25GGBR07A08M2G",
+      "signal-quality": {
+        "recent": "yes",
+        "value": "0"
+      },
+      "sim": "/org/freedesktop/ModemManager1/SIM/14",
+      "sim-slots": [
+        "/org/freedesktop/ModemManager1/SIM/14",
+        "/"
+      ],
+      "state": "disabled",
+      "state-failed-reason": "--",
+      "supported-bands": [
+        "egsm",
+        "dcs",
+        "pcs",
+        "g850",
+        "utran-1",
+        "utran-4",
+        "utran-6",
+        "utran-5",
+        "utran-8",
+        "utran-2",
+        "eutran-1",
+        "eutran-2",
+        "eutran-3",
+        "eutran-4",
+        "eutran-5",
+        "eutran-7",
+        "eutran-8",
+        "eutran-12",
+        "eutran-13",
+        "eutran-18",
+        "eutran-19",
+        "eutran-20",
+        "eutran-25",
+        "eutran-26",
+        "eutran-28",
+        "eutran-38",
+        "eutran-39",
+        "eutran-40",
+        "eutran-41",
+        "utran-19"
+      ],
+      "supported-capabilities": [
+        "gsm-umts, lte"
+      ],
+      "supported-ip-families": [
+        "ipv4",
+        "ipv6",
+        "ipv4v6"
+      ],
+      "supported-modes": [
+        "allowed: 2g; preferred: none",
+        "allowed: 3g; preferred: none",
+        "allowed: 4g; preferred: none",
+        "allowed: 2g, 3g; preferred: 3g",
+        "allowed: 2g, 3g; preferred: 2g",
+        "allowed: 2g, 4g; preferred: 4g",
+        "allowed: 2g, 4g; preferred: 2g",
+        "allowed: 3g, 4g; preferred: 4g",
+        "allowed: 3g, 4g; preferred: 3g",
+        "allowed: 2g, 3g, 4g; preferred: 4g",
+        "allowed: 2g, 3g, 4g; preferred: 3g",
+        "allowed: 2g, 3g, 4g; preferred: 2g"
+      ],
+      "unlock-required": "sim-pin2",
+      "unlock-retries": [
+        "sim-pin (3)",
+        "sim-puk (10)",
+        "sim-pin2 (3)",
+        "sim-puk2 (10)"
+      ]
+    }
+  }
+}

--- a/tests/test_modemcard_manager/shims/no_device/services/hal/mmcli.lua
+++ b/tests/test_modemcard_manager/shims/no_device/services/hal/mmcli.lua
@@ -1,0 +1,17 @@
+local sleep = require "fibers.sleep"
+
+-- For testing a modem not existing we only need
+-- the information function, this will signify a fail
+-- during modem_driver init function
+local function information(ctx, device)
+    return {
+        combined_output = function()
+            sleep.sleep(0.05)
+            return nil, "no device of address 0"
+        end
+    }
+end
+
+return {
+    information = information
+}

--- a/tests/test_utils/SimuCommands.lua
+++ b/tests/test_utils/SimuCommands.lua
@@ -7,6 +7,8 @@ local sleep = require "fibers.sleep"
 local StreamCommand = {}
 StreamCommand.__index = StreamCommand
 
+-- Given a json file, acts as a fake command that outputs
+-- defined messages and blocks for a set time
 function StreamCommand.new(events_directory)
     local events_file, err = file.open(events_directory, "r")
     if err then return nil end

--- a/tests/test_utils/assertions.lua
+++ b/tests/test_utils/assertions.lua
@@ -1,0 +1,31 @@
+local json = require 'dkjson'
+
+local function to_str(value)
+    if type(value) == 'nil' then return "nil" end
+    return value
+end
+-- Traverses a table, excludes function attributes
+local function assert_table(expected, recieved, root_key)
+    assert(type(expected) == 'table')
+    assert(type(recieved) == 'table', string.format(
+        '%s: expected a table but recieved %s',
+        root_key,
+        type(recieved)
+    ))
+
+    for k, v in pairs(expected) do
+        local key = string.format("%s.%s", root_key, k)
+        if type(v) == 'table' then
+            assert_table(v, recieved[k], key)
+        else
+            if type(v) ~= 'function' then
+                assert(v == recieved[k], string.format("%s: expected %s but got %s", key, v, to_str(recieved[k])))
+            end
+        end
+    end
+end
+
+return {
+    assert_table = assert_table,
+    to_str = to_str
+}

--- a/tests/test_utils/utils.lua
+++ b/tests/test_utils/utils.lua
@@ -4,16 +4,39 @@ local function update_shim_path(shim_base_dir, shim_name)
     package.path = shim_base_dir .. shim_name .. "/?.lua;" .. path
 end
 
--- make sure the old shims are not still around
+-- Old implementation of loading packages after shim switching, used for driver tests
 local function uncached_require(module)
     package.loaded[module] = nil
     package.loaded['services.hal.mmcli'] = nil
     package.loaded['services.hal.qmicli'] = nil
     package.loaded['services.hal.at'] = nil
+    package.loaded['services.hal.modem_driver'] = nil
     return require(module)
 end
 
+-- new implemeentation of loading packages after shim switching
+-- build up a list of modules to be purged every time a package is loaded
+-- makes sure packages stay up to date
+local ModuleLoader = {}
+ModuleLoader.__index = ModuleLoader
+
+local function new_module_loader()
+    return setmetatable({ uncached_modules = {} }, ModuleLoader)
+end
+
+function ModuleLoader:add_uncacheable(module)
+    table.insert(self.uncached_modules, module)
+end
+
+function ModuleLoader:require(module)
+    for _, uncache_module in ipairs(self.uncached_modules) do
+        package.loaded[uncache_module] = nil
+    end
+    package.loaded[module] = nil
+    return require(module)
+end
 return {
     update_shim_path = update_shim_path,
-    uncached_require = uncached_require
+    uncached_require = uncached_require,
+    new_module_loader = new_module_loader
 }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [x] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description
Modem Card Manager listens for modem cards and creates/removes drivers as cards are inserted, removed, configured. MCM builds drivers and interfaces for HAL (called capabilities) to interact with them before passing a modemcard event to HAL. The test suite uses shims to perform stateless modem card emulation when using the mmcli library.

## Related Issues, Tickets & Documents
Adds onto #17 
#17 should be reviewed before this PR

## Manual test
<!-- Have you manually tested this code and confirmed it is working? -->
- [x] 👍 yes
- [ ] 🙅 no

## Manual test description
run `make test`

## Added tests?
- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?
- [x] 📜 sprint-docs/modemcard_manager.md
- [ ] 🙅 no documentation needed

