### PR TITLE
Fix modem network interface not coming back online

### DIFF
--- a/src/services/net.lua
+++ b/src/services/net.lua
@@ -670,12 +670,11 @@ local function modem_state_listener(ctx)
                 if err then
                     log.error("NET: Interface listen error:", err)
                 else
-                    if msg.payload then
-                        if msg.payload.prev_state ~= "connected" and msg.payload.curr_state == "connected" then
-                            -- Extract modem_id from topic gsm/modem/<modem_id>/state
-                            local modem_id = msg.topic[3]
-                            modem_on_connected_channel:put(modem_id)
-                        end
+                    local payload = msg.payload
+                    if payload and payload.prev_state ~= "connected" and payload.curr_state == "connected" then
+                        -- Extract modem_id from topic gsm/modem/<modem_id>/state
+                        local modem_id = msg.topic[3]
+                        modem_on_connected_channel:put(modem_id)
                     end
                 end
             end),


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] 🍕 Feature
- [X] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description
This was caused by sending the mmcli network interface (e.g. wwan0) instead of the expected mwan3 interface (e.g. mdm0). Also fixed a bug where a conditional wasn't triggering because the expected data was nested one level deeper in the message payload than assumed, we were checking for a top-level field, but it was actually inside a payload table.

## Related Issues, Tickets & Documents
https://github.com/jangala-dev/devicecode-lua/issues/51

## Screenshots/Recordings
<!-- Visual changes require screenshots -->

## Manual test
<!-- Have you manually tested this code and confirmed it is working? -->
- [X] 👍 yes
- [ ] 🙅 no

## Manual test description
<!-- If you selected "Yes" for manual testing, please provide a brief description of the test steps and results here. -->
1) Eject sim card
2) Reinsert sim card
3) Check interface is online

## Added tests?
- [ ] 👍 yes
- [X] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?
- [ ] 📜 README.md
- [X] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?

