### PR TITLE
Fix wan status change race condition

### DIFF
--- a/src/services/net.lua
+++ b/src/services/net.lua
@@ -461,10 +461,15 @@ local function uci_manager(ctx)
 
     local function on_wan_status(msg)
         local network, status = msg.network, msg.status
-        networks[network] = networks[network] or {}
+        if networks[network] == nil then
+            log.warn("NET: WAN state change ignored due to nil network:", network, status)
+            return
+        end
         local old_status = networks[network].status
         networks[network].status = status
-        if old_status ~= status then
+        if not networks[network].resolved then
+            log.warn("NET: cannot process WAN state change as network interface is not resolved:", network, status)
+        elseif old_status ~= status then
             log.debug("NET: WAN state change", network, status)
 
             -- Trigger speedtest only on new connections


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description
Fixes issue where scheduling a speedtest in `on_wan_status` causes the following error.
```
Error while running fiber: ./services/net.lua:477: attempt to index field 'interfaces' (a nil value)
stack traceback:
        ./services/net.lua: in function 'perform'
        ./services/net.lua:524: in function 'uci_manager'
        ./services/net.lua:607: in function <./services/net.lua:607>
fibers history:
        ./services/net.lua:607: in function 'start'
        ./service.lua:56: in function 'spawn'
        main.lua:30: in function 'launch_services'
        main.lua:37: in function <main.lua:35>
        main.lua:35: in main chunk
        [C]: at 0x0040233c
```
This happens because interfaces is nil - interfaces haven't yet been "resolved" (this happens in `on_config`).

This is quite a simple fix, the thing doesn't crash anymore, but I don't know the full implications of not running a speedtest. Will the wan status change be fired again eventually? Or is it an event we kind of want to catch every time?

If that's the case, then we could add another channel that on_wan_status waits on for interface resolutions? 

## Related Issues, Tickets & Documents
<!-- 
Please use this format link issue numbers: Fixes #123
Include links to any clickup or other external relevant tickets
-->

## Screenshots/Recordings
<!-- Visual changes require screenshots -->

## Manual test
<!-- Have you manually tested this code and confirmed it is working? -->
- [x] 👍 yes
- [ ] 🙅 no

## Added tests?
- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?
- [ ] 📜 README.md
- [ ] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?

