### PR TITLE
set prdeathsig for long running commands

### DIFF
--- a/src/services/hal/drivers/modem.lua
+++ b/src/services/hal/drivers/modem.lua
@@ -413,7 +413,7 @@ function Driver:wait_for_sim()
                 high_power = false
             end
         end
-        sleep.sleep(0.1)
+        sleep.sleep(1)
         if not high_power then
             out, err = self.set_power_high(warm_swap_ctx)
             if err then
@@ -426,7 +426,7 @@ function Driver:wait_for_sim()
                 high_power = true
             end
         end
-        sleep.sleep(0.1)
+        sleep.sleep(1)
     end
     -- we must attempt to put modem into high power state even if disconnected
     -- as we could otherwise get stuck in a failed state boot-loop
@@ -435,7 +435,7 @@ function Driver:wait_for_sim()
         for _ = 1, 3 do
             out, err = self.set_power_high(context.with_timeout(context.background(), CMD_TIMEOUT))
             if err then
-                sleep.sleep(0.1)
+                sleep.sleep(1)
             else
                 high_power = true
                 break

--- a/src/services/hal/managers/modemcard.lua
+++ b/src/services/hal/managers/modemcard.lua
@@ -3,6 +3,7 @@ local channel = require "fibers.channel"
 local sleep = require "fibers.sleep"
 local context = require "fibers.context"
 local op = require "fibers.op"
+local sc = require "fibers.utils.syscall"
 local utils = require "services.hal.utils"
 local modem_driver = require "services.hal.drivers.modem"
 local mmcli = require "services.hal.drivers.modem.mmcli"
@@ -33,7 +34,7 @@ function ModemManagement:_detector(ctx)
     while not ctx:err() do
         -- First, we start the modem detector
         local cmd = mmcli.monitor_modems()
-        cmd:setpgid(false)
+        cmd:setprdeathsig(sc.SIGKILL)
         local stdout = assert(cmd:stdout_pipe())
         local err = cmd:start()
 

--- a/src/services/net.lua
+++ b/src/services/net.lua
@@ -594,6 +594,7 @@ local function wan_monitor(ctx)
 
     -- now we start a continuous loop to monitor for changes in interface state
     local cmd = exec.command("ubus", "listen", "hotplug.mwan3")
+    cmd:setprdeathsig(sc.SIGKILL) -- Ensure the process is killed on parent death
     local stdout = cmd:stdout_pipe()
     if not stdout then
         log.error("NET: could not create stdout pipe for ubus listen")


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description
Added `setprdeathsig` functionality implemented in fibers to fix issue where long running child processes would not close in case of interrupt or crash.

## Related Issues, Tickets & Documents
#45 

## Manual test
<!-- Have you manually tested this code and confirmed it is working? -->
- [x] 👍 yes
- [ ] 🙅 no

## Manual test description
Run code with both sims removed and modems in failed state. First do CTRL+C to test interrupt, run `ps | grep mmcli` and `ps | grep qmicli` there should be no running processes. Next edit the code such that the main control fiber in `main.lua` calls `print(obj.obj)` after the line `sleep.sleep(5)` and rerun the code, after crashing check again that there are no mmcli or qmicli processes running.

## Added tests?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?
- [ ] 📜 README.md
- [x] 🙅 no documentation needed

