### PR TITLE
now installs luajit from same branch as builder

### DIFF
--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -10,7 +10,7 @@ sudo apt install -y lua5.1 liblua5.1-dev luarocks lua-dkjson
 
 cd /tmp
 sudo rm -rf LuaJIT
-git clone -b v2.1.ROLLING https://github.com/LuaJIT/LuaJIT.git
+git clone -b v2.1 https://github.com/LuaJIT/LuaJIT.git
 cd LuaJIT
 make -j$(nproc)
 sudo make install

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -6,7 +6,15 @@ sudo apt install -y apt-utils unzip curl wget git build-essential libreadline-de
 
 # install core lua packages
 
-sudo apt install -y lua5.1 liblua5.1-dev luajit luarocks lua-dkjson
+sudo apt install -y lua5.1 liblua5.1-dev luarocks lua-dkjson
+
+cd /tmp
+sudo rm -rf LuaJIT
+git clone -b v2.1.ROLLING https://github.com/LuaJIT/LuaJIT.git
+cd LuaJIT
+make -j$(nproc)
+sudo make install
+sudo ldconfig
 
 # install luarocks packages
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [x] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [x] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description
Images from builder now use the rolling branch of luajit which causes issues in the old dev container as it uses luajit beta3 which does not have string buffers. I have upgraded the container to use v2.1.

## Manual test
<!-- Have you manually tested this code and confirmed it is working? -->
- [x] 👍 yes
- [ ] 🙅 no

## Manual test description
Rebuild container and run
```
luajit
# enters luajit shell
tst = require "strings.buffer"
```

## Added tests?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?
- [ ] 📜 README.md
- [x] 🙅 no documentation needed

