### PR TITLE
Add unifi domain to bigbox config

### DIFF
--- a/src/configs/bigbox_v0-9.json
+++ b/src/configs/bigbox_v0-9.json
@@ -35,6 +35,10 @@
     "dhcp": {
       "domains": [
         {
+          "name": "unifi",
+          "ip": "$UNIFI_IP"
+        },
+        {
           "name": "config.bigbox.home",
           "ip": "172.28.8.1"
         }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] 🍕 Feature
- [X] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description
Fix unifi not working because unifi domain not added in config

## Related Issues, Tickets & Documents
<!-- 
Please use this format link issue numbers: Fixes #123
Include links to any clickup or other external relevant tickets
-->

## Screenshots/Recordings
<!-- Visual changes require screenshots -->

## Manual test
<!-- Have you manually tested this code and confirmed it is working? -->
- [X] 👍 yes
- [ ] 🙅 no

## Manual test description
<!-- If you selected "Yes" for manual testing, please provide a brief description of the test steps and results here. -->
Add domain on local box and confirmed connected to unifi.

## Added tests?
- [ ] 👍 yes
- [X] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?
- [ ] 📜 README.md
- [X] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?

