### PR TITLE
Gsm mutiple pdn bug (part 2)

### DIFF
--- a/src/services/hal/drivers/modem/mmcli.lua
+++ b/src/services/hal/drivers/modem/mmcli.lua
@@ -10,8 +10,7 @@ end
 
 local function connect(ctx, device, connection_string)
     connection_string = string.format("--simple-connect=%s", connection_string)
-    return exec.command_context(ctx, 'mmcli', '-m', device,
-        connection_string)
+    return exec.command_context(ctx, 'mmcli', '-m', device, connection_string)
 end
 
 local function disconnect(ctx, device)
@@ -52,6 +51,12 @@ end
 local function signal_get(ctx, device)
     return exec.command_context(ctx, 'mmcli', '-J', '-m', device, '--signal-get')
 end
+
+local function three_gpp_set_initial_eps_bearer_settings(ctx, device, settings)
+    local settings_string = string.format("--3gpp-set-initial-eps-bearer-settings=%s", settings)
+    return exec.command_context(ctx, 'mmcli', '-m', device, settings_string)
+end
+
 return {
     monitor_modems = monitor_modems,
     inhibit = inhibit,
@@ -65,5 +70,6 @@ return {
     sim_information = sim_information,
     location_status = location_status,
     signal_setup = signal_setup,
-    signal_get = signal_get
+    signal_get = signal_get,
+    three_gpp_set_initial_eps_bearer_settings = three_gpp_set_initial_eps_bearer_settings,
 }

--- a/src/services/hal/drivers/modem/model/quectel.lua
+++ b/src/services/hal/drivers/modem/model/quectel.lua
@@ -1,12 +1,17 @@
+local context = require "fibers.context"
+local mmcli = require "services.hal.drivers.modem.mmcli"
+
+local CMD_TIMEOUT = 3
+
 -- driver/model/quectel.lua
 local funcs = {
     {
         name = 'func1',
         conditionals = {
-            function (modem)
+            function(modem)
                 return modem.model == 'eg25'
             end,
-            function (modem)
+            function(modem)
                 return modem.model == 'em06'
             end
         },
@@ -14,13 +19,42 @@ local funcs = {
             print("Special function for EG25 and EM06")
         end
     },
+    -- This is a special case for the RM520N, it has a initial bearer which will always cause a
+    -- multiple PDN failure unless set to the APN we want to use OR set to empty.
+    {
+        name = 'connect',
+        conditionals = {
+            function(modem)
+                return modem.model == 'rm520n'
+            end
+        },
+        func = function(modem, connection_string)
+            local clear_initial_bearer_ctx = context.with_timeout(modem.ctx, CMD_TIMEOUT)
+            local cmd_clear = mmcli.three_gpp_set_initial_eps_bearer_settings(
+                clear_initial_bearer_ctx,
+                modem.address,
+                "apn="
+            )
+            local out_clear, err_clear = cmd_clear:combined_output()
+            if err_clear then
+                return out_clear, err_clear
+            end
+            local connect_ctx = context.with_timeout(modem.ctx, CMD_TIMEOUT)
+            local cmd = mmcli.connect(connect_ctx, modem.address, connection_string)
+            local out, err = cmd:combined_output()
+            return out, err
+        end
+    }
     -- Other functions
 }
 
 return function(modem)
     for _, f in ipairs(funcs) do
         for _, cond in ipairs(f.conditionals) do
-            if cond(modem) then modem[f.name] = f.func break end
+            if cond(modem) then
+                modem[f.name] = f.func
+                break
+            end
         end
     end
     return true


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description
The primary modem of BBv1 was observed constantly getting multi pdn connection errors, preventing it from ever successfully connecting via any sim. Previously a PR #125 was thought to have solved this but upon further testing it seemed that the benefits those changes made were, while improvements, not fixing the heart of the issue. The rm520n has a feature that the eg25 and em12 do not: an initial bearer. The initial bearer defaults to a Spanish telecom company, setting the initial bearer to 'apn=' (basically empty) prevents this initial bearer from getting in the way of making valid APN connections. I have decided to make the modem apply this clearing on every connection request for reliability sake. We may later test if only one clearing on init is needed for stable connections to be made. 

## Related Issues, Tickets & Documents
Adds onto #125 

## Manual test
<!-- Have you manually tested this code and confirmed it is working? -->
- [x] 👍 yes
- [ ] 🙅 no

## Manual test description
Run the code on BBv1 or Tera, if the primary modem gets a connection request and successfully connects then all is good. Note that APNs which do not work normally may cause a PDN error but this should not cause the working APN to output a PDN error.

## Added tests?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?
- [ ] 📜 README.md
- [x] 🙅 no documentation needed

