### PR TITLE
Fix traffic shaping not applying when interface not ready

### DIFF
--- a/src/configs/bigbox_v0-9.json
+++ b/src/configs/bigbox_v0-9.json
@@ -113,8 +113,8 @@
                 {
                   "qdisc": "htb",
                   "config": {
-                    "rate": "450kbit",
-                    "ceil": "2mbit",
+                    "rate": "2mbit",
+                    "ceil": "8mbit",
                     "burst": "500k"
                   },
                   "classes": [
@@ -143,9 +143,9 @@
                 {
                   "qdisc": "htb",
                   "config": {
-                    "rate": "450kbit",
-                    "ceil": "2mbit",
-                    "burst": "500k"
+                    "rate": "1.5mbit",
+                    "ceil": "6mbit",
+                    "burst": "225k"
                   },
                   "classes": [
                     {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] 🍕 Feature
- [X] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description
Fix traffic shaping not being applied if network interface not ready. Note this is probably not the best way to do it. In the future we should be able to listen to hotplug events and apply shaping upon this.

## Related Issues, Tickets & Documents
https://github.com/jangala-dev/devicecode-lua/issues/94

## Screenshots/Recordings
<!-- Visual changes require screenshots -->

## Manual test
<!-- Have you manually tested this code and confirmed it is working? -->
- [X] 👍 yes
- [ ] 🙅 no

## Manual test description
<!-- If you selected "Yes" for manual testing, please provide a brief description of the test steps and results here. -->
Update devicecode with latest code and then run following:
1) `killall luajit`
2) Run following commands to mimic starting state of box:
```
ip link set dev br-jan down
ip link delete br-jan
ip link set dev br-jan-i down
ip link delete br-jan-i

tc qdisc del dev br-jan root
tc qdisc del dev br-jan ingress
tc qdisc del dev br-jan-i root
tc qdisc del dev br-jan-i ingress

uci delete network.jan
uci delete dhcp.jan
uci delete mwan3.jan
uci delete mwan3.jan_member
uci commit

/etc/init.d/network restart
/etc/init.d/firewall restart
/etc/init.d/dnsmasq restart
/etc/init.d/mwan3 restart
```
3) luajit main.lua bigbox_v0-9
4) Run speedtest

## Added tests?
- [ ] 👍 yes
- [X] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?
- [ ] 📜 README.md
- [X] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?

