### PR TITLE
Substatial improvements to NET

### DIFF
--- a/src/configs/bigbox_v0-9.json
+++ b/src/configs/bigbox_v0-9.json
@@ -188,7 +188,7 @@
         "name": "Primary Modem",
         "id": "mdm0",
         "type": "backhaul",
-        "modem_id": "primary",
+        "modem_id": "Primary",
         "ipv4": {
           "enabled": true,
           "proto": "dhcp",
@@ -214,7 +214,7 @@
         "name": "Secondary Modem",
         "id": "mdm1",
         "type": "backhaul",
-        "modem_id": "secondary",
+        "modem_id": "Secondary",
         "ipv4": {
           "enabled": true,
           "proto": "dhcp"

--- a/src/ubus_scripts/mwan3.user
+++ b/src/ubus_scripts/mwan3.user
@@ -16,3 +16,4 @@ ubus send "$EVENT_NAME" "$JSON_PAYLOAD"
 # Default mwan3 action
 if [ "${ACTION}" = "connected" ] ; then
    /etc/init.d/sysntpd restart
+fi


### PR DESCRIPTION
Significant changes to Net, adds debounce for config application (1 second) and debounce for speedtests (30 seconds). Changes name of modem interfaces in config to match GSMs (should revert though - system names shouldn't start with capitals)