### PR TITLE
Fd maxcount fix

### DIFF
--- a/src/services/net.lua
+++ b/src/services/net.lua
@@ -583,7 +583,9 @@ local function uci_manager(ctx)
             if not f then return nil, "Failed to open interface file: "..path end
 
             f:seek(0)  -- Rewind to beginning
-            return tonumber(f:read_all_chars())
+            local metric = tonumber(f:read_all_chars())
+            f:close()
+            return metric
         end
 
         local report_period = report_period_channel:get()


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description
Net metrics were not closing the files which meant file descriptors were building up and eventually hitting the maximum amount of fds. 

## Manual test
<!-- Have you manually tested this code and confirmed it is working? -->
- [x] 👍 yes
- [ ] 🙅 no

## Manual test description
Run DC for 2 minutes and check if the file descriptor count has gone up significantly 

## Added tests?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?
- [ ] 📜 README.md
- [x] 🙅 no documentation needed

