### PR TITLE
Metrics migration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,9 +7,3 @@
 [submodule "vendor/lua-bus"]
 	path = vendor/lua-bus
 	url = https://github.com/jangala-dev/lua-bus.git
-[submodule "vendor/local-ui"]
-	path = vendor/local-ui
-	url = https://github.com/jangala-dev/local-ui.git
-[submodule "vendor/lua-fibers"]
-	path = vendor/fibers
-	url = https://github.com/jangala-dev/lua-fibers.git

--- a/.luarc.json
+++ b/.luarc.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://raw.githubusercontent.com/LuaLS/vscode-lua/master/setting/schema.json",
+
+  "runtime.version": "LuaJIT",
+
+  "runtime.path": [
+    "src/?.lua",
+    "src/?/init.lua",
+
+    "vendor/lua-fibers/src/?.lua",
+    "vendor/lua-fibers/src/?/init.lua",
+
+    "vendor/lua-bus/src/?.lua",
+    "vendor/lua-bus/src/?/init.lua",
+
+    "vendor/lua-trie/src/?.lua",
+    "vendor/lua-trie/src/?/init.lua"
+  ],
+
+  "workspace.library": [
+    "src",
+    "vendor/lua-fibers/src",
+    "vendor/lua-bus/src",
+    "vendor/lua-trie/src"
+  ],
+
+  "workspace.checkThirdParty": false,
+  "workspace.maxPreload": 10000,
+
+  "diagnostics.enable": true,
+  "diagnostics.workspaceDelay": -1
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,26 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug Lua Interpreter",
+      "type": "lua-local",
+      "request": "launch",
+      "program": {
+        "lua": "lua",
+        "file": "${file}"
+      }
+    },
+    {
+      "name": "Debug Custom Lua Environment",
+      "type": "lua-local",
+      "request": "launch",
+      "program": {
+        "command": "command"
+      },
+      "args": []
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,10 +14,7 @@
     "[lua]": {
       "editor.tabSize": 4
     },
-    "Lua.workspace.checkThirdParty": false,
-    "Lua.workspace.maxPreload": 0,
     "Lua.diagnostics.workspaceDelay": -1,
-    "Lua.workspace.library": [],
     "Lua.diagnostics.enable": true,
     "cSpell.words": [
       "autopin",

--- a/docs/services/hal.md
+++ b/docs/services/hal.md
@@ -45,3 +45,70 @@
   - resources
     - bigbox_v1_cm.lua
     - bigbox_ss.lua
+
+## HAl monitor acticheture
+
+```mermaid
+sequenceDiagram
+  participant Config
+  participant Bus
+  participant Core
+  participant Monitors
+  Core->>Core: Init storage driver and cap (for config loading)
+  Config->>Core: Request config blob
+  Core->>StoreCap: Parrot Request
+  StoreCap->>Core: Return blob
+  Core->>Config: Response
+  Config->>Core: Load config
+  Core->>Core: Create monitors
+  Core->>Monitors: op choice over monitors (and bus etc)
+  Monitors->>Core: (UART) use config to build uart driver, return driver in connected event
+  Core->>Core: Init driver and get capabilities
+  Core->>Bus: Broadcast uart device and capability
+```
+
+Monitors are scope protected modules that provide a event based op which returns when a device is either connected or disconnected.
+```lua
+local device_event = perform(uart_monitor:monitor_op())
+if device_event.connected then
+  -- somthing
+else
+  --somthing else
+end
+```
+
+Monitors can scale for complexity, for example the simplest case of a monitor would be uart, where the monitor would recieve a config and build drivers immediately based on that config, the monitor_op would iterate over the drivers and then block forever
+```lua
+function monitor:monitor_op()
+  if self._progress >= #self._drivers then
+    return op.never()
+  end
+  return op.always(
+    -- device connected event goes here
+  )
+end
+```
+
+Some devices are not defined at config time, and appear dynamically. These monitors can return a scope_op which listens to an underlying command to build device events
+```lua
+function monitor.new()
+  return setmetatable({
+    scope = -- child scope to protect HAL from montior based failure
+    cmd = -- monitoring command here
+  }, monitor)
+end
+
+-- A monitor op that is dependant on command line output
+function monitor:monitor_op()
+  return scope:scope_op(function ()
+    return self.cmd:read_line_op():wrap(parser)
+  end)
+end
+```
+
+Both of these examples are fiberless
+
+Monitors may also spawn fibers in the background, although the majority won't need to, to mediate command output between drivers
+
+
+

--- a/docs/services/hal.md
+++ b/docs/services/hal.md
@@ -13,6 +13,12 @@
     - modem
       - provider.lua <-- selects modem provider (OpenWrt ModemManager, testing, etc)
       - iface.lua <-- the modem-backend interface contract (documented + validated)
+      - mode
+        - qmi.lua
+        - mbim.lua
+      - model
+        - quectel.lua
+        - fibcocom.lua
       - providers
         - openwrt_mm
           - init.lua <-- constructs a backend that implements modem/iface.lua
@@ -22,16 +28,9 @@
           - init.lua
 
   - drivers <-- domain logic + stable capability surface
+    - modem.lua <-- specific modem functionality and HAL interaction
     - modem
-      - driver.lua <-- assembles base + mode + model strategies
-      - mode.lua
-      - model.lua
-      - mode
-        - qmi.lua
-        - mbim.lua
-      - model
-        - quectel.lua
-        - fibcocom.lua
+      - any helper stuff here
 
   - managers <-- owns lifecycles, supervision, (re)announce capabilities
     - modemcard.lua

--- a/docs/services/hal.md
+++ b/docs/services/hal.md
@@ -1,0 +1,48 @@
+# HAL
+## File Structure
+- hal.lua
+- hal
+
+  - backends <-- portability layer: choose a provider implementation per device family
+    - uart
+      - provider.lua <-- selects UART provider (fibers, ubus, etc)
+      - providers
+        - fibers_core
+          - init.lua
+
+    - modem
+      - provider.lua <-- selects modem provider (OpenWrt ModemManager, testing, etc)
+      - iface.lua <-- the modem-backend interface contract (documented + validated)
+      - providers
+        - openwrt_mm
+          - init.lua <-- constructs a backend that implements modem/iface.lua
+          - mmcli.lua <-- executor: mmcli bindings
+          - at.lua <-- ModemManager-specific AT bridge (if needed)
+        - some_other_software
+          - init.lua
+
+  - drivers <-- domain logic + stable capability surface
+    - modem
+      - driver.lua <-- assembles base + mode + model strategies
+      - mode.lua
+      - model.lua
+      - mode
+        - qmi.lua
+        - mbim.lua
+      - model
+        - quectel.lua
+        - fibcocom.lua
+
+  - managers <-- owns lifecycles, supervision, (re)announce capabilities
+    - modemcard.lua
+
+  - types <-- structured tables + validation
+    - core.lua
+    - capabilities.lua
+    - external.lua
+    - modem.lua
+
+  - resources.lua <-- loads managers based on hardware target (declarative wiring)
+  - resources
+    - bigbox_v1_cm.lua
+    - bigbox_ss.lua

--- a/docs/specs/metrics.md
+++ b/docs/specs/metrics.md
@@ -1,0 +1,376 @@
+# Metrics Service
+
+## Description
+
+The metrics service listens to the bus for metrics, applies processing to these metrics and publishes the result to the cloud.
+
+## Config
+
+The metric service takes a selection of configs, validates them and then applies all parts of the condig that are valid. If globaly required parts of the config are not valid then the whole service fails (publish_period, all pipelines fail). Any pipeline that uses a failed template also fails. A missing cloud url means any http protol metrics also fail and the http publisher cannot be started.
+
+`publish_period`: The period for which metrics are cached before publishing to the cloud, recorded in seconds
+
+`cloud_url`: The url used to publish http metrics to
+
+`templates`: a k-v set of metric pipelines that can be reused in the pipelines section, good for different metrics that use the same pipeline without repitition
+
+`pipelines`: a k-v set of metric pipelines (`name` to pipeline)
+- `name`: The name of the metric e.g. `rx_bytes`
+
+A pipeline is defined as:
+
+- `template`: An optional argument for using a template (can be modified with further arguments)
+- `protocol`: The procotol to be used for publication, either log or http
+- `process`: A list of processing blocks to be used on the metric
+- - `type`: The process block name
+- - `args`: A collection of args required by that block
+
+An example config
+
+```json
+"metrics": {
+  "publish_period": 60,
+  "cloud_url": "cloud.com",
+  "templates": {
+    "network_stat": {
+      "protocol": "http",
+      "process": [
+        {
+          "type": "DiffTrigger",
+          "args": {
+            "diff_method": "percent",
+            "threshold": 5,
+            "initial_val": 0
+          }
+        },
+        {
+          "type": "DeltaValue"
+        }
+      ]
+    }
+  },
+  "pipelines": {
+    "rx_bytes": {
+      "template": "network_stat"
+    },
+    "sim": {
+      "protocol": "log",
+      "process": [
+        {
+          "type": "DiffTrigger",
+          "args": {
+            "diff_method": "any-change"
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+## Metrics over the Bus
+
+Metrics recieved over the bus will need to be in a specific format to be processed. The metric payload must include a `value` field and may also contain a `namespace` field. The namespace is a list of string or integer tokens which denotes the full senml key of that metric. Without a namespace, the metric key will be derived from the bus topic path.
+
+The bus topic path determines which pipeline config is applied to the metric. The topic is an array of strings/integers that form the metric's endpoint identifier. The exact topic structure depends on the bus namespace conventions used (see runtime model documentation for topic organization).
+
+An example bus message for a simple metric:
+
+```lua
+{
+  topic = { <prefix_tokens>, <metric_name> },  -- e.g., { 'obs', 'v1', 'network', 'metric', 'rx_bytes' }
+  payload = {
+    value = 50
+  }
+}
+```
+
+Or a metric with a namespace override:
+
+```lua
+{
+  topic = { <prefix_tokens>, <metric_name> },  -- e.g., { 'obs', 'v1', 'modem', 'metric', 'sim' }
+  payload = {
+    value = 'present',
+    namespace = { 'modem', 1 }  -- overrides the senml key structure
+  }
+}
+```
+
+To make creation and validation of a metric easier the service will provide an sdk which will include a types module; with the types module the user can create a metric type which will validate the arguments provided and return a metric type or error. The service can accept metrics types or tables which it will validate by trying to cast to a metric type.
+
+## Configuration & Validation
+
+The metrics service validates all configuration on receipt and handles invalid configs gracefully:
+
+### Validation Rules
+
+- `publish_period`: Must be a positive number (seconds). Invalid values cause service to reject entire config.
+- `cloud_url`: Must be a string. Missing URL prevents HTTP protocol from functioning.
+- `templates`: Each template must have valid `protocol` and optional `process` array. Invalid templates are dropped.
+- `pipelines`: Each pipeline must specify a valid `protocol`. Pipelines referencing dropped templates are also dropped.
+- `protocol`: Must be one of: `http`, `log`, or `bus`. Invalid protocols cause that pipeline to be dropped.
+- `process`: Must be an array of process block tables, each with `type` and optional `args`.
+
+### Warning Handling
+
+When invalid configurations are detected:
+
+1. **Template Failures**: Invalid templates are removed from the config
+2. **Dependent Metrics**: Any pipeline referencing a failed template is also removed
+3. **Protocol Errors**: Pipelines with invalid protocols are dropped
+4. **Graceful Degradation**: Service continues with all valid pipelines; only fails if no valid pipelines remain or `publish_period` is invalid
+
+All dropped metrics and templates are logged with detailed warning messages including:
+- Specific validation errors for each dropped item
+- Summary of total dropped metrics and templates
+- List of affected pipeline names
+
+This allows partial config updates to succeed even if some pipelines are misconfigured.
+
+### Mainflux Config Normalization
+
+The mainflux configuration supports both legacy and current naming conventions:
+- `mainflux_id` or `thing_id` (normalized to `thing_id`)
+- `mainflux_key` or `thing_key` (normalized to `thing_key`)
+- `mainflux_channels` or `channels` (normalized to `channels`)
+
+Channel metadata is automatically injected by scanning channel names:
+- Channels containing "data" get `metadata.channel_type = "data"`
+- Channels containing "control" get `metadata.channel_type = "events"`
+
+The metrics service merges the mainflux config with the metrics `cloud_url` to build the final HTTP publication config.
+
+## Publication of metrics
+
+Once the publish period has triggered the cache will be purged and all k-v pairs will be converted to a senml representation with correct timestamping. There will be 3 possible protocol for sending of the metrics.
+
+### Log
+
+This method will iterate over the list of senml items and log them using the logging module with info mode (`log.info(key, value)`).
+
+### HTTP
+
+This method will send the senml list to the cloud by building up a cloud config by merging the cloud_url with the mainflux config. The mainflux config is retreieved by loading it from hal via the `filesystem` capability called `config` with the mainflux.cfg file name, this is then decoded from json to a lua table and then normalised (`mainflux_id` -> `thing_id`, `mainflux_key` -> `thing_key`). The mainflux config is of the structure:
+
+```json
+{
+  "thing_id": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+  "thing_key": "550e8400-e29b-41d4-a716-446655440000",
+  "channels": [
+    {
+      "id": "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+      "name": "f47ac10b-58cc-4372-a567-0e02b2c3d479_data",
+      "metadata": {
+        "channel_type": "data"
+      }
+    },
+    {
+      "id": "6ba7b811-9dad-11d1-80b4-00c04fd430c8",
+      "name": "f47ac10b-58cc-4372-a567-0e02b2c3d479_control",
+      "metadata": {
+        "channel_type": "control"
+      }
+    }
+  ],
+  "content": "{\"hawkbit\":{\"hawkbit_key\": \"examplehawkbitkey0123456789abcdef\",\"hawkbit_url\": \"https://example.com/hawkbit\"},\"serial\": \"EX1234567890ABCD\",\"networks\":{\"networks\":[{\"name\": \"example-network\",\"ssid\": \"Example WiFi-aB1xY\",\"password\": \"examplepassword123\"}]}}"
+}
+```
+The resulting merger should be formatted into the structure:
+
+```lua
+{
+  url = "cloud.com",
+  data_id = "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+  thing_key = "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+The cloud URI is composed as `cloud.url` + `/http/channels/` + `cloud.data_id` + `/messages`
+
+The authentications is composed as `Thing ` + `cloud.thing_key`
+
+The body is a json encoding of the senml list
+
+As http publications can fail due to lack of backhaul, boot time metrics are very important, and publiscations can cause a long blokcing time to the fiber they are running on, we run the http sending in a seperate fiber with a queue between the main metrics service fiber and the http fiber.
+
+**Queue Behavior**:
+- Fixed capacity: **10 items**
+- On queue full: New metrics are **dropped silently** with error log
+- No retry mechanism for queue-full conditions (older metrics are preserved)
+
+**Network Failure Retry**:
+- When HTTP send fails (network unavailable), the fiber implements exponential backoff
+- Sleep duration doubles on each failure: 1s → 2s → 4s → 8s → ... → max 60s
+- Retries indefinitely until successful or service shutdown
+- Queue-full and network-failure are handled separately: only network failures trigger retry
+
+### Bus
+
+For testablility a bus protocol should be provided which will publish the metrics under the topic
+`svc/metrics/<key>` for example `svc/metrics/modem/1/sim`. The payload will just be the value and timestamp of the metric.
+
+## Processing
+
+Each metric goes through a processing pipeline which can be composed of a variable amount of process blocks or none at all.
+
+### Pipeline Architecture
+
+The metrics service uses a **shared pipeline with per-endpoint state** model:
+- Each configured pipeline (from config) is instantiated **once** as a processing pipeline object
+- Each unique metric endpoint (topic path) gets its own **state table**
+- The same pipeline logic processes metrics from different endpoints using different state tables
+- This allows pipeline code reuse while maintaining isolated state per endpoint
+
+**State Isolation**: A metric published to namespace `network.wan.rx_bytes` and another to namespace `network.lan.rx_bytes` use the same pipeline logic but maintain separate DiffTrigger/DeltaValue state, preventing cross-endpoint interference.
+
+All process blocks and the pipeline itself have an interface to reset state when a value has been published. The pipeline and blocks are logic and config only; they require a state table as input for each invocation.
+
+### ProcessPipeline
+
+The process pipeline contains all processing blocks and runs them sequentially until either:
+1. A block returns a short-circuit flag (stops processing early)
+2. All blocks complete successfully
+
+The pipeline returns: `(value, short_circuit_flag, error)`
+
+**Short-Circuit Behavior**: When a processing block returns `short_circuit = true`, the pipeline immediately stops processing and the metric is **not stored or published**. This is intentional control flow (e.g., DiffTrigger suppressing unchanged values), not an error condition.
+
+**Reset Behavior**: The pipeline only resets individual block state if a complete run was achieved (no short-circuit). This ensures state is only updated when metrics are actually published.
+
+**Metric Storage Structure**: Successfully processed metrics are stored in a nested structure: `metric_values[protocol][endpoint] = {value, time}`, allowing the same endpoint to publish via multiple protocols (e.g., both "http" and "log").
+
+### DiffTrigger
+
+The difference trigger is a block which only outputs a value if the difference between the last output value and the current value hits a threshold. There are 3 different types of threshold:
+
+- `percent`: Only triggers if the current value is a percentage difference of the last output value
+- `absolute`: Only triggers if the current value is an absolute difference of the last output value
+- `any-change`: Triggers if the current value does not match the last output value
+
+**Arguments**
+
+- `diff_method`: This can either be `percent`, `absolute` or `any-change`
+- `initial_val`: This is an optional argument to set the previous value before any value has been set. If this value is not set then the block will always output the first value received
+- `threshold`: This argument is only for `percent` and `absolute` types, the threshold that must be hit to trigger an output
+
+**Behavior Details**
+
+- **First Value**: The first value received always publishes (triggers) regardless of threshold, unless `initial_val` is specified
+- **Reset**: DiffTrigger state is **not affected by reset** - it maintains `last_val` across publish cycles
+- **Short-Circuit**: When threshold is not met, returns `short_circuit = true` to prevent publishing
+
+### TimeTrigger
+
+The time trigger outputs a value only once a certain time period has elapsed since the last value output. Uses monotonic time to ensure immunity to system clock changes.
+
+**Arguments**
+- `duration`: the time between value outputs (seconds)
+
+**Behavior Details**
+
+- **Timing**: Timer is reset after each successful output, ensuring periodic publishing every `duration` seconds
+- **Reset**: TimeTrigger state is **not affected by reset** - timeout persists across publish cycles
+- **Short-Circuit**: When timeout has not expired, returns `short_circuit = true` to suppress output
+
+### DeltaValue
+
+The delta value block always outputs the difference between the last published value and the current value. This is useful for converting cumulative counters into per-period deltas.
+
+**Arguments**
+
+- `initial_val`: An optional initial value to compare the first values to before the first publish, if this is not set the default is 0
+
+**Behavior Details**
+
+- **Calculation**: Returns `current_value - last_published_value`
+- **Reset**: On reset, sets `last_val = current_val` (resets to the current value, not zero)
+- **Reset Trigger**: Only resets after a successful publish cycle (when pipeline completes without short-circuit)
+- **Always Publishes**: Does not short-circuit; always returns a delta value
+
+## Timestamping
+
+Each metric must have an accurate time stamp. As the time at boot will be incorrect until the time service has done a ntp time sync, the metrics service must hold metrics with a relative timestamp which can be converted into a real timestamp once both time has been synced and the publish cache is ready to publish (via the publish period).
+
+### NTP Sync Dependency
+
+The metrics service **blocks all publishing** until NTP time synchronization is confirmed:
+
+- Service subscribes to `{time, ntp_synced}` bus topic
+- When `ntp_synced = true` is received:
+  - **First sync**: Calculates base time offset and schedules first publish
+  - **Subsequent syncs**: Continues using existing offset
+- When `ntp_synced = false` is received:
+  - Publishing is suspended indefinitely
+  - Publish timer is disabled (`next_publish_time = infinity`)
+  - Metrics continue to be collected but not published
+
+### Time Conversion
+
+We can convert between relative and real time by using monotonic time stamps on the metrics and holding the monotonic time that the ntp sync was done as well as the real time that the sync was done.
+
+**Base Time Calculation** (on first NTP sync):
+- `base_real = current_realtime - (current_monotime - initial_monotime)`
+- This calculates what the real time was at the initial monotonic reference point
+
+**Metric Timestamp Conversion** (at publish time):
+- `metric_timestamp_ms = floor(base_real + (metric_monotime - base_monotime)) * 1000`
+- This converts the metric's monotonic timestamp to real time in milliseconds
+
+**Important**: If NTP sync is lost and regained, the original base time offset is preserved rather than recalculated. This ensures timestamp consistency across sync interruptions.
+
+## Testing
+
+Current automated coverage is in `tests/test_metrics.lua`.
+
+Run command:
+
+```bash
+cd tests && luajit test_metrics.lua
+```
+
+Covered test groups:
+
+- **Processing blocks (`TestProcessing`)**
+  - `DiffTrigger` behavior for `absolute`, `percent`, and `any-change`
+  - `DeltaValue` behavior and reset semantics
+  - `ProcessPipeline` sequencing, reset, and short-circuit behavior
+
+- **Config module (`TestConfig`)**
+  - `validate_http_config` valid + invalid inputs
+  - `merge_config` recursive merge behavior
+  - `apply_config` builds valid pipeline maps
+  - `validate_config` hard rejection (`publish_period <= 0`)
+  - `validate_config` warning path for invalid protocol
+  - invalid template propagation to dependent pipeline warnings
+
+- **SenML encoder (`TestSenML`)**
+  - encode number/string/boolean/time records
+  - reject unsupported value types
+  - `encode_r` flattening behavior for nested keys
+
+- **HTTP publisher module (`TestHttpModule`)**
+  - `start_http_publisher` builds expected HTTP request shape
+  - verifies method/header/body composition via mocked `http.request`
+
+- **Service-level behavior (`TestMetricsService`)**
+  - bus protocol publish end-to-end
+  - namespace override routing/topic mapping
+  - unknown metrics are dropped
+  - `DiffTrigger` suppresses unchanged values
+  - `DeltaValue` emits per-period deltas
+  - config update replaces active pipelines
+  - per-endpoint state isolation across namespaces
+  - HTTP protocol pipeline enqueues expected Mainflux payload
+
+Notes:
+
+- Service tests use virtual time helpers from `tests/test_utils/virtual_time.lua` and `tests/test_utils/time_harness.lua`.
+- Service tests subscribe to `{'svc','metrics','#'}` and intentionally filter out `status` lifecycle messages when asserting metric payload publications.
+
+
+
+
+
+
+

--- a/docs/specs/metrics.md
+++ b/docs/specs/metrics.md
@@ -6,13 +6,13 @@ The metrics service listens to the bus for metrics, applies processing to these 
 
 ## Config
 
-The metric service takes a selection of configs, validates them and then applies all parts of the condig that are valid. If globaly required parts of the config are not valid then the whole service fails (publish_period, all pipelines fail). Any pipeline that uses a failed template also fails. A missing cloud url means any http protol metrics also fail and the http publisher cannot be started.
+The metrics service takes a selection of configs, validates them and then applies all parts of the config that are valid. If globally required parts of the config are not valid then the whole service fails (publish_period, all pipelines fail). Any pipeline that uses a failed template also fails. A missing cloud URL means any HTTP protocol metrics also fail and the HTTP publisher cannot be started.
 
 `publish_period`: The period for which metrics are cached before publishing to the cloud, recorded in seconds
 
 `cloud_url`: The url used to publish http metrics to
 
-`templates`: a k-v set of metric pipelines that can be reused in the pipelines section, good for different metrics that use the same pipeline without repitition
+`templates`: a k-v set of metric pipelines that can be reused in the pipelines section, good for different metrics that use the same pipeline without repetition
 
 `pipelines`: a k-v set of metric pipelines (`name` to pipeline)
 - `name`: The name of the metric e.g. `rx_bytes`
@@ -20,7 +20,7 @@ The metric service takes a selection of configs, validates them and then applies
 A pipeline is defined as:
 
 - `template`: An optional argument for using a template (can be modified with further arguments)
-- `protocol`: The procotol to be used for publication, either log or http
+- `protocol`: The protocol to be used for publication, either log or http
 - `process`: A list of processing blocks to be used on the metric
 - - `type`: The process block name
 - - additional fields are the arguments for that block (flat, not nested under an `args` key)
@@ -66,7 +66,7 @@ An example config
 
 ## Metrics over the Bus
 
-Metrics recieved over the bus will need to be in a specific format to be processed. The metric payload must include a `value` field and may also contain a `namespace` field. The namespace is a list of string or integer tokens which denotes the full senml key of that metric. Without a namespace, the metric key will be derived from the bus topic path.
+Metrics received over the bus will need to be in a specific format to be processed. The metric payload must include a `value` field and may also contain a `namespace` field. The namespace is a list of string or integer tokens which denotes the full senml key of that metric. Without a namespace, the metric key will be derived from the bus topic path.
 
 The bus topic path determines which pipeline config is applied to the metric. The topic is an array of strings/integers that form the metric's endpoint identifier. The exact topic structure depends on the bus namespace conventions used (see runtime model documentation for topic organization).
 
@@ -147,7 +147,7 @@ This method will iterate over the list of senml items and log them using the log
 
 ### HTTP
 
-This method will send the senml list to the cloud by building up a cloud config by merging the cloud_url with the mainflux config. The mainflux config is retreieved by loading it from hal via the `filesystem` capability called `config` with the mainflux.cfg file name, this is then decoded from json to a lua table and then normalised (`mainflux_id` -> `thing_id`, `mainflux_key` -> `thing_key`). The mainflux config is of the structure:
+This method will send the senml list to the cloud by building up a cloud config by merging the cloud_url with the mainflux config. The mainflux config is retrieved by loading it from HAL via the `filesystem` capability with the mainflux.cfg file name, this is then decoded from JSON to a Lua table and then normalised (`mainflux_id` -> `thing_id`, `mainflux_key` -> `thing_key`). The mainflux config is of the structure:
 
 ```json
 {
@@ -184,11 +184,11 @@ The resulting merger should be formatted into the structure:
 
 The cloud URI is composed as `cloud.url` + `/http/channels/` + `cloud.data_id` + `/messages`
 
-The authentications is composed as `Thing ` + `cloud.thing_key`
+The authentication header is composed as `Thing ` + `cloud.thing_key`
 
 The body is a json encoding of the senml list
 
-As http publications can fail due to lack of backhaul, boot time metrics are very important, and publiscations can cause a long blokcing time to the fiber they are running on, we run the http sending in a seperate fiber with a queue between the main metrics service fiber and the http fiber.
+As HTTP publications can fail due to lack of backhaul, boot-time metrics are very important, and publications can cause long blocking time on the fiber they are running on, so we run the HTTP sending in a separate fiber with a queue between the main metrics service fiber and the HTTP fiber.
 
 **Queue Behavior**:
 - Fixed capacity: **10 items**
@@ -203,7 +203,7 @@ As http publications can fail due to lack of backhaul, boot time metrics are ver
 
 ### Bus
 
-For testablility a bus protocol should be provided which will publish the metrics under the topic
+For testability a bus protocol should be provided which will publish the metrics under the topic
 `svc/metrics/<key>` for example `svc/metrics/modem/1/sim`. The payload will just be the value and timestamp of the metric.
 
 ## Processing
@@ -292,11 +292,11 @@ Each metric must have an accurate time stamp. As the time at boot will be incorr
 
 The metrics service **blocks all publishing** until NTP time synchronization is confirmed:
 
-- Service subscribes to `{time, ntp_synced}` bus topic
-- When `ntp_synced = true` is received:
+- Service subscribes to `{'svc', 'time', 'synced'}` bus topic
+- When `synced = true` is received:
   - **First sync**: Calculates base time offset and schedules first publish
   - **Subsequent syncs**: Continues using existing offset
-- When `ntp_synced = false` is received:
+- When `synced = false` is received:
   - Publishing is suspended indefinitely
   - Publish timer is disabled (`next_publish_time = infinity`)
   - Metrics continue to be collected but not published

--- a/docs/specs/metrics.md
+++ b/docs/specs/metrics.md
@@ -23,7 +23,7 @@ A pipeline is defined as:
 - `protocol`: The procotol to be used for publication, either log or http
 - `process`: A list of processing blocks to be used on the metric
 - - `type`: The process block name
-- - `args`: A collection of args required by that block
+- - additional fields are the arguments for that block (flat, not nested under an `args` key)
 
 An example config
 
@@ -37,11 +37,9 @@ An example config
       "process": [
         {
           "type": "DiffTrigger",
-          "args": {
-            "diff_method": "percent",
-            "threshold": 5,
-            "initial_val": 0
-          }
+          "diff_method": "percent",
+          "threshold": 5,
+          "initial_val": 0
         },
         {
           "type": "DeltaValue"
@@ -58,9 +56,7 @@ An example config
       "process": [
         {
           "type": "DiffTrigger",
-          "args": {
-            "diff_method": "any-change"
-          }
+          "diff_method": "any-change"
         }
       ]
     }
@@ -110,7 +106,7 @@ The metrics service validates all configuration on receipt and handles invalid c
 - `templates`: Each template must have valid `protocol` and optional `process` array. Invalid templates are dropped.
 - `pipelines`: Each pipeline must specify a valid `protocol`. Pipelines referencing dropped templates are also dropped.
 - `protocol`: Must be one of: `http`, `log`, or `bus`. Invalid protocols cause that pipeline to be dropped.
-- `process`: Must be an array of process block tables, each with `type` and optional `args`.
+- `process`: Must be an array of process block tables, each with a `type` field; additional fields are the block's arguments.
 
 ### Warning Handling
 
@@ -248,7 +244,7 @@ The difference trigger is a block which only outputs a value if the difference b
 - `absolute`: Only triggers if the current value is an absolute difference of the last output value
 - `any-change`: Triggers if the current value does not match the last output value
 
-**Arguments**
+**Arguments** (fields on the process block table, alongside `type`)
 
 - `diff_method`: This can either be `percent`, `absolute` or `any-change`
 - `initial_val`: This is an optional argument to set the previous value before any value has been set. If this value is not set then the block will always output the first value received
@@ -264,7 +260,7 @@ The difference trigger is a block which only outputs a value if the difference b
 
 The time trigger outputs a value only once a certain time period has elapsed since the last value output. Uses monotonic time to ensure immunity to system clock changes.
 
-**Arguments**
+**Arguments** (fields on the process block table, alongside `type`)
 - `duration`: the time between value outputs (seconds)
 
 **Behavior Details**

--- a/src/configs/config.json
+++ b/src/configs/config.json
@@ -39,7 +39,7 @@
         "publish_period": 10,
         "templates": {
             "network_stat": {
-                "protocol": "log",
+                "protocol": "http",
                 "process": [
                     {
                         "type": "DiffTrigger",
@@ -53,7 +53,7 @@
                 ]
             },
             "any_change": {
-                "protocol": "log",
+                "protocol": "http",
                 "process": [
                     {
                         "type": "DiffTrigger",
@@ -62,7 +62,7 @@
                 ]
             },
             "percent_5": {
-                "protocol": "log",
+                "protocol": "http",
                 "process": [
                     {
                         "type": "DiffTrigger",
@@ -72,7 +72,7 @@
                 ]
             },
             "absolute_10": {
-                "protocol": "log",
+                "protocol": "http",
                 "process": [
                     {
                         "type": "DiffTrigger",
@@ -150,7 +150,7 @@
                 "template": "any_change"
             },
             "boot_time": {
-                "protocol": "log",
+                "protocol": "http",
                 "process": [
                     {
                         "type": "DiffTrigger",
@@ -175,7 +175,7 @@
                 "template": "percent_5"
             },
             "temperature": {
-                "protocol": "log",
+                "protocol": "http",
                 "process": [
                     {
                         "type": "DiffTrigger",
@@ -185,7 +185,7 @@
                 ]
             },
             "alloc": {
-                "protocol": "log",
+                "protocol": "http",
                 "process": [
                     {
                         "type": "TimeTrigger",
@@ -194,7 +194,7 @@
                 ]
             },
             "internal": {
-                "protocol": "log",
+                "protocol": "http",
                 "process": [
                     {
                         "type": "DiffTrigger",
@@ -303,11 +303,11 @@
                 "template": "any_change"
             },
             "session_start": {
-                "protocol": "log",
+                "protocol": "http",
                 "process": []
             },
             "session_end": {
-                "protocol": "log",
+                "protocol": "http",
                 "process": []
             },
             "hostname": {
@@ -317,7 +317,7 @@
                 "template": "percent_5"
             },
             "power": {
-                "protocol": "log",
+                "protocol": "http",
                 "process": [
                     {
                         "type": "DiffTrigger",
@@ -331,7 +331,7 @@
                 "template": "any_change"
             },
             "noise": {
-                "protocol": "log",
+                "protocol": "http",
                 "process": [
                     {
                         "type": "DiffTrigger",

--- a/src/configs/config.json
+++ b/src/configs/config.json
@@ -1,73 +1,14 @@
 {
-    "network": {
-        "networks": [
+    "hal": {
+        "modemcard": {},
+        "filesystem": [
             {
-                "name": "Wired Internet",
-                "id": "wan",
-                "interface": "eth1",
-                "protocol": "dhcp",
-                "ipv6": true
+                "name": "configs",
+                "root": "/data/configs/"
             },
             {
-                "name": "Primary Modem",
-                "id": "mwan0",
-                "protocol": "dhcp",
-                "ipv6": true
-            },
-            {
-                "name": "Secondary Modem",
-                "id": "mwan1",
-                "protocol": "dhcp",
-                "ipv6": true
-            },
-            {
-                "name": "Admin Network",
-                "id": "adm",
-                "interface": "eth0",
-                "vlan": "1",
-                "protocol": "static",
-                "ipaddr": "172.28.1.1/24"
-            },
-            {
-                "name": "Guest Network",
-                "id": "jng",
-                "interface": "eth0",
-                "vlan": "2",
-                "protocol": "static",
-                "ipaddr": "172.28.2.1/24"
-            }
-        ]
-    },
-    "wifi": {
-        "radios": [
-            {
-                "id": "radio1",
-                "type": "mac80211",
-                "path": "platform/ahb/18100000.wmac",
-                "band": "2g",
-                "channel": "auto",
-                "channels": ["1", "6", "11"],
-                "country": "GB",
-                "htmode": "HT20",
-                "txpower": "20"
-            }
-        ],
-        "ssids": [
-            {
-                "name": "GetBox-PmWBH",
-                "encryption": "psk2",
-                "mode": "access_point",
-                "password": "shiny-huge-valet",
-                "network": "jng",
-                "radios": ["radio1"]
-            },
-            {
-                "name": "GetBox-PmWBH-admin",
-                "encryption": "psk2",
-                "mode": "access_point",
-                "password": "shiny-huge-valet",
-                "network": "adm",
-                "radios": ["radio1"]
+                "name": "state",
+                "root": "/tmp/dc-states/"
             }
         ]
     },
@@ -75,67 +16,346 @@
         "modems": {
             "default": {
                 "enabled": true,
-                "autoconnect": true
+                "signal_freq": 10
             },
-            "known": {
-                "primary": {
+            "known": [
+                {
+                    "name": "primary",
                     "id_field": "device",
-                    "device": "/sys/devices/platform/axi/1000120000.pcie/1f00300000.usb/xhci-hcd.1/usb4/4-1",
-                    "enabled": true,
+                    "device": "/sys/devices/platform/scb/fd500000.pcie/pci0000:00/0000:00:00.0/0000:01:00.0/usb1/1-1/1-1.2",
                     "autoconnect": true
                 },
-                "secondary": {
+                {
+                    "name": "secondary",
                     "id_field": "device",
-                    "device": "/sys/devices/platform/axi/1000120000.pcie/1f00300000.usb/xhci-hcd.1/usb3/3-2",
-                    "enabled": true,
-                    "autoconnect": true
-                },
-                "modem1": {
-                    "id_field": "imei",
-                    "imei": "123456789054321",
-                    "enabled": true,
+                    "device": "/sys/devices/platform/scb/fd500000.pcie/pci0000:00/0000:00:00.0/0000:01:00.0/usb1/1-1/1-1.4",
                     "autoconnect": true
                 }
-            }
-        },
-        "sims": {
-        },
-        "connectors": {
-            "known": {
-                "builtin": {
-                    "id_field": "specific USB identifier here if more than one switcher connected?",
-                    "device": "if attached on usb something like /sys/devices/platform/scb/fd500000.pcie/pci0000:00/0000:00:00.0/0000:01:00.0/usb1/1-1/1-1.2",
-                    "enabled": true,
-                    "always_connected": true,
-                    "type": "bbv1_internal"
-                }
-            }
+            ]
         }
     },
-    "service2": {
-        "paramX": "valueX",
-        "paramY": "valueY"
-    },
-    "hub": {
-        "ws_host": "172.19.0.2",
-        "ws_port": "9003",
-        "connections": [
-            // {
-            //     "type": "http",
-            //     "url": "http://cloud.dev.janga.la/http/channels/{channel}/messages",
-            //     "mainflux_id":"{ID}",
-            //     "mainflux_key":"{KEY}",
-            //     "mainflux_datachannel":"{DATACHANNEL_ID}"
-            // },
-            {
-                "type": "fd",
-                "path_read": "/dev/ttyAMA0",
-                "path_send": "/dev/ttyAMA0"
+    "metrics": {
+        "cloud_url": "$CLOUD_URL",
+        "publish_period": 10,
+        "templates": {
+            "network_stat": {
+                "protocol": "log",
+                "process": [
+                    {
+                        "type": "DiffTrigger",
+                        "diff_method": "percent",
+                        "threshold": 5,
+                        "initial_val": 0
+                    },
+                    {
+                        "type": "DeltaValue"
+                    }
+                ]
+            },
+            "any_change": {
+                "protocol": "log",
+                "process": [
+                    {
+                        "type": "DiffTrigger",
+                        "diff_method": "any-change"
+                    }
+                ]
+            },
+            "percent_5": {
+                "protocol": "log",
+                "process": [
+                    {
+                        "type": "DiffTrigger",
+                        "diff_method": "percent",
+                        "threshold": 5
+                    }
+                ]
+            },
+            "absolute_10": {
+                "protocol": "log",
+                "process": [
+                    {
+                        "type": "DiffTrigger",
+                        "diff_method": "absolute",
+                        "threshold": 10
+                    }
+                ]
             }
-        ]
-    },
-    "testdevice":{
-        "fd_path": "/dev/ttyAMA0",
-        "interval": 10
+        },
+        "pipelines": {
+            "rx_bytes": {
+                "template": "network_stat"
+            },
+            "rx_packets": {
+                "template": "network_stat"
+            },
+            "rx_dropped": {
+                "template": "network_stat"
+            },
+            "rx_errors": {
+                "template": "network_stat"
+            },
+            "tx_bytes": {
+                "template": "network_stat"
+            },
+            "tx_packets": {
+                "template": "network_stat"
+            },
+            "tx_dropped": {
+                "template": "network_stat"
+            },
+            "tx_errors": {
+                "template": "network_stat"
+            },
+            "firmware": {
+                "template": "any_change"
+            },
+            "band": {
+                "template": "any_change"
+            },
+            "access-tech": {
+                "template": "any_change"
+            },
+            "access-family": {
+                "template": "any_change"
+            },
+            "imei": {
+                "template": "any_change"
+            },
+            "sim": {
+                "template": "any_change"
+            },
+            "rssi": {
+                "template": "percent_5"
+            },
+            "rsrp": {
+                "template": "percent_5"
+            },
+            "rsrq": {
+                "template": "percent_5"
+            },
+            "bars": {
+                "template": "any_change"
+            },
+            "operator": {
+                "template": "any_change"
+            },
+            "iccid": {
+                "template": "any_change"
+            },
+            "state": {
+                "template": "any_change"
+            },
+            "interface": {
+                "template": "any_change"
+            },
+            "boot_time": {
+                "protocol": "log",
+                "process": [
+                    {
+                        "type": "DiffTrigger",
+                        "diff_method": "absolute",
+                        "threshold": 1000
+                    }
+                ]
+            },
+            "version": {
+                "template": "any_change"
+            },
+            "revision": {
+                "template": "any_change"
+            },
+            "serial": {
+                "template": "any_change"
+            },
+            "overall_utilisation": {
+                "template": "percent_5"
+            },
+            "util": {
+                "template": "percent_5"
+            },
+            "temperature": {
+                "protocol": "log",
+                "process": [
+                    {
+                        "type": "DiffTrigger",
+                        "diff_method": "absolute",
+                        "threshold": 2
+                    }
+                ]
+            },
+            "alloc": {
+                "protocol": "log",
+                "process": [
+                    {
+                        "type": "TimeTrigger",
+                        "duration": 60
+                    }
+                ]
+            },
+            "internal": {
+                "protocol": "log",
+                "process": [
+                    {
+                        "type": "DiffTrigger",
+                        "diff_method": "absolute",
+                        "threshold": 1
+                    }
+                ]
+            },
+            "core": {
+                "template": "percent_5"
+            },
+            "vbat": {
+                "template": "absolute_10"
+            },
+            "ibat": {
+                "template": "absolute_10"
+            },
+            "vin": {
+                "template": "absolute_10"
+            },
+            "vsys": {
+                "template": "absolute_10"
+            },
+            "iin": {
+                "template": "absolute_10"
+            },
+            "charger_enabled": {
+                "template": "any_change"
+            },
+            "mppt_en_pin": {
+                "template": "any_change"
+            },
+            "equalize_req": {
+                "template": "any_change"
+            },
+            "drvcc_good": {
+                "template": "any_change"
+            },
+            "cell_count_error": {
+                "template": "any_change"
+            },
+            "ok_to_charge": {
+                "template": "any_change"
+            },
+            "no_rt": {
+                "template": "any_change"
+            },
+            "thermal_shutdown": {
+                "template": "any_change"
+            },
+            "vin_ovlo": {
+                "template": "any_change"
+            },
+            "vin_gt_vbat": {
+                "template": "any_change"
+            },
+            "intvcc_gt_4p3v": {
+                "template": "any_change"
+            },
+            "intvcc_gt_2p8v": {
+                "template": "any_change"
+            },
+            "iin_limited": {
+                "template": "any_change"
+            },
+            "uvcl_active": {
+                "template": "any_change"
+            },
+            "cc_phase": {
+                "template": "any_change"
+            },
+            "cv_phase": {
+                "template": "any_change"
+            },
+            "bat_short": {
+                "template": "any_change"
+            },
+            "bat_missing": {
+                "template": "any_change"
+            },
+            "max_charge_time_fault": {
+                "template": "any_change"
+            },
+            "c_over_x_term": {
+                "template": "any_change"
+            },
+            "timer_term": {
+                "template": "any_change"
+            },
+            "ntc_pause": {
+                "template": "any_change"
+            },
+            "precharge": {
+                "template": "any_change"
+            },
+            "cccv": {
+                "template": "any_change"
+            },
+            "absorb": {
+                "template": "any_change"
+            },
+            "equalize": {
+                "template": "any_change"
+            },
+            "suspended": {
+                "template": "any_change"
+            },
+            "session_start": {
+                "protocol": "log",
+                "process": []
+            },
+            "session_end": {
+                "protocol": "log",
+                "process": []
+            },
+            "hostname": {
+                "template": "any_change"
+            },
+            "signal": {
+                "template": "percent_5"
+            },
+            "power": {
+                "protocol": "log",
+                "process": [
+                    {
+                        "type": "DiffTrigger",
+                        "diff_method": "percent",
+                        "threshold": 10,
+                        "initial_val": 0
+                    }
+                ]
+            },
+            "channel": {
+                "template": "any_change"
+            },
+            "noise": {
+                "protocol": "log",
+                "process": [
+                    {
+                        "type": "DiffTrigger",
+                        "diff_method": "percent",
+                        "threshold": 10,
+                        "initial_val": 0
+                    }
+                ]
+            },
+            "num_sta": {
+                "template": "percent_5"
+            },
+            "mem": {
+                "template": "any_change"
+            },
+            "cpu": {
+                "template": "any_change"
+            },
+            "temp": {
+                "template": "any_change"
+            },
+            "curr_time": {
+                "template": "any_change"
+            }
+        }
     }
 }

--- a/src/configs/config.json
+++ b/src/configs/config.json
@@ -36,7 +36,7 @@
     },
     "metrics": {
         "cloud_url": "$CLOUD_URL",
-        "publish_period": 10,
+        "publish_period": 60,
         "templates": {
             "network_stat": {
                 "protocol": "http",

--- a/src/main.lua
+++ b/src/main.lua
@@ -16,17 +16,25 @@ end
 local env = os.getenv('DEVICECODE_ENV') or 'dev'
 if env == 'prod' then
 	add_path('./lib/')
+	-- Include system Lua paths for OpenWrt packages (e.g. http.request, ssl, etc.)
+	add_path('/usr/share/lua/')
+	add_path('/usr/lib/lua/')
 else
 	add_path('../vendor/lua-fibers/src/')
 	add_path('../vendor/lua-bus/src/')
 	add_path('../vendor/lua-trie/src/')
 	add_path('./')
+	-- Include system Lua paths for locally-installed packages (e.g. http.request)
+	add_path('/usr/share/lua/')
+	add_path('/usr/lib/lua/')
 end
 
 local fibers = require 'fibers'
+local op = require 'fibers.op'
 local sleep  = require 'fibers.sleep'
 local scope = require 'fibers.scope'
 local busmod = require 'bus'
+local log = require 'services.log'
 
 if env == 'dev' then
 	scope.set_debug(true) -- enable debug mode for better error traces
@@ -53,7 +61,7 @@ fibers.run(function ()
 	local root = fibers.current_scope()
 
 	-- Validate required env early.
-	require_env('DEVICECODE_STATE_DIR')
+	require_env('DEVICECODE_CONFIG_DIR')
 	local service_names = parse_csv(require_env('DEVICECODE_SERVICES'))
 	if #service_names == 0 then
 		error('DEVICECODE_SERVICES must contain at least one service name', 2)
@@ -83,14 +91,20 @@ fibers.run(function ()
 
 	-- Keep alive until scope cancellation.
 	while true do
-		sleep.sleep(10)
-		for name, sc in pairs(scopes) do
-			local st, _ = sc:status()
-			if st ~= 'ok' then
-				fibers.perform(sc:join_op()) -- propagate any errors
-				print(("main: scope %s exited with status %s"):format(name, st))
-				scopes[name] = nil
-			end
+		local ops = {}
+		for name, s in pairs(scopes) do
+			ops[#ops + 1] = s:fault_op():wrap(function (_, pr)
+				return { name = name, scope = s, pr = pr }
+			end)
+		end
+		local source, msg, err = fibers.perform(op.named_choice(ops))
+
+		if source then
+			log.error("main", "service", msg.name, "failed with error:", msg.pr)
+			fibers.perform(msg.scope:join_op())
+			scopes[msg.name] = nil
+		else
+			log.error("main", "error in main loop:", err)
 		end
 	end
 end)

--- a/src/main.lua
+++ b/src/main.lua
@@ -25,7 +25,12 @@ end
 
 local fibers = require 'fibers'
 local sleep  = require 'fibers.sleep'
+local scope = require 'fibers.scope'
 local busmod = require 'bus'
+
+if env == 'dev' then
+	scope.set_debug(true) -- enable debug mode for better error traces
+end
 
 local function require_env(name)
 	local v = os.getenv(name)
@@ -61,6 +66,8 @@ fibers.run(function ()
 		m_wild   = '#',
 	})
 
+	local scopes = {}
+
 	for i = 1, #service_names do
 		local name = service_names[i]
 		local mod  = require('services.' .. name)
@@ -71,8 +78,19 @@ fibers.run(function ()
 			local conn = bus:connect() -- created inside the service scope
 			mod.start(conn, { name = name })
 		end)
+		scopes[name] = s
 	end
 
 	-- Keep alive until scope cancellation.
-	sleep.sleep(math.huge)
+	while true do
+		sleep.sleep(10)
+		for name, sc in pairs(scopes) do
+			local st, _ = sc:status()
+			if st ~= 'ok' then
+				fibers.perform(sc:join_op()) -- propagate any errors
+				print(("main: scope %s exited with status %s"):format(name, st))
+				scopes[name] = nil
+			end
+		end
+	end
 end)

--- a/src/rxilog.lua
+++ b/src/rxilog.lua
@@ -1,0 +1,100 @@
+--
+-- log.lua
+--
+-- Copyright (c) 2016 rxi
+--
+-- This library is free software; you can redistribute it and/or modify it
+-- under the terms of the MIT license. See LICENSE for details.
+--
+
+local log = { _version = "0.1.0" }
+
+
+log.usecolor = true
+log.outfile = nil
+log.level = "trace"
+
+
+local modes = {
+  { name = "trace", color = "\27[34m", },
+  { name = "debug", color = "\27[36m", },
+  { name = "info",  color = "\27[32m", },
+  { name = "warn",  color = "\27[33m", },
+  { name = "error", color = "\27[31m", },
+  { name = "fatal", color = "\27[35m", },
+}
+
+
+local levels = {}
+for i, v in ipairs(modes) do
+  levels[v.name] = i
+end
+
+
+local round = function(x, increment)
+  increment = increment or 1
+  x = x / increment
+  return (x > 0 and math.floor(x + .5) or math.ceil(x - .5)) * increment
+end
+
+
+local _tostring = tostring
+
+local tostring = function(...)
+  local t = {}
+  for i = 1, select('#', ...) do
+    local x = select(i, ...)
+    if type(x) == "number" then
+      x = round(x, .01)
+    end
+    t[#t + 1] = _tostring(x)
+  end
+  return table.concat(t, " ")
+end
+
+local format_log_message = function(level, lineinfo, msg)
+  return string.format("[%-6s%s] %s: %s",
+    level:upper(),
+    os.date(),
+    lineinfo,
+    msg)
+end
+
+for i, x in ipairs(modes) do
+  local nameupper = x.name:upper()
+  log[x.name] = function(...)
+
+    -- Return early if we're below the log level
+    if i < levels[log.level] then
+      return
+    end
+
+    local msg = tostring(...)
+    -- Set to three levels up the call stack i.e avoid this file and the log service
+    local info = debug.getinfo(3, "Sl")
+    local lineinfo = info.short_src .. ":" .. info.currentline
+
+    -- Output to console
+    print(string.format("%s[%-6s%s]%s %s: %s",
+                        log.usecolor and x.color or "",
+                        nameupper,
+                        os.date("%H:%M:%S"),
+                        log.usecolor and "\27[0m" or "",
+                        lineinfo,
+                        msg))
+
+    -- Output to log file
+    if log.outfile then
+      local fp = io.open(log.outfile, "a")
+      local str = format_log_message(nameupper, lineinfo, msg)
+      fp:write(str)
+      fp:close()
+    end
+  end
+end
+
+log.modes = modes
+log.tostring = tostring
+log.format_log_message = format_log_message
+
+return log

--- a/src/services/config.lua
+++ b/src/services/config.lua
@@ -1,23 +1,24 @@
 -- services/config.lua
 --
 -- Config service:
---  - discovers HAL via {'svc','+','announce'} where payload.role == "hal"
---  - reads a single JSON blob from HAL (string) keyed at top level by service name
---  - publishes retained to {'config', <service_name>} with the nested settings table
---  - accepts updates:
---      * pub/sub: {'config', <service_name>, 'set'} payload is a table (settings)
+--  - discovers filesystem capability {'cap', 'fs', 'config', ...}
+--  - reads config.json from the filesystem capability
+--  - publishes retained to {'cfg', <service_name>} with the nested settings table
+--  - accepts updates (in-memory only, not persisted):
+--      * pub/sub: {'cfg', <service_name>, 'set'} payload is a table (settings)
 --
--- Persisted state location (within HAL):
---   ns  = "config"
---   key = "services"
+-- Config file location: ${DC_CONFIG_DIR}/config.json
+-- Format: { "service_name": { ...settings... }, ... }
 --
--- Assumes cjson.safe is available.
+-- Note: Write/persistence not yet implemented.
 
 local op      = require 'fibers.op'
 local runtime = require 'fibers.runtime'
 local perform = require 'fibers.performer'.perform
+local log     = require 'services.log'
 
 local cjson = require 'cjson.safe'
+local external_types = require 'services.hal.types.external'
 
 local M = {}
 
@@ -58,11 +59,12 @@ local function is_service_map(x)
 end
 
 -------------------------------------------------------------------------------
--- HAL discovery + client
+-- Filesystem capability discovery + client
 -------------------------------------------------------------------------------
 
-local function discover_hal_rpc_root(conn)
-	local sub = conn:subscribe(t('svc', '+', 'announce'), { queue_len = 10, full = 'drop_oldest' })
+local function wait_for_fs_capability(conn)
+	-- Wait for filesystem capability with ID 'config' to become available
+	local sub = conn:subscribe(t('cap', 'fs', 'config', 'state'), { queue_len = 10, full = 'drop_oldest' })
 
 	while true do
 		local msg, err = perform(sub:recv_op())
@@ -70,33 +72,31 @@ local function discover_hal_rpc_root(conn)
 			return nil, err
 		end
 
-		local p = msg.payload or {}
-		if p.role == 'hal' and type(p.rpc_root) == 'table' then
-			-- rpc_root is a topic array
+		if msg.payload == 'added' then
 			sub:unsubscribe()
-			return p.rpc_root, nil
+			return true, nil
 		end
 	end
 end
 
-local function hal_call(conn, rpc_root, method, payload)
-	local topic = { rpc_root[1], rpc_root[2], rpc_root[3], method }
-	return conn:call(topic, payload)
-end
+local function fs_read_config(conn)
+	-- Read config.json from the filesystem capability
+	local opts, opts_err = external_types.new.FilesystemReadOpts('config.json')
+	if not opts then
+		return nil, 'failed to create read options: ' .. tostring(opts_err)
+	end
 
-local function hal_read_blob(conn, rpc_root, ns, key)
-	local reply, err = hal_call(conn, rpc_root, 'read_state', { ns = ns, key = key })
-	if not reply then return nil, err end
-	if reply.ok ~= true then return nil, reply.err or 'hal read failed' end
-	if reply.found ~= true then return nil, 'not_found' end
-	return reply.data, nil
-end
+	local reply, err = conn:call(t('cap', 'fs', 'config', 'rpc', 'read'), opts)
+	if not reply then
+		return nil, err
+	end
 
-local function hal_write_blob(conn, rpc_root, ns, key, data)
-	local reply, err = hal_call(conn, rpc_root, 'write_state', { ns = ns, key = key, data = data })
-	if not reply then return nil, err end
-	if reply.ok ~= true then return nil, reply.err or 'hal write failed' end
-	return true, nil
+	if reply.ok ~= true then
+		return nil, reply.reason or 'filesystem read failed'
+	end
+
+	-- File content is in reply.reason
+	return reply.reason, nil
 end
 
 -------------------------------------------------------------------------------
@@ -109,54 +109,50 @@ function M.start(conn, opts)
 
 	publish_status(conn, name, 'starting')
 
-	-- Discover HAL without naming it.
-	local hal_rpc_root, herr = discover_hal_rpc_root(conn)
-	if not hal_rpc_root then
-		publish_status(conn, name, 'stopped', { reason = herr or 'no hal available' })
+	-- Wait for filesystem capability to become available
+	local ok, cap_err = wait_for_fs_capability(conn)
+	if not ok then
+		publish_status(conn, name, 'stopped', { reason = cap_err or 'filesystem capability not available' })
 		return
 	end
-
-	local STATE_NS  = 'config'
-	local STATE_KEY = 'services'
 
 	-- Current config: service_name -> settings_table
 	local current = {}
 
 	local function publish_all_retained()
 		for svc, settings in pairs(current) do
-			conn:retain(t('config', svc), settings)
+			conn:retain(t('cfg', svc), settings)
 		end
 	end
 
-	local function load_from_hal()
-		local blob, err = hal_read_blob(conn, hal_rpc_root, STATE_NS, STATE_KEY)
+	local function load_from_fs()
+		local blob, err = fs_read_config(conn)
 		if not blob then
-			-- Missing is not fatal: start with empty.
+			log.warn(("Config: %s"):format(err))
+			-- Missing file is not fatal: start with empty config.
+			if err and (err:find('not found') or err:find('No such file')) then
+				current = {}
+				publish_all_retained()
+				return true
+			end
+			-- Other errors are more serious
+			publish_status(conn, name, 'degraded', { reason = 'failed to read config: ' .. tostring(err) })
 			current = {}
-			publish_all_retained()
-			return true
+			return false
 		end
 
 		local decoded = cjson.decode(blob)
+		print(decoded)
 		if not is_service_map(decoded) then
 			-- Do not guess: publish nothing and surface an error status.
 			publish_status(conn, name, 'degraded', { reason = 'invalid config JSON shape' })
 			current = {}
-			return true
+			return false
 		end
 
 		current = decoded
 		publish_all_retained()
 		return true
-	end
-
-	local function persist_to_hal()
-		local blob = cjson.encode(current) or '{}'
-		local ok, err = hal_write_blob(conn, hal_rpc_root, STATE_NS, STATE_KEY, blob)
-		if not ok then
-			return nil, err
-		end
-		return true, nil
 	end
 
 	local function set_service(service, settings)
@@ -167,21 +163,17 @@ function M.start(conn, opts)
 			return nil, 'settings must be a table'
 		end
 
+		-- Update in-memory only (persistence not yet implemented)
 		current[service] = settings
-		local ok, err = persist_to_hal()
-		if not ok then
-			return nil, err
-		end
-
-		conn:retain(t('config', service), settings)
+		conn:retain(t('cfg', service), settings)
 		return true, nil
 	end
 
 	-- Initial load
-	load_from_hal()
+	load_from_fs()
 
 	-- Updates from other sources (UI/cloud/etc)
-	local sub_set = conn:subscribe(t('config', '+', 'set'), { queue_len = 50, full = 'drop_oldest' })
+	local sub_set = conn:subscribe(t('cfg', '+', 'set'), { queue_len = 50, full = 'drop_oldest' })
 
 	publish_status(conn, name, 'running')
 
@@ -195,10 +187,10 @@ function M.start(conn, opts)
 		local service = msg.topic and msg.topic[2]
 		local settings = msg.payload
 
-		local ok, uerr = set_service(service, settings)
+		local success, uerr = set_service(service, settings)
 		-- Best-effort reply if request-style publish provided reply_to.
 		if msg.reply_to ~= nil then
-			if ok then
+			if success then
 				conn:publish_one(msg.reply_to, { ok = true }, { id = msg.id })
 			else
 				conn:publish_one(msg.reply_to, { ok = false, err = tostring(uerr) }, { id = msg.id })

--- a/src/services/gsm.lua
+++ b/src/services/gsm.lua
@@ -14,9 +14,10 @@ local perform = fibers.perform
 
 local log = require "services.log"
 local external_types = require "services.hal.types.external"
+local apns = require "services.gsm.apn"
 
 local REQUEST_TIMEOUT = 10
-local DEFAULT_RETRY_TIMEOUT = 5
+local DEFAULT_RETRY_TIMEOUT = 20
 local DEFAULT_METRICS_INTERVAL = 10
 local DEFAULT_SIGNAL_FREQ = 5
 
@@ -31,13 +32,13 @@ local SCOREMAP = {
 
 local ACCESS_TECH_MAP = {
 	{ tokens = { 'lte', '5gnr' }, tech = '5g' },
-	{ tokens = { '5gnr' }, tech = '5g' },
-	{ tokens = { '5g' }, tech = '5g' },
-	{ tokens = { 'lte' }, tech = 'lte' },
-	{ tokens = { 'umts' }, tech = 'umts' },
-	{ tokens = { 'gsm' }, tech = 'gsm' },
-	{ tokens = { 'evdo' }, tech = 'evdo' },
-	{ tokens = { 'cdma1x' }, tech = 'cdma1x' },
+	{ tokens = { '5gnr' },        tech = '5g' },
+	{ tokens = { '5g' },          tech = '5g' },
+	{ tokens = { 'lte' },         tech = 'lte' },
+	{ tokens = { 'umts' },        tech = 'umts' },
+	{ tokens = { 'gsm' },         tech = 'gsm' },
+	{ tokens = { 'evdo' },        tech = 'evdo' },
+	{ tokens = { 'cdma1x' },      tech = 'cdma1x' },
 }
 
 ---@return table
@@ -56,6 +57,12 @@ end
 ---@return table
 local function t_cap_state(id)
 	return { 'cap', 'modem', id, 'state' }
+end
+
+---@param id string|number
+---@return table
+local function t_cap_card_state(id)
+	return { 'cap', 'modem', id, 'state', 'card' }
 end
 
 ---@param id string|number
@@ -103,13 +110,10 @@ local function call_modem_rpc(conn, id, method, payload, timeout)
 		timeout = timeout or REQUEST_TIMEOUT,
 	})
 	if not reply then
-		return false, err or "rpc failed"
+		return nil, err or "rpc failed"
 	end
 	if reply.ok ~= true then
-		return false, reply.reason or 'rpc failed'
-	end
-	if reply.reason == nil then
-		return false, "empty reply"
+		return nil, reply.reason or 'rpc failed'
 	end
 	return reply.reason, ""
 end
@@ -118,12 +122,13 @@ end
 ---@param id string|number
 ---@param field string
 ---@param timeout number?
+---@param timescale number?
 ---@return any
 ---@return string
-local function modem_get_field(conn, id, field, timeout)
-	local opts, opts_err = external_types.new.ModemGetOpts(field)
+local function modem_get_field(conn, id, field, timeout, timescale)
+	local opts, opts_err = external_types.new.ModemGetOpts(field, timescale)
 	if not opts then
-		return false, opts_err or "invalid modem get opts"
+		return nil, opts_err or "invalid modem get opts"
 	end
 	return call_modem_rpc(conn, id, 'get', opts, timeout)
 end
@@ -254,18 +259,14 @@ local function normalize_sim_presence(sim_value)
 end
 
 ---@param access_techs any
----@param access_err string
 ---@param rssi any
----@param rssi_err string
 ---@param rsrp any
----@param rsrp_err string
 ---@param rscp any
----@param rscp_err string
 ---@return string
 ---@return number
 ---@return string
-local function select_signal_for_bars(access_techs, access_err, rssi, rssi_err, rsrp, rsrp_err, rscp, rscp_err)
-	if access_err ~= "" then
+local function select_signal_for_bars(access_techs, rssi, rsrp, rscp)
+	if not access_techs then
 		return "", 0, "access tech unavailable"
 	end
 
@@ -274,21 +275,21 @@ local function select_signal_for_bars(access_techs, access_err, rssi, rssi_err, 
 		return "", 0, "access tech unknown"
 	end
 
-	if access_tech == 'umts' and rscp_err == "" then
+	if access_tech == 'umts' and rscp ~= nil then
 		local rscp_value = tonumber(rscp)
 		if rscp_value then
 			return access_tech, rscp_value, "rscp"
 		end
 	end
 
-	if (access_tech == 'lte' or access_tech == '5g') and rsrp_err == "" then
+	if (access_tech == 'lte' or access_tech == '5g') and rsrp ~= nil then
 		local rsrp_value = tonumber(rsrp)
 		if rsrp_value then
 			return access_tech, rsrp_value, "rsrp"
 		end
 	end
 
-	if rssi_err == "" then
+	if rssi ~= nil then
 		local rssi_value = tonumber(rssi)
 		if rssi_value then
 			return access_tech, rssi_value, "rssi"
@@ -335,7 +336,7 @@ local function get_modem_config(cfg, imei, device)
 			if is_plain_table(entry) then
 				local id_field = entry.id_field or 'imei'
 				if (id_field == 'device' and device ~= "" and entry.device == device)
-					or (id_field ~= 'device' and ((entry.imei == imei) or (entry.id == imei)))
+					or (id_field ~= 'device' and (entry.imei == imei))
 				then
 					local merged = shallow_copy(entry)
 					apply_defaults(merged, base)
@@ -346,6 +347,25 @@ local function get_modem_config(cfg, imei, device)
 	end
 
 	return base, "", ""
+end
+
+--- Waits for a modem state to move out of connecting
+---@param name string
+---@param state_sub Subscription
+---@return boolean ok
+---@return string error
+local function wait_for_connection(name, state_sub)
+	while true do
+		local msg, err = state_sub:recv()
+		if err then
+			return false, "state subscription interrupted"
+		end
+		local state = msg.payload and msg.payload.to
+		log.trace(("GSM %s connection progress - modem state change: %s"):format(tostring(name), tostring(state)))
+		if state and state ~= 'connecting' then
+			return true, ""
+		end
+	end
 end
 
 ---@class GsmModem
@@ -394,6 +414,7 @@ end
 ---@param value any
 ---@return nil
 function GsmModem:_emit_metric(key, value)
+	log.info("GSM", self.name, "- emitting metric", key, "=", tostring(value))
 	if value == nil then
 		return
 	end
@@ -414,10 +435,7 @@ end
 function GsmModem:_emit_metrics_once()
 	-- Derived metrics only; HAL remains the source of truth.
 	local access_techs, access_err = modem_get_field(self.conn, self.id, 'access_techs', REQUEST_TIMEOUT)
-	if access_err ~= "" then
-		log.debug("GSM", self.id, "- access_techs:", access_err)
-	else
-		self:_emit_metric('access_techs', access_techs)
+	if access_err == "" then
 		local access_tech = derive_access_tech(access_techs)
 		if access_tech ~= "" then
 			self:_emit_metric('access_tech', access_tech)
@@ -428,118 +446,88 @@ function GsmModem:_emit_metrics_once()
 		end
 	end
 
-	local band, band_err = modem_get_field(self.conn, self.id, 'band', REQUEST_TIMEOUT)
-	if band_err ~= "" then
-		log.debug("GSM", self.id, "- band:", band_err)
-	else
+	local band, band_err = modem_get_field(self.conn, self.id, 'active_band_class', REQUEST_TIMEOUT)
+	if band_err == "" then
 		self:_emit_metric('band', band)
 	end
 
 	local imei, imei_err = modem_get_field(self.conn, self.id, 'imei', REQUEST_TIMEOUT)
-	if imei_err ~= "" then
-		log.debug("GSM", self.id, "- imei:", imei_err)
-	else
+	if imei_err == "" then
 		self:_emit_metric('imei', imei)
 	end
 
 	local operator, operator_err = modem_get_field(self.conn, self.id, 'operator', REQUEST_TIMEOUT)
-	if operator_err ~= "" then
-		log.debug("GSM", self.id, "- operator:", operator_err)
-	else
+	if operator_err == "" then
 		self:_emit_metric('operator', operator)
 	end
 
 	local sim, sim_err = modem_get_field(self.conn, self.id, 'sim', REQUEST_TIMEOUT)
-	if sim_err ~= "" then
-		log.debug("GSM", self.id, "- sim:", sim_err)
-	else
+	if sim_err == "" then
 		self:_emit_metric('sim', normalize_sim_presence(sim))
 	end
 
 	local iccid, iccid_err = modem_get_field(self.conn, self.id, 'iccid', REQUEST_TIMEOUT)
-	if iccid_err ~= "" then
-		log.debug("GSM", self.id, "- iccid:", iccid_err)
-	else
+	if iccid_err == "" then
 		self:_emit_metric('iccid', iccid)
 	end
 
 	local firmware, firmware_err = modem_get_field(self.conn, self.id, 'firmware', REQUEST_TIMEOUT)
-	if firmware_err ~= "" then
-		log.debug("GSM", self.id, "- firmware:", firmware_err)
-	else
+	if firmware_err == "" then
 		self:_emit_metric('firmware', firmware)
 	end
 
-	local state, state_err = modem_get_field(self.conn, self.id, 'state', REQUEST_TIMEOUT)
-	if state_err ~= "" then
-		log.debug("GSM", self.id, "- state:", state_err)
-	else
+	local state_sub = self.conn:subscribe(t_cap_card_state(self.id))
+	local state_msg, msg_err = state_sub:recv()
+	if msg_err then
+		log.debug("GSM", self.name, "- state: ", msg_err)
+	end
+	local state = state_msg.payload and state_msg.payload.to
+	if state then
 		self:_emit_metric('state', state)
 	end
 
 	local net_ports, net_ports_err = modem_get_field(self.conn, self.id, 'net_ports', REQUEST_TIMEOUT)
-	if net_ports_err ~= "" then
-		log.debug("GSM", self.id, "- net_ports:", net_ports_err)
-	else
+	if net_ports_err == "" then
 		local interface = net_ports and net_ports[1]
 		if interface then
 			self:_emit_metric('interface', interface)
 		else
-			log.debug("GSM", self.id, "- no net_ports available")
+			log.debug("GSM", self.name, "- no net_ports available")
 		end
 	end
 
 	local rx_bytes, rx_err = modem_get_field(self.conn, self.id, 'rx_bytes', REQUEST_TIMEOUT)
-	if rx_err ~= "" then
-		log.debug("GSM", self.id, "- rx_bytes:", rx_err)
-	else
+	if rx_err == "" then
 		self:_emit_metric('rx_bytes', rx_bytes)
 	end
 
 	local tx_bytes, tx_err = modem_get_field(self.conn, self.id, 'tx_bytes', REQUEST_TIMEOUT)
-	if tx_err ~= "" then
-		log.debug("GSM", self.id, "- tx_bytes:", tx_err)
-	else
+	if tx_err == "" then
 		self:_emit_metric('tx_bytes', tx_bytes)
 	end
 
-	local rssi, rssi_err = modem_get_field(self.conn, self.id, 'rssi', REQUEST_TIMEOUT)
-	if rssi_err ~= "" then
-		log.debug("GSM", self.id, "- rssi:", rssi_err)
-	else
-		self:_emit_metric('signal_rssi', rssi)
+	local signal, signal_err = modem_get_field(self.conn, self.id, 'signal', REQUEST_TIMEOUT)
+	local rssi, rsrp, rsrq, rscp = nil, nil, nil, nil
+	if signal_err == "" then
+		rssi = signal.rssi
+		rsrp = signal.rsrp
+		rsrq = signal.rsrq
+		rscp = signal.rscp
 	end
 
-	local rsrp, rsrp_err = modem_get_field(self.conn, self.id, 'rsrp', REQUEST_TIMEOUT)
-	if rsrp_err ~= "" then
-		log.debug("GSM", self.id, "- rsrp:", rsrp_err)
-	else
-		self:_emit_metric('signal_rsrp', rsrp)
+	if rsrp then
+		self:_emit_metric('rsrp', rsrp)
 	end
 
-	local rsrq, rsrq_err = modem_get_field(self.conn, self.id, 'rsrq', REQUEST_TIMEOUT)
-	if rsrq_err ~= "" then
-		log.debug("GSM", self.id, "- rsrq:", rsrq_err)
-	else
-		self:_emit_metric('signal_rsrq', rsrq)
-	end
-
-	local rscp, rscp_err = modem_get_field(self.conn, self.id, 'rscp', REQUEST_TIMEOUT)
-	if rscp_err ~= "" then
-		log.debug("GSM", self.id, "- rscp:", rscp_err)
-	else
-		self:_emit_metric('signal_rscp', rscp)
+	if rsrq then
+		self:_emit_metric('rsrq', rsrq)
 	end
 
 	local bars_access_tech, signal_value, signal_type = select_signal_for_bars(
 		access_techs,
-		access_err,
 		rssi,
-		rssi_err,
 		rsrp,
-		rsrp_err,
-		rscp,
-		rscp_err
+		rscp
 	)
 
 	if bars_access_tech ~= "" and signal_type ~= "" then
@@ -573,68 +561,161 @@ function GsmModem:_metrics_loop()
 	end
 end
 
----@return boolean
----@return string
-function GsmModem:_connect_once()
-	-- TODO: Add APN selection logic; currently uses a precomputed connection string.
-	if not self.cfg.connection_string then
-		return false, "missing connection_string"
+---@return table|nil apn
+---@return string error
+---@return number? retry_timeout
+function GsmModem:_apn_connect()
+	-- Fetch network/SIM identifiers from HAL
+	local mcc, mcc_err = modem_get_field(self.conn, self.id, 'mcc', REQUEST_TIMEOUT)
+	if mcc_err ~= "" then
+		return nil, "mcc: " .. mcc_err, DEFAULT_RETRY_TIMEOUT
 	end
 
-	local opts, opts_err = external_types.new.ModemConnectOpts(self.cfg.connection_string)
-	if not opts then
-		return false, opts_err or "invalid connection string"
+	local mnc, mnc_err = modem_get_field(self.conn, self.id, 'mnc', REQUEST_TIMEOUT)
+	if mnc_err ~= "" then
+		return nil, "mnc: " .. mnc_err, DEFAULT_RETRY_TIMEOUT
 	end
 
-	local _, err = call_modem_rpc(self.conn, self.id, 'connect', opts, REQUEST_TIMEOUT)
-	if err ~= "" then
-		return false, err
+	local imsi, imsi_err = modem_get_field(self.conn, self.id, 'imsi', REQUEST_TIMEOUT)
+	if imsi_err ~= "" then
+		return nil, "imsi: " .. imsi_err, DEFAULT_RETRY_TIMEOUT
 	end
 
-	return true, ""
+	local gid1, gid1_err = modem_get_field(self.conn, self.id, 'gid1', REQUEST_TIMEOUT)
+	if gid1_err ~= "" then
+		return nil, "gid1: " .. gid1_err, DEFAULT_RETRY_TIMEOUT
+	end
+
+	-- Get ranked APNs
+	local rank_cutoff = tonumber(self.cfg.apn_rank_cutoff) or 4
+	local ranked_apns, rankings = apns.get_ranked_apns(mcc, mnc, imsi, nil, gid1)
+
+	-- Iterate through ranked APNs
+	for _, ranking in ipairs(rankings) do
+		if ranking.rank > rank_cutoff then break end
+
+		local apn_table = ranked_apns[ranking.name]
+		local conn_str, build_err = apns.build_connection_string(apn_table, self.cfg.roaming_allow)
+
+		if not build_err and conn_str then
+			-- Build and send connect RPC
+			local opts, opts_err = external_types.new.ModemConnectOpts(conn_str)
+			if opts then
+				log.trace("GSM", self.name, "- attempting to connect APN", ranking.name, "with connection string:",
+					conn_str)
+
+				local _, conn_err = call_modem_rpc(self.conn, self.id, 'connect', opts, REQUEST_TIMEOUT)
+
+				log.debug("GSM", self.name, "- connect RPC for APN", ranking.name, "returned:", conn_err)
+				if conn_err == "" then
+					-- Connect succeeded
+					log.trace("GSM", self.name, "- APN", ranking.name, "connected successfully")
+					return apn_table, "", nil
+				end
+
+				-- Check for throttled error
+				if string.find(conn_err, "pdn-ipv4-call-throttled") then
+					log.debug("GSM", self.name, "- APN connection throttled")
+					return nil, conn_err, 360 -- 6-minute backoff
+				end
+
+				-- Connection attempt failed, wait for modem state to stabilize before trying next APN
+				log.debug("GSM", self.name, "- APN", ranking.name, "connect failed:", conn_err,
+					"waiting for state change")
+
+				-- Subscribe to state changes to monitor connection progress
+				local state_sub = self.conn:subscribe(t_cap_card_state(self.id), {
+					queue_len = 1,
+					full = 'drop_oldest',
+				})
+				local ok, wait_err = wait_for_connection(self.name, state_sub)
+				state_sub:unsubscribe()
+				if not ok then
+					log.debug("GSM", self.name, "- error while waiting for state change, failure:", wait_err)
+					return nil, wait_err, DEFAULT_RETRY_TIMEOUT
+				end
+
+				log.trace("GSM", self.name, "- APN", ranking.name, "connection attempt failed")
+			else
+				log.debug("GSM", self.name, "- invalid connect opts for APN", ranking.name, ":", opts_err)
+			end
+		else
+			log.debug("GSM", self.name, "- failed to build connection string for APN", ranking.name, ":",
+				build_err or "nil")
+		end
+	end
+
+	state_sub:unsubscribe()
+	return nil, "no apn connected", DEFAULT_RETRY_TIMEOUT
 end
 
--- Autoconnect loop: reconnects on a simple backoff and reacts to config changes.
+-- Autoconnect loop: listens to modem state changes and reacts with enable/fix/connect.
+-- Retry logic with exponential backoff and state change preemption.
 ---@return nil
 function GsmModem:_autoconnect_loop()
 	local seen = self.config_pulse:version()
+	local state_sub = self.conn:subscribe(t_cap_card_state(self.id), {
+		queue_len = 1,
+		full = 'drop_oldest',
+	})
+
+	local current_state = nil
+	local backoff = math.huge
 
 	while true do
-		if not self.cfg.autoconnect then
-			local which, ver = perform(op.named_choice({
-				idle = sleep.sleep_op(DEFAULT_RETRY_TIMEOUT),
-				config = self.config_pulse:changed_op(seen),
-			}))
+		local which, msg_or_ver = perform(op.named_choice({
+			state = state_sub:recv_op(),
+			backoff = sleep.sleep_op(backoff),
+			config = self.config_pulse:changed_op(seen),
+		}))
 
-			if which == 'config' then
-				if not ver then
-					return
-				end
-				seen = ver
+		if which == 'config' then
+			if not msg_or_ver then
+				-- pulse closed, exit
+				break
 			end
-		else
-			local ok, err = self:_connect_once()
-			if ok then
-				self:_emit_event('autoconnect', 'connected')
+			seen = msg_or_ver
+			backoff = math.huge
+		elseif which == 'state' then
+			local msg = msg_or_ver
+			if msg then
+				current_state = msg.payload.to
+				log.trace("GSM", self.name, "- modem state changed:", current_state)
+			end
+		elseif which == 'backoff' then
+			log.trace("GSM", self.name, "- retrying state:", current_state)
+		end
+
+		-- Act on current_state
+		if current_state and self.cfg.autoconnect then
+			local err, retry_timeout
+
+			if current_state == 'disabled' then
+				local _, err_inner = call_modem_rpc(self.conn, self.id, 'enable', {}, REQUEST_TIMEOUT)
+				err = err_inner
+			elseif current_state == 'failed' then
+				local _, err_inner = call_modem_rpc(self.conn, self.id, 'listen_for_sim', {}, REQUEST_TIMEOUT)
+				err = err_inner
+			elseif current_state == 'registered' then
+				local _, err_inner, retry_inner = self:_apn_connect()
+				err = err_inner
+				retry_timeout = retry_inner
+				if err == "" then
+					self:_emit_event('autoconnect', 'connected')
+				end
+			end
+
+			if err and err ~= "" then
+				backoff = retry_timeout or DEFAULT_RETRY_TIMEOUT
+				log.error("GSM", self.name, "- state", current_state, "failed:", err,
+					"retrying after", backoff, "seconds")
 			else
-				self:_emit_event('autoconnect', 'failed')
-				log.debug("GSM", self.id, "- autoconnect failed:", err)
-			end
-
-			local retry = tonumber(self.cfg.retry_interval) or DEFAULT_RETRY_TIMEOUT
-			local which, ver = perform(op.named_choice({
-				backoff = sleep.sleep_op(retry),
-				config = self.config_pulse:changed_op(seen),
-			}))
-
-			if which == 'config' then
-				if not ver then
-					return
-				end
-				seen = ver
+				backoff = math.huge
 			end
 		end
 	end
+
+	state_sub:unsubscribe()
 end
 
 ---@param parent_scope Scope
@@ -656,29 +737,29 @@ function GsmModem:start(parent_scope)
 
 	self.scope = child
 
-	child:finally(function ()
-		log.trace("GSM", self.id, "- modem scope closed")
+	child:finally(function()
+		log.trace("GSM", self.name, "- modem scope closed")
 	end)
 
-	local ok, spawn_err = child:spawn(function ()
+	local ok, spawn_err = child:spawn(function()
 		local signal_freq = tonumber(self.cfg.signal_freq) or DEFAULT_SIGNAL_FREQ
 		local _, sig_err = modem_set_signal_freq(self.conn, self.id, signal_freq)
 		if sig_err ~= "" then
-			log.debug("GSM", self.id, "- set_signal_update_freq:", sig_err)
+			log.debug("GSM", self.name, "- set_signal_update_freq:", sig_err)
 		end
 	end)
 	if not ok then
 		return false, spawn_err or "failed to spawn signal update"
 	end
 
-	ok, spawn_err = child:spawn(function ()
+	ok, spawn_err = child:spawn(function()
 		self:_metrics_loop()
 	end)
 	if not ok then
 		return false, spawn_err or "failed to spawn metrics loop"
 	end
 
-	ok, spawn_err = child:spawn(function ()
+	ok, spawn_err = child:spawn(function()
 		self:_autoconnect_loop()
 	end)
 	if not ok then
@@ -696,13 +777,13 @@ function GsmModem:stop(reason, close_pulse)
 		return
 	end
 
-	self.scope:cancel(reason or 'modem stopped')
-	perform(self.scope:join_op())
-	self.scope = nil
-
 	if close_pulse then
 		self.config_pulse:close(reason or 'modem stopped')
 	end
+
+	self.scope:cancel(reason or 'modem stopped')
+	perform(self.scope:join_op())
+	self.scope = nil
 end
 
 ---@class GsmService
@@ -720,11 +801,13 @@ function GsmService.start(conn, opts)
 
 	local current_cfg = {}
 	local config_ready = false
+
+	---@type table<string, GsmModem>
 	local modems = {}
 
 	local parent_scope = fibers.current_scope()
 
-	parent_scope:finally(function (_, st, primary)
+	parent_scope:finally(function(_, st, primary)
 		for _, modem in pairs(modems) do
 			modem:stop(primary or st, true)
 		end
@@ -752,7 +835,7 @@ function GsmService.start(conn, opts)
 
 		local ok, err = modem:start(parent_scope)
 		if not ok then
-			log.debug("GSM", id, "- failed to start modem scope:", err)
+			log.error("GSM", id, "- failed to start modem scope:", err)
 		end
 
 		return modem
@@ -767,10 +850,7 @@ function GsmService.start(conn, opts)
 		modems[id] = nil
 	end
 
-	local cfg_sub = conn:subscribe(t_cfg(name), {
-		queue_len = 1,
-		full = 'drop_oldest',
-	})
+	local cfg_sub = conn:subscribe(t_cfg(name))
 
 	while not config_ready do
 		local which, msg, err = perform(op.named_choice({
@@ -799,18 +879,28 @@ function GsmService.start(conn, opts)
 		end
 	end
 
-	local cap_sub = conn:subscribe(t_cap_state('+'), {
-		queue_len = 1,
-		full = 'drop_oldest',
-	})
+	local cap_sub = conn:subscribe(t_cap_state('+'))
 
 	publish_status(conn, name, 'running')
 
 	while true do
-		local which, msg, err = perform(op.named_choice({
+		local choices = {
 			cap = cap_sub:recv_op(),
 			cfg = cfg_sub:recv_op(),
-		}))
+		}
+
+		local modem_fault_ops = {}
+		for id, modem in pairs(modems) do
+			table.insert(modem_fault_ops, modem.scope:fault_op():wrap(function(_, pr)
+				return { id = id, primary = pr }
+			end))
+		end
+
+		if #modem_fault_ops > 0 then
+			choices.modem_fault = op.choice(unpack(modem_fault_ops))
+		end
+
+		local which, msg, err = perform(op.named_choice(choices))
 
 		if not msg then
 			log.debug("GSM", "- subscription closed:", err)
@@ -826,7 +916,13 @@ function GsmService.start(conn, opts)
 			else
 				log.debug("GSM", id, "- unknown modem state:", msg.payload)
 			end
-		else
+		elseif which == 'modem_fault' then
+			local modem = modems[msg.id]
+			if modem then
+				log.debug("GSM", msg.id, "- modem scope faulted: " .. tostring(msg.primary))
+				modem:stop()
+			end
+		elseif which == 'cfg' then
 			if not is_plain_table(msg.payload) then
 				log.debug("GSM", "- invalid config payload")
 			else

--- a/src/services/gsm.lua
+++ b/src/services/gsm.lua
@@ -72,11 +72,10 @@ local function t_cap_rpc(id, method)
 	return { 'cap', 'modem', id, 'rpc', method }
 end
 
----@param id string|number
 ---@param key string
 ---@return table
-local function t_obs_metric(id, key)
-	return { 'obs', 'v1', 'gsm', 'metric', id, key }
+local function t_obs_metric(key)
+	return { 'obs', 'v1', 'gsm', 'metric', key }
 end
 
 ---@param id string|number
@@ -418,7 +417,19 @@ function GsmModem:_emit_metric(key, value)
 	if value == nil then
 		return
 	end
-	self.conn:publish(t_obs_metric(self.id, key), value)
+	local ns_name = nil
+	if self.name == "primary" then
+		ns_name = "1"
+	elseif self.name == "secondary" then
+		ns_name = "2"
+	else
+		return
+	end
+	local metric = {
+		value = value,
+		namespace = {'modem', ns_name, key}
+	}
+	self.conn:publish(t_obs_metric(key), metric)
 end
 
 ---@param key string
@@ -482,8 +493,9 @@ function GsmModem:_emit_metrics_once()
 		log.debug("GSM", self.name, "- state: ", msg_err)
 	end
 	local state = state_msg.payload and state_msg.payload.to
+	---@cast state ModemStateEvent
 	if state then
-		self:_emit_metric('state', state)
+		self:_emit_metric('state', state.to)
 	end
 
 	local net_ports, net_ports_err = modem_get_field(self.conn, self.id, 'net_ports', REQUEST_TIMEOUT)

--- a/src/services/gsm.lua
+++ b/src/services/gsm.lua
@@ -1,0 +1,850 @@
+-- services/gsm.lua
+--
+-- GSM service (new fibers):
+--  - consumes HAL modem capabilities
+--  - runs per-modem child scopes for autoconnect + metrics
+--  - publishes derived observability metrics only
+
+local fibers = require "fibers"
+local op = require "fibers.op"
+local sleep = require "fibers.sleep"
+local pulse = require "fibers.pulse"
+
+local perform = fibers.perform
+
+local log = require "services.log"
+local external_types = require "services.hal.types.external"
+
+local REQUEST_TIMEOUT = 10
+local DEFAULT_RETRY_TIMEOUT = 5
+local DEFAULT_METRICS_INTERVAL = 10
+local DEFAULT_SIGNAL_FREQ = 5
+
+local SCOREMAP = {
+	cdma1x = { rssi = { -110, -100, -86, -70, 1000000 } },
+	evdo = { rssi = { -110, -100, -86, -70, 1000000 } },
+	gsm = { rssi = { -110, -100, -86, -70, 1000000 } },
+	umts = { rscp = { -124, -95, -85, -75, 1000000 } },
+	lte = { rsrp = { -115, -105, -95, -85, 1000000 } },
+	["5g"] = { rsrp = { -115, -105, -95, -85, 1000000 } },
+}
+
+local ACCESS_TECH_MAP = {
+	{ tokens = { 'lte', '5gnr' }, tech = '5g' },
+	{ tokens = { '5gnr' }, tech = '5g' },
+	{ tokens = { '5g' }, tech = '5g' },
+	{ tokens = { 'lte' }, tech = 'lte' },
+	{ tokens = { 'umts' }, tech = 'umts' },
+	{ tokens = { 'gsm' }, tech = 'gsm' },
+	{ tokens = { 'evdo' }, tech = 'evdo' },
+	{ tokens = { 'cdma1x' }, tech = 'cdma1x' },
+}
+
+---@return table
+local function t(...)
+	return { ... }
+end
+
+-- Topic helpers (centralized so we can remap if needed)
+---@param name string
+---@return table
+local function t_cfg(name)
+	return { 'cfg', name }
+end
+
+---@param id string|number
+---@return table
+local function t_cap_state(id)
+	return { 'cap', 'modem', id, 'state' }
+end
+
+---@param id string|number
+---@param method string
+---@return table
+local function t_cap_rpc(id, method)
+	return { 'cap', 'modem', id, 'rpc', method }
+end
+
+---@param id string|number
+---@param key string
+---@return table
+local function t_obs_metric(id, key)
+	return { 'obs', 'v1', 'gsm', 'metric', id, key }
+end
+
+---@param id string|number
+---@param key string
+---@return table
+local function t_obs_event(id, key)
+	return { 'obs', 'v1', 'gsm', 'event', id, key }
+end
+
+---@param conn Connection
+---@param name string
+---@param state string
+---@param extra table?
+local function publish_status(conn, name, state, extra)
+	local payload = { state = state, ts = fibers.now() }
+	if type(extra) == 'table' then
+		for k, v in pairs(extra) do payload[k] = v end
+	end
+	conn:retain(t('svc', name, 'status'), payload)
+end
+
+---@param conn Connection
+---@param id string|number
+---@param method string
+---@param payload table?
+---@param timeout number?
+---@return any
+---@return string
+local function call_modem_rpc(conn, id, method, payload, timeout)
+	local reply, err = conn:call(t_cap_rpc(id, method), payload or {}, {
+		timeout = timeout or REQUEST_TIMEOUT,
+	})
+	if not reply then
+		return false, err or "rpc failed"
+	end
+	if reply.ok ~= true then
+		return false, reply.reason or 'rpc failed'
+	end
+	if reply.reason == nil then
+		return false, "empty reply"
+	end
+	return reply.reason, ""
+end
+
+---@param conn Connection
+---@param id string|number
+---@param field string
+---@param timeout number?
+---@return any
+---@return string
+local function modem_get_field(conn, id, field, timeout)
+	local opts, opts_err = external_types.new.ModemGetOpts(field)
+	if not opts then
+		return false, opts_err or "invalid modem get opts"
+	end
+	return call_modem_rpc(conn, id, 'get', opts, timeout)
+end
+
+---@param conn Connection
+---@param id string|number
+---@param freq number
+---@return any
+---@return string
+local function modem_set_signal_freq(conn, id, freq)
+	local opts, opts_err = external_types.new.ModemSignalUpdateOpts(freq)
+	if not opts then
+		return false, opts_err or "invalid signal update opts"
+	end
+	return call_modem_rpc(conn, id, 'set_signal_update_freq', opts, REQUEST_TIMEOUT)
+end
+
+---@param tbl table?
+---@return table
+local function shallow_copy(tbl)
+	local out = {}
+	if tbl then
+		for k, v in pairs(tbl) do out[k] = v end
+	end
+	return out
+end
+
+---@param cfg table
+---@param defaults table
+local function apply_defaults(cfg, defaults)
+	for key, value in pairs(defaults) do
+		if cfg[key] == nil then
+			cfg[key] = value
+		elseif type(value) == 'table' and type(cfg[key]) == 'table' then
+			apply_defaults(cfg[key], value)
+		end
+	end
+end
+
+---@param value any
+---@return boolean
+local function is_plain_table(value)
+	return type(value) == 'table' and getmetatable(value) == nil
+end
+
+---@param access_techs any
+---@return string
+local function derive_access_tech(access_techs)
+	local techs = {}
+	if type(access_techs) == 'string' then
+		for token in string.gmatch(access_techs, "([^,]+)") do
+			techs[token] = true
+		end
+	elseif is_plain_table(access_techs) then
+		for _, token in ipairs(access_techs) do
+			techs[token] = true
+		end
+	end
+
+	for _, rule in ipairs(ACCESS_TECH_MAP) do
+		local all_match = true
+		for _, required_token in ipairs(rule.tokens) do
+			if not techs[required_token] then
+				all_match = false
+				break
+			end
+		end
+		if all_match then
+			return rule.tech
+		end
+	end
+
+	return ""
+end
+
+---@param access_tech string
+---@return string
+local function get_access_family(access_tech)
+	local map = {
+		cdma1x = '3G',
+		evdo = '3G',
+		gsm = '2G',
+		umts = '3G',
+		lte = '4G',
+		['5g'] = '5G',
+	}
+	return map[access_tech] or ""
+end
+
+---@param access_tech string
+---@param signal_type string
+---@param signal number
+---@return number
+---@return string
+local function get_signal_bars(access_tech, signal_type, signal)
+	local tech_map = SCOREMAP[access_tech]
+	if not tech_map then
+		return 0, "invalid access tech"
+	end
+
+	local thresholds = tech_map[signal_type]
+	if not thresholds then
+		return 0, "invalid signal type"
+	end
+
+	for index, threshold in ipairs(thresholds) do
+		if signal < threshold then
+			return index, ""
+		end
+	end
+
+	return 0, ""
+end
+
+---@param sim_value any
+---@return string
+local function normalize_sim_presence(sim_value)
+	if sim_value == nil or sim_value == '--' then
+		return "--"
+	end
+	if type(sim_value) == 'table' then
+		return "present"
+	end
+	if tostring(sim_value) ~= '' then
+		return "present"
+	end
+	return "--"
+end
+
+---@param access_techs any
+---@param access_err string
+---@param rssi any
+---@param rssi_err string
+---@param rsrp any
+---@param rsrp_err string
+---@param rscp any
+---@param rscp_err string
+---@return string
+---@return number
+---@return string
+local function select_signal_for_bars(access_techs, access_err, rssi, rssi_err, rsrp, rsrp_err, rscp, rscp_err)
+	if access_err ~= "" then
+		return "", 0, "access tech unavailable"
+	end
+
+	local access_tech = derive_access_tech(access_techs)
+	if access_tech == "" then
+		return "", 0, "access tech unknown"
+	end
+
+	if access_tech == 'umts' and rscp_err == "" then
+		local rscp_value = tonumber(rscp)
+		if rscp_value then
+			return access_tech, rscp_value, "rscp"
+		end
+	end
+
+	if (access_tech == 'lte' or access_tech == '5g') and rsrp_err == "" then
+		local rsrp_value = tonumber(rsrp)
+		if rsrp_value then
+			return access_tech, rsrp_value, "rsrp"
+		end
+	end
+
+	if rssi_err == "" then
+		local rssi_value = tonumber(rssi)
+		if rssi_value then
+			return access_tech, rssi_value, "rssi"
+		end
+	end
+
+	return access_tech, 0, ""
+end
+
+---@param cfg table?
+---@return table
+---@return string
+local function normalize_config(cfg)
+	if not is_plain_table(cfg) then
+		return {}, "config must be a table"
+	end
+	---@cast cfg table
+	local modems_cfg = rawget(cfg, 'modems')
+	if not is_plain_table(modems_cfg) then
+		return {}, "config.modems must be a table"
+	end
+	local modems_default = rawget(modems_cfg, 'default')
+	if not is_plain_table(modems_default) then
+		return {}, "config.modems.default must be a table"
+	end
+	local modems_known = rawget(modems_cfg, 'known')
+	if modems_known ~= nil and type(modems_known) ~= 'table' then
+		return {}, "config.modems.known must be a list"
+	end
+	return shallow_copy(cfg), ""
+end
+
+---@param cfg table
+---@param imei string|number
+---@param device string
+---@return table
+---@return string
+---@return string
+local function get_modem_config(cfg, imei, device)
+	local base = shallow_copy(cfg.modems and cfg.modems.default or {})
+	local known = cfg.modems and cfg.modems.known
+	if type(known) == 'table' then
+		for _, entry in ipairs(known) do
+			if is_plain_table(entry) then
+				local id_field = entry.id_field or 'imei'
+				if (id_field == 'device' and device ~= "" and entry.device == device)
+					or (id_field ~= 'device' and ((entry.imei == imei) or (entry.id == imei)))
+				then
+					local merged = shallow_copy(entry)
+					apply_defaults(merged, base)
+					return merged, (merged.name or ""), ""
+				end
+			end
+		end
+	end
+
+	return base, "", ""
+end
+
+---@class GsmModem
+---@field conn Connection
+---@field id string|number
+---@field name string
+---@field cfg table
+---@field device string
+---@field scope Scope?
+---@field config_pulse Pulse
+local GsmModem = {}
+GsmModem.__index = GsmModem
+
+---@param conn Connection
+---@param id string|number
+---@return GsmModem
+function GsmModem.new(conn, id)
+	local self = setmetatable({}, GsmModem)
+	self.conn = conn
+	self.id = id
+	self.name = tostring(id)
+	self.cfg = {}
+	self.device = ""
+	self.scope = nil
+	self.config_pulse = pulse.new()
+	return self
+end
+
+---@return nil
+function GsmModem:_signal_config_change()
+	self.config_pulse:signal()
+end
+
+---@param cfg table
+---@param name string?
+---@return nil
+function GsmModem:apply_config(cfg, name)
+	self.cfg = cfg or {}
+	if name and name ~= "" then
+		self.name = name
+	end
+	self:_signal_config_change()
+end
+
+---@param key string
+---@param value any
+---@return nil
+function GsmModem:_emit_metric(key, value)
+	if value == nil then
+		return
+	end
+	self.conn:publish(t_obs_metric(self.id, key), value)
+end
+
+---@param key string
+---@param value any
+---@return nil
+function GsmModem:_emit_event(key, value)
+	if value == nil then
+		return
+	end
+	self.conn:publish(t_obs_event(self.id, key), value)
+end
+
+---@return nil
+function GsmModem:_emit_metrics_once()
+	-- Derived metrics only; HAL remains the source of truth.
+	local access_techs, access_err = modem_get_field(self.conn, self.id, 'access_techs', REQUEST_TIMEOUT)
+	if access_err ~= "" then
+		log.debug("GSM", self.id, "- access_techs:", access_err)
+	else
+		self:_emit_metric('access_techs', access_techs)
+		local access_tech = derive_access_tech(access_techs)
+		if access_tech ~= "" then
+			self:_emit_metric('access_tech', access_tech)
+			local access_family = get_access_family(access_tech)
+			if access_family ~= "" then
+				self:_emit_metric('access_family', access_family)
+			end
+		end
+	end
+
+	local band, band_err = modem_get_field(self.conn, self.id, 'band', REQUEST_TIMEOUT)
+	if band_err ~= "" then
+		log.debug("GSM", self.id, "- band:", band_err)
+	else
+		self:_emit_metric('band', band)
+	end
+
+	local imei, imei_err = modem_get_field(self.conn, self.id, 'imei', REQUEST_TIMEOUT)
+	if imei_err ~= "" then
+		log.debug("GSM", self.id, "- imei:", imei_err)
+	else
+		self:_emit_metric('imei', imei)
+	end
+
+	local operator, operator_err = modem_get_field(self.conn, self.id, 'operator', REQUEST_TIMEOUT)
+	if operator_err ~= "" then
+		log.debug("GSM", self.id, "- operator:", operator_err)
+	else
+		self:_emit_metric('operator', operator)
+	end
+
+	local sim, sim_err = modem_get_field(self.conn, self.id, 'sim', REQUEST_TIMEOUT)
+	if sim_err ~= "" then
+		log.debug("GSM", self.id, "- sim:", sim_err)
+	else
+		self:_emit_metric('sim', normalize_sim_presence(sim))
+	end
+
+	local iccid, iccid_err = modem_get_field(self.conn, self.id, 'iccid', REQUEST_TIMEOUT)
+	if iccid_err ~= "" then
+		log.debug("GSM", self.id, "- iccid:", iccid_err)
+	else
+		self:_emit_metric('iccid', iccid)
+	end
+
+	local firmware, firmware_err = modem_get_field(self.conn, self.id, 'firmware', REQUEST_TIMEOUT)
+	if firmware_err ~= "" then
+		log.debug("GSM", self.id, "- firmware:", firmware_err)
+	else
+		self:_emit_metric('firmware', firmware)
+	end
+
+	local state, state_err = modem_get_field(self.conn, self.id, 'state', REQUEST_TIMEOUT)
+	if state_err ~= "" then
+		log.debug("GSM", self.id, "- state:", state_err)
+	else
+		self:_emit_metric('state', state)
+	end
+
+	local net_ports, net_ports_err = modem_get_field(self.conn, self.id, 'net_ports', REQUEST_TIMEOUT)
+	if net_ports_err ~= "" then
+		log.debug("GSM", self.id, "- net_ports:", net_ports_err)
+	else
+		local interface = net_ports and net_ports[1]
+		if interface then
+			self:_emit_metric('interface', interface)
+		else
+			log.debug("GSM", self.id, "- no net_ports available")
+		end
+	end
+
+	local rx_bytes, rx_err = modem_get_field(self.conn, self.id, 'rx_bytes', REQUEST_TIMEOUT)
+	if rx_err ~= "" then
+		log.debug("GSM", self.id, "- rx_bytes:", rx_err)
+	else
+		self:_emit_metric('rx_bytes', rx_bytes)
+	end
+
+	local tx_bytes, tx_err = modem_get_field(self.conn, self.id, 'tx_bytes', REQUEST_TIMEOUT)
+	if tx_err ~= "" then
+		log.debug("GSM", self.id, "- tx_bytes:", tx_err)
+	else
+		self:_emit_metric('tx_bytes', tx_bytes)
+	end
+
+	local rssi, rssi_err = modem_get_field(self.conn, self.id, 'rssi', REQUEST_TIMEOUT)
+	if rssi_err ~= "" then
+		log.debug("GSM", self.id, "- rssi:", rssi_err)
+	else
+		self:_emit_metric('signal_rssi', rssi)
+	end
+
+	local rsrp, rsrp_err = modem_get_field(self.conn, self.id, 'rsrp', REQUEST_TIMEOUT)
+	if rsrp_err ~= "" then
+		log.debug("GSM", self.id, "- rsrp:", rsrp_err)
+	else
+		self:_emit_metric('signal_rsrp', rsrp)
+	end
+
+	local rsrq, rsrq_err = modem_get_field(self.conn, self.id, 'rsrq', REQUEST_TIMEOUT)
+	if rsrq_err ~= "" then
+		log.debug("GSM", self.id, "- rsrq:", rsrq_err)
+	else
+		self:_emit_metric('signal_rsrq', rsrq)
+	end
+
+	local rscp, rscp_err = modem_get_field(self.conn, self.id, 'rscp', REQUEST_TIMEOUT)
+	if rscp_err ~= "" then
+		log.debug("GSM", self.id, "- rscp:", rscp_err)
+	else
+		self:_emit_metric('signal_rscp', rscp)
+	end
+
+	local bars_access_tech, signal_value, signal_type = select_signal_for_bars(
+		access_techs,
+		access_err,
+		rssi,
+		rssi_err,
+		rsrp,
+		rsrp_err,
+		rscp,
+		rscp_err
+	)
+
+	if bars_access_tech ~= "" and signal_type ~= "" then
+		local bars, bars_err = get_signal_bars(bars_access_tech, signal_type, signal_value)
+		if bars_err == "" then
+			self:_emit_metric('bars', bars)
+		end
+	end
+end
+
+---@return nil
+function GsmModem:_metrics_loop()
+	local seen = self.config_pulse:version()
+	local interval = tonumber(self.cfg.metrics_interval) or DEFAULT_METRICS_INTERVAL
+
+	while true do
+		local which, ver = perform(op.named_choice({
+			tick = sleep.sleep_op(interval),
+			config = self.config_pulse:changed_op(seen),
+		}))
+
+		if which == 'config' then
+			if not ver then
+				return
+			end
+			seen = ver
+			interval = tonumber(self.cfg.metrics_interval) or DEFAULT_METRICS_INTERVAL
+		else
+			self:_emit_metrics_once()
+		end
+	end
+end
+
+---@return boolean
+---@return string
+function GsmModem:_connect_once()
+	-- TODO: Add APN selection logic; currently uses a precomputed connection string.
+	if not self.cfg.connection_string then
+		return false, "missing connection_string"
+	end
+
+	local opts, opts_err = external_types.new.ModemConnectOpts(self.cfg.connection_string)
+	if not opts then
+		return false, opts_err or "invalid connection string"
+	end
+
+	local _, err = call_modem_rpc(self.conn, self.id, 'connect', opts, REQUEST_TIMEOUT)
+	if err ~= "" then
+		return false, err
+	end
+
+	return true, ""
+end
+
+-- Autoconnect loop: reconnects on a simple backoff and reacts to config changes.
+---@return nil
+function GsmModem:_autoconnect_loop()
+	local seen = self.config_pulse:version()
+
+	while true do
+		if not self.cfg.autoconnect then
+			local which, ver = perform(op.named_choice({
+				idle = sleep.sleep_op(DEFAULT_RETRY_TIMEOUT),
+				config = self.config_pulse:changed_op(seen),
+			}))
+
+			if which == 'config' then
+				if not ver then
+					return
+				end
+				seen = ver
+			end
+		else
+			local ok, err = self:_connect_once()
+			if ok then
+				self:_emit_event('autoconnect', 'connected')
+			else
+				self:_emit_event('autoconnect', 'failed')
+				log.debug("GSM", self.id, "- autoconnect failed:", err)
+			end
+
+			local retry = tonumber(self.cfg.retry_interval) or DEFAULT_RETRY_TIMEOUT
+			local which, ver = perform(op.named_choice({
+				backoff = sleep.sleep_op(retry),
+				config = self.config_pulse:changed_op(seen),
+			}))
+
+			if which == 'config' then
+				if not ver then
+					return
+				end
+				seen = ver
+			end
+		end
+	end
+end
+
+---@param parent_scope Scope
+---@return boolean
+---@return string
+function GsmModem:start(parent_scope)
+	if self.scope then
+		return true, ""
+	end
+
+	if self.config_pulse:is_closed() then
+		self.config_pulse = pulse.new()
+	end
+
+	local child, err = parent_scope:child()
+	if not child then
+		return false, err or "failed to create modem scope"
+	end
+
+	self.scope = child
+
+	child:finally(function ()
+		log.trace("GSM", self.id, "- modem scope closed")
+	end)
+
+	local ok, spawn_err = child:spawn(function ()
+		local signal_freq = tonumber(self.cfg.signal_freq) or DEFAULT_SIGNAL_FREQ
+		local _, sig_err = modem_set_signal_freq(self.conn, self.id, signal_freq)
+		if sig_err ~= "" then
+			log.debug("GSM", self.id, "- set_signal_update_freq:", sig_err)
+		end
+	end)
+	if not ok then
+		return false, spawn_err or "failed to spawn signal update"
+	end
+
+	ok, spawn_err = child:spawn(function ()
+		self:_metrics_loop()
+	end)
+	if not ok then
+		return false, spawn_err or "failed to spawn metrics loop"
+	end
+
+	ok, spawn_err = child:spawn(function ()
+		self:_autoconnect_loop()
+	end)
+	if not ok then
+		return false, spawn_err or "failed to spawn autoconnect loop"
+	end
+
+	return true, ""
+end
+
+---@param reason string?
+---@param close_pulse boolean?
+---@return nil
+function GsmModem:stop(reason, close_pulse)
+	if not self.scope then
+		return
+	end
+
+	self.scope:cancel(reason or 'modem stopped')
+	perform(self.scope:join_op())
+	self.scope = nil
+
+	if close_pulse then
+		self.config_pulse:close(reason or 'modem stopped')
+	end
+end
+
+---@class GsmService
+---@field name string
+local GsmService = {}
+
+---@param conn Connection
+---@param opts table?
+---@return nil
+function GsmService.start(conn, opts)
+	opts = opts or {}
+	local name = opts.name or 'gsm'
+
+	publish_status(conn, name, 'starting')
+
+	local current_cfg = {}
+	local config_ready = false
+	local modems = {}
+
+	local parent_scope = fibers.current_scope()
+
+	parent_scope:finally(function (_, st, primary)
+		for _, modem in pairs(modems) do
+			modem:stop(primary or st, true)
+		end
+		publish_status(conn, name, 'stopped', { reason = primary or st })
+	end)
+
+	local function ensure_modem(id)
+		local modem = modems[id]
+		if modem then
+			return modem
+		end
+
+		modem = GsmModem.new(conn, id)
+		modems[id] = modem
+
+		local device, device_err = modem_get_field(conn, id, 'device', REQUEST_TIMEOUT)
+		if device_err ~= "" then
+			log.debug("GSM", id, "- device lookup:", device_err)
+		else
+			modem.device = tostring(device or "")
+		end
+
+		local cfg, modem_name, _ = get_modem_config(current_cfg, id, modem.device)
+		modem:apply_config(cfg, modem_name)
+
+		local ok, err = modem:start(parent_scope)
+		if not ok then
+			log.debug("GSM", id, "- failed to start modem scope:", err)
+		end
+
+		return modem
+	end
+
+	local function remove_modem(id)
+		local modem = modems[id]
+		if not modem then
+			return
+		end
+		modem:stop('modem removed', true)
+		modems[id] = nil
+	end
+
+	local cfg_sub = conn:subscribe(t_cfg(name), {
+		queue_len = 1,
+		full = 'drop_oldest',
+	})
+
+	while not config_ready do
+		local which, msg, err = perform(op.named_choice({
+			cfg = cfg_sub:recv_op(),
+			timeout = sleep.sleep_op(REQUEST_TIMEOUT),
+		}))
+
+		if which == 'timeout' then
+			log.warn("GSM", "- waiting for initial config")
+		else
+			if not msg then
+				log.warn("GSM", "- config subscription closed:", err)
+				return
+			end
+			if not is_plain_table(msg.payload) then
+				log.warn("GSM", "- invalid config payload")
+			else
+				local cfg, cfg_err = normalize_config(msg.payload)
+				if cfg_err ~= "" then
+					log.warn("GSM", "- invalid config:", cfg_err)
+				else
+					current_cfg = cfg
+					config_ready = true
+				end
+			end
+		end
+	end
+
+	local cap_sub = conn:subscribe(t_cap_state('+'), {
+		queue_len = 1,
+		full = 'drop_oldest',
+	})
+
+	publish_status(conn, name, 'running')
+
+	while true do
+		local which, msg, err = perform(op.named_choice({
+			cap = cap_sub:recv_op(),
+			cfg = cfg_sub:recv_op(),
+		}))
+
+		if not msg then
+			log.debug("GSM", "- subscription closed:", err)
+			return
+		end
+
+		if which == 'cap' then
+			local id = msg.topic and msg.topic[3]
+			if msg.payload == 'added' then
+				ensure_modem(id)
+			elseif msg.payload == 'removed' then
+				remove_modem(id)
+			else
+				log.debug("GSM", id, "- unknown modem state:", msg.payload)
+			end
+		else
+			if not is_plain_table(msg.payload) then
+				log.debug("GSM", "- invalid config payload")
+			else
+				local updated_cfg, cfg_err = normalize_config(msg.payload)
+				if cfg_err ~= "" then
+					log.debug("GSM", "- invalid config:", cfg_err)
+				else
+					current_cfg = updated_cfg
+					for id, modem in pairs(modems) do
+						local modem_cfg, modem_name, _ = get_modem_config(current_cfg, id, modem.device)
+						modem:apply_config(modem_cfg, modem_name)
+						modem:stop('config change')
+						modem:start(parent_scope)
+					end
+				end
+			end
+		end
+	end
+end
+
+return GsmService

--- a/src/services/gsm/apn.lua
+++ b/src/services/gsm/apn.lua
@@ -1,0 +1,73 @@
+local binser = require "shared.binser"
+
+-- ask rich what these fellas do
+local g_authtypes = {}
+g_authtypes["0"] = "none"
+g_authtypes["1"] = "pap"
+g_authtypes["2"] = "chap"
+g_authtypes["3"] = "pap|chap"
+
+-- deserialise the apn database and return the apn for the sim
+local function get_apns(mcc, mnc)
+    local apndb = binser.r("etc/apns")[1]
+    local apns = apndb[mcc][mnc]
+    return apns
+end
+
+local function build_connection_string(apn, roaming_allow)
+    if not apn or next(apn) == nil then return nil, "apn table empty" end
+    local a = {}
+    for k,v in pairs(apn) do
+        if k == "apn" then table.insert(a, "apn="..v)
+        elseif k == "user" then table.insert(a, "user="..v)
+        elseif k == "password" then table.insert(a, "password="..v)
+        elseif k == "authtype" then table.insert(a, "allowed-auth="..g_authtypes[v])
+        end
+    end
+    if roaming_allow then table.insert(a, "allow-roaming=true") end
+    local conn_string = table.concat(a,",")
+    return conn_string, nil
+end
+
+-- the connect function takes a list of apns and applies
+local function rank(apns, imsi, spn, gid1)
+    -- first comes MVNO matches, next general MNO APNs, then generic "apn=internet", finally non-match MVNO
+    local rankings = {}
+    for k, v in pairs(apns) do
+        -- print("k is: ", k)
+        if v.mvno_type then
+            -- print("v is: ", v.mvno_type)
+            if v.mvno_type == "spn" and spn and string.find(spn, v.mvno_match_data) then
+                table.insert(rankings, {name=k, rank=1})
+            elseif v.mvno_type == "gid" and gid1 and string.find(gid1, v.mvno_match_data) then
+                table.insert(rankings, {name=k, rank=1})
+            elseif v.mvno_type == "imsi" and string.find(imsi, v.mvno_match_data) then
+                table.insert(rankings, {name=k, rank=1})
+            else
+                table.insert(rankings, {name=k, rank=4})
+            end
+        else
+            table.insert(rankings, {name=k, rank=2})
+        end
+    end
+    table.insert(apns, {default={apn='internet'}})
+    table.insert(rankings, {name='default', rank=3})
+    table.sort(rankings, function (k1, k2) return k1.rank < k2.rank end )
+    return apns, rankings
+end
+
+local function get_ranked_apns(mcc, mnc, imsi, spn, gid1)
+    if mnc == nil then return {}, {} end
+    if #mnc == 1 then mnc = "0"..mnc end
+    -- get apns from the network service
+    local apns = get_apns(mcc, mnc)
+    -- or read directly
+    -- local apns = binser.r("etc/apns")[1]
+    local rankapns, rankings = rank(apns, imsi, spn, gid1)
+    return rankapns, rankings
+end
+
+return {
+    get_ranked_apns = get_ranked_apns,
+    build_connection_string = build_connection_string
+}

--- a/src/services/hal.lua
+++ b/src/services/hal.lua
@@ -61,10 +61,11 @@ end
 ---@field capabilities table<string, Capability>
 local HalService = {
     cap_emit_ch = channel.new(DEFAULT_Q_LEN), -- capability emits of state, meta or events
-    dev_ev_ch = channel.new(DEFAULT_Q_LEN), -- manager emits of device events (added/removed)
+    dev_ev_ch = channel.new(DEFAULT_Q_LEN),   -- manager emits of device events (added/removed)
     managers = {},
     devices = {},
     capabilities = {},
+    rpc_subs = {}
 }
 
 ---Publishes the HAL service status
@@ -140,16 +141,21 @@ local function get_cap(class, id)
 end
 
 ---Sets the capability instance
+---@param conn Connection
 ---@param class CapabilityClass
 ---@param id CapabilityId
 ---@param cap_inst Capability
 ---@return string? error
-local function set_cap(class, id, cap_inst)
+local function set_cap(conn, class, id, cap_inst)
     HalService.capabilities[class] = HalService.capabilities[class] or {}
     if HalService.capabilities[class][id] then
         return "capability already exists"
     end
-    HalService.capabilities[class][id] = cap_inst
+    HalService.capabilities[class][id] = { inst = cap_inst, rpc = {} }
+    for offering, _ in pairs(cap_inst.offerings) do
+        print(class, id, offering)
+        HalService.capabilities[class][id].rpc[offering] = conn:bind({ 'cap', class, id, 'rpc', offering })
+    end
 end
 
 ---Removes the capability instance
@@ -160,6 +166,10 @@ local function remove_cap(class, id)
     local caps = HalService.capabilities[class]
     if not caps or not caps[id] then
         return "capability does not exist"
+    end
+    for _, rpc_sub in pairs(HalService.capabilities[class][id].rpc) do
+        ---@cast rpc_sub Endpoint
+        rpc_sub:unbind()
     end
     HalService.capabilities[class][id] = nil
 end
@@ -235,7 +245,7 @@ local function register_device(conn, event_type, device)
     end
 
     for _, cap in ipairs(device.capabilities) do
-        local cap_set_err = set_cap(cap.class, cap.id, cap)
+        local cap_set_err = set_cap(conn, cap.class, cap.id, cap)
         if cap_set_err then
             log.debug(HalService.name, "-", cap_set_err)
         else
@@ -310,37 +320,85 @@ local function on_device_event(conn, device_event)
     end
 end
 
-
 ---Spawns all HAL service long running fibers
 ---@param conn Connection
 ---@param opts any
 function HalService.start(conn, opts)
+    log.trace("HAL: starting")
     HalService.name = opts.name or "hal"
     publish_status(conn, HalService.name, "starting")
 
-    local cap_ctrl_sub = conn:bind({ 'cap', '+', '+', 'rpc', '+' })
+    fibers.current_scope():finally(function()
+        local scope = fibers.current_scope()
+        local st, primary = scope:status()
+        if st == 'failed' then
+            log.error(("HAL: error - %s"):format(tostring(primary)))
+            log.trace("HAL: scope exiting with status", st)
+        end
+        publish_status(conn, HalService.name, "stopped")
+        log.trace("HAL: stopped")
+    end)
 
-    -- Setup managers based on hard-coded config here
+    local modemcard_manager = require "services.hal.managers.modemcard"
+    HalService.managers.modemcard = modemcard_manager
+
+    for name, manager in pairs(HalService.managers) do
+        local err = manager.start(HalService.dev_ev_ch, HalService.cap_emit_ch)
+        if err ~= "" then
+            log.error("HAL failed to start " .. name .. " manager", err)
+        end
+    end
 
     publish_status(conn, HalService.name, "running")
 
-    fibers.current_scope():finally(function ()
-        publish_status(conn, HalService.name, "stopped")
-    end)
-
     while true do
-        local source, msg = perform(op.named_choice({
-            cap_ctrl = cap_ctrl_sub:recv_op(),
+        local rpc_ops = {} -- choice needs at least 1 op to aviod fatal error
+
+        for _, class in pairs(HalService.capabilities) do
+            for _, cap in pairs(class) do
+                for _, rpc_sub in pairs(cap.rpc) do
+                    table.insert(rpc_ops, rpc_sub:recv_op())
+                end
+            end
+        end
+
+        local manager_fault_ops = {}
+
+        for name, manager in pairs(HalService.managers) do
+            table.insert(manager_fault_ops, manager.scope:fault_op():wrap(function () return name end))
+        end
+
+        local ops = {
             cap_emit = HalService.cap_emit_ch:get_op(),
             device_event = HalService.dev_ev_ch:get_op()
-        }))
+        }
 
-        if source == 'cap_ctrl' then
+        if #rpc_ops > 0 then
+            ops.rpc = op.choice(unpack(rpc_ops))
+        end
+
+        if #manager_fault_ops > 0 then
+            ops.modem_manager_fault = op.choice(unpack(manager_fault_ops))
+        end
+
+        local source, msg = perform(op.named_choice(ops))
+
+        if source == 'rpc' then
             on_cap_ctrl(conn, msg)
         elseif source == 'cap_emit' then
             on_cap_emit(conn, msg)
         elseif source == 'device_event' then
             on_device_event(conn, msg)
+        elseif source == 'modem_manager_fault' then
+            local name = msg
+            local manager = HalService.managers[name]
+            if manager then
+                log.error("HAL: modem manager fault detected")
+                manager.stop()
+                HalService.managers[name] = nil
+            end
+        else
+            log.error("HAL: unknown operation source:", source)
         end
     end
 end

--- a/src/services/hal.lua
+++ b/src/services/hal.lua
@@ -52,13 +52,15 @@ local function t_cap_state(class, id)
     return { 'cap', class, id, 'state' }
 end
 
+---@alias CapabilityEntry { inst: Capability, rpc: table<string, Endpoint> }
+
 ---@class HalService
 ---@field name string
 ---@field cap_emit_ch Channel
 ---@field dev_ev_ch Channel
 ---@field managers table<string, Manager>
 ---@field devices table<string, Device>
----@field capabilities table<string, Capability>
+---@field capabilities table<CapabilityClass, table<CapabilityId, CapabilityEntry>>
 local HalService = {
     cap_emit_ch = channel.new(DEFAULT_Q_LEN), -- capability emits of state, meta or events
     dev_ev_ch = channel.new(DEFAULT_Q_LEN),   -- manager emits of device events (added/removed)
@@ -133,7 +135,7 @@ end
 ---Gets the capability instance or returns nil
 ---@param class CapabilityClass
 ---@param id CapabilityId
----@return Capability?
+---@return CapabilityEntry?
 local function get_cap(class, id)
     local caps = HalService.capabilities[class]
     if not caps then return nil end
@@ -153,7 +155,6 @@ local function set_cap(conn, class, id, cap_inst)
     end
     HalService.capabilities[class][id] = { inst = cap_inst, rpc = {} }
     for offering, _ in pairs(cap_inst.offerings) do
-        print(class, id, offering)
         HalService.capabilities[class][id].rpc[offering] = conn:bind({ 'cap', class, id, 'rpc', offering })
     end
 end
@@ -167,7 +168,8 @@ local function remove_cap(class, id)
     if not caps or not caps[id] then
         return "capability does not exist"
     end
-    for _, rpc_sub in pairs(HalService.capabilities[class][id].rpc) do
+
+    for _, rpc_sub in pairs(caps[id].rpc) do
         ---@cast rpc_sub Endpoint
         rpc_sub:unbind()
     end
@@ -200,16 +202,16 @@ local function on_cap_ctrl(conn, msg)
         return
     end
 
-    local cap_inst = get_cap(class, id)
-    if not cap_inst then return end -- could be a capability owned by another service
+    local cap_entry = get_cap(class, id)
+    if not cap_entry then return end -- could be a capability owned by another service
 
-    if not cap_inst.offerings[verb] then
+    if not cap_entry.inst.offerings[verb] then
         log.debug(HalService.name, "- capability", class, "does not offer verb:", verb)
         return
     end
 
     spawn(function()
-        cap_inst.control_ch:put(control_req)
+        cap_entry.inst.control_ch:put(control_req)
         local reply, reply_err = control_req.reply_ch:get()
         if not reply then
             reply = types.new.Reply(false, reply_err)
@@ -320,6 +322,95 @@ local function on_device_event(conn, device_event)
     end
 end
 
+--- Checks that HAL config is valid
+---@param config table
+---@return boolean
+---@return string error
+local function validate_config(config)
+    if type(config) ~= 'table' then
+        return false, "config must be a table"
+    end
+
+    for key, value in pairs(config) do
+        if type(key) ~= 'string' then
+            return false, "config keys must be strings"
+        end
+        if type(value) ~= 'table' then
+            return false, "config values must be tables"
+        end
+    end
+
+    return true, ""
+end
+
+--- Uses config to setup managers
+---@param config table
+local function on_config(config)
+    log.trace("HAL: received config update")
+    local valid, valid_err = validate_config(config)
+    if not valid then
+        log.debug(HalService.name, "- invalid config:", valid_err)
+        return
+    end
+
+    for name, manager_config in pairs(config) do
+        if HalService.managers[name] then
+            local ok, apply_err = HalService.managers[name].apply_config(manager_config)
+            if not ok then
+                log.debug(HalService.name, "- failed to apply config for manager:", name, apply_err)
+            end
+        else
+            local ok, manager = pcall(require, "services.hal.managers." .. name)
+            if not ok then
+                log.debug("HAL: failed to load manager module for manager:", name)
+            else
+                ---@cast manager Manager
+                local start_err = manager.start(HalService.dev_ev_ch, HalService.cap_emit_ch)
+                if start_err ~= "" then
+                    log.debug(HalService.name, "- failed to start manager:", name, start_err)
+                else
+                    HalService.managers[name] = manager
+                end
+            end
+        end
+    end
+
+    for name, manager in pairs(HalService.managers) do
+        if not config[name] then
+            HalService.managers[name] = nil
+            fibers.current_scope():spawn(function()
+                manager.stop()
+            end)
+        end
+    end
+
+    log.trace("HAL: config update complete")
+end
+
+--- Creates initial utilities required for loading config which will bring up rest of HAL
+local function bootstrap()
+    local fs_manager = require "services.hal.managers.filesystem"
+    ---@cast fs_manager Manager
+
+    local fs_manager_err = fs_manager.start(HalService.dev_ev_ch, HalService.cap_emit_ch)
+    if fs_manager_err ~= "" then
+        error("HAL bootstrap failed: Failed to start filesystem manager: " .. fs_manager_err)
+    end
+
+    local ok, cfg_err = fs_manager.apply_config({
+        {
+            name = "config",
+            root = os.getenv("DEVICECODE_CONFIG_DIR")
+        }
+    })
+
+    if not ok then
+        error("HAL bootstrap failed: " .. tostring(cfg_err))
+    end
+
+    HalService.managers["filesystem"] = fs_manager
+end
+
 ---Spawns all HAL service long running fibers
 ---@param conn Connection
 ---@param opts any
@@ -339,21 +430,21 @@ function HalService.start(conn, opts)
         log.trace("HAL: stopped")
     end)
 
-    local modemcard_manager = require "services.hal.managers.modemcard"
-    HalService.managers.modemcard = modemcard_manager
+    -- bootstrap will start the filesystem manager and apply config which will bring up the rest of HAL
+    -- will also fail fast if not successful
+    bootstrap()
+    log.trace("HAL: Bootstrap successful")
 
-    for name, manager in pairs(HalService.managers) do
-        local err = manager.start(HalService.dev_ev_ch, HalService.cap_emit_ch)
-        if err ~= "" then
-            log.error("HAL failed to start " .. name .. " manager", err)
-        end
-    end
-
-    publish_status(conn, HalService.name, "running")
+    local config_sub = conn:subscribe({ 'cfg', HalService.name })
 
     while true do
-        local rpc_ops = {} -- choice needs at least 1 op to aviod fatal error
+        local ops = {
+            cap_emit = HalService.cap_emit_ch:get_op(),
+            device_event = HalService.dev_ev_ch:get_op(),
+            config = config_sub:recv_op(),
+        }
 
+        local rpc_ops = {}
         for _, class in pairs(HalService.capabilities) do
             for _, cap in pairs(class) do
                 for _, rpc_sub in pairs(cap.rpc) do
@@ -361,24 +452,16 @@ function HalService.start(conn, opts)
                 end
             end
         end
-
-        local manager_fault_ops = {}
-
-        for name, manager in pairs(HalService.managers) do
-            table.insert(manager_fault_ops, manager.scope:fault_op():wrap(function () return name end))
-        end
-
-        local ops = {
-            cap_emit = HalService.cap_emit_ch:get_op(),
-            device_event = HalService.dev_ev_ch:get_op()
-        }
-
         if #rpc_ops > 0 then
             ops.rpc = op.choice(unpack(rpc_ops))
         end
 
+        local manager_fault_ops = {}
+        for name, manager in pairs(HalService.managers) do
+            table.insert(manager_fault_ops, manager.scope:fault_op():wrap(function () return name end))
+        end
         if #manager_fault_ops > 0 then
-            ops.modem_manager_fault = op.choice(unpack(manager_fault_ops))
+            ops.manager_fault = op.choice(unpack(manager_fault_ops))
         end
 
         local source, msg = perform(op.named_choice(ops))
@@ -389,11 +472,13 @@ function HalService.start(conn, opts)
             on_cap_emit(conn, msg)
         elseif source == 'device_event' then
             on_device_event(conn, msg)
-        elseif source == 'modem_manager_fault' then
+        elseif source == 'config' then
+            on_config(msg.payload)
+        elseif source == 'manager_fault' then
             local name = msg
             local manager = HalService.managers[name]
             if manager then
-                log.error("HAL: modem manager fault detected")
+                log.error(("HAL: %s manager fault detected"):format(name))
                 manager.stop()
                 HalService.managers[name] = nil
             end

--- a/src/services/hal.lua
+++ b/src/services/hal.lua
@@ -361,12 +361,7 @@ local function on_config(config)
     end
 
     for name, manager_config in pairs(config) do
-        if HalService.managers[name] then
-            local ok, apply_err = HalService.managers[name].apply_config(manager_config)
-            if not ok then
-                log.debug(HalService.name, "- failed to apply config for manager:", name, apply_err)
-            end
-        else
+        if not HalService.managers[name] then
             local ok, manager = pcall(require, "services.hal.managers." .. name)
             if not ok then
                 log.debug("HAL: failed to load manager module for manager:", name)
@@ -378,6 +373,14 @@ local function on_config(config)
                 else
                     HalService.managers[name] = manager
                 end
+            end
+        end
+
+        local manager = HalService.managers[name]
+        if manager then
+            local ok, apply_err = manager.apply_config(manager_config)
+            if not ok then
+                log.debug(HalService.name, "- failed to apply config for manager:", name, apply_err)
             end
         end
     end

--- a/src/services/hal.lua
+++ b/src/services/hal.lua
@@ -219,7 +219,7 @@ local function on_cap_ctrl(conn, msg)
         if msg.reply_to then
             local ok, pub_err = conn:publish_one(msg.reply_to, reply)
             if not ok then
-                log.debug(HalService.name, "-", pub_err)
+                log.debug("HAL - failed to send control response for ", class, id, verb, ": ", pub_err)
             end
         end
     end)
@@ -232,7 +232,14 @@ local function on_cap_emit(conn, emit)
         log.debug(HalService.name, "- invalid emit message")
         return
     end
-    conn:publish({ 'cap', emit.class, emit.id, emit.mode, emit.key }, emit.data)
+    local topic = { 'cap', emit.class, emit.id, emit.mode, emit.key }
+
+    -- Events are in the moment but state and meta can be held on the bus
+    if emit.mode == 'event' then
+        conn:publish(topic, emit.data)
+    else
+        conn:retain(topic, emit.data)
+    end
 end
 
 ---Adds a device and its capabilities to HAL and broadcasts event to bus
@@ -458,7 +465,7 @@ function HalService.start(conn, opts)
 
         local manager_fault_ops = {}
         for name, manager in pairs(HalService.managers) do
-            table.insert(manager_fault_ops, manager.scope:fault_op():wrap(function () return name end))
+            table.insert(manager_fault_ops, manager.scope:fault_op():wrap(function() return name end))
         end
         if #manager_fault_ops > 0 then
             ops.manager_fault = op.choice(unpack(manager_fault_ops))

--- a/src/services/hal.lua
+++ b/src/services/hal.lua
@@ -1,243 +1,348 @@
--- services/hal.lua
---
--- HAL service: owns all OS/filesystem interactions for persisted state.
---
--- Env:
---   DEVICECODE_STATE_DIR           required
---   DEVICECODE_STATE_NS_ROOT       optional (default: "state")
---
--- Announce (retained):
---   {'svc', <name>, 'announce'} payload { role="hal", rpc_root={...}, ts=... }
---
--- RPC endpoints (lane B, under rpc_root):
---   <rpc_root + {'read_state'}>  payload { ns=string, key=string } -> { ok=true, found=bool, data=string? } | { ok=false, err=string }
---   <rpc_root + {'write_state'}> payload { ns=string, key=string, data=string } -> { ok=true } | { ok=false, err=string }
---   <rpc_root + {'ping'}>        payload {} -> { ok=true, now=number }
+-- HAL modules
+local types = require "services.hal.types.core"
 
-local op      = require 'fibers.op'
-local runtime = require 'fibers.runtime'
-local perform = require 'fibers.performer'.perform
+-- Fibers modules
+local fibers = require "fibers"
+local op = require "fibers.op"
+local channel = require "fibers.channel"
 
-local mailbox = require 'fibers.mailbox' -- used only for type availability (optional)
-local M = {}
+local perform = fibers.perform
+local spawn = fibers.spawn
+local now = fibers.now
 
-local function t(...)
-	return { ... }
+-- General modules
+local log = require "services.log"
+
+local DEFAULT_Q_LEN = 10
+
+-- Topic helpers
+
+---@param class DeviceClass
+---@param id DeviceId
+---@return string[] topic
+local function t_dev_event(class, id)
+    return { 'dev', class, id, 'event' }
 end
 
-local function now()
-	return runtime.now()
+---@param class DeviceClass
+---@param id DeviceId
+---@return string[] topic
+local function t_dev_meta(class, id)
+    return { 'dev', class, id, 'meta' }
 end
 
-local function require_env(name)
-	local v = os.getenv(name)
-	if not v or v == '' then
-		error(('missing required environment variable %s'):format(name), 2)
-	end
-	return v
+---@param class DeviceClass
+---@param id DeviceId
+---@return string[] topic
+local function t_dev_state(class, id)
+    return { 'dev', class, id, 'state' }
 end
 
-local function shell_quote(s)
-	-- Minimal single-quote shell escaping.
-	s = tostring(s)
-	return "'" .. s:gsub("'", [['"'"']]) .. "'"
+---@param class CapabilityClass
+---@param id CapabilityId
+---@return string[] topic
+local function t_cap_meta(class, id)
+    return { 'cap', class, id, 'meta' }
 end
 
-local function valid_name(s)
-	return type(s) == 'string' and s:match('^[A-Za-z0-9][A-Za-z0-9._-]*$') ~= nil
+---@param class CapabilityClass
+---@param id CapabilityId
+---@return string[] topic
+local function t_cap_state(class, id)
+    return { 'cap', class, id, 'state' }
 end
 
+---@class HalService
+---@field name string
+---@field cap_emit_ch Channel
+---@field dev_ev_ch Channel
+---@field managers table<string, Manager>
+---@field devices table<string, Device>
+---@field capabilities table<string, Capability>
+local HalService = {
+    cap_emit_ch = channel.new(DEFAULT_Q_LEN), -- capability emits of state, meta or events
+    dev_ev_ch = channel.new(DEFAULT_Q_LEN), -- manager emits of device events (added/removed)
+    managers = {},
+    devices = {},
+    capabilities = {},
+}
+
+---Publishes the HAL service status
+---@param conn Connection
+---@param name string
+---@param state string
+---@param extra table?
 local function publish_status(conn, name, state, extra)
-	local payload = { state = state, ts = now() }
-	if type(extra) == 'table' then
-		for k, v in pairs(extra) do payload[k] = v end
-	end
-	conn:retain(t('svc', name, 'status'), payload)
+    local payload = { state = state, ts = now() }
+    if type(extra) == 'table' then
+        for k, v in pairs(extra) do payload[k] = v end
+    end
+    conn:retain({ 'svc', name, 'status' }, payload)
 end
 
--------------------------------------------------------------------------------
--- FS backend
--------------------------------------------------------------------------------
-
-local function join_path(a, b, c, d)
-	if d ~= nil then
-		return a .. '/' .. b .. '/' .. c .. '/' .. d
-	end
-	return a .. '/' .. b .. '/' .. c
+---Validates class string
+---@param class CapabilityClass|DeviceClass
+---@return boolean
+local function class_valid(class)
+    return type(class) == 'string' and class ~= ''
 end
 
-local function mkdir_p(path)
-	-- Busybox-compatible and acceptable within HAL.
-	local cmd = 'mkdir -p ' .. shell_quote(path)
-	local ok = os.execute(cmd)
-	return ok == true or ok == 0
+---Validates id string or number
+---@param id CapabilityId|DeviceId
+---@return boolean
+local function id_valid(id)
+    return (type(id) == 'string' and id ~= '') or (type(id) == 'number' and id >= 0)
 end
 
-local function read_file(p)
-	local f, err = io.open(p, 'rb')
-	if not f then return nil, err end
-	local data = f:read('*a')
-	f:close()
-	return data or '', nil
+---Gets the device instance or returns nil
+---@param class DeviceClass
+---@param id DeviceId
+---@return Device?
+local function get_device(class, id)
+    local devices = HalService.devices[class]
+    if not devices then return nil end
+    return devices[id]
 end
 
-local function write_atomic(p, data)
-	local tmp = p .. '.tmp.' .. tostring(math.random(1, 1e9))
-	local f, err = io.open(tmp, 'wb')
-	if not f then return nil, err end
-
-	local ok_w, werr = pcall(function () f:write(data) end)
-	f:close()
-
-	if not ok_w then
-		pcall(function () os.remove(tmp) end)
-		return nil, tostring(werr)
-	end
-
-	local ok, rerr = os.rename(tmp, p)
-	if not ok then
-		pcall(function () os.remove(tmp) end)
-		return nil, tostring(rerr)
-	end
-	return true, nil
+---Sets the device instance
+---@param class DeviceClass
+---@param id DeviceId
+---@param device_inst Device
+---@return string? error
+local function set_device(class, id, device_inst)
+    HalService.devices[class] = HalService.devices[class] or {}
+    if HalService.devices[class][id] then
+        return "device already exists"
+    end
+    HalService.devices[class][id] = device_inst
 end
 
-function M.new_fs_backend(state_dir, opts)
-	opts = opts or {}
-	local ns_root = opts.ns_root or 'state'
-	local ext     = opts.ext or '.json'
-
-	local function path_for(ns, key)
-		if not valid_name(ns) then return nil, 'invalid ns' end
-		if not valid_name(key) then return nil, 'invalid key' end
-		local dir = join_path(state_dir, ns_root, ns)
-		local p   = join_path(state_dir, ns_root, ns, key .. ext)
-		return dir, p
-	end
-
-	return {
-		read_state = function (_, ns, key)
-			local _, p = path_for(ns, key)
-			local data, err = read_file(p)
-			if not data then
-				return nil, 'not_found:' .. tostring(err)
-			end
-			return data, nil
-		end,
-
-		write_state = function (_, ns, key, data)
-			local dir, p = path_for(ns, key)
-			if not mkdir_p(dir) then
-				return nil, 'failed to create state directory'
-			end
-			local ok, err = write_atomic(p, data)
-			if not ok then return nil, err end
-			return true, nil
-		end,
-	}
+---Removes the device instance
+---@param class DeviceClass
+---@param id DeviceId
+---@return string? error
+local function remove_device(class, id)
+    local devices = HalService.devices[class]
+    if not devices or not devices[id] then
+        return "device does not exist"
+    end
+    HalService.devices[class][id] = nil
 end
 
--- In-memory backend for unit tests.
-function M.new_mem_backend(initial)
-	local store = {}
-	if type(initial) == 'table' then
-		for k, v in pairs(initial) do store[k] = v end
-	end
-	local function k(ns, key) return tostring(ns) .. '/' .. tostring(key) end
-
-	return {
-		read_state = function (_, ns, key)
-			local v = store[k(ns, key)]
-			if v == nil then return nil, 'not_found' end
-			return v, nil
-		end,
-		write_state = function (_, ns, key, data)
-			store[k(ns, key)] = data
-			return true, nil
-		end,
-		_store = store,
-	}
+---Gets the capability instance or returns nil
+---@param class CapabilityClass
+---@param id CapabilityId
+---@return Capability?
+local function get_cap(class, id)
+    local caps = HalService.capabilities[class]
+    if not caps then return nil end
+    return caps[id]
 end
 
--------------------------------------------------------------------------------
--- Service
--------------------------------------------------------------------------------
-
-function M.start(conn, opts)
-	opts = opts or {}
-	local name = opts.name or 'hal'
-
-	local state_dir = require_env('DEVICECODE_STATE_DIR')
-	local ns_root   = os.getenv('DEVICECODE_STATE_NS_ROOT') or 'state'
-
-	local backend = opts.backend or M.new_fs_backend(state_dir, { ns_root = ns_root })
-
-	local rpc_root = t('svc', name, 'rpc')
-
-	conn:retain(t('svc', name, 'announce'), {
-		role     = 'hal',
-		rpc_root = rpc_root,
-		ts       = now(),
-	})
-
-	publish_status(conn, name, 'starting')
-
-	local ep_read  = conn:bind({ rpc_root[1], rpc_root[2], rpc_root[3], 'read_state' })
-	local ep_write = conn:bind({ rpc_root[1], rpc_root[2], rpc_root[3], 'write_state' })
-	local ep_ping  = conn:bind({ rpc_root[1], rpc_root[2], rpc_root[3], 'ping' })
-
-	publish_status(conn, name, 'running')
-
-	while true do
-		local which, msg, err = perform(op.named_choice({
-			read  = ep_read:recv_op(),
-			write = ep_write:recv_op(),
-			ping  = ep_ping:recv_op(),
-		}))
-
-		if not msg then
-			publish_status(conn, name, 'stopped', { reason = err })
-			return
-		end
-
-		local function reply(payload)
-			if msg.reply_to ~= nil then
-				conn:publish_one(msg.reply_to, payload, { id = msg.id })
-			end
-		end
-
-		if which == 'ping' then
-			reply({ ok = true, now = now() })
-
-		elseif which == 'read' then
-			local p = msg.payload or {}
-			local ns, key = p.ns, p.key
-			if not valid_name(ns) or not valid_name(key) then
-				reply({ ok = false, err = 'invalid ns/key' })
-			else
-				local data, rerr = backend:read_state(ns, key)
-				if data ~= nil then
-					reply({ ok = true, found = true, data = data })
-				else
-					reply({ ok = true, found = false, err = rerr })
-				end
-			end
-
-		elseif which == 'write' then
-			local p = msg.payload or {}
-			local ns, key, data = p.ns, p.key, p.data
-			if not valid_name(ns) or not valid_name(key) or type(data) ~= 'string' then
-				reply({ ok = false, err = 'invalid ns/key/data' })
-			else
-				local ok_w, werr = backend:write_state(ns, key, data)
-				if ok_w then
-					reply({ ok = true })
-				else
-					reply({ ok = false, err = tostring(werr) })
-				end
-			end
-		end
-	end
+---Sets the capability instance
+---@param class CapabilityClass
+---@param id CapabilityId
+---@param cap_inst Capability
+---@return string? error
+local function set_cap(class, id, cap_inst)
+    HalService.capabilities[class] = HalService.capabilities[class] or {}
+    if HalService.capabilities[class][id] then
+        return "capability already exists"
+    end
+    HalService.capabilities[class][id] = cap_inst
 end
 
-return M
+---Removes the capability instance
+---@param class CapabilityClass
+---@param id CapabilityId
+---@return string? error
+local function remove_cap(class, id)
+    local caps = HalService.capabilities[class]
+    if not caps or not caps[id] then
+        return "capability does not exist"
+    end
+    HalService.capabilities[class][id] = nil
+end
+
+---Handles running driver functions for control requests
+---@param conn Connection
+---@param msg Message
+local function on_cap_ctrl(conn, msg)
+    local class, id, verb = msg.topic[2], msg.topic[3], msg.topic[5]
+
+    if not class_valid(class) then
+        log.debug(HalService.name, "- invalid class")
+        return
+    end
+
+    if not id_valid(id) then
+        log.debug(HalService.name, "- invalid id")
+        return
+    end
+
+    local control_req, ctrl_req_err = types.new.ControlRequest(
+        verb,
+        msg.payload,
+        channel.new()
+    )
+    if not control_req then
+        log.debug(HalService.name, "-", ctrl_req_err)
+        return
+    end
+
+    local cap_inst = get_cap(class, id)
+    if not cap_inst then return end -- could be a capability owned by another service
+
+    if not cap_inst.offerings[verb] then
+        log.debug(HalService.name, "- capability", class, "does not offer verb:", verb)
+        return
+    end
+
+    spawn(function()
+        cap_inst.control_ch:put(control_req)
+        local reply, reply_err = control_req.reply_ch:get()
+        if not reply then
+            reply = types.new.Reply(false, reply_err)
+        end
+        if msg.reply_to then
+            local ok, pub_err = conn:publish_one(msg.reply_to, reply)
+            if not ok then
+                log.debug(HalService.name, "-", pub_err)
+            end
+        end
+    end)
+end
+
+---@param conn Connection
+---@param emit Emit
+local function on_cap_emit(conn, emit)
+    if getmetatable(emit) ~= types.Emit then
+        log.debug(HalService.name, "- invalid emit message")
+        return
+    end
+    conn:publish({ 'cap', emit.class, emit.id, emit.mode, emit.key }, emit.data)
+end
+
+---Adds a device and its capabilities to HAL and broadcasts event to bus
+---@param conn Connection
+---@param event_type EventType
+---@param device Device
+local function register_device(conn, event_type, device)
+    local set_err = set_device(device.class, device.id, device)
+    if set_err then
+        log.debug(HalService.name, "-", set_err)
+        return
+    end
+
+    for _, cap in ipairs(device.capabilities) do
+        local cap_set_err = set_cap(cap.class, cap.id, cap)
+        if cap_set_err then
+            log.debug(HalService.name, "-", cap_set_err)
+        else
+            conn:retain(t_cap_state(cap.class, cap.id), event_type)
+            conn:retain(t_cap_meta(cap.class, cap.id), { offerings = cap.offerings })
+        end
+    end
+
+    conn:retain(t_dev_meta(device.class, device.id), device.meta)
+    conn:retain(t_dev_state(device.class, device.id), event_type)
+end
+
+---Removes a device and its capabilities from HAL and broadcasts event to bus
+---@param conn Connection
+---@param event_type EventType
+---@param device Device
+local function unregister_device(conn, event_type, device)
+    for _, cap in ipairs(device.capabilities) do
+        local cap_remove_err = remove_cap(cap.class, cap.id)
+        if cap_remove_err then
+            log.debug(HalService.name, "-", cap_remove_err)
+        else
+            conn:retain(t_cap_state(cap.class, cap.id), event_type)
+            conn:unretain(t_cap_meta(cap.class, cap.id))
+        end
+    end
+
+    local remove_err = remove_device(device.class, device.id)
+    if remove_err then
+        log.debug(HalService.name, "-", remove_err)
+        return
+    end
+    conn:unretain(t_dev_meta(device.class, device.id))
+    conn:retain(t_dev_state(device.class, device.id), event_type)
+end
+
+---@param conn Connection
+---@param device_event DeviceEvent
+local function on_device_event(conn, device_event)
+    if getmetatable(device_event) ~= types.DeviceEvent then
+        log.debug(HalService.name, "- invalid device event message")
+        return
+    end
+
+    if device_event.event_type == 'added' then
+        local dev_inst, dev_err = types.new.Device(
+            device_event.class,
+            device_event.id,
+            device_event.meta,
+            device_event.capabilities
+        )
+        if not dev_inst then
+            log.debug(HalService.name, "-", dev_err)
+            return
+        end
+        register_device(conn, device_event.event_type, dev_inst)
+    elseif device_event.event_type == 'removed' then
+        local dev_inst = get_device(device_event.class, device_event.id)
+        if not dev_inst then
+            log.debug(HalService.name, "- device does not exist")
+            return
+        end
+        unregister_device(conn, device_event.event_type, dev_inst)
+    else
+        log.debug(HalService.name,
+            "- unhandled device event type for ",
+            device_event.class,
+            device_event.id,
+            device_event.event_type
+        )
+        return
+    end
+end
+
+
+---Spawns all HAL service long running fibers
+---@param conn Connection
+---@param opts any
+function HalService.start(conn, opts)
+    HalService.name = opts.name or "hal"
+    publish_status(conn, HalService.name, "starting")
+
+    local cap_ctrl_sub = conn:bind({ 'cap', '+', '+', 'rpc', '+' })
+
+    -- Setup managers based on hard-coded config here
+
+    publish_status(conn, HalService.name, "running")
+
+    fibers.current_scope():finally(function ()
+        publish_status(conn, HalService.name, "stopped")
+    end)
+
+    while true do
+        local source, msg = perform(op.named_choice({
+            cap_ctrl = cap_ctrl_sub:recv_op(),
+            cap_emit = HalService.cap_emit_ch:get_op(),
+            device_event = HalService.dev_ev_ch:get_op()
+        }))
+
+        if source == 'cap_ctrl' then
+            on_cap_ctrl(conn, msg)
+        elseif source == 'cap_emit' then
+            on_cap_emit(conn, msg)
+        elseif source == 'device_event' then
+            on_device_event(conn, msg)
+        end
+    end
+end
+
+return HalService

--- a/src/services/hal/backends/fetch.lua
+++ b/src/services/hal/backends/fetch.lua
@@ -14,7 +14,7 @@ local function get_cached_value(identity, key, cache, ret_type, timeout, fetch_f
 
     local err = fetch_fn(identity, cache)
     if err ~= "" then
-        return nil, "Failed to fetch modem info: " .. tostring(err)
+        return nil, "Failed to fetch info: " .. tostring(err)
     end
 
     local value = cache:get(key, timeout)

--- a/src/services/hal/backends/fetch.lua
+++ b/src/services/hal/backends/fetch.lua
@@ -1,0 +1,34 @@
+--- Default try to get value from cache, if not present fetch modem info and try again
+---@param identity ModemIdentity
+---@param key string
+---@param cache Cache
+---@param ret_type string
+---@param timeout number?
+---@return any value
+---@return string error
+local function get_cached_value(identity, key, cache, ret_type, timeout, fetch_fn)
+    local cached = cache:get(key, timeout)
+    if cached then
+        return cached, ""
+    end
+
+    local err = fetch_fn(identity, cache)
+    if err ~= "" then
+        return nil, "Failed to fetch modem info: " .. tostring(err)
+    end
+
+    local value = cache:get(key, timeout)
+    if not value then
+        return nil, "Value not found in cache after refresh: " .. tostring(key)
+    end
+
+    if type(value) == ret_type then
+        return value, ""
+    else
+        return nil, "Cached value has wrong type: expected " .. ret_type .. ", got " .. type(value)
+    end
+end
+
+return {
+    get_cached_value = get_cached_value,
+}

--- a/src/services/hal/backends/modem/at.lua
+++ b/src/services/hal/backends/modem/at.lua
@@ -1,11 +1,36 @@
 package.path = '/usr/lib/lua/?.lua;/usr/lib/lua/?/init.lua;' .. package.path
 
-local file = require 'fibers.io.file'
-local fibers = require 'fibers'
+local file  = require 'fibers.io.file'
+local scope = require 'fibers.scope'
 
 ---@alias ATCommand string
 ---@alias SerialPortPath string
 ---@alias ATResponseLine string
+
+---@class ATTerminalPattern
+---@field pattern string  Lua pattern matched against trimmed lines
+---@field is_error boolean  When true the matched line is returned as an error string
+
+---@class ATSendOpts
+---@field terminal_patterns ATTerminalPattern[]?
+
+-- Usage example:
+--
+--   local op     = require 'fibers.op'
+--   local sleep  = require 'fibers.sleep'
+--   local fibers = require 'fibers'
+--
+--   while true do
+--       local src, lines, err = fibers.perform(op.named_choice({
+--           response = at.send_op(port, "AT+QGMR"),
+--           timeout  = sleep.sleep_op(5),
+--       }))
+--       if src == "response" then
+--           -- lines: ATResponseLine[]?, err: string?
+--           break
+--       end
+--       -- timeout arm: loop retries with a fresh op; port re-opened cleanly
+--   end
 
 local function trim(input)
     -- Pattern matches non-printable characters and spaces at the start and end of the string
@@ -17,70 +42,85 @@ end
 ---@class AT
 local at = {}
 
----Send an AT command to a serial port and collect response lines until OK/ERROR.
+---Return an Op that sends an AT command and collects response lines until a
+---terminal line is hit.
 ---
----Notes:
---- - Returns a list of non-empty response lines.
---- - On success, error is nil.
---- - On error, error may be a generic string ('error', 'unknown error') or a
----   numeric string parsed from +CME/+CMS.
+---The Op yields `(lines, err)`:
+--- - On success: `lines` is a list of non-empty response lines, `err` is nil.
+--- - On AT error: `lines` is the accumulated lines so far, `err` is a string
+---   (`'error'`, `'unknown error'`, or a numeric code string from +CME/+CMS).
+--- - On cancellation (e.g. the op loses a race against a timeout): `lines` is
+---   nil, `err` is `'cancelled'`. The port is closed as part of losing the race.
+---
+---`opts.terminal_patterns` is an optional list of additional terminal patterns.
+---Each entry is `{ pattern = string, is_error = bool }`. When a trimmed line
+---matches, that line is appended to `lines` and the op completes. If `is_error`
+---is true, the matched line is also returned as `err`.
+---
 ---@param port SerialPortPath
 ---@param command ATCommand
----@return ATResponseLine[]? lines
----@return string error
-function at.send(port, command)
-    local st, _, err, result = fibers.run_scope(function()
+---@param opts ATSendOpts?
+---@return Op  -- yields (ATResponseLine[]?, string?)
+function at.send_op(port, command, opts)
+    local terminal_patterns = (opts and opts.terminal_patterns) or {}
+
+    return scope.run_op(function(s)
         local reader, rd_err = file.open(port, "r")
-        if not reader then return "error opening AT read port: " .. rd_err, nil end
+        if not reader then
+            return nil, "error opening AT read port: " .. rd_err
+        end
+
+        -- Centralised cleanup: reader is closed however this scope exits
+        -- (success, AT error, unhandled error, or cancelled by losing a race).
+        s:finally(function() reader:close() end)
 
         local writer, wr_err = file.open(port, "w")
-        if not writer then return "error opening AT write port: " .. wr_err, nil end
+        if not writer then
+            return nil, "error opening AT write port: " .. wr_err
+        end
 
-        -- file write
         writer:write(command .. '\r')
-
         writer:close()
 
         local res = {}
-
         while true do
-            local line = reader:read_line()
+            local line, read_err = s:perform(reader:read_line_op())
 
-            if not line then return "unknown error", nil end
+            if not line then
+                return nil, read_err or "unknown error"
+            end
 
             line = trim(line)
 
-            -- check for non-descriptive success/fail
+            -- Built-in terminals
             if line:find("^OK$") then
-                reader:close()
-                return "", res
+                return res, nil
             elseif line:find("^ERROR$") then
-                reader:close()
-                return 'error', res
+                return res, "error"
             else
-                -- check for descriptive fail
-                local error_code
-                error_code = line:match("^%+CME ERROR: (%d+)$")
+                local error_code = line:match("^%+CME ERROR: (%d+)$")
+                                or line:match("^%+CMS ERROR: (%d+)$")
                 if error_code then
-                    reader:close()
-                    return error_code, res
+                    return res, error_code
                 end
-                error_code = line:match("^%+CMS ERROR: (%d+)$")
-                if error_code then
-                    reader:close()
-                    return error_code, res
+            end
+
+            -- User-supplied terminal patterns
+            for _, tp in ipairs(terminal_patterns) do
+                if line:find(tp.pattern) then
+                    table.insert(res, line)
+                    return res, tp.is_error and line or nil
                 end
             end
 
             if #line > 0 then table.insert(res, line) end
         end
+    end):wrap(function(st, _report, a, b)
+        if st == 'ok' then return a, b end
+        if st == 'cancelled' then return nil, 'cancelled' end
+        -- 'failed': a is the primary error string
+        return nil, a or "AT command failed"
     end)
-
-    if st == 'ok' then
-        return result, ""
-    else
-        return nil, err or "AT command failed"
-    end
 end
 
 return at

--- a/src/services/hal/backends/modem/at.lua
+++ b/src/services/hal/backends/modem/at.lua
@@ -30,14 +30,14 @@ local at = {}
 ---@return string error
 function at.send(port, command)
     local st, _, err, result = fibers.run_scope(function()
-        local reader, err = file.open(port, "r")
-        if not reader then return "error opening AT read port: " .. err, nil end
+        local reader, rd_err = file.open(port, "r")
+        if not reader then return "error opening AT read port: " .. rd_err, nil end
 
-        local writer = assert(file.open(port, "w"))
-        if not writer then return "error opening AT write port: " .. err, nil end
+        local writer, wr_err = file.open(port, "w")
+        if not writer then return "error opening AT write port: " .. wr_err, nil end
 
         -- file write
-        writer:write_chars(command .. '\r')
+        writer:write(command .. '\r')
 
         writer:close()
 
@@ -46,17 +46,17 @@ function at.send(port, command)
         while true do
             local line = reader:read_line()
 
-            if not line then return 'unknown error', nil end
+            if not line then return "unknown error", nil end
 
             line = trim(line)
 
             -- check for non-descriptive success/fail
             if line:find("^OK$") then
                 reader:close()
-                return res, nil
+                return "", res
             elseif line:find("^ERROR$") then
                 reader:close()
-                return res, 'error'
+                return 'error', res
             else
                 -- check for descriptive fail
                 local error_code

--- a/src/services/hal/backends/modem/at.lua
+++ b/src/services/hal/backends/modem/at.lua
@@ -1,0 +1,86 @@
+package.path = '/usr/lib/lua/?.lua;/usr/lib/lua/?/init.lua;' .. package.path
+
+local file = require 'fibers.io.file'
+local fibers = require 'fibers'
+
+---@alias ATCommand string
+---@alias SerialPortPath string
+---@alias ATResponseLine string
+
+local function trim(input)
+    -- Pattern matches non-printable characters and spaces at the start and end of the string
+    -- %c matches control characters, %s matches all whitespace characters
+    -- %z matches the character with representation 0x00 (NUL byte)
+    return (input:gsub("^[%c%s%z]+", ""):gsub("[%c%s%z]+$", ""))
+end
+
+---@class AT
+local at = {}
+
+---Send an AT command to a serial port and collect response lines until OK/ERROR.
+---
+---Notes:
+--- - Returns a list of non-empty response lines.
+--- - On success, error is nil.
+--- - On error, error may be a generic string ('error', 'unknown error') or a
+---   numeric string parsed from +CME/+CMS.
+---@param port SerialPortPath
+---@param command ATCommand
+---@return ATResponseLine[]? lines
+---@return string error
+function at.send(port, command)
+    local st, _, err, result = fibers.run_scope(function()
+        local reader, err = file.open(port, "r")
+        if not reader then return "error opening AT read port: " .. err, nil end
+
+        local writer = assert(file.open(port, "w"))
+        if not writer then return "error opening AT write port: " .. err, nil end
+
+        -- file write
+        writer:write_chars(command .. '\r')
+
+        writer:close()
+
+        local res = {}
+
+        while true do
+            local line = reader:read_line()
+
+            if not line then return 'unknown error', nil end
+
+            line = trim(line)
+
+            -- check for non-descriptive success/fail
+            if line:find("^OK$") then
+                reader:close()
+                return res, nil
+            elseif line:find("^ERROR$") then
+                reader:close()
+                return res, 'error'
+            else
+                -- check for descriptive fail
+                local error_code
+                error_code = line:match("^%+CME ERROR: (%d+)$")
+                if error_code then
+                    reader:close()
+                    return error_code, res
+                end
+                error_code = line:match("^%+CMS ERROR: (%d+)$")
+                if error_code then
+                    reader:close()
+                    return error_code, res
+                end
+            end
+
+            if #line > 0 then table.insert(res, line) end
+        end
+    end)
+
+    if st == 'ok' then
+        return result, ""
+    else
+        return nil, err or "AT command failed"
+    end
+end
+
+return at

--- a/src/services/hal/backends/modem/contract.lua
+++ b/src/services/hal/backends/modem/contract.lua
@@ -31,6 +31,7 @@ local BACKEND_FUNCTIONS = list_to_map {
     "active_band_class",
     "firmware",
     "iccid",
+    "imsi",
 
     -- State monitoring
     "start_state_monitor",

--- a/src/services/hal/backends/modem/contract.lua
+++ b/src/services/hal/backends/modem/contract.lua
@@ -55,6 +55,27 @@ local BACKEND_FUNCTIONS = list_to_map {
     "set_signal_update_interval"
 }
 
+local MONITOR_FUNCTIONS = list_to_map {
+    "next_event_op",
+}
+
+--- Check that a modem monitor provides all required functions and no extras.
+---@param monitor ModemMonitor
+---@return string error
+local function validate_monitor(monitor)
+    for func in pairs(MONITOR_FUNCTIONS) do
+        if type(monitor[func]) ~= "function" then
+            return "Missing required function: " .. func
+        end
+    end
+    for key, value in pairs(monitor) do
+        if type(value) == "function" and not MONITOR_FUNCTIONS[key] then
+            return "Monitor provides unsupported function: " .. key
+        end
+    end
+    return ""
+end
+
 --- Check that a modem backend provides all required functions and no more
 ---@param backend ModemBackend
 ---@return string error
@@ -75,5 +96,6 @@ local function validate(backend)
 end
 
 return {
-    validate = validate
+    validate = validate,
+    validate_monitor = validate_monitor,
 }

--- a/src/services/hal/backends/modem/contract.lua
+++ b/src/services/hal/backends/modem/contract.lua
@@ -30,6 +30,7 @@ local BACKEND_FUNCTIONS = list_to_map {
     "gid1",
     "active_band_class",
     "firmware",
+    "iccid",
 
     -- State monitoring
     "start_state_monitor",

--- a/src/services/hal/backends/modem/contract.lua
+++ b/src/services/hal/backends/modem/contract.lua
@@ -29,8 +29,20 @@ local BACKEND_FUNCTIONS = list_to_map {
     "mnc",
     "gid1",
     "active_band_class",
+    "firmware",
 
-    -- others
+    -- State monitoring
+    "start_state_monitor",
+    "monitor_state_op",
+
+    -- SIM monitoring
+    "start_sim_presence_monitor",
+    "wait_for_sim_present_op",
+    "wait_for_sim_present",
+    "is_sim_present",
+    "trigger_sim_presence_check",
+
+    -- Control operations
     "enable",
     "disable",
     "reset",
@@ -38,11 +50,7 @@ local BACKEND_FUNCTIONS = list_to_map {
     "disconnect",
     "inhibit",
     "uninhibit",
-    "monitor_state_op",
-    "wait_for_sim_present_op",
-    "wait_for_sim_present",
-    "is_sim_present",
-    "trigger_sim_presence_check",
+    "set_signal_update_interval"
 }
 
 --- Check that a modem backend provides all required functions and no more

--- a/src/services/hal/backends/modem/iface.lua
+++ b/src/services/hal/backends/modem/iface.lua
@@ -1,0 +1,69 @@
+local function list_to_map(list)
+    local map = {}
+    for _, item in ipairs(list) do
+        map[item] = true
+    end
+    return map
+end
+
+local BACKEND_FUNCTIONS = list_to_map {
+    -- Getters
+    "imei",
+    "device",
+    "primary_port",
+    "at_ports",
+    "qmi_ports",
+    "gps_ports",
+    "net_ports",
+    "access_techs",
+    "sim",
+    "drivers",
+    "plugin",
+    "model",
+    "revision",
+    "operator",
+    "rx_bytes",
+    "tx_bytes",
+    "signal",
+    "mcc",
+    "mnc",
+    "gid1",
+    "active_band_class",
+
+    -- others
+    "enable",
+    "disable",
+    "reset",
+    "connect",
+    "disconnect",
+    "inhibit",
+    "uninhibit",
+    "monitor_state_op",
+    "wait_for_sim_present_op",
+    "wait_for_sim_present",
+    "is_sim_present",
+    "trigger_sim_presence_check",
+}
+
+--- Check that a modem backend provides all required functions and no more
+---@param backend ModemBackend
+---@return string error
+local function validate(backend)
+    for func, _ in pairs(BACKEND_FUNCTIONS) do
+        if type(backend[func]) ~= "function" then
+            return "Missing required function: " .. func
+        end
+    end
+
+    for key, value in pairs(backend) do
+        if type(value) == "function" and not BACKEND_FUNCTIONS[key] then
+            return "Backend provides unsupported function: " .. key
+        end
+    end
+
+    return ""
+end
+
+return {
+    validate = validate
+}

--- a/src/services/hal/backends/modem/models/fibocom.lua
+++ b/src/services/hal/backends/modem/models/fibocom.lua
@@ -1,0 +1,6 @@
+local function add_model_funcs(_, _, _)
+end
+
+return {
+    add_model_funcs = add_model_funcs
+}

--- a/src/services/hal/backends/modem/models/quectel.lua
+++ b/src/services/hal/backends/modem/models/quectel.lua
@@ -1,7 +1,11 @@
 local exec = require "fibers.io.exec"
 local fibers = require "fibers"
+local sleep = require "fibers.sleep"
+local op = require "fibers.op"
 
 local at = require "services.hal.backends.modem.at"
+
+local DEFAULT_TIMEOUT = 5
 
 local funcs = {
     -- This is a special case for the RM520N, it has a initial bearer which will always cause a
@@ -55,18 +59,31 @@ local funcs = {
             ---@cast backend ModemBackend
             local firmware = backend.cache:get("firmware")
             if firmware then return firmware, "" end
-            local lines, err = at.send(backend.identity.at_port, "AT+QGMR")
-            if err ~= "" then
+            local at_send_op = at.send_op(backend.identity.at_port, "AT+QGMR", {
+                terminal_patterns = {
+                    { pattern = "^%w+_%w+%.%w+%.%w+%.%w+$", is_error = false }
+                }
+            })
+            local source, resp, err = fibers.perform(op.named_choice({
+                at = at_send_op,
+                timeout = sleep.sleep_op(DEFAULT_TIMEOUT)
+            }))
+
+            if err then
                 return nil, "Failed to get firmware version: " .. err
             end
-            for _, line in ipairs(lines or {}) do
-                local firmware_version = string.match(line, "([%w]+_[%w]+%.[%w]+%.[%w]+%.[%w]+)")
+
+            if source == "timeout" then
+                return nil, "Timed out while getting firmware version"
+            elseif source == "at" then
+                local firmware_version = string.match(resp[#resp], "([%w]+_[%w]+%.[%w]+%.[%w]+%.[%w]+)")
                 if firmware_version then
                     backend.cache:set("firmware", firmware_version)
                     return firmware_version, ""
+                else
+                    return nil, "Firmware version not found in AT response"
                 end
             end
-            return nil, "Firmware version not found in AT response"
         end
     }
     -- Other functions

--- a/src/services/hal/backends/modem/models/quectel.lua
+++ b/src/services/hal/backends/modem/models/quectel.lua
@@ -59,13 +59,11 @@ local funcs = {
             if err ~= "" then
                 return nil, "Failed to get firmware version: " .. err
             end
-            if lines then
-                for _, line in ipairs(lines) do
-                    local fw = line:match("Revision:%s*(%S+)")
-                    if fw then
-                        backend.cache:set("firmware", fw)
-                        return fw, ""
-                    end
+            for _, line in ipairs(lines or {}) do
+                local firmware_version = string.match(line, "([%w]+_[%w]+%.[%w]+%.[%w]+%.[%w]+)")
+                if firmware_version then
+                    backend.cache:set("firmware", firmware_version)
+                    return firmware_version, ""
                 end
             end
             return nil, "Firmware version not found in AT response"

--- a/src/services/hal/backends/modem/models/quectel.lua
+++ b/src/services/hal/backends/modem/models/quectel.lua
@@ -1,0 +1,94 @@
+local exec = require "fibers.io.exec"
+local fibers = require "fibers"
+
+local at = require "services.hal.backends.modem.at"
+
+local funcs = {
+    -- This is a special case for the RM520N, it has a initial bearer which will always cause a
+    -- multiple PDN failure unless set to the APN we want to use OR set to empty.
+    {
+        name = 'connect',
+        conditionals = {
+            function(backend, model, _)
+                return model == 'rm520n' and backend.base == "linux_mm"
+            end
+        },
+        func = function(backend, connection_string)
+            local st, _, result_or_err = fibers.run_scope(function()
+                local cmd_clear = exec.command {
+                    "mmcli", "-m", backend.identity.address, "--3gpp-set-initial-eps-bearer-settings=apn=",
+                    stdin = "null",
+                    stdout = "pipe",
+                    stderr = "stdout"
+                }
+                local _, status, code, _, err = fibers.perform(cmd_clear:combined_output_op())
+                if status ~= "exited" or code ~= 0 then
+                    error(err or "Failed to clear initial bearer settings")
+                end
+                local connect_cmd = exec.command {
+                    "mmcli", "-m", backend.identity.address, "--connect=" .. connection_string,
+                    stdin = "null",
+                    stdout = "pipe",
+                    stderr = "stdout"
+                }
+                local out, conn_status, conn_code, _, conn_err = fibers.perform(connect_cmd:combined_output_op())
+                if conn_status ~= "exited" or conn_code ~= 0 then
+                    error(conn_err or "Failed to connect")
+                end
+                return out
+            end)
+            if st == "ok" then
+                return result_or_err, ""
+            else
+                return false, result_or_err or "Command failed"
+            end
+        end
+    },
+    {
+        name = 'firmware',
+        conditionals = {
+            function(_, model, _)
+                return model == 'rm520n' or model == 'eg25' or model == 'ec25' or model == 'em12'
+            end
+        },
+        func = function(backend)
+            ---@cast backend ModemBackend
+            local firmware = backend.cache:get("firmware")
+            if firmware then return firmware, "" end
+            local lines, err = at.send(backend.identity.at_port, "AT+QGMR")
+            if err ~= "" then
+                return nil, "Failed to get firmware version: " .. err
+            end
+            if lines then
+                for _, line in ipairs(lines) do
+                    local fw = line:match("Revision:%s*(%S+)")
+                    if fw then
+                        backend.cache:set("firmware", fw)
+                        return fw, ""
+                    end
+                end
+            end
+            return nil, "Firmware version not found in AT response"
+        end
+    }
+    -- Other functions
+}
+
+--- Add model specific functions to the backend
+---@param backend ModemBackend
+---@param model string
+---@param variant string
+local function add_model_funcs(backend, model, variant)
+    for _, f in ipairs(funcs) do
+        for _, cond in ipairs(f.conditionals) do
+            if cond(backend, model, variant) then
+                backend[f.name] = f.func
+                break
+            end
+        end
+    end
+end
+
+return {
+    add_model_funcs = add_model_funcs
+}

--- a/src/services/hal/backends/modem/modes/mbim.lua
+++ b/src/services/hal/backends/modem/modes/mbim.lua
@@ -1,0 +1,6 @@
+local function add_mode_funcs(_)
+end
+
+return {
+    add_mode_funcs = add_mode_funcs
+}

--- a/src/services/hal/backends/modem/modes/qmi.lua
+++ b/src/services/hal/backends/modem/modes/qmi.lua
@@ -28,26 +28,28 @@ end
 ---@param cache Cache
 ---@return string error
 local function fetch_home_network_info(identity, cache)
-    local cmd = exec.command {
-        "qmicli", "-p", "-d", identity.mode_port, "--nas-get-home-network",
-        stdin = "null",
-        stdout = "pipe",
-        stderr = "stdout"
-    }
-    local out, status, code, _, err = fibers.perform(cmd:combined_output_op())
-    if status ~= "exited" or code ~= 0 then
-        return "Failed to execute qmicli command: " .. tostring(err)
-    end
+    local st, _, err = fibers.run_scope(function()
+        local cmd = exec.command {
+            "qmicli", "-p", "-d", identity.mode_port, "--nas-get-home-network",
+            stdin = "null",
+            stdout = "pipe",
+            stderr = "stdout"
+        }
+        local out, status, code, _, err = fibers.perform(cmd:combined_output_op())
+        if status ~= "exited" or code ~= 0 then
+            error("Failed to execute qmicli command: " .. tostring(err))
+        end
 
-    local mcc = out:match("MCC:%s+'(%d+)'")
-    local mnc = out:match("MNC:%s+'(%d+)'")
-    if not mcc or not mnc then
-        return "Failed to parse qmicli output: " .. tostring(out)
-    end
+        local mcc = out:match("MCC:%s+'(%d+)'")
+        local mnc = out:match("MNC:%s+'(%d+)'")
+        if not mcc or not mnc then
+            error("Failed to parse qmicli output: " .. tostring(out))
+        end
 
-    cache:set("mcc", mcc)
-    cache:set("mnc", mnc)
-    return ""
+        cache:set("mcc", mcc)
+        cache:set("mnc", mnc)
+    end)
+    return st ~= "ok" and err or ""
 end
 
 --- Gets gid1 for a sim card and caches it
@@ -55,25 +57,27 @@ end
 ---@param cache Cache
 ---@return string error
 local function fetch_gid1(identity, cache)
-    local cmd = exec.command {
-        "qmicli", "-p", "-d", identity.mode_port, "--uim-read-transparent=0x3F00,0x7FFF,0x6F3E",
-        stdin = "null",
-        stdout = "pipe",
-        stderr = "stdout"
-    }
-    local out, status, code, _, err = fibers.perform(cmd:combined_output_op())
-    if status ~= "exited" or code ~= 0 then
-        return "Failed to execute qmicli command: " .. tostring(err)
-    end
+    local st, _, err = fibers.run_scope(function()
+        local cmd = exec.command {
+            "qmicli", "-p", "-d", identity.mode_port, "--uim-read-transparent=0x3F00,0x7FFF,0x6F3E",
+            stdin = "null",
+            stdout = "pipe",
+            stderr = "stdout"
+        }
+        local out, status, code, _, err = fibers.perform(cmd:combined_output_op())
+        if status ~= "exited" or code ~= 0 then
+            error("Failed to execute qmicli command: " .. tostring(err))
+        end
 
-    -- Parse the hex string after "Read result:"
-    local gid1 = out:match("Read result:%s*([%x:]+)")
-    if not gid1 then
-        return "Failed to parse qmicli output: " .. tostring(out)
-    end
+        -- Parse the hex string after "Read result:"
+        local gid1 = out:match("Read result:%s*([%x:]+)$")
+        if not gid1 then
+            error("Failed to parse qmicli output: " .. tostring(out))
+        end
 
-    cache:set("gid1", gid1)
-    return ""
+        cache:set("gid1", gid1)
+    end)
+    return st ~= "ok" and err or ""
 end
 
 --- Gets the RF band info for a modem and caches active_band_class
@@ -81,83 +85,97 @@ end
 ---@param cache Cache
 ---@return string error
 local function fetch_rf_band_info(identity, cache)
-    local cmd = exec.command {
-        "qmicli", "-p", "-d", identity.mode_port, "--nas-get-rf-band-info",
-        stdin = "null",
-        stdout = "pipe",
-        stderr = "stdout"
-    }
-    local out, status, code, _, err = fibers.perform(cmd:combined_output_op())
-    if status ~= "exited" or code ~= 0 then
-        return "Failed to execute qmicli command: " .. tostring(err)
-    end
+    local st, _, err = fibers.run_scope(function()
+        local cmd = exec.command {
+            "qmicli", "-p", "-d", identity.mode_port, "--nas-get-rf-band-info",
+            stdin = "null",
+            stdout = "pipe",
+            stderr = "stdout"
+        }
+        local out, status, code, _, err = fibers.perform(cmd:combined_output_op())
+        if status ~= "exited" or code ~= 0 then
+            error("Failed to execute qmicli command: " .. tostring(err))
+        end
 
-    local active_band_class = out:match("Active Band Class:%s*'([^']+)'")
-    if not active_band_class then
-        return "Failed to parse qmicli output: " .. tostring(out)
-    end
+        local active_band_class = out:match("Active Band Class:%s*'([^']+)'")
+        if not active_band_class then
+            error("Failed to parse qmicli output: " .. tostring(out))
+        end
 
-    cache:set("active_band_class", active_band_class)
-    return ""
+        cache:set("active_band_class", active_band_class)
+    end)
+    return st ~= "ok" and err or ""
 end
 
 
 local function add_mode_funcs(ModemBackend)
+    --- Start command to read sim presence
+    ---@return boolean ok
+    ---@return string error
+    function ModemBackend:start_sim_presence_monitor()
+        if self.sim_present then
+            return false, "Already monitoring sim presence"
+        end
+
+        local cmd = exec.command {
+            "qmicli", "-p", "-d", self.identity.mode_port, "--uim-monitor-slot-status",
+            stdin = "null",
+            stdout = "pipe",
+            stderr = "stdout"
+        }
+
+        local stdout, err = cmd:stdout_stream()
+        if not stdout then
+            return false, "Failed to start QMI monitor: " .. tostring(err)
+        end
+        self.sim_present = {
+            cmd = cmd,
+            stdout = stdout
+        }
+        return true, ""
+    end
+
     --- Make an op to listen for sim presence
     ---@return Op
     function ModemBackend:wait_for_sim_present_op()
         return op.guard(function()
             return scope.run_op(function(s)
-                -- Start QMI monitor command
-                local cmd = exec.command {
-                    "qmicli", "-p", "-d", self.identity.mode_port, "--uim-monitor-slot-status",
-                    stdin = "null",
-                    stdout = "pipe",
-                    stderr = "stdout"
-                }
-
-                -- Get stdout stream (starts command automatically)
-                local stdout, err = cmd:stdout_stream()
-                if not stdout then
-                    -- Return error result from scope - won't propagate to caller
-                    return false, "Failed to start QMI monitor: " .. tostring(err)
-                end
-
-                -- Command handles stream cleanup automatically via scope finalizer
-
-                -- Read chunks until we find "Slot status: active"
-                while true do
-                    local chunk = s:perform(stdout:read_line_op({
-                        terminator = "Slot status: active",
-                        keep_terminator = true,
-                    }))
-
-                    if not chunk then
-                        -- EOF - return error result from scope
-                        return false, "QMI monitor stream closed"
+                    if not self.sim_present then
+                        return false, "Sim presence monitor not started"
                     end
+                    -- Read chunks until we find "Slot status: active"
+                    while true do
+                        local chunk = s:perform(self.sim_present.stdout:read_line_op({
+                            terminator = "Slot status: active",
+                            keep_terminator = true,
+                        }))
 
-                    -- Parse the chunk (includes Card status + Slot status lines)
-                    local card_status, parse_err = parse_slot_status(chunk)
+                        if not chunk then
+                            -- EOF - return error result from scope
+                            return false, "Stream closed"
+                        end
 
-                    if parse_err == "" and card_status ~= "" then
-                        -- Valid parse - return true if present, false if absent
-                        return card_status == "present"
+                        -- Parse the chunk (includes Card status + Slot status lines)
+                        local card_status, parse_err = parse_slot_status(chunk)
+
+                        if parse_err == "" and card_status ~= "" then
+                            -- Valid parse - return true if present, false if absent
+                            return card_status == "present", ""
+                        end
+
+                        -- If parse failed, continue reading next chunk
                     end
-
-                    -- If parse failed, continue reading next chunk
-                end
-            end)
-            :wrap(function(st, _, ...)
-                if st == 'ok' then
-                    return ...  -- Returns the boolean (and optional error string)
-                elseif st == 'cancelled' then
-                    return false, "cancelled"
-                else
-                    -- Scope failed - return the error from scope body
-                    return false, (... or "QMI monitor failed")
-                end
-            end)
+                end)
+                :wrap(function(st, _, ...)
+                    if st == 'ok' then
+                        return ... -- Returns the boolean (and optional error string)
+                    elseif st == 'cancelled' then
+                        return false, "cancelled"
+                    else
+                        -- Scope failed - return the error from scope body
+                        return false, (... or "QMI monitor failed")
+                    end
+                end)
         end)
     end
 
@@ -171,22 +189,30 @@ local function add_mode_funcs(ModemBackend)
     ---@return boolean sim_present
     ---@return string error
     function ModemBackend:is_sim_present()
-        local cmd = exec.command {
-            "qmicli", "-p", "-d", self.identity.mode_port, "--uim-get-card-status",
-            stdin = "null",
-            stdout = "pipe",
-            stderr = "stdout"
-        }
-        local out, status, code, _, err = fibers.perform(cmd:combined_output_op())
-        if status ~= "exited" or code ~= 0 then
-            return false, "Failed to execute qmicli command: " .. tostring(err)
-        end
+        local st, _, present_or_err = fibers.run_scope(function()
+            local cmd = exec.command {
+                "qmicli", "-p", "-d", self.identity.mode_port, "--uim-get-card-status",
+                stdin = "null",
+                stdout = "pipe",
+                stderr = "stdout"
+            }
+            local out, status, code, _, err = fibers.perform(cmd:combined_output_op())
+            if status ~= "exited" or code ~= 0 then
+                error("Failed to execute qmicli command: " .. tostring(err))
+            end
 
-        local state, parse_err = parse_slot_status(out)
-        if parse_err ~= "" then
-            return false, "Failed to parse qmicli output: " .. tostring(parse_err)
+            local state, parse_err = parse_slot_status(out)
+            if parse_err ~= "" then
+                error("Failed to parse qmicli output: " .. tostring(parse_err))
+            end
+            return state == 'present'
+        end)
+
+        if st == "ok" then
+            return present_or_err, ""
+        else
+            return false, present_or_err or "Unknown error"
         end
-        return state == 'present', ""
     end
 
     --- Check for sim presence, will cause a sim_present_op to emit if present
@@ -194,34 +220,41 @@ local function add_mode_funcs(ModemBackend)
     ---@return boolean ok
     ---@return string error
     function ModemBackend:trigger_sim_presence_check(cooldown)
-        cooldown = cooldown or 1
-        --- Set power low
-        local cmd = exec.command {
-            "qmicli", "-p", "-d", self.identity.mode_port, "--uim-sim-power-off=1",
-            stdin = "null",
-            stdout = "pipe",
-            stderr = "stdout"
-        }
-        local _, status, code, _, err = fibers.perform(cmd:combined_output_op())
-        if status ~= "exited" or code ~= 0 then
-            return false, "Failed to execute qmicli power off command: " .. tostring(err)
-        end
+        local st, _, err = fibers.run_scope(function()
+            local errors = {}
+            cooldown = cooldown or 1
+            --- Set power low
+            local cmd = exec.command {
+                "qmicli", "-p", "-d", self.identity.mode_port, "--uim-sim-power-off=1",
+                stdin = "null",
+                stdout = "pipe",
+                stderr = "stdout"
+            }
+            local _, status, code, _, err = fibers.perform(cmd:combined_output_op())
+            if status ~= "exited" or code ~= 0 then
+                table.insert(errors, "Failed to execute qmicli power off command: " .. tostring(err))
+            end
 
-        sleep.sleep(cooldown)
+            sleep.sleep(cooldown)
 
-        --- Set power high
-        local cmd_on = exec.command {
-            "qmicli", "-p", "-d", self.identity.mode_port, "--uim-sim-power-on=1",
-            stdin = "null",
-            stdout = "pipe",
-            stderr = "stdout"
-        }
-        local _, status_on, code_on, _, err_on = fibers.perform(cmd_on:combined_output_op())
-        if status_on ~= "exited" or code_on ~= 0 then
-            return false, "Failed to execute qmicli power on command: " .. tostring(err_on)
-        end
+            --- Set power high
+            local cmd_on = exec.command {
+                "qmicli", "-p", "-d", self.identity.mode_port, "--uim-sim-power-on=1",
+                stdin = "null",
+                stdout = "pipe",
+                stderr = "stdout"
+            }
+            local _, status_on, code_on, _, err_on = fibers.perform(cmd_on:combined_output_op())
+            if status_on ~= "exited" or code_on ~= 0 then
+                table.insert(errors, "Failed to execute qmicli power on command: " .. tostring(err_on))
+            end
 
-        return true, ""
+            if #errors > 0 then
+                error(table.concat(errors, ";\n"))
+            end
+        end)
+
+        return st == "ok", err or ""
     end
 
     --- Gets a simcards MCC
@@ -253,7 +286,8 @@ local function add_mode_funcs(ModemBackend)
     ---@return string active_band_class
     ---@return string error
     function ModemBackend:active_band_class(timeout)
-        return fetch.get_cached_value(self.identity, "active_band_class", self.cache, "string", timeout, fetch_rf_band_info)
+        return fetch.get_cached_value(self.identity, "active_band_class", self.cache, "string", timeout,
+            fetch_rf_band_info)
     end
 end
 

--- a/src/services/hal/backends/modem/modes/qmi.lua
+++ b/src/services/hal/backends/modem/modes/qmi.lua
@@ -70,7 +70,7 @@ local function fetch_gid1(identity, cache)
         end
 
         -- Parse the hex string after "Read result:"
-        local gid1 = out:match("Read result:%s*([%x:]+)$")
+        local gid1 = out:match("%s+(%S+)%s*$"):gsub(":", "")
         if not gid1 then
             error("Failed to parse qmicli output: " .. tostring(out))
         end

--- a/src/services/hal/backends/modem/modes/qmi.lua
+++ b/src/services/hal/backends/modem/modes/qmi.lua
@@ -4,6 +4,8 @@ local sleep = require "fibers.sleep"
 local scope = require "fibers.scope"
 local op = require "fibers.op"
 
+local fetch = require "services.hal.backends.fetch"
+
 --- Parses the output of a sim slot status line
 ---@param status string?
 ---@return string card_status
@@ -21,16 +23,94 @@ local function parse_slot_status(status)
     return "", 'could not parse (no active slot or invalid string format)'
 end
 
+--- Gets the home network info (MCC/MNC) for a modem, with caching
+---@param identity ModemIdentity
+---@param cache Cache
+---@return string error
+local function fetch_home_network_info(identity, cache)
+    local cmd = exec.command {
+        "qmicli", "-p", "-d", identity.mode_port, "--nas-get-home-network",
+        stdin = "null",
+        stdout = "pipe",
+        stderr = "stdout"
+    }
+    local out, status, code, _, err = fibers.perform(cmd:combined_output_op())
+    if status ~= "exited" or code ~= 0 then
+        return "Failed to execute qmicli command: " .. tostring(err)
+    end
+
+    local mcc = out:match("MCC:%s+'(%d+)'")
+    local mnc = out:match("MNC:%s+'(%d+)'")
+    if not mcc or not mnc then
+        return "Failed to parse qmicli output: " .. tostring(out)
+    end
+
+    cache:set("mcc", mcc)
+    cache:set("mnc", mnc)
+    return ""
+end
+
+--- Gets gid1 for a sim card and caches it
+---@param identity ModemIdentity
+---@param cache Cache
+---@return string error
+local function fetch_gid1(identity, cache)
+    local cmd = exec.command {
+        "qmicli", "-p", "-d", identity.mode_port, "--uim-read-transparent=0x3F00,0x7FFF,0x6F3E",
+        stdin = "null",
+        stdout = "pipe",
+        stderr = "stdout"
+    }
+    local out, status, code, _, err = fibers.perform(cmd:combined_output_op())
+    if status ~= "exited" or code ~= 0 then
+        return "Failed to execute qmicli command: " .. tostring(err)
+    end
+
+    -- Parse the hex string after "Read result:"
+    local gid1 = out:match("Read result:%s*([%x:]+)")
+    if not gid1 then
+        return "Failed to parse qmicli output: " .. tostring(out)
+    end
+
+    cache:set("gid1", gid1)
+    return ""
+end
+
+--- Gets the RF band info for a modem and caches active_band_class
+---@param identity ModemIdentity
+---@param cache Cache
+---@return string error
+local function fetch_rf_band_info(identity, cache)
+    local cmd = exec.command {
+        "qmicli", "-p", "-d", identity.mode_port, "--nas-get-rf-band-info",
+        stdin = "null",
+        stdout = "pipe",
+        stderr = "stdout"
+    }
+    local out, status, code, _, err = fibers.perform(cmd:combined_output_op())
+    if status ~= "exited" or code ~= 0 then
+        return "Failed to execute qmicli command: " .. tostring(err)
+    end
+
+    local active_band_class = out:match("Active Band Class:%s*'([^']+)'")
+    if not active_band_class then
+        return "Failed to parse qmicli output: " .. tostring(out)
+    end
+
+    cache:set("active_band_class", active_band_class)
+    return ""
+end
+
 
 local function add_mode_funcs(ModemBackend)
-    --- Make an op to listen for sim prescence
+    --- Make an op to listen for sim presence
     ---@return Op
     function ModemBackend:wait_for_sim_present_op()
         return op.guard(function()
             return scope.run_op(function(s)
                 -- Start QMI monitor command
                 local cmd = exec.command {
-                    "qmicli", "-p", "-d", self.identity.primary_port, "--uim-monitor-slot-status",
+                    "qmicli", "-p", "-d", self.identity.mode_port, "--uim-monitor-slot-status",
                     stdin = "null",
                     stdout = "pipe",
                     stderr = "stdout"
@@ -92,7 +172,7 @@ local function add_mode_funcs(ModemBackend)
     ---@return string error
     function ModemBackend:is_sim_present()
         local cmd = exec.command {
-            "qmicli", "-p", "-d", self.identity.primary_port, "--uim-get-card-status",
+            "qmicli", "-p", "-d", self.identity.mode_port, "--uim-get-card-status",
             stdin = "null",
             stdout = "pipe",
             stderr = "stdout"
@@ -117,7 +197,7 @@ local function add_mode_funcs(ModemBackend)
         cooldown = cooldown or 1
         --- Set power low
         local cmd = exec.command {
-            "qmicli", "-p", "-d", self.identity.primary_port, "--uim-sim-power-off=1",
+            "qmicli", "-p", "-d", self.identity.mode_port, "--uim-sim-power-off=1",
             stdin = "null",
             stdout = "pipe",
             stderr = "stdout"
@@ -131,7 +211,7 @@ local function add_mode_funcs(ModemBackend)
 
         --- Set power high
         local cmd_on = exec.command {
-            "qmicli", "-p", "-d", self.identity.primary_port, "--uim-sim-power-on=1",
+            "qmicli", "-p", "-d", self.identity.mode_port, "--uim-sim-power-on=1",
             stdin = "null",
             stdout = "pipe",
             stderr = "stdout"
@@ -142,6 +222,38 @@ local function add_mode_funcs(ModemBackend)
         end
 
         return true, ""
+    end
+
+    --- Gets a simcards MCC
+    ---@param timeout number? Cache timeout in seconds (optional)
+    ---@return string mcc
+    ---@return string error
+    function ModemBackend:mcc(timeout)
+        return fetch.get_cached_value(self.identity, "mcc", self.cache, "string", timeout, fetch_home_network_info)
+    end
+
+    --- Gets a simcards MNC
+    ---@param timeout number? Cache timeout in seconds (optional)
+    ---@return string mnc
+    ---@return string error
+    function ModemBackend:mnc(timeout)
+        return fetch.get_cached_value(self.identity, "mnc", self.cache, "string", timeout, fetch_home_network_info)
+    end
+
+    --- Gets a simcards GID1 value
+    ---@param timeout number? Cache timeout in seconds (optional)
+    ---@return string gid1
+    ---@return string error
+    function ModemBackend:gid1(timeout)
+        return fetch.get_cached_value(self.identity, "gid1", self.cache, "string", timeout, fetch_gid1)
+    end
+
+    --- Gets the active band class for the modem
+    ---@param timeout number? Cache timeout in seconds (optional)
+    ---@return string active_band_class
+    ---@return string error
+    function ModemBackend:active_band_class(timeout)
+        return fetch.get_cached_value(self.identity, "active_band_class", self.cache, "string", timeout, fetch_rf_band_info)
     end
 end
 

--- a/src/services/hal/backends/modem/modes/qmi.lua
+++ b/src/services/hal/backends/modem/modes/qmi.lua
@@ -1,0 +1,150 @@
+local fibers = require "fibers"
+local exec = require "fibers.io.exec"
+local sleep = require "fibers.sleep"
+local scope = require "fibers.scope"
+local op = require "fibers.op"
+
+--- Parses the output of a sim slot status line
+---@param status string?
+---@return string card_status
+---@return string error
+local function parse_slot_status(status)
+    if not status or status == "" then
+        return "", "Command closed"
+    end
+    for card_status, slot_status in status:gmatch("Card status:%s*(%S+).-Slot status:%s*(%S+)") do
+        if slot_status == "active" then
+            return card_status, ""
+        end
+    end
+
+    return "", 'could not parse (no active slot or invalid string format)'
+end
+
+
+local function add_mode_funcs(ModemBackend)
+    --- Make an op to listen for sim prescence
+    ---@return Op
+    function ModemBackend:wait_for_sim_present_op()
+        return op.guard(function()
+            return scope.run_op(function(s)
+                -- Start QMI monitor command
+                local cmd = exec.command {
+                    "qmicli", "-p", "-d", self.identity.primary_port, "--uim-monitor-slot-status",
+                    stdin = "null",
+                    stdout = "pipe",
+                    stderr = "stdout"
+                }
+
+                -- Get stdout stream (starts command automatically)
+                local stdout, err = cmd:stdout_stream()
+                if not stdout then
+                    -- Return error result from scope - won't propagate to caller
+                    return false, "Failed to start QMI monitor: " .. tostring(err)
+                end
+
+                -- Command handles stream cleanup automatically via scope finalizer
+
+                -- Read chunks until we find "Slot status: active"
+                while true do
+                    local chunk = s:perform(stdout:read_line_op({
+                        terminator = "Slot status: active",
+                        keep_terminator = true,
+                    }))
+
+                    if not chunk then
+                        -- EOF - return error result from scope
+                        return false, "QMI monitor stream closed"
+                    end
+
+                    -- Parse the chunk (includes Card status + Slot status lines)
+                    local card_status, parse_err = parse_slot_status(chunk)
+
+                    if parse_err == "" and card_status ~= "" then
+                        -- Valid parse - return true if present, false if absent
+                        return card_status == "present"
+                    end
+
+                    -- If parse failed, continue reading next chunk
+                end
+            end)
+            :wrap(function(st, _, ...)
+                if st == 'ok' then
+                    return ...  -- Returns the boolean (and optional error string)
+                elseif st == 'cancelled' then
+                    return false, "cancelled"
+                else
+                    -- Scope failed - return the error from scope body
+                    return false, (... or "QMI monitor failed")
+                end
+            end)
+        end)
+    end
+
+    --- Wait for sim to become present
+    ---@return boolean sim_present
+    function ModemBackend:wait_for_sim_present()
+        return fibers.perform(self:wait_for_sim_present_op())
+    end
+
+    --- Poll for sim presence, returns true if sim is present, false if not, or error if an error occurs
+    ---@return boolean sim_present
+    ---@return string error
+    function ModemBackend:is_sim_present()
+        local cmd = exec.command {
+            "qmicli", "-p", "-d", self.identity.primary_port, "--uim-get-card-status",
+            stdin = "null",
+            stdout = "pipe",
+            stderr = "stdout"
+        }
+        local out, status, code, _, err = fibers.perform(cmd:combined_output_op())
+        if status ~= "exited" or code ~= 0 then
+            return false, "Failed to execute qmicli command: " .. tostring(err)
+        end
+
+        local state, parse_err = parse_slot_status(out)
+        if parse_err ~= "" then
+            return false, "Failed to parse qmicli output: " .. tostring(parse_err)
+        end
+        return state == 'present', ""
+    end
+
+    --- Check for sim presence, will cause a sim_present_op to emit if present
+    ---@param cooldown number? time to wait between power off and on commands, default 1 second
+    ---@return boolean ok
+    ---@return string error
+    function ModemBackend:trigger_sim_presence_check(cooldown)
+        cooldown = cooldown or 1
+        --- Set power low
+        local cmd = exec.command {
+            "qmicli", "-p", "-d", self.identity.primary_port, "--uim-sim-power-off=1",
+            stdin = "null",
+            stdout = "pipe",
+            stderr = "stdout"
+        }
+        local _, status, code, _, err = fibers.perform(cmd:combined_output_op())
+        if status ~= "exited" or code ~= 0 then
+            return false, "Failed to execute qmicli power off command: " .. tostring(err)
+        end
+
+        sleep.sleep(cooldown)
+
+        --- Set power high
+        local cmd_on = exec.command {
+            "qmicli", "-p", "-d", self.identity.primary_port, "--uim-sim-power-on=1",
+            stdin = "null",
+            stdout = "pipe",
+            stderr = "stdout"
+        }
+        local _, status_on, code_on, _, err_on = fibers.perform(cmd_on:combined_output_op())
+        if status_on ~= "exited" or code_on ~= 0 then
+            return false, "Failed to execute qmicli power on command: " .. tostring(err_on)
+        end
+
+        return true, ""
+    end
+end
+
+return {
+    add_mode_funcs = add_mode_funcs
+}

--- a/src/services/hal/backends/modem/modes/qmi.lua
+++ b/src/services/hal/backends/modem/modes/qmi.lua
@@ -37,7 +37,7 @@ local function fetch_home_network_info(identity, cache)
         }
         local out, status, code, _, err = fibers.perform(cmd:combined_output_op())
         if status ~= "exited" or code ~= 0 then
-            error("Failed to execute qmicli command: " .. tostring(err))
+            error("Failed to execute qmicli command: --nas-get-home-network, reason: " .. tostring(err))
         end
 
         local mcc = out:match("MCC:%s+'(%d+)'")
@@ -66,7 +66,7 @@ local function fetch_gid1(identity, cache)
         }
         local out, status, code, _, err = fibers.perform(cmd:combined_output_op())
         if status ~= "exited" or code ~= 0 then
-            error("Failed to execute qmicli command: " .. tostring(err))
+            error("Failed to execute qmicli command: --uim-read-transparent, reason: " .. tostring(err))
         end
 
         -- Parse the hex string after "Read result:"
@@ -94,7 +94,7 @@ local function fetch_rf_band_info(identity, cache)
         }
         local out, status, code, _, err = fibers.perform(cmd:combined_output_op())
         if status ~= "exited" or code ~= 0 then
-            error("Failed to execute qmicli command: " .. tostring(err))
+            error("Failed to execute qmicli command: --nas-get-rf-band-info, reason: " .. tostring(err))
         end
 
         local active_band_class = out:match("Active Band Class:%s*'([^']+)'")

--- a/src/services/hal/backends/modem/provider.lua
+++ b/src/services/hal/backends/modem/provider.lua
@@ -1,4 +1,4 @@
-local iface = require "services.hal.backends.modem.iface"
+local contract = require "services.hal.backends.modem.contract"
 
 local MODEL_INFO = {
     quectel = {
@@ -7,7 +7,8 @@ local MODEL_INFO = {
         { mod_string = "UNKNOWN",   rev_string = "eg25g",    model = "eg25",   model_variant = "g" },
         { mod_string = "UNKNOWN",   rev_string = "ec25e",    model = "ec25",   model_variant = "e" },
         { mod_string = "em06-e",    rev_string = "em06e",    model = "em06",   model_variant = "e" },
-        { mod_string = "rm520n-gl", rev_string = "rm520ngl", model = "rm520n", model_variant = "gl" }
+        { mod_string = "rm520n-gl", rev_string = "rm520ngl", model = "rm520n", model_variant = "gl" },
+        { mod_string = "em12-g", rev_string = "em12g", model = "em12", model_variant = "g" },
         -- more quectel models here
     },
     fibocom = {}
@@ -28,21 +29,32 @@ local function starts_with(str, start)
     return string.sub(str, 1, string.len(start)) == start
 end
 
-local backend_impl = nil
-for _, backend_name in ipairs(BACKENDS) do
-    local ok, mod = pcall(require, "services.hal.backends.modem.providers." .. backend_name .. ".init")
-    if ok and type(mod.is_supported) == "function" and mod.is_supported() then
-        backend_impl = mod.backend
-        break
-    end
-end
+-- local backend_impl = nil
 
-if backend_impl == nil then
-    error("No supported modem backend found")
+--- select and initialize the backend implementation
+---@return table backend_impl
+local function get_backend_impl()
+    local backend_impl = nil
+    for _, backend_name in ipairs(BACKENDS) do
+        print("Checking backend: services.hal.backends.modem.providers." .. backend_name .. ".init")
+        local ok, backend_mod = pcall(require, "services.hal.backends.modem.providers." .. backend_name .. ".init")
+        if ok and type(backend_mod) == "table" and backend_mod.is_supported and backend_mod.is_supported() then
+            backend_impl = backend_mod.backend
+            print("Selected backend:", backend_name)
+            break
+        end
+    end
+
+    if backend_impl == nil then
+        error("No supported modem backend found")
+    end
+
+    return backend_impl
 end
 
 local function new(address)
-    local backend = backend_impl.new(address)
+    local impl = get_backend_impl()
+    local backend = impl.new(address)
     ---@cast backend ModemBackend
     local drivers, dr_err = backend:drivers()
     if dr_err ~= "" then
@@ -50,17 +62,19 @@ local function new(address)
     end
 
     local drivers_str = table.concat(drivers, ",")
+    print(drivers_str)
     local mode
     if drivers_str:match("qmi_wwan") then
         mode = "qmi"
     elseif drivers_str:match("cdc_mbim") then
         mode = "mbim"
     end
+    print(mode)
 
     if mode then
-        local ok, mod = pcall(require, "services.hal.backends.modem.modes." .. mode)
-        if ok and mod and mod.add_mode_funcs and type(mod.add_mode_funcs) == "function" then
-            mod.add_mode_funcs(backend)
+        local ok, driver_mod = pcall(require, "services.hal.backends.modem.modes." .. mode)
+        if ok and type(driver_mod) == "table" and driver_mod.add_mode_funcs then
+            driver_mod.add_mode_funcs(backend)
         end
     end
 
@@ -79,6 +93,8 @@ local function new(address)
         error("Failed to get modem revision: " .. tostring(rev_err))
     end
 
+    print("Plugin:", plugin, "Model:", model, "Revision:", revision)
+
     local model_funcs_loaded = false
     for manufacturer, models in pairs(MODEL_INFO) do
         if string.match(plugin:lower(), manufacturer) then
@@ -87,9 +103,9 @@ local function new(address)
                     or starts_with(revision, details.rev_string) then
                     model = details.model
                     local model_variant = details.model_variant
-                    local ok, mod = pcall(require, "services.hal.backends.modem.models." .. manufacturer)
-                    if ok and mod and mod.add_model_funcs and type(mod.add_model_funcs) == "function" then
-                        mod.add_model_funcs(backend, model, model_variant)
+                    local ok, model_mod = pcall(require, "services.hal.backends.modem.models." .. manufacturer)
+                    if ok and type(model_mod) == "table" and model_mod.add_model_funcs then
+                        model_mod.add_model_funcs(backend, model, model_variant)
                         model_funcs_loaded = true
                     end
                     break
@@ -99,7 +115,7 @@ local function new(address)
         if model_funcs_loaded then break end
     end
 
-    local iface_err = iface.validate(backend)
+    local iface_err = contract.validate(backend)
     if iface_err ~= "" then
         error("Modem backend does not implement required interface: " .. tostring(iface_err))
     end

--- a/src/services/hal/backends/modem/provider.lua
+++ b/src/services/hal/backends/modem/provider.lua
@@ -29,29 +29,21 @@ local function starts_with(str, start)
     return string.sub(str, 1, string.len(start)) == start
 end
 
--- local backend_impl = nil
-
---- select and initialize the backend implementation
----@return table backend_impl
-local function get_backend_impl()
-    local backend_impl = nil
+--- Select the first supported provider for the current environment.
+---@return table provider
+local function get_provider()
     for _, backend_name in ipairs(BACKENDS) do
-        local ok, backend_mod = pcall(require, "services.hal.backends.modem.providers." .. backend_name .. ".init")
-        if ok and type(backend_mod) == "table" and backend_mod.is_supported and backend_mod.is_supported() then
-            backend_impl = backend_mod.backend
-            break
+        local ok, mod = pcall(require, "services.hal.backends.modem.providers." .. backend_name .. ".init")
+        if ok and type(mod) == "table" and mod.is_supported and mod.is_supported() then
+            return mod
         end
     end
-
-    if backend_impl == nil then
-        error("No supported modem backend found")
-    end
-
-    return backend_impl
+    error("No supported modem provider found")
 end
 
 local function new(address)
-    local impl = get_backend_impl()
+    local provider = get_provider()
+    local impl = provider.backend
     local backend = impl.new(address)
     ---@cast backend ModemBackend
     local drivers, dr_err = backend:drivers()
@@ -117,6 +109,25 @@ local function new(address)
     return backend
 end
 
+--- Create a new ModemMonitor using the selected provider.
+---@return ModemMonitor monitor
+local function new_monitor()
+    local provider = get_provider()
+    if not provider.new_monitor then
+        error("Selected modem provider does not support modem monitoring")
+    end
+    local monitor, err = provider.new_monitor()
+    if not monitor then
+        error("Failed to create modem monitor: " .. tostring(err))
+    end
+    local validate_err = contract.validate_monitor(monitor)
+    if validate_err ~= "" then
+        error("Modem monitor does not satisfy required interface: " .. validate_err)
+    end
+    return monitor
+end
+
 return {
-    new = new
+    new = new,
+    new_monitor = new_monitor,
 }

--- a/src/services/hal/backends/modem/provider.lua
+++ b/src/services/hal/backends/modem/provider.lua
@@ -1,0 +1,53 @@
+local iface = require "services.hal.backends.modem.iface"
+
+local backends = {
+    "linux_mm"
+}
+
+local backend = nil
+for _, backend_name in ipairs(backends) do
+    local ok, mod = pcall(require, "services.hal.backends.modem.providers." .. backend_name .. ".init")
+    if ok and type(mod.is_supported) == "function" and mod.is_supported() then
+        backend = mod
+        break
+    end
+end
+
+if backend == nil then
+    error("No supported modem backend found")
+end
+
+--- Apply mode specific functions
+---@param mode string
+---@return boolean ok
+function backend:override_mode(mode)
+    local ok, mod = pcall(require, "services.hal.backends.modem.modes." .. mode)
+    if ok and type(mod) == "function" then
+        mod(self)
+        return true
+    end
+    return false
+end
+
+--- Apply model specific functions
+---@param manufacturer string
+---@param model string
+---@param variant string
+---@return boolean ok
+function backend:override_model(manufacturer, model, variant)
+    local ok, mod = pcall(require, "services.hal.backends.modem.models." .. manufacturer)
+    if ok and type(mod) == "function" then
+        mod(self, model, variant)
+        return true
+    end
+    return false
+end
+
+--- Check that all required backend functions are implemented
+---@return boolean ok
+---@return string? error
+function backend:validate()
+    return iface.validate_backend(self)
+end
+
+return backend

--- a/src/services/hal/backends/modem/provider.lua
+++ b/src/services/hal/backends/modem/provider.lua
@@ -1,53 +1,112 @@
 local iface = require "services.hal.backends.modem.iface"
 
-local backends = {
+local MODEL_INFO = {
+    quectel = {
+        -- these are ordered, as eg25gl should match before eg25g
+        { mod_string = "UNKNOWN",   rev_string = "eg25gl",   model = "eg25",   model_variant = "gl" },
+        { mod_string = "UNKNOWN",   rev_string = "eg25g",    model = "eg25",   model_variant = "g" },
+        { mod_string = "UNKNOWN",   rev_string = "ec25e",    model = "ec25",   model_variant = "e" },
+        { mod_string = "em06-e",    rev_string = "em06e",    model = "em06",   model_variant = "e" },
+        { mod_string = "rm520n-gl", rev_string = "rm520ngl", model = "rm520n", model_variant = "gl" }
+        -- more quectel models here
+    },
+    fibocom = {}
+}
+
+local BACKENDS = {
     "linux_mm"
 }
 
-local backend = nil
-for _, backend_name in ipairs(backends) do
+--- Utility function to check if a string starts with a given prefix (case-insensitive)
+---@param str string
+---@param start string
+---@return boolean
+local function starts_with(str, start)
+    if str == nil or start == nil then return false end
+    str, start = str:lower(), start:lower()
+    -- Use string.sub to get the prefix of mainString that is equal in length to startString
+    return string.sub(str, 1, string.len(start)) == start
+end
+
+local backend_impl = nil
+for _, backend_name in ipairs(BACKENDS) do
     local ok, mod = pcall(require, "services.hal.backends.modem.providers." .. backend_name .. ".init")
     if ok and type(mod.is_supported) == "function" and mod.is_supported() then
-        backend = mod
+        backend_impl = mod.backend
         break
     end
 end
 
-if backend == nil then
+if backend_impl == nil then
     error("No supported modem backend found")
 end
 
---- Apply mode specific functions
----@param mode string
----@return boolean ok
-function backend:override_mode(mode)
-    local ok, mod = pcall(require, "services.hal.backends.modem.modes." .. mode)
-    if ok and type(mod) == "function" then
-        mod(self)
-        return true
+local function new(address)
+    local backend = backend_impl.new(address)
+    ---@cast backend ModemBackend
+    local drivers, dr_err = backend:drivers()
+    if dr_err ~= "" then
+        error("Failed to get modem drivers: " .. tostring(dr_err))
     end
-    return false
-end
 
---- Apply model specific functions
----@param manufacturer string
----@param model string
----@param variant string
----@return boolean ok
-function backend:override_model(manufacturer, model, variant)
-    local ok, mod = pcall(require, "services.hal.backends.modem.models." .. manufacturer)
-    if ok and type(mod) == "function" then
-        mod(self, model, variant)
-        return true
+    local drivers_str = table.concat(drivers, ",")
+    local mode
+    if drivers_str:match("qmi_wwan") then
+        mode = "qmi"
+    elseif drivers_str:match("cdc_mbim") then
+        mode = "mbim"
     end
-    return false
+
+    if mode then
+        local ok, mod = pcall(require, "services.hal.backends.modem.modes." .. mode)
+        if ok and mod and mod.add_mode_funcs and type(mod.add_mode_funcs) == "function" then
+            mod.add_mode_funcs(backend)
+        end
+    end
+
+    local plugin, pl_err = backend:plugin()
+    if pl_err ~= "" then
+        error("Failed to get modem plugin status: " .. tostring(pl_err))
+    end
+
+    local model, model_err = backend:model()
+    if model_err ~= "" then
+        error("Failed to get modem model: " .. tostring(model_err))
+    end
+
+    local revision, rev_err = backend:revision()
+    if rev_err ~= "" then
+        error("Failed to get modem revision: " .. tostring(rev_err))
+    end
+
+    local model_funcs_loaded = false
+    for manufacturer, models in pairs(MODEL_INFO) do
+        if string.match(plugin:lower(), manufacturer) then
+            for _, details in ipairs(models) do
+                if details.mod_string == model:lower()
+                    or starts_with(revision, details.rev_string) then
+                    model = details.model
+                    local model_variant = details.model_variant
+                    local ok, mod = pcall(require, "services.hal.backends.modem.models." .. manufacturer)
+                    if ok and mod and mod.add_model_funcs and type(mod.add_model_funcs) == "function" then
+                        mod.add_model_funcs(backend, model, model_variant)
+                        model_funcs_loaded = true
+                    end
+                    break
+                end
+            end
+        end
+        if model_funcs_loaded then break end
+    end
+
+    local iface_err = iface.validate(backend)
+    if iface_err ~= "" then
+        error("Modem backend does not implement required interface: " .. tostring(iface_err))
+    end
+
+    return backend
 end
 
---- Check that all required backend functions are implemented
----@return boolean ok
----@return string? error
-function backend:validate()
-    return iface.validate_backend(self)
-end
-
-return backend
+return {
+    new = new
+}

--- a/src/services/hal/backends/modem/provider.lua
+++ b/src/services/hal/backends/modem/provider.lua
@@ -36,11 +36,9 @@ end
 local function get_backend_impl()
     local backend_impl = nil
     for _, backend_name in ipairs(BACKENDS) do
-        print("Checking backend: services.hal.backends.modem.providers." .. backend_name .. ".init")
         local ok, backend_mod = pcall(require, "services.hal.backends.modem.providers." .. backend_name .. ".init")
         if ok and type(backend_mod) == "table" and backend_mod.is_supported and backend_mod.is_supported() then
             backend_impl = backend_mod.backend
-            print("Selected backend:", backend_name)
             break
         end
     end
@@ -62,14 +60,12 @@ local function new(address)
     end
 
     local drivers_str = table.concat(drivers, ",")
-    print(drivers_str)
     local mode
     if drivers_str:match("qmi_wwan") then
         mode = "qmi"
     elseif drivers_str:match("cdc_mbim") then
         mode = "mbim"
     end
-    print(mode)
 
     if mode then
         local ok, driver_mod = pcall(require, "services.hal.backends.modem.modes." .. mode)
@@ -92,8 +88,6 @@ local function new(address)
     if rev_err ~= "" then
         error("Failed to get modem revision: " .. tostring(rev_err))
     end
-
-    print("Plugin:", plugin, "Model:", model, "Revision:", revision)
 
     local model_funcs_loaded = false
     for manufacturer, models in pairs(MODEL_INFO) do

--- a/src/services/hal/backends/modem/providers/linux_mm/getters.lua
+++ b/src/services/hal/backends/modem/providers/linux_mm/getters.lua
@@ -1,47 +1,41 @@
 --- Modem backend getter methods
 --- This module defines all the attribute accessor methods for ModemBackend
 
---- Default try to get value from cache, if not present fetch modem info and try again
----@param identity ModemIdentity
----@param key string
----@param cache Cache
----@param ret_type string
----@param timeout number?
----@return any value
+local fetch = require "services.hal.backends.fetch"
+
+--- Read a net stat
+---@param net_port string
+---@return integer rx_bytes
 ---@return string error
-local function get_cached_value(identity, key, cache, ret_type, timeout, fetch_fn)
-    local cached = cache:get(key, timeout)
-    if cached then
-        return cached, ""
+local function read_net_stat(net_port, stat)
+    local path = '/sys/class/net/' .. net_port .. '/statistics/' .. stat
+    local file = io.open(path, "r")
+    if not file then
+        return -1, "Failed to open file: " .. tostring(path)
     end
-
-    local err = fetch_fn(identity, cache)
-    if err ~= "" then
-        return nil, "Failed to fetch modem info: " .. tostring(err)
+    local content = file:read("*a")
+    file:close()
+    if not content then
+        return -1, "Failed to read file: " .. tostring(path)
     end
-
-    local value = cache:get(key, timeout)
-    if not value then
-        return nil, "Value not found in cache after refresh: " .. tostring(key)
+    local rx_bytes = tonumber(content)
+    if not rx_bytes then
+        return -1, "Failed to parse rx_bytes: " .. tostring(content)
     end
-
-    if type(value) == ret_type then
-        return value, ""
-    else
-        return nil, "Cached value has wrong type: expected " .. ret_type .. ", got " .. type(value)
-    end
+    return rx_bytes, ""
 end
 
 --- Adds all getter methods to the ModemBackend class
 ---@param ModemBackend table The ModemBackend class table
 ---@param fetch_modem_info function The fetch function for modem info
-local function add_getters(ModemBackend, fetch_modem_info)
+---@param fetch_signal_info function The fetch function for signal info
+local function add_getters(ModemBackend, fetch_modem_info, fetch_signal_info)
     --- Gets the modem's IMEI number
     ---@param timeout number? Cache timeout in seconds (optional)
     ---@return string imei
     ---@return string error
     function ModemBackend:imei(timeout)
-        return get_cached_value(self.identity, "imei", self.cache, "string", timeout, fetch_modem_info)
+        return fetch.get_cached_value(self.identity, "imei", self.cache, "string", timeout, fetch_modem_info)
     end
 
     --- Gets the modem's device path
@@ -49,7 +43,7 @@ local function add_getters(ModemBackend, fetch_modem_info)
     ---@return string device
     ---@return string error
     function ModemBackend:device(timeout)
-        return get_cached_value(self.identity, "device", self.cache, "string", timeout, fetch_modem_info)
+        return fetch.get_cached_value(self.identity, "device", self.cache, "string", timeout, fetch_modem_info)
     end
 
     --- Gets the modem's primary port
@@ -57,7 +51,7 @@ local function add_getters(ModemBackend, fetch_modem_info)
     ---@return string primary_port
     ---@return string error
     function ModemBackend:primary_port(timeout)
-        return get_cached_value(self.identity, "primary_port", self.cache, "string", timeout, fetch_modem_info)
+        return fetch.get_cached_value(self.identity, "primary_port", self.cache, "string", timeout, fetch_modem_info)
     end
 
     --- Gets the modem's AT ports
@@ -65,7 +59,7 @@ local function add_getters(ModemBackend, fetch_modem_info)
     ---@return table at_ports
     ---@return string error
     function ModemBackend:at_ports(timeout)
-        return get_cached_value(self.identity, "at_ports", self.cache, "table", timeout, fetch_modem_info)
+        return fetch.get_cached_value(self.identity, "at_ports", self.cache, "table", timeout, fetch_modem_info)
     end
 
     --- Gets the modem's QMI ports
@@ -73,7 +67,7 @@ local function add_getters(ModemBackend, fetch_modem_info)
     ---@return table qmi_ports
     ---@return string error
     function ModemBackend:qmi_ports(timeout)
-        return get_cached_value(self.identity, "qmi_ports", self.cache, "table", timeout, fetch_modem_info)
+        return fetch.get_cached_value(self.identity, "qmi_ports", self.cache, "table", timeout, fetch_modem_info)
     end
 
     --- Gets the modem's GPS ports
@@ -81,7 +75,7 @@ local function add_getters(ModemBackend, fetch_modem_info)
     ---@return table gps_ports
     ---@return string error
     function ModemBackend:gps_ports(timeout)
-        return get_cached_value(self.identity, "gps_ports", self.cache, "table", timeout, fetch_modem_info)
+        return fetch.get_cached_value(self.identity, "gps_ports", self.cache, "table", timeout, fetch_modem_info)
     end
 
     --- Gets the modem's network ports
@@ -89,15 +83,7 @@ local function add_getters(ModemBackend, fetch_modem_info)
     ---@return table net_ports
     ---@return string error
     function ModemBackend:net_ports(timeout)
-        return get_cached_value(self.identity, "net_ports", self.cache, "table", timeout, fetch_modem_info)
-    end
-
-    --- Gets the modem's ignored ports
-    ---@param timeout number? Cache timeout in seconds (optional)
-    ---@return table ignored_ports
-    ---@return string error
-    function ModemBackend:ignored_ports(timeout)
-        return get_cached_value(self.identity, "ignored_ports", self.cache, "table", timeout, fetch_modem_info)
+        return fetch.get_cached_value(self.identity, "net_ports", self.cache, "table", timeout, fetch_modem_info)
     end
 
     --- Gets the modem's access technologies
@@ -105,7 +91,7 @@ local function add_getters(ModemBackend, fetch_modem_info)
     ---@return table access_techs
     ---@return string error
     function ModemBackend:access_techs(timeout)
-        return get_cached_value(self.identity, "access_techs", self.cache, "table", timeout, fetch_modem_info)
+        return fetch.get_cached_value(self.identity, "access_techs", self.cache, "table", timeout, fetch_modem_info)
     end
 
     --- Gets the modem's SIM path
@@ -113,7 +99,7 @@ local function add_getters(ModemBackend, fetch_modem_info)
     ---@return string sim
     ---@return string error
     function ModemBackend:sim(timeout)
-        return get_cached_value(self.identity, "sim", self.cache, "string", timeout, fetch_modem_info)
+        return fetch.get_cached_value(self.identity, "sim", self.cache, "string", timeout, fetch_modem_info)
     end
 
     --- Gets the modem's drivers
@@ -121,15 +107,15 @@ local function add_getters(ModemBackend, fetch_modem_info)
     ---@return table drivers
     ---@return string error
     function ModemBackend:drivers(timeout)
-        return get_cached_value(self.identity, "drivers", self.cache, "table", timeout, fetch_modem_info)
+        return fetch.get_cached_value(self.identity, "drivers", self.cache, "table", timeout, fetch_modem_info)
     end
 
     --- Gets the modem's plugin
     ---@param timeout number? Cache timeout in seconds (optional)
-    ---@return boolean plugin
+    ---@return string plugin
     ---@return string error
     function ModemBackend:plugin(timeout)
-        return get_cached_value(self.identity, "plugin", self.cache, "boolean", timeout, fetch_modem_info)
+        return fetch.get_cached_value(self.identity, "plugin", self.cache, "string", timeout, fetch_modem_info)
     end
 
     --- Gets the modem's model
@@ -137,7 +123,7 @@ local function add_getters(ModemBackend, fetch_modem_info)
     ---@return string model
     ---@return string error
     function ModemBackend:model(timeout)
-        return get_cached_value(self.identity, "model", self.cache, "string", timeout, fetch_modem_info)
+        return fetch.get_cached_value(self.identity, "model", self.cache, "string", timeout, fetch_modem_info)
     end
 
     --- Gets the modem's revision
@@ -145,8 +131,39 @@ local function add_getters(ModemBackend, fetch_modem_info)
     ---@return string revision
     ---@return string error
     function ModemBackend:revision(timeout)
-        return get_cached_value(self.identity, "revision", self.cache, "string", timeout, fetch_modem_info)
+        return fetch.get_cached_value(self.identity, "revision", self.cache, "string", timeout, fetch_modem_info)
     end
+
+    --- Gets the modem's operator name
+    ---@param timeout number? Cache timeout in seconds (optional)
+    ---@return string operator
+    ---@return string error
+    function ModemBackend:operator(timeout)
+        return fetch.get_cached_value(self.identity, "operator", self.cache, "string", timeout, fetch_modem_info)
+    end
+
+    --- Gets the modems rx bytes
+    ---@return integer rx_bytes
+    ---@return string error
+    function ModemBackend:rx_bytes()
+        return read_net_stat(self.identity.net_port, "rx_bytes")
+    end
+
+    --- Gets the modems tx bytes
+    ---@return integer tx_bytes
+    ---@return string error
+    function ModemBackend:tx_bytes()
+        return read_net_stat(self.identity.net_port, "tx_bytes")
+    end
+
+    --- Gets the modems signal
+    ---@param timeout number? Cache timeout in seconds (optional)
+    ---@return table signal_info
+    ---@return string error
+    function ModemBackend:signal(timeout)
+        return fetch.get_cached_value(self.identity, "signal", self.cache, "table", timeout, fetch_signal_info)
+    end
+
 end
 
 return {

--- a/src/services/hal/backends/modem/providers/linux_mm/getters.lua
+++ b/src/services/hal/backends/modem/providers/linux_mm/getters.lua
@@ -152,6 +152,14 @@ local function add_getters(ModemBackend, fetch_modem_info, fetch_sim_info, fetch
         return fetch.get_cached_value(self.identity, "iccid", self.cache, "string", timeout, fetch_sim_info)
     end
 
+    --- Gets the modem's IMSI
+    ---@param timeout number? Cache timeout in seconds (optional)
+    ---@return string imsi
+    ---@return string error
+    function ModemBackend:imsi(timeout)
+        return fetch.get_cached_value(self.identity, "imsi", self.cache, "string", timeout, fetch_sim_info)
+    end
+
 end
 
 return {

--- a/src/services/hal/backends/modem/providers/linux_mm/getters.lua
+++ b/src/services/hal/backends/modem/providers/linux_mm/getters.lua
@@ -6,9 +6,10 @@ local fetch = require "services.hal.backends.fetch"
 --- Adds all getter methods to the ModemBackend class
 ---@param ModemBackend table The ModemBackend class table
 ---@param fetch_modem_info function The fetch function for modem info
+---@param fetch_sim_info function The fetch function for SIM info
 ---@param fetch_signal_info function The fetch function for signal info
 ---@param read_net_stat function The function to read network statistics
-local function add_getters(ModemBackend, fetch_modem_info, fetch_signal_info, read_net_stat)
+local function add_getters(ModemBackend, fetch_modem_info, fetch_sim_info, fetch_signal_info, read_net_stat)
     --- Gets the modem's IMEI number
     ---@param timeout number? Cache timeout in seconds (optional)
     ---@return string imei
@@ -141,6 +142,14 @@ local function add_getters(ModemBackend, fetch_modem_info, fetch_signal_info, re
     ---@return string error
     function ModemBackend:signal(timeout)
         return fetch.get_cached_value(self.identity, "signal", self.cache, "table", timeout, fetch_signal_info)
+    end
+
+    --- Gets the modem's ICCID
+    ---@param timeout number? Cache timeout in seconds (optional)
+    ---@return string iccid
+    ---@return string error
+    function ModemBackend:iccid(timeout)
+        return fetch.get_cached_value(self.identity, "iccid", self.cache, "string", timeout, fetch_sim_info)
     end
 
 end

--- a/src/services/hal/backends/modem/providers/linux_mm/getters.lua
+++ b/src/services/hal/backends/modem/providers/linux_mm/getters.lua
@@ -1,0 +1,154 @@
+--- Modem backend getter methods
+--- This module defines all the attribute accessor methods for ModemBackend
+
+--- Default try to get value from cache, if not present fetch modem info and try again
+---@param identity ModemIdentity
+---@param key string
+---@param cache Cache
+---@param ret_type string
+---@param timeout number?
+---@return any value
+---@return string error
+local function get_cached_value(identity, key, cache, ret_type, timeout, fetch_fn)
+    local cached = cache:get(key, timeout)
+    if cached then
+        return cached, ""
+    end
+
+    local err = fetch_fn(identity, cache)
+    if err ~= "" then
+        return nil, "Failed to fetch modem info: " .. tostring(err)
+    end
+
+    local value = cache:get(key, timeout)
+    if not value then
+        return nil, "Value not found in cache after refresh: " .. tostring(key)
+    end
+
+    if type(value) == ret_type then
+        return value, ""
+    else
+        return nil, "Cached value has wrong type: expected " .. ret_type .. ", got " .. type(value)
+    end
+end
+
+--- Adds all getter methods to the ModemBackend class
+---@param ModemBackend table The ModemBackend class table
+---@param fetch_modem_info function The fetch function for modem info
+local function add_getters(ModemBackend, fetch_modem_info)
+    --- Gets the modem's IMEI number
+    ---@param timeout number? Cache timeout in seconds (optional)
+    ---@return string imei
+    ---@return string error
+    function ModemBackend:imei(timeout)
+        return get_cached_value(self.identity, "imei", self.cache, "string", timeout, fetch_modem_info)
+    end
+
+    --- Gets the modem's device path
+    ---@param timeout number? Cache timeout in seconds (optional)
+    ---@return string device
+    ---@return string error
+    function ModemBackend:device(timeout)
+        return get_cached_value(self.identity, "device", self.cache, "string", timeout, fetch_modem_info)
+    end
+
+    --- Gets the modem's primary port
+    ---@param timeout number? Cache timeout in seconds (optional)
+    ---@return string primary_port
+    ---@return string error
+    function ModemBackend:primary_port(timeout)
+        return get_cached_value(self.identity, "primary_port", self.cache, "string", timeout, fetch_modem_info)
+    end
+
+    --- Gets the modem's AT ports
+    ---@param timeout number? Cache timeout in seconds (optional)
+    ---@return table at_ports
+    ---@return string error
+    function ModemBackend:at_ports(timeout)
+        return get_cached_value(self.identity, "at_ports", self.cache, "table", timeout, fetch_modem_info)
+    end
+
+    --- Gets the modem's QMI ports
+    ---@param timeout number? Cache timeout in seconds (optional)
+    ---@return table qmi_ports
+    ---@return string error
+    function ModemBackend:qmi_ports(timeout)
+        return get_cached_value(self.identity, "qmi_ports", self.cache, "table", timeout, fetch_modem_info)
+    end
+
+    --- Gets the modem's GPS ports
+    ---@param timeout number? Cache timeout in seconds (optional)
+    ---@return table gps_ports
+    ---@return string error
+    function ModemBackend:gps_ports(timeout)
+        return get_cached_value(self.identity, "gps_ports", self.cache, "table", timeout, fetch_modem_info)
+    end
+
+    --- Gets the modem's network ports
+    ---@param timeout number? Cache timeout in seconds (optional)
+    ---@return table net_ports
+    ---@return string error
+    function ModemBackend:net_ports(timeout)
+        return get_cached_value(self.identity, "net_ports", self.cache, "table", timeout, fetch_modem_info)
+    end
+
+    --- Gets the modem's ignored ports
+    ---@param timeout number? Cache timeout in seconds (optional)
+    ---@return table ignored_ports
+    ---@return string error
+    function ModemBackend:ignored_ports(timeout)
+        return get_cached_value(self.identity, "ignored_ports", self.cache, "table", timeout, fetch_modem_info)
+    end
+
+    --- Gets the modem's access technologies
+    ---@param timeout number? Cache timeout in seconds (optional)
+    ---@return table access_techs
+    ---@return string error
+    function ModemBackend:access_techs(timeout)
+        return get_cached_value(self.identity, "access_techs", self.cache, "table", timeout, fetch_modem_info)
+    end
+
+    --- Gets the modem's SIM path
+    ---@param timeout number? Cache timeout in seconds (optional)
+    ---@return string sim
+    ---@return string error
+    function ModemBackend:sim(timeout)
+        return get_cached_value(self.identity, "sim", self.cache, "string", timeout, fetch_modem_info)
+    end
+
+    --- Gets the modem's drivers
+    ---@param timeout number? Cache timeout in seconds (optional)
+    ---@return table drivers
+    ---@return string error
+    function ModemBackend:drivers(timeout)
+        return get_cached_value(self.identity, "drivers", self.cache, "table", timeout, fetch_modem_info)
+    end
+
+    --- Gets the modem's plugin
+    ---@param timeout number? Cache timeout in seconds (optional)
+    ---@return boolean plugin
+    ---@return string error
+    function ModemBackend:plugin(timeout)
+        return get_cached_value(self.identity, "plugin", self.cache, "boolean", timeout, fetch_modem_info)
+    end
+
+    --- Gets the modem's model
+    ---@param timeout number? Cache timeout in seconds (optional)
+    ---@return string model
+    ---@return string error
+    function ModemBackend:model(timeout)
+        return get_cached_value(self.identity, "model", self.cache, "string", timeout, fetch_modem_info)
+    end
+
+    --- Gets the modem's revision
+    ---@param timeout number? Cache timeout in seconds (optional)
+    ---@return string revision
+    ---@return string error
+    function ModemBackend:revision(timeout)
+        return get_cached_value(self.identity, "revision", self.cache, "string", timeout, fetch_modem_info)
+    end
+end
+
+return {
+    add_getters = add_getters
+}

--- a/src/services/hal/backends/modem/providers/linux_mm/getters.lua
+++ b/src/services/hal/backends/modem/providers/linux_mm/getters.lua
@@ -3,33 +3,12 @@
 
 local fetch = require "services.hal.backends.fetch"
 
---- Read a net stat
----@param net_port string
----@return integer rx_bytes
----@return string error
-local function read_net_stat(net_port, stat)
-    local path = '/sys/class/net/' .. net_port .. '/statistics/' .. stat
-    local file = io.open(path, "r")
-    if not file then
-        return -1, "Failed to open file: " .. tostring(path)
-    end
-    local content = file:read("*a")
-    file:close()
-    if not content then
-        return -1, "Failed to read file: " .. tostring(path)
-    end
-    local rx_bytes = tonumber(content)
-    if not rx_bytes then
-        return -1, "Failed to parse rx_bytes: " .. tostring(content)
-    end
-    return rx_bytes, ""
-end
-
 --- Adds all getter methods to the ModemBackend class
 ---@param ModemBackend table The ModemBackend class table
 ---@param fetch_modem_info function The fetch function for modem info
 ---@param fetch_signal_info function The fetch function for signal info
-local function add_getters(ModemBackend, fetch_modem_info, fetch_signal_info)
+---@param read_net_stat function The function to read network statistics
+local function add_getters(ModemBackend, fetch_modem_info, fetch_signal_info, read_net_stat)
     --- Gets the modem's IMEI number
     ---@param timeout number? Cache timeout in seconds (optional)
     ---@return string imei

--- a/src/services/hal/backends/modem/providers/linux_mm/impl.lua
+++ b/src/services/hal/backends/modem/providers/linux_mm/impl.lua
@@ -1,0 +1,392 @@
+-- service modules
+local modem_types = require "services.hal.types.modem"
+local log = require "services.log"
+
+-- Fiber modules
+local fibers = require "fibers"
+local exec = require "fibers.io.exec"
+local op = require "fibers.op"
+local fiber = require "fibers.fiber"
+local scope = require "fibers.scope"
+
+-- Other modules
+local cache_mod = require "shared.cache"
+local json = require "cjson.safe"
+local getters = require "services.hal.backends.modem.providers.linux_mm.getters"
+
+
+---- Constants ----
+local CACHE_TIMEOUT = 10 -- seconds
+
+local MODEM_INFO_PATHS = {
+    imei = { "generic", "equipment-identifier" },
+    device = { "generic", "device" },
+    primary_port = { "generic", "primary-port" },
+    ports = { "generic", "ports" },
+    access_techs = { "generic", "access-technologies" },
+    sim = { "generic", "sim" },
+    drivers = { "generic", "drivers" },
+    plugin = { "generic", "plugin" },
+    model = { "generic", "model" },
+    revision = { "generic", "revision" },
+}
+
+
+---- Private functions ----
+
+--- Format nested table into k-v pairs
+---@param nested table
+---@param key_paths table<string, string[]>
+---@return table<string, any>
+---@return string[] errors
+local function nested_to_flat(nested, key_paths)
+    local flat = {}
+    local errors = {}
+    for key, path in pairs(key_paths) do
+        local value = nested
+        for _, p in ipairs(path) do
+            if type(value) ~= 'table' then
+                table.insert(errors, "Expected table at path " .. table.concat(path, ".") .. ", got " .. type(value))
+                break
+            end
+            value = value[p]
+            if value == nil then
+                table.insert(errors, "Missing value at path " .. table.concat(path, "."))
+                break
+            end
+        end
+        if value ~= nil then
+            flat[key] = value
+        end
+    end
+    return flat, errors
+end
+
+--- Formats each port from a string list of "name (type)" to a map of type_ports:name[]
+--- Returns a table of cache keys to be stored separately
+---@param ports string[]
+---@return table<string, string[]> cache_entries Map of cache keys to values
+local function format_ports(ports)
+    local cache_entries = {}
+    for _, port in ipairs(ports) do
+        local name, type = port:match("^(.*) %((.*)%)$")
+        if name and type then
+            local key = type .. "_ports"
+            if not cache_entries[key] then
+                cache_entries[key] = {}
+            end
+            table.insert(cache_entries[key], name)
+        else
+            log.warn("Failed to parse port string: " .. tostring(port))
+        end
+    end
+    return cache_entries
+end
+
+-- Post-processors transform field values before caching
+-- Each processor must return a table of {key = value} pairs to cache
+-- Example: ports -> {at_ports = [...], qmi_ports = [...]}
+local FIELD_POST_PROCESSORS = {
+    ports = format_ports, -- Expands to at_ports, qmi_ports, etc.
+}
+
+
+--- Fetches modem info using mmcli and caches it
+---@param identity ModemIdentity
+---@param cache Cache
+---@return string error
+local function fetch_modem_info(identity, cache)
+    local cmd = exec.command {
+        "mmcli", "-J", "-m", identity.address,
+        stdin = "null",
+        stdout = "pipe",
+        stderr = "stdout"
+    }
+    local output, status, code, _, err = fibers.perform(cmd:combined_output_op())
+    if status ~= "exited" or code ~= 0 then
+        return "mmcli command failed: " .. tostring(err) .. ", output: " .. tostring(output)
+    end
+
+    local data, json_err = json.decode(output)
+    if not data then
+        return "Failed to decode mmcli output as JSON: " .. tostring(json_err) .. ", output: " .. tostring(output)
+    end
+
+    local modem = data.modem
+
+    local flat, errors = nested_to_flat(modem, MODEM_INFO_PATHS)
+    if #errors > 0 then
+        log.warn("Errors formatting modem info: " .. table.concat(errors, ";\n\t"))
+    end
+
+    -- Apply post-processors to transform fields before caching
+    for field_name, processor in pairs(FIELD_POST_PROCESSORS) do
+        if flat[field_name] then
+            local cache_entries = processor(flat[field_name])
+            for k, v in pairs(cache_entries) do
+                cache:set(k, v)
+            end
+            flat[field_name] = nil -- Remove original field since we cached the processed entries
+        end
+    end
+
+    for k, v in pairs(flat) do
+        cache:set(k, v)
+    end
+    return ""
+end
+
+--- Returns all attributes needed for modem identity
+---@param address string
+---@param cache Cache
+---@return ModemIdentity identity
+local function get_identity(address, cache)
+    -- Build a temp id
+    local fake_id = assert(modem_types.new.ModemIdentity("unknown", address, "unknown", "unknown", "unknown"))
+    local err = fetch_modem_info(fake_id, cache)                            -- We need modem info to build the identity
+    if err ~= "" then
+        error("Failed to fetch modem info for identity: " .. tostring(err)) -- Fatal error if we cannot get modem info
+    end
+
+    local imei = cache:get("imei")
+    local primary_port = cache:get("primary_port")
+    local device = cache:get("device")
+    local at_ports = cache:get("at_ports")
+    local at_port
+    if at_ports and type(at_ports) == "table" then
+        at_port = at_ports[1]
+    end
+
+    local id, id_err = modem_types.new.ModemIdentity(
+        imei,
+        address,
+        primary_port,
+        at_port,
+        device
+    )
+    if not id then
+        error("Failed to get modem identity: " .. tostring(id_err)) -- Fatal error if we cannot build the identity
+    end
+
+    return id
+end
+
+--- Parses the output of a modem state line
+---@param line string?
+---@return ModemStateEvent?
+---@return string error
+local function parse_modem_state_line(line)
+    if not line or line == "" then
+        return nil, "Command closed"
+    end
+
+    -- Remove leading/trailing whitespace
+    line = line:match("^%s*(.-)%s*$")
+
+    -- Pattern 1: Initial state, 'state'
+    local initial_state = line:match(": Initial state, '([^']+)'")
+    if initial_state then
+        return modem_types.new.ModemStateInitialEvent(initial_state, "initial")
+    end
+
+    -- Pattern 2: State changed, 'old' --> 'new' (Reason: reason)
+    local old_state, new_state, reason = line:match(": State changed, '([^']+)' %-%-> '([^']+)' %(Reason: ([^)]+)%)")
+    if old_state and new_state then
+        return modem_types.new.ModemStateChangeEvent(old_state, new_state, reason)
+    end
+
+    -- Pattern 3: Removed
+    if line:match(": Removed") then
+        return modem_types.new.ModemStateRemovedEvent("removed")
+    end
+
+    -- Unknown format
+    return nil, "Unknown modem state line format: " .. line
+end
+
+
+---- Public backend interface ----
+
+---@class ModemBackend
+---@field identity ModemIdentity
+---@field cache Cache
+---@field inhibit_cmd Command|nil
+---@field imei fun(timeout: number?): string, string
+---@field device fun(timeout: number?): string, string
+---@field primary_port fun(timeout: number?): string, string
+---@field at_ports fun(timeout: number?): table, string
+---@field qmi_ports fun(timeout: number?): table, string
+---@field gps_ports fun(timeout: number?): table, string
+---@field net_ports fun(timeout: number?): table, string
+---@field ignored_ports fun(timeout: number?): table, string
+---@field access_techs fun(timeout: number?): table, string
+---@field sim fun(timeout: number?): string, string
+---@field drivers fun(timeout: number?): table, string
+---@field plugin fun(timeout: number?): boolean, string
+---@field model fun(timeout: number?): string, string
+---@field revision fun(timeout: number?): string, string
+local ModemBackend = {}
+ModemBackend.__index = ModemBackend
+
+-- Add all getter methods to ModemBackend
+getters.add_getters(ModemBackend, fetch_modem_info)
+
+--- Enable the modem
+---@return string result
+---@return number exit_code
+function ModemBackend:enable()
+    local cmd = exec.command {
+        "mmcli", "-m", self.identity.address, "-e",
+        stdin = "null",
+        stdout = "pipe",
+        stderr = "stdout"
+    }
+    local output, status, code, _, err = fibers.perform(cmd:combined_output_op())
+    if status ~= "exited" then
+        return "mmcli command failed to execute: " .. tostring(err), code
+    end
+    return output, code
+end
+
+--- Disable the modem
+---@return string result
+---@return number exit_code
+function ModemBackend:disable()
+    local cmd = exec.command {
+        "mmcli", "-m", self.identity.address, "-d",
+        stdin = "null",
+        stdout = "pipe",
+        stderr = "stdout"
+    }
+    local output, status, code, _, err = fibers.perform(cmd:combined_output_op())
+    if status ~= "exited" then
+        return "mmcli command failed to execute: " .. tostring(err), code
+    end
+    return output, code
+end
+
+--- Reset the modem
+---@return string result
+---@return number exit_code
+function ModemBackend:reset()
+    local cmd = exec.command {
+        "mmcli", "-m", self.identity.address, "--reset",
+        stdin = "null",
+        stdout = "pipe",
+        stderr = "stdout"
+    }
+    local output, status, code, _, err = fibers.perform(cmd:combined_output_op())
+    if status ~= "exited" then
+        return "mmcli command failed to execute: " .. tostring(err), code
+    end
+    return output, code
+end
+
+--- Connect the modem
+---@param conn_string string
+---@return string result
+---@return number exit_code
+function ModemBackend:connect(conn_string)
+    local full_conn_string = "--simple-connect=" .. conn_string
+    local cmd = exec.command {
+        "mmcli", "-m", self.identity.address, full_conn_string,
+        stdin = "null",
+        stdout = "pipe",
+        stderr = "stdout"
+    }
+    local output, status, code, _, err = fibers.perform(cmd:combined_output_op())
+    if status ~= "exited" then
+        return "mmcli command failed to execute: " .. tostring(err), code
+    end
+    return output, code
+end
+
+--- Disconnect the modem
+---@return string result
+---@return number exit_code
+function ModemBackend:disconnect()
+    local cmd = exec.command {
+        "mmcli", "-m", self.identity.address, "--simple-disconnect",
+        stdin = "null",
+        stdout = "pipe",
+        stderr = "stdout"
+    }
+    local output, status, code, _, err = fibers.perform(cmd:combined_output_op())
+    if status ~= "exited" then
+        return "mmcli command failed to execute: " .. tostring(err), code
+    end
+    return output, code
+end
+
+--- Inhibit the modem
+---@return string result
+---@return number exit_code
+function ModemBackend:inhibit()
+    if self.inhibit_cmd then
+        return "Modem is already inhibited", 1
+    end
+
+    local cmd = exec.command {
+        "mmcli", "-m", self.identity.address, "--inhibit",
+        stdin = "null",
+        stdout = "pipe",
+        stderr = "stdout"
+    }
+
+    -- Accessing stdout_stream() triggers the command to start
+    -- The command will run in the background, managed by the scope
+    local stream, err = cmd:stdout_stream()
+    if not stream then
+        return "Failed to start inhibit command: " .. tostring(err), 1
+    end
+
+    self.inhibit_cmd = cmd
+    return "Modem inhibit started", 0
+end
+
+--- Uninhibit the modem
+---@return string result
+---@return number exit_code
+function ModemBackend:uninhibit()
+    if not self.inhibit_cmd then
+        return "Modem is not inhibited", 0
+    end
+
+    self.inhibit_cmd:kill()
+    self.inhibit_cmd = nil
+
+    return "Modem uninhibited", 0
+end
+
+--- Listen for modem state changes
+---@return Op
+function ModemBackend:monitor_state_op()
+    local cmd = exec.command {
+        "mmcli", "-m", self.identity.address, "-w",
+        stdin = "null",
+        stdout = "pipe",
+        stderr = "stdout"
+    }
+    local stream, err = cmd:stdout_stream()
+    if not stream then
+        error("Failed to start monitor state command: " .. tostring(err))
+    end
+    return stream:read_line_op():wrap(parse_modem_state_line)
+end
+
+
+
+--- Builds the backend instance
+--- @return ModemBackend
+local function new(address)
+    local cache = cache_mod.new(CACHE_TIMEOUT, nil, '.')
+    local self = {
+        cache = cache,
+        identity = get_identity(address, cache),
+    }
+    return setmetatable(self, ModemBackend)
+end
+
+return {
+    new = new
+}

--- a/src/services/hal/backends/modem/providers/linux_mm/impl.lua
+++ b/src/services/hal/backends/modem/providers/linux_mm/impl.lua
@@ -22,7 +22,7 @@ local function list_to_map(list)
 end
 
 ---- Constants ----
-local CACHE_TIMEOUT = 10 -- seconds
+local CACHE_TIMEOUT = math.huge -- The default for cache is to hold a value indefinitely
 
 local MODEM_INFO_PATHS = {
     imei = { "generic", "equipment-identifier" },
@@ -39,7 +39,8 @@ local MODEM_INFO_PATHS = {
 }
 
 local SIM_INFO_PATHS = {
-    iccid = { "properties", "iccid" }
+    iccid = { "properties", "iccid" },
+    imsi = { "properties", "imsi" },
 }
 
 local SIGNAL_TECHNOLOGIES = list_to_map {
@@ -124,23 +125,6 @@ end
 local FIELD_POST_PROCESSORS = {
     ports = format_ports, -- Expands to at_ports, qmi_ports, etc.
 }
-
---- Dumps a nested table in a well-formatted form
----@param tbl table
----@param indent number
-local function dump(tbl, indent)
-    indent = indent or 0
-    local prefix = string.rep("  ", indent)
-    for k, v in pairs(tbl) do
-        if type(v) == "table" then
-            print(prefix .. tostring(k) .. " = {")
-            dump(v, indent + 1)
-            print(prefix .. "}")
-        else
-            print(prefix .. tostring(k) .. " = " .. tostring(v))
-        end
-    end
-end
 
 
 --- Fetches modem info using mmcli and caches it
@@ -256,7 +240,7 @@ local function fetch_signal_info(identity, cache)
         }
         local output, status, code, _, err = fibers.perform(cmd:combined_output_op())
         if status ~= "exited" or code ~= 0 then
-            error("mmcli command failed: " .. tostring(err) .. ", output: " .. tostring(output))
+            error("mmcli command failed: --signal-get, reason: " .. tostring(err) .. ", output: " .. tostring(output))
         end
 
         local data, json_err = json.decode(output)
@@ -273,7 +257,7 @@ local function fetch_signal_info(identity, cache)
         if active_err ~= "" then
             error("Failed to get active signal: " .. tostring(active_err))
         end
-        cache:set("signal", shallow_copy(active_signal))
+        cache:set("signal", shallow_copy(active_signal)) -- Cache a copy of the active signal fields
     end)
     return st ~= "ok" and err or ""
 end
@@ -292,6 +276,9 @@ local function fetch_sim_info(identity, cache)
                 error("Failed to get SIM path for fetching SIM info")
             end
         end
+        if sim == "--" then
+            return "" -- no sim means we cannot get sim info
+        end
         local cmd = exec.command {
             "mmcli", "-J", "-i", sim,
             stdin = "null",
@@ -300,7 +287,8 @@ local function fetch_sim_info(identity, cache)
         }
         local output, status, code, _, err = fibers.perform(cmd:combined_output_op())
         if status ~= "exited" or code ~= 0 then
-            error("mmcli command failed: " .. tostring(err) .. ", output: " .. tostring(output))
+            error("mmcli command failed: mmcli -J -i " ..
+            sim .. ", reason:" .. tostring(err) .. ", output: " .. tostring(output))
         end
         local data, json_err = json.decode(output)
         if not data then
@@ -442,7 +430,7 @@ function ModemBackend:enable()
         }
         local _, status, _, _, err = fibers.perform(cmd:combined_output_op())
         if status ~= "exited" then
-            error("mmcli command failed to execute: " .. tostring(err))
+            error("mmcli command failed to execute: enable, reason: " .. tostring(err))
         end
     end)
     return st == "ok", err or ""
@@ -461,7 +449,7 @@ function ModemBackend:disable()
         }
         local _, status, _, _, err = fibers.perform(cmd:combined_output_op())
         if status ~= "exited" then
-            error("mmcli command failed to execute: " .. tostring(err))
+            error("mmcli command failed to execute: disable, reason: " .. tostring(err))
         end
     end)
     return st == "ok", err or ""
@@ -480,7 +468,7 @@ function ModemBackend:reset()
         }
         local _, status, _, _, err = fibers.perform(cmd:combined_output_op())
         if status ~= "exited" then
-            error("mmcli command failed to execute: " .. tostring(err))
+            error("mmcli command failed to execute: --reset, reason: " .. tostring(err))
         end
     end)
     return st == "ok", err or ""
@@ -501,7 +489,7 @@ function ModemBackend:connect(conn_string)
         }
         local _, status, _, _, err = fibers.perform(cmd:combined_output_op())
         if status ~= "exited" then
-            error("mmcli command failed to execute: " .. tostring(err))
+            error("mmcli command failed to execute: --simple-connect, reason: " .. tostring(err))
         end
     end)
     return st == "ok", err or ""
@@ -520,7 +508,7 @@ function ModemBackend:disconnect()
         }
         local _, status, _, _, err = fibers.perform(cmd:combined_output_op())
         if status ~= "exited" then
-            error("mmcli command failed to execute: " .. tostring(err))
+            error("mmcli command failed to execute: --simple-disconnect, reason: " .. tostring(err))
         end
     end)
     return st == "ok", err or ""
@@ -545,7 +533,7 @@ function ModemBackend:inhibit()
     -- The command will run in the background, managed by the scope
     local stream, err = cmd:stdout_stream()
     if not stream then
-        return false, "Failed to start inhibit command: " .. tostring(err)
+        return false, "Failed to start inhibit command: --inhibit, reason: " .. tostring(err)
     end
 
     self.inhibit_cmd = cmd

--- a/src/services/hal/backends/modem/providers/linux_mm/impl.lua
+++ b/src/services/hal/backends/modem/providers/linux_mm/impl.lua
@@ -38,6 +38,10 @@ local MODEM_INFO_PATHS = {
     operator = { "3gpp", "operator-name" },
 }
 
+local SIM_INFO_PATHS = {
+    iccid = { "properties", "iccid" }
+}
+
 local SIGNAL_TECHNOLOGIES = list_to_map {
     "5g",
     "cdma1x",
@@ -82,6 +86,17 @@ local function nested_to_flat(nested, key_paths)
     return flat, errors
 end
 
+--- Shallow copy of a table
+---@param tbl table
+---@return table copy
+local function shallow_copy(tbl)
+    local copy = {}
+    for k, v in pairs(tbl) do
+        copy[k] = v
+    end
+    return copy
+end
+
 --- Formats each port from a string list of "name (type)" to a map of type_ports:name[]
 --- Returns a table of cache keys to be stored separately
 ---@param ports string[]
@@ -109,6 +124,23 @@ end
 local FIELD_POST_PROCESSORS = {
     ports = format_ports, -- Expands to at_ports, qmi_ports, etc.
 }
+
+--- Dumps a nested table in a well-formatted form
+---@param tbl table
+---@param indent number
+local function dump(tbl, indent)
+    indent = indent or 0
+    local prefix = string.rep("  ", indent)
+    for k, v in pairs(tbl) do
+        if type(v) == "table" then
+            print(prefix .. tostring(k) .. " = {")
+            dump(v, indent + 1)
+            print(prefix .. "}")
+        else
+            print(prefix .. tostring(k) .. " = " .. tostring(v))
+        end
+    end
+end
 
 
 --- Fetches modem info using mmcli and caches it
@@ -197,7 +229,7 @@ local function get_active_signal(signal_techs)
             local active_signal = false
             local filtered_fields = {}
             for signal_name, signal_value in pairs(signals) do
-                if not SIGNAL_IGNORE_FIELDS[signal_name] then
+                if not SIGNAL_IGNORE_FIELDS[signal_name] and signal_value ~= "--" then
                     filtered_fields[signal_name] = signal_value
                     active_signal = true
                 end
@@ -241,7 +273,46 @@ local function fetch_signal_info(identity, cache)
         if active_err ~= "" then
             error("Failed to get active signal: " .. tostring(active_err))
         end
-        cache:set("signal", active_signal)
+        cache:set("signal", shallow_copy(active_signal))
+    end)
+    return st ~= "ok" and err or ""
+end
+
+--- Fetches SIM info using mmcli and caches it
+---@param identity ModemIdentity
+---@param cache Cache
+---@return string error
+local function fetch_sim_info(identity, cache)
+    local st, _, err = fibers.run_scope(function()
+        local sim = cache:get("sim")
+        if not sim then
+            fetch_modem_info(identity, cache) -- SIM info is needed to fetch SIM details, so fetch modem info if SIM path is not cached
+            sim = cache:get("sim")
+            if not sim then
+                error("Failed to get SIM path for fetching SIM info")
+            end
+        end
+        local cmd = exec.command {
+            "mmcli", "-J", "-i", sim,
+            stdin = "null",
+            stdout = "pipe",
+            stderr = "stdout"
+        }
+        local output, status, code, _, err = fibers.perform(cmd:combined_output_op())
+        if status ~= "exited" or code ~= 0 then
+            error("mmcli command failed: " .. tostring(err) .. ", output: " .. tostring(output))
+        end
+        local data, json_err = json.decode(output)
+        if not data then
+            error("Failed to decode mmcli output as JSON: " .. tostring(json_err) .. " , output: " .. tostring(output))
+        end
+        local flat, errors = nested_to_flat(data.sim, SIM_INFO_PATHS)
+        if #errors > 0 then
+            log.warn("Errors formatting SIM info: " .. table.concat(errors, ";\n\t"))
+        end
+        for k, v in pairs(flat) do
+            cache:set(k, v)
+        end
     end)
     return st ~= "ok" and err or ""
 end
@@ -281,12 +352,12 @@ local function get_identity(address, cache)
         mbim_port = mbim_ports[1]
     end
 
-    local mode_port = mbim_port or qmi_port -- Prefer mbim port if available, otherwise use qmi port
+    local mode_port = "/dev/" .. (mbim_port or qmi_port) -- Prefer mbim port if available, otherwise use qmi port
 
     local at_ports = cache:get("at_ports")
     local at_port
     if at_ports and type(at_ports) == "table" then
-        at_port = at_ports[1]
+        at_port = "/dev/" .. at_ports[1]
     end
 
     local net_ports = cache:get("net_ports")
@@ -353,6 +424,7 @@ ModemBackend.__index = ModemBackend
 -- Add all getter methods to ModemBackend
 getters.add_getters(ModemBackend,
     fetch_modem_info,
+    fetch_sim_info,
     fetch_signal_info,
     read_net_stat
 )

--- a/src/services/hal/backends/modem/providers/linux_mm/impl.lua
+++ b/src/services/hal/backends/modem/providers/linux_mm/impl.lua
@@ -15,6 +15,14 @@ local json = require "cjson.safe"
 local getters = require "services.hal.backends.modem.providers.linux_mm.getters"
 
 
+local function list_to_map(list)
+    local map = {}
+    for _, item in ipairs(list) do
+        map[item] = true
+    end
+    return map
+end
+
 ---- Constants ----
 local CACHE_TIMEOUT = 10 -- seconds
 
@@ -29,6 +37,20 @@ local MODEM_INFO_PATHS = {
     plugin = { "generic", "plugin" },
     model = { "generic", "model" },
     revision = { "generic", "revision" },
+    operator = { "3gpp", "operator-name" },
+}
+
+local SIGNAL_TECHNOLOGIES = list_to_map {
+    "5g",
+    "cdma1x",
+    "evdo",
+    "gsm",
+    "lte",
+    "umts"
+}
+
+local SIGNAL_IGNORE_FIELDS = list_to_map {
+    "error-rate"
 }
 
 
@@ -136,32 +158,110 @@ local function fetch_modem_info(identity, cache)
     return ""
 end
 
+--- Get the table values from the active signal tech
+---@param signal_techs table
+---@return table signals
+---@return string error
+local function get_active_signal(signal_techs)
+    for tech, signals in pairs(signal_techs) do
+        if SIGNAL_TECHNOLOGIES[tech] then
+            local active_signal = false
+            local filtered_fields = {}
+            for signal_name, signal_value in pairs(signals) do
+                if not SIGNAL_IGNORE_FIELDS[signal_name] then
+                    filtered_fields[signal_name] = signal_value
+                    active_signal = true
+                end
+            end
+            if active_signal then
+                return filtered_fields, ""
+            end
+        end
+    end
+    return {}, "No active signal found"
+end
+
+--- Fetches signal info using mmcli and caches it
+---@param identity ModemIdentity
+---@param cache Cache
+---@return string error
+local function fetch_signal_info(identity, cache)
+    local cmd = exec.command {
+        "mmcli", "-J", "-m", identity.address, "--signal-get",
+        stdin = "null",
+        stdout = "pipe",
+        stderr = "stdout"
+    }
+    local output, status, code, _, err = fibers.perform(cmd:combined_output_op())
+    if status ~= "exited" or code ~= 0 then
+        return "mmcli command failed: " .. tostring(err) .. ", output: " .. tostring(output)
+    end
+
+    local data, json_err = json.decode(output)
+    if not data then
+        return "Failed to decode mmcli output as JSON: " .. tostring(json_err) .. ", output: " .. tostring(output)
+    end
+
+    local signal_techs = data.modem and data.modem.signal or nil
+    if not signal_techs then
+        return "No signal info found in mmcli output: " .. tostring(output)
+    end
+
+    local active_signal, active_err = get_active_signal(signal_techs)
+    if active_err ~= "" then
+        return "Failed to get active signal: " .. tostring(active_err)
+    end
+    cache:set("signal", active_signal)
+    return ""
+end
+
+
 --- Returns all attributes needed for modem identity
 ---@param address string
 ---@param cache Cache
 ---@return ModemIdentity identity
 local function get_identity(address, cache)
     -- Build a temp id
-    local fake_id = assert(modem_types.new.ModemIdentity("unknown", address, "unknown", "unknown", "unknown"))
+    local fake_id = assert(modem_types.new.ModemIdentity(
+        "unknown",
+        address,
+        "unknown",
+        "unknown",
+        "unknown",
+        "unknown"
+    ))
     local err = fetch_modem_info(fake_id, cache)                            -- We need modem info to build the identity
     if err ~= "" then
         error("Failed to fetch modem info for identity: " .. tostring(err)) -- Fatal error if we cannot get modem info
     end
 
     local imei = cache:get("imei")
-    local primary_port = cache:get("primary_port")
     local device = cache:get("device")
+
+    local qmi_ports = cache:get("qmi_ports")
+    local qmi_port
+    if qmi_ports and type(qmi_ports) == "table" then
+        qmi_port = qmi_ports[1]
+    end
+
     local at_ports = cache:get("at_ports")
     local at_port
     if at_ports and type(at_ports) == "table" then
         at_port = at_ports[1]
     end
 
+    local net_ports = cache:get("net_ports")
+    local net_port
+    if net_ports and type(net_ports) == "table" then
+        net_port = net_ports[1]
+    end
+
     local id, id_err = modem_types.new.ModemIdentity(
         imei,
         address,
-        primary_port,
+        qmi_port,
         at_port,
+        net_port,
         device
     )
     if not id then
@@ -211,29 +311,37 @@ end
 ---@field identity ModemIdentity
 ---@field cache Cache
 ---@field inhibit_cmd Command|nil
----@field imei fun(timeout: number?): string, string
----@field device fun(timeout: number?): string, string
----@field primary_port fun(timeout: number?): string, string
----@field at_ports fun(timeout: number?): table, string
----@field qmi_ports fun(timeout: number?): table, string
----@field gps_ports fun(timeout: number?): table, string
----@field net_ports fun(timeout: number?): table, string
----@field ignored_ports fun(timeout: number?): table, string
----@field access_techs fun(timeout: number?): table, string
----@field sim fun(timeout: number?): string, string
----@field drivers fun(timeout: number?): table, string
----@field plugin fun(timeout: number?): boolean, string
----@field model fun(timeout: number?): string, string
----@field revision fun(timeout: number?): string, string
+---@field imei fun(self: ModemBackend, timeout: number?): string, string
+---@field device fun(self: ModemBackend, timeout: number?): string, string
+---@field primary_port fun(self: ModemBackend, timeout: number?): string, string
+---@field at_ports fun(self: ModemBackend, timeout: number?): table, string
+---@field qmi_ports fun(self: ModemBackend, timeout: number?): table, string
+---@field gps_ports fun(self: ModemBackend, timeout: number?): table, string
+---@field net_ports fun(self: ModemBackend, timeout: number?): table, string
+---@field ignored_ports fun(self: ModemBackend, timeout: number?): table, string
+---@field access_techs fun(self: ModemBackend, timeout: number?): table, string
+---@field sim fun(self: ModemBackend, timeout: number?): string, string
+---@field drivers fun(self: ModemBackend, timeout: number?): table, string
+---@field plugin fun(self: ModemBackend, timeout: number?): string, string
+---@field model fun(self: ModemBackend, timeout: number?): string, string
+---@field revision fun(self: ModemBackend, timeout: number?): string, string
+---@field enable fun(self: ModemBackend): boolean, string
+---@field disable fun(self: ModemBackend): boolean, string
+---@field reset fun(self: ModemBackend): boolean, string
+---@field connect fun(self: ModemBackend, conn_string: string): boolean, string
+---@field disconnect fun(self: ModemBackend): boolean, string
+---@field inhibit fun(self: ModemBackend): boolean, string
+---@field uninhibit fun(self: ModemBackend): boolean, string
+---@field monitor_state_op fun(self: ModemBackend): Op
 local ModemBackend = {}
 ModemBackend.__index = ModemBackend
 
 -- Add all getter methods to ModemBackend
-getters.add_getters(ModemBackend, fetch_modem_info)
+getters.add_getters(ModemBackend, fetch_modem_info, fetch_signal_info)
 
 --- Enable the modem
----@return string result
----@return number exit_code
+---@return boolean ok
+---@return string error
 function ModemBackend:enable()
     local cmd = exec.command {
         "mmcli", "-m", self.identity.address, "-e",
@@ -241,16 +349,16 @@ function ModemBackend:enable()
         stdout = "pipe",
         stderr = "stdout"
     }
-    local output, status, code, _, err = fibers.perform(cmd:combined_output_op())
+    local _, status, _, _, err = fibers.perform(cmd:combined_output_op())
     if status ~= "exited" then
-        return "mmcli command failed to execute: " .. tostring(err), code
+        return false, "mmcli command failed to execute: " .. tostring(err)
     end
-    return output, code
+    return true, ""
 end
 
 --- Disable the modem
----@return string result
----@return number exit_code
+---@return boolean ok
+---@return string error
 function ModemBackend:disable()
     local cmd = exec.command {
         "mmcli", "-m", self.identity.address, "-d",
@@ -258,16 +366,16 @@ function ModemBackend:disable()
         stdout = "pipe",
         stderr = "stdout"
     }
-    local output, status, code, _, err = fibers.perform(cmd:combined_output_op())
+    local _, status, _, _, err = fibers.perform(cmd:combined_output_op())
     if status ~= "exited" then
-        return "mmcli command failed to execute: " .. tostring(err), code
+        return false, "mmcli command failed to execute: " .. tostring(err)
     end
-    return output, code
+    return true, ""
 end
 
 --- Reset the modem
----@return string result
----@return number exit_code
+---@return boolean ok
+---@return string error
 function ModemBackend:reset()
     local cmd = exec.command {
         "mmcli", "-m", self.identity.address, "--reset",
@@ -275,17 +383,17 @@ function ModemBackend:reset()
         stdout = "pipe",
         stderr = "stdout"
     }
-    local output, status, code, _, err = fibers.perform(cmd:combined_output_op())
+    local _, status, _, _, err = fibers.perform(cmd:combined_output_op())
     if status ~= "exited" then
-        return "mmcli command failed to execute: " .. tostring(err), code
+        return false, "mmcli command failed to execute: " .. tostring(err)
     end
-    return output, code
+    return true, ""
 end
 
 --- Connect the modem
 ---@param conn_string string
----@return string result
----@return number exit_code
+---@return boolean ok
+---@return string error
 function ModemBackend:connect(conn_string)
     local full_conn_string = "--simple-connect=" .. conn_string
     local cmd = exec.command {
@@ -294,16 +402,16 @@ function ModemBackend:connect(conn_string)
         stdout = "pipe",
         stderr = "stdout"
     }
-    local output, status, code, _, err = fibers.perform(cmd:combined_output_op())
+    local _, status, _, _, err = fibers.perform(cmd:combined_output_op())
     if status ~= "exited" then
-        return "mmcli command failed to execute: " .. tostring(err), code
+        return false, "mmcli command failed to execute: " .. tostring(err)
     end
-    return output, code
+    return true, ""
 end
 
 --- Disconnect the modem
----@return string result
----@return number exit_code
+---@return boolean ok
+---@return string error
 function ModemBackend:disconnect()
     local cmd = exec.command {
         "mmcli", "-m", self.identity.address, "--simple-disconnect",
@@ -311,19 +419,19 @@ function ModemBackend:disconnect()
         stdout = "pipe",
         stderr = "stdout"
     }
-    local output, status, code, _, err = fibers.perform(cmd:combined_output_op())
+    local _, status, _, _, err = fibers.perform(cmd:combined_output_op())
     if status ~= "exited" then
-        return "mmcli command failed to execute: " .. tostring(err), code
+        return false, "mmcli command failed to execute: " .. tostring(err)
     end
-    return output, code
+    return true, ""
 end
 
 --- Inhibit the modem
----@return string result
----@return number exit_code
+---@return boolean ok
+---@return string error
 function ModemBackend:inhibit()
     if self.inhibit_cmd then
-        return "Modem is already inhibited", 1
+        return false, "Modem is already inhibited"
     end
 
     local cmd = exec.command {
@@ -337,25 +445,25 @@ function ModemBackend:inhibit()
     -- The command will run in the background, managed by the scope
     local stream, err = cmd:stdout_stream()
     if not stream then
-        return "Failed to start inhibit command: " .. tostring(err), 1
+        return false, "Failed to start inhibit command: " .. tostring(err)
     end
 
     self.inhibit_cmd = cmd
-    return "Modem inhibit started", 0
+    return true, "Modem inhibit started"
 end
 
 --- Uninhibit the modem
----@return string result
----@return number exit_code
+---@return boolean ok
+---@return string error
 function ModemBackend:uninhibit()
     if not self.inhibit_cmd then
-        return "Modem is not inhibited", 0
+        return false, "Modem is not inhibited"
     end
 
     self.inhibit_cmd:kill()
     self.inhibit_cmd = nil
 
-    return "Modem uninhibited", 0
+    return true, "Modem uninhibited"
 end
 
 --- Listen for modem state changes
@@ -373,8 +481,6 @@ function ModemBackend:monitor_state_op()
     end
     return stream:read_line_op():wrap(parse_modem_state_line)
 end
-
-
 
 --- Builds the backend instance
 --- @return ModemBackend

--- a/src/services/hal/backends/modem/providers/linux_mm/impl.lua
+++ b/src/services/hal/backends/modem/providers/linux_mm/impl.lua
@@ -6,8 +6,6 @@ local log = require "services.log"
 local fibers = require "fibers"
 local exec = require "fibers.io.exec"
 local op = require "fibers.op"
-local fiber = require "fibers.fiber"
-local scope = require "fibers.scope"
 
 -- Other modules
 local cache_mod = require "shared.cache"
@@ -118,44 +116,75 @@ local FIELD_POST_PROCESSORS = {
 ---@param cache Cache
 ---@return string error
 local function fetch_modem_info(identity, cache)
-    local cmd = exec.command {
-        "mmcli", "-J", "-m", identity.address,
-        stdin = "null",
-        stdout = "pipe",
-        stderr = "stdout"
-    }
-    local output, status, code, _, err = fibers.perform(cmd:combined_output_op())
-    if status ~= "exited" or code ~= 0 then
-        return "mmcli command failed: " .. tostring(err) .. ", output: " .. tostring(output)
-    end
-
-    local data, json_err = json.decode(output)
-    if not data then
-        return "Failed to decode mmcli output as JSON: " .. tostring(json_err) .. ", output: " .. tostring(output)
-    end
-
-    local modem = data.modem
-
-    local flat, errors = nested_to_flat(modem, MODEM_INFO_PATHS)
-    if #errors > 0 then
-        log.warn("Errors formatting modem info: " .. table.concat(errors, ";\n\t"))
-    end
-
-    -- Apply post-processors to transform fields before caching
-    for field_name, processor in pairs(FIELD_POST_PROCESSORS) do
-        if flat[field_name] then
-            local cache_entries = processor(flat[field_name])
-            for k, v in pairs(cache_entries) do
-                cache:set(k, v)
-            end
-            flat[field_name] = nil -- Remove original field since we cached the processed entries
+    local st, _, err = fibers.run_scope(function()
+        local cmd = exec.command {
+            "mmcli", "-J", "-m", identity.address,
+            stdin = "null",
+            stdout = "pipe",
+            stderr = "stdout"
+        }
+        local output, status, code, _, err = fibers.perform(cmd:combined_output_op())
+        if status ~= "exited" or code ~= 0 then
+            error("mmcli command failed: " .. tostring(err) .. ", output: " .. tostring(output))
         end
-    end
 
-    for k, v in pairs(flat) do
-        cache:set(k, v)
+        local data, json_err = json.decode(output)
+        if not data then
+            error("Failed to decode mmcli output as JSON: " .. tostring(json_err) .. ", output: " .. tostring(output))
+        end
+
+        local modem = data.modem
+
+        local flat, errors = nested_to_flat(modem, MODEM_INFO_PATHS)
+        if #errors > 0 then
+            log.warn("Errors formatting modem info: " .. table.concat(errors, ";\n\t"))
+        end
+
+        -- Apply post-processors to transform fields before caching
+        for field_name, processor in pairs(FIELD_POST_PROCESSORS) do
+            if flat[field_name] then
+                local cache_entries = processor(flat[field_name])
+                for k, v in pairs(cache_entries) do
+                    cache:set(k, v)
+                end
+                flat[field_name] = nil -- Remove original field since we cached the processed entries
+            end
+        end
+
+        for k, v in pairs(flat) do
+            cache:set(k, v)
+        end
+    end)
+    return st ~= "ok" and err or ""
+end
+
+--- Read a net stat
+---@param net_port string
+---@return integer rx_bytes
+---@return string error
+local function read_net_stat(net_port, stat)
+    local st, _, rx_bytes_or_err = fibers.run_scope(function()
+        local path = '/sys/class/net/' .. net_port .. '/statistics/' .. stat
+        local file = io.open(path, "r")
+        if not file then
+            error("Failed to open file: " .. tostring(path))
+        end
+        local content = file:read("*a")
+        file:close()
+        if not content then
+            error("Failed to read file: " .. tostring(path))
+        end
+        local rx_bytes = tonumber(content)
+        if not rx_bytes then
+            error("Failed to parse rx_bytes: " .. tostring(content))
+        end
+        return rx_bytes
+    end)
+
+    if st == "ok" then
+        return rx_bytes_or_err, ""
     end
-    return ""
+    return -1, rx_bytes_or_err or "Unknown error"
 end
 
 --- Get the table values from the active signal tech
@@ -186,33 +215,35 @@ end
 ---@param cache Cache
 ---@return string error
 local function fetch_signal_info(identity, cache)
-    local cmd = exec.command {
-        "mmcli", "-J", "-m", identity.address, "--signal-get",
-        stdin = "null",
-        stdout = "pipe",
-        stderr = "stdout"
-    }
-    local output, status, code, _, err = fibers.perform(cmd:combined_output_op())
-    if status ~= "exited" or code ~= 0 then
-        return "mmcli command failed: " .. tostring(err) .. ", output: " .. tostring(output)
-    end
+    local st, _, err = fibers.run_scope(function()
+        local cmd = exec.command {
+            "mmcli", "-J", "-m", identity.address, "--signal-get",
+            stdin = "null",
+            stdout = "pipe",
+            stderr = "stdout"
+        }
+        local output, status, code, _, err = fibers.perform(cmd:combined_output_op())
+        if status ~= "exited" or code ~= 0 then
+            error("mmcli command failed: " .. tostring(err) .. ", output: " .. tostring(output))
+        end
 
-    local data, json_err = json.decode(output)
-    if not data then
-        return "Failed to decode mmcli output as JSON: " .. tostring(json_err) .. ", output: " .. tostring(output)
-    end
+        local data, json_err = json.decode(output)
+        if not data then
+            error("Failed to decode mmcli output as JSON: " .. tostring(json_err) .. ", output: " .. tostring(output))
+        end
 
-    local signal_techs = data.modem and data.modem.signal or nil
-    if not signal_techs then
-        return "No signal info found in mmcli output: " .. tostring(output)
-    end
+        local signal_techs = data.modem and data.modem.signal or nil
+        if not signal_techs then
+            error("No signal info found in mmcli output: " .. tostring(output))
+        end
 
-    local active_signal, active_err = get_active_signal(signal_techs)
-    if active_err ~= "" then
-        return "Failed to get active signal: " .. tostring(active_err)
-    end
-    cache:set("signal", active_signal)
-    return ""
+        local active_signal, active_err = get_active_signal(signal_techs)
+        if active_err ~= "" then
+            error("Failed to get active signal: " .. tostring(active_err))
+        end
+        cache:set("signal", active_signal)
+    end)
+    return st ~= "ok" and err or ""
 end
 
 
@@ -244,6 +275,14 @@ local function get_identity(address, cache)
         qmi_port = qmi_ports[1]
     end
 
+    local mbim_ports = cache:get("mbim_ports")
+    local mbim_port
+    if mbim_ports and type(mbim_ports) == "table" then
+        mbim_port = mbim_ports[1]
+    end
+
+    local mode_port = mbim_port or qmi_port -- Prefer mbim port if available, otherwise use qmi port
+
     local at_ports = cache:get("at_ports")
     local at_port
     if at_ports and type(at_ports) == "table" then
@@ -259,7 +298,7 @@ local function get_identity(address, cache)
     local id, id_err = modem_types.new.ModemIdentity(
         imei,
         address,
-        qmi_port,
+        mode_port,
         at_port,
         net_port,
         device
@@ -306,88 +345,73 @@ end
 
 
 ---- Public backend interface ----
+--- See ModemBackend class definition in services.hal.types.modem
 
----@class ModemBackend
----@field identity ModemIdentity
----@field cache Cache
----@field inhibit_cmd Command|nil
----@field imei fun(self: ModemBackend, timeout: number?): string, string
----@field device fun(self: ModemBackend, timeout: number?): string, string
----@field primary_port fun(self: ModemBackend, timeout: number?): string, string
----@field at_ports fun(self: ModemBackend, timeout: number?): table, string
----@field qmi_ports fun(self: ModemBackend, timeout: number?): table, string
----@field gps_ports fun(self: ModemBackend, timeout: number?): table, string
----@field net_ports fun(self: ModemBackend, timeout: number?): table, string
----@field ignored_ports fun(self: ModemBackend, timeout: number?): table, string
----@field access_techs fun(self: ModemBackend, timeout: number?): table, string
----@field sim fun(self: ModemBackend, timeout: number?): string, string
----@field drivers fun(self: ModemBackend, timeout: number?): table, string
----@field plugin fun(self: ModemBackend, timeout: number?): string, string
----@field model fun(self: ModemBackend, timeout: number?): string, string
----@field revision fun(self: ModemBackend, timeout: number?): string, string
----@field enable fun(self: ModemBackend): boolean, string
----@field disable fun(self: ModemBackend): boolean, string
----@field reset fun(self: ModemBackend): boolean, string
----@field connect fun(self: ModemBackend, conn_string: string): boolean, string
----@field disconnect fun(self: ModemBackend): boolean, string
----@field inhibit fun(self: ModemBackend): boolean, string
----@field uninhibit fun(self: ModemBackend): boolean, string
----@field monitor_state_op fun(self: ModemBackend): Op
 local ModemBackend = {}
 ModemBackend.__index = ModemBackend
 
 -- Add all getter methods to ModemBackend
-getters.add_getters(ModemBackend, fetch_modem_info, fetch_signal_info)
+getters.add_getters(ModemBackend,
+    fetch_modem_info,
+    fetch_signal_info,
+    read_net_stat
+)
 
 --- Enable the modem
 ---@return boolean ok
 ---@return string error
 function ModemBackend:enable()
-    local cmd = exec.command {
-        "mmcli", "-m", self.identity.address, "-e",
-        stdin = "null",
-        stdout = "pipe",
-        stderr = "stdout"
-    }
-    local _, status, _, _, err = fibers.perform(cmd:combined_output_op())
-    if status ~= "exited" then
-        return false, "mmcli command failed to execute: " .. tostring(err)
-    end
-    return true, ""
+    local st, _, err = fibers.run_scope(function()
+        local cmd = exec.command {
+            "mmcli", "-m", self.identity.address, "-e",
+            stdin = "null",
+            stdout = "pipe",
+            stderr = "stdout"
+        }
+        local _, status, _, _, err = fibers.perform(cmd:combined_output_op())
+        if status ~= "exited" then
+            error("mmcli command failed to execute: " .. tostring(err))
+        end
+    end)
+    return st == "ok", err or ""
 end
 
 --- Disable the modem
 ---@return boolean ok
 ---@return string error
 function ModemBackend:disable()
-    local cmd = exec.command {
-        "mmcli", "-m", self.identity.address, "-d",
-        stdin = "null",
-        stdout = "pipe",
-        stderr = "stdout"
-    }
-    local _, status, _, _, err = fibers.perform(cmd:combined_output_op())
-    if status ~= "exited" then
-        return false, "mmcli command failed to execute: " .. tostring(err)
-    end
-    return true, ""
+    local st, _, err = fibers.run_scope(function()
+        local cmd = exec.command {
+            "mmcli", "-m", self.identity.address, "-d",
+            stdin = "null",
+            stdout = "pipe",
+            stderr = "stdout"
+        }
+        local _, status, _, _, err = fibers.perform(cmd:combined_output_op())
+        if status ~= "exited" then
+            error("mmcli command failed to execute: " .. tostring(err))
+        end
+    end)
+    return st == "ok", err or ""
 end
 
 --- Reset the modem
 ---@return boolean ok
 ---@return string error
 function ModemBackend:reset()
-    local cmd = exec.command {
-        "mmcli", "-m", self.identity.address, "--reset",
-        stdin = "null",
-        stdout = "pipe",
-        stderr = "stdout"
-    }
-    local _, status, _, _, err = fibers.perform(cmd:combined_output_op())
-    if status ~= "exited" then
-        return false, "mmcli command failed to execute: " .. tostring(err)
-    end
-    return true, ""
+    local st, _, err = fibers.run_scope(function()
+        local cmd = exec.command {
+            "mmcli", "-m", self.identity.address, "--reset",
+            stdin = "null",
+            stdout = "pipe",
+            stderr = "stdout"
+        }
+        local _, status, _, _, err = fibers.perform(cmd:combined_output_op())
+        if status ~= "exited" then
+            error("mmcli command failed to execute: " .. tostring(err))
+        end
+    end)
+    return st == "ok", err or ""
 end
 
 --- Connect the modem
@@ -396,34 +420,38 @@ end
 ---@return string error
 function ModemBackend:connect(conn_string)
     local full_conn_string = "--simple-connect=" .. conn_string
-    local cmd = exec.command {
-        "mmcli", "-m", self.identity.address, full_conn_string,
-        stdin = "null",
-        stdout = "pipe",
-        stderr = "stdout"
-    }
-    local _, status, _, _, err = fibers.perform(cmd:combined_output_op())
-    if status ~= "exited" then
-        return false, "mmcli command failed to execute: " .. tostring(err)
-    end
-    return true, ""
+    local st, _, err = fibers.run_scope(function()
+        local cmd = exec.command {
+            "mmcli", "-m", self.identity.address, full_conn_string,
+            stdin = "null",
+            stdout = "pipe",
+            stderr = "stdout"
+        }
+        local _, status, _, _, err = fibers.perform(cmd:combined_output_op())
+        if status ~= "exited" then
+            error("mmcli command failed to execute: " .. tostring(err))
+        end
+    end)
+    return st == "ok", err or ""
 end
 
 --- Disconnect the modem
 ---@return boolean ok
 ---@return string error
 function ModemBackend:disconnect()
-    local cmd = exec.command {
-        "mmcli", "-m", self.identity.address, "--simple-disconnect",
-        stdin = "null",
-        stdout = "pipe",
-        stderr = "stdout"
-    }
-    local _, status, _, _, err = fibers.perform(cmd:combined_output_op())
-    if status ~= "exited" then
-        return false, "mmcli command failed to execute: " .. tostring(err)
-    end
-    return true, ""
+    local st, _, err = fibers.run_scope(function()
+        local cmd = exec.command {
+            "mmcli", "-m", self.identity.address, "--simple-disconnect",
+            stdin = "null",
+            stdout = "pipe",
+            stderr = "stdout"
+        }
+        local _, status, _, _, err = fibers.perform(cmd:combined_output_op())
+        if status ~= "exited" then
+            error("mmcli command failed to execute: " .. tostring(err))
+        end
+    end)
+    return st == "ok", err or ""
 end
 
 --- Inhibit the modem
@@ -466,9 +494,13 @@ function ModemBackend:uninhibit()
     return true, "Modem uninhibited"
 end
 
---- Listen for modem state changes
----@return Op
-function ModemBackend:monitor_state_op()
+--- Start monitoring modem state changes
+---@return boolean ok
+---@return string error
+function ModemBackend:start_state_monitor()
+    if self.state_monitor then
+        return false, "Already monitoring modem state"
+    end
     local cmd = exec.command {
         "mmcli", "-m", self.identity.address, "-w",
         stdin = "null",
@@ -477,9 +509,41 @@ function ModemBackend:monitor_state_op()
     }
     local stream, err = cmd:stdout_stream()
     if not stream then
-        error("Failed to start monitor state command: " .. tostring(err))
+        return false, "Failed to start monitor state command: " .. tostring(err)
     end
-    return stream:read_line_op():wrap(parse_modem_state_line)
+    self.state_monitor = { cmd = cmd, stream = stream }
+    return true, ""
+end
+
+--- Listen for modem state changes
+---@return Op
+function ModemBackend:monitor_state_op()
+    return op.guard(function()
+        if not self.state_monitor then
+            return op.always(nil)
+        end
+        return self.state_monitor.stream:read_line_op():wrap(parse_modem_state_line)
+    end)
+end
+
+--- Set the modem signal update interval
+---@param period number
+---@return boolean ok
+---@return string error
+function ModemBackend:set_signal_update_interval(period)
+    local st, _, err = fibers.run_scope(function()
+        local cmd = exec.command {
+            "mmcli", "-m", self.identity.address, "--signal-setup=" .. tostring(period),
+            stdin = "null",
+            stdout = "pipe",
+            stderr = "stdout"
+        }
+        local _, status, _, _, err = fibers.perform(cmd:combined_output_op())
+        if status ~= "exited" then
+            error("mmcli command failed to execute: " .. tostring(err))
+        end
+    end)
+    return st == "ok", err or ""
 end
 
 --- Builds the backend instance
@@ -489,6 +553,7 @@ local function new(address)
     local self = {
         cache = cache,
         identity = get_identity(address, cache),
+        base = "linux_mm"
     }
     return setmetatable(self, ModemBackend)
 end

--- a/src/services/hal/backends/modem/providers/linux_mm/init.lua
+++ b/src/services/hal/backends/modem/providers/linux_mm/init.lua
@@ -1,16 +1,19 @@
 local file = require "fibers.io.file"
 local exec = require "fibers.io.exec"
 local op = require "fibers.op"
+local fibers = require "fibers"
+
+local backend = require "services.hal.backends.modem.providers.linux_mm.impl"
 
 local function is_linux()
-    local fh = file.open("/proc/version", "r")
-    if not fh then
+    local fh, open_err = file.open("/proc/version", "r")
+    if not fh or open_err then
         return false
     end
 
-    local content = fh:read("*a")
+    local content, read_err = fh:read_all()
     fh:close()
-    if not content then
+    if not content or read_err then
         return false
     end
 
@@ -26,7 +29,7 @@ local function has_mmcli()
         stdout = "pipe",
         stderr = "stdout"
     }
-    local _, status, code, _, err = op.perform(cmd:combined_output_op())
+    local _, status, code, _, err = fibers.perform(cmd:combined_output_op())
     if status == "exited" and code == 0 then
         return true
     end
@@ -36,10 +39,9 @@ end
 --- Returns if linux with modem manager is supported
 ---@return boolean
 local function is_supported()
-    return is_linux() and has_mmcli()
+    local res = is_linux() and has_mmcli()
+    return res
 end
-
-local backend = require "services.hal.backends.modem.providers.linux_mm.impl"
 
 return {
     is_supported = is_supported,

--- a/src/services/hal/backends/modem/providers/linux_mm/init.lua
+++ b/src/services/hal/backends/modem/providers/linux_mm/init.lua
@@ -39,6 +39,8 @@ local function is_supported()
     return is_linux() and has_mmcli()
 end
 
+local backend = require "services.hal.backends.modem.providers.linux_mm.impl"
+
 return {
     is_supported = is_supported,
     backend = backend

--- a/src/services/hal/backends/modem/providers/linux_mm/init.lua
+++ b/src/services/hal/backends/modem/providers/linux_mm/init.lua
@@ -1,0 +1,46 @@
+local file = require "fibers.io.file"
+local exec = require "fibers.io.exec"
+local op = require "fibers.op"
+
+local function is_linux()
+    local fh = file.open("/proc/version", "r")
+    if not fh then
+        return false
+    end
+
+    local content = fh:read("*a")
+    fh:close()
+    if not content then
+        return false
+    end
+
+    return content:lower():find("linux") ~= nil
+end
+
+--- Returns true if `mmcli` is runnable
+---@return boolean ok
+local function has_mmcli()
+    local cmd = exec.command{
+        "mmcli", "--version",
+        stdin = "null",
+        stdout = "pipe",
+        stderr = "stdout"
+    }
+    local _, status, code, _, err = op.perform(cmd:combined_output_op())
+    if status == "exited" and code == 0 then
+        return true
+    end
+    return false
+end
+
+--- Returns if linux with modem manager is supported
+---@return boolean
+local function is_supported()
+    return is_linux() and has_mmcli()
+end
+
+return {
+    is_supported = is_supported,
+    backend = backend
+}
+

--- a/src/services/hal/backends/modem/providers/linux_mm/init.lua
+++ b/src/services/hal/backends/modem/providers/linux_mm/init.lua
@@ -4,6 +4,7 @@ local op = require "fibers.op"
 local fibers = require "fibers"
 
 local backend = require "services.hal.backends.modem.providers.linux_mm.impl"
+local monitor = require "services.hal.backends.modem.providers.linux_mm.monitor"
 
 local function is_linux()
     local fh, open_err = file.open("/proc/version", "r")
@@ -43,8 +44,15 @@ local function is_supported()
     return res
 end
 
+---@return ModemMonitor? monitor
+---@return string error
+local function new_monitor()
+    return monitor.new()
+end
+
 return {
     is_supported = is_supported,
-    backend = backend
+    backend = backend,
+    new_monitor = new_monitor,
 }
 

--- a/src/services/hal/backends/modem/providers/linux_mm/monitor.lua
+++ b/src/services/hal/backends/modem/providers/linux_mm/monitor.lua
@@ -1,0 +1,65 @@
+local exec = require "fibers.io.exec"
+local op = require "fibers.op"
+local modem_types = require "services.hal.types.modem"
+
+---@class ModemMonitor
+---@field cmd Command
+---@field stream any
+local ModemMonitor = {}
+ModemMonitor.__index = ModemMonitor
+
+--- Parse one line from `mmcli -M` output into a ModemMonitorEvent.
+--- Returns (nil, "Command closed") when the stream yields nil (end of stream).
+--- Returns (nil, error) for lines that cannot be parsed.
+---@param line string?
+---@return ModemMonitorEvent?
+---@return string error
+local function parse_monitor_line(line)
+    if not line then
+        return nil, "Command closed"
+    end
+
+    local status, address = line:match("^(.-)(/org%S+)")
+    if not address then
+        return nil, "line could not be parsed: " .. tostring(line)
+    end
+
+    local is_added = not status:match("-")
+    local event, err = modem_types.new.ModemMonitorEvent(is_added, address)
+    if not event then
+        return nil, "failed to create monitor event: " .. tostring(err)
+    end
+
+    return event, ""
+end
+
+--- Returns an Op that when performed yields the next ModemMonitorEvent.
+--- (nil, "Command closed") signals end of stream.
+--- (nil, error) signals an unparseable line — the caller should continue looping.
+---@return Op
+function ModemMonitor:next_event_op()
+    return op.guard(function()
+        return self.stream:read_line_op():wrap(parse_monitor_line)
+    end)
+end
+
+--- Create and start a new ModemMonitor backed by `mmcli -M`.
+---@return ModemMonitor? monitor
+---@return string error
+local function new()
+    local cmd = exec.command {
+        "mmcli", "-M",
+        stdin = "null",
+        stdout = "pipe",
+        stderr = "stdout"
+    }
+    local stream, err = cmd:stdout_stream()
+    if not stream then
+        return nil, "failed to start modem monitor: " .. tostring(err)
+    end
+    return setmetatable({ cmd = cmd, stream = stream }, ModemMonitor), ""
+end
+
+return {
+    new = new,
+}

--- a/src/services/hal/drivers/filesystem.lua
+++ b/src/services/hal/drivers/filesystem.lua
@@ -1,0 +1,373 @@
+-- HAL modules
+local hal_types = require "services.hal.types.core"
+local cap_types = require "services.hal.types.capabilities"
+local external_types = require "services.hal.types.external"
+
+-- Service modules
+local log = require "services.log"
+
+-- Fibers modules
+local fibers = require "fibers"
+local sleep = require "fibers.sleep"
+local op = require "fibers.op"
+local channel = require "fibers.channel"
+local file = require "fibers.io.file"
+
+---@class FSDriver
+---@field scope Scope
+---@field roots table<string, string>
+---@field control_chs table<string, Channel>
+---@field cap_emit_ch Channel
+---@field initialised boolean
+---@field caps_applied boolean
+local FSDriver = {}
+FSDriver.__index = FSDriver
+
+---- Constant Definitions ----
+
+local DEFAULT_STOP_TIMEOUT = 5
+local CONTROL_Q_LEN = 8
+
+---- Utility Functions ----
+
+--- Return a ControlError
+---@param err string?
+---@param code integer?
+---@return boolean ok
+---@return string reason
+---@return integer? code
+local function return_error(err, code)
+    if err == nil then
+        err = "unknown error"
+    end
+    return false, err, code
+end
+
+--- Emit from the filesystem capability
+---@param emit_ch Channel
+---@param root_name string
+---@param mode EmitMode
+---@param key string
+---@param data any
+---@return boolean ok
+---@return string? error
+local function emit(emit_ch, root_name, mode, key, data)
+    local payload, err = hal_types.new.Emit(
+        'fs',
+        root_name,
+        mode,
+        key,
+        data
+    )
+    if not payload then
+        return false, err
+    end
+    emit_ch:put(payload)
+    return true
+end
+
+---- Filesystem Capabilities ----
+
+--- Read a file from a root
+---@param root_name string
+---@param opts FilesystemReadOpts?
+---@return boolean ok
+---@return string reason_or_content
+---@return integer? code
+function FSDriver:read(root_name, opts)
+    if opts == nil or getmetatable(opts) ~= external_types.FilesystemReadOpts then
+        return return_error("invalid options", 1)
+    end
+
+    local filename = opts.filename
+    if filename == nil then
+        return return_error("missing filename", 1)
+    end
+
+    local root_path = self.roots[root_name]
+    if not root_path then
+        return return_error("unknown root: " .. tostring(root_name), 1)
+    end
+
+    local full_path = root_path .. "/" .. filename
+
+    -- Open file using fibers stream
+    local f, open_err = file.open(full_path, "r")
+    if not f then
+        return return_error("failed to open file: " .. tostring(open_err), 1)
+    end
+
+    local content, read_err = f:read_all()
+    local _, close_err = f:close()
+
+    if not content then
+        return return_error("failed to read file: " .. tostring(read_err), 1)
+    end
+
+    if close_err then
+        log.warn("FS Driver", "read: warning closing file:", close_err)
+    end
+
+    -- Emit success event
+    local ok, emit_err = emit(self.cap_emit_ch, root_name, 'event', 'read_success', {
+        filename = filename
+    })
+    if not ok then
+        log.warn("FS Driver", "read: failed to emit success event:", emit_err)
+    end
+
+    return true, content
+end
+
+--- Write a file to a root
+---@param root_name string
+---@param opts FilesystemWriteOpts?
+---@return boolean ok
+---@return string? reason
+---@return integer? code
+function FSDriver:write(root_name, opts)
+    if opts == nil or getmetatable(opts) ~= external_types.FilesystemWriteOpts then
+        return return_error("invalid options", 1)
+    end
+
+    local filename = opts.filename
+    if filename == nil then
+        return return_error("missing filename", 1)
+    end
+
+    local root_path = self.roots[root_name]
+    if not root_path then
+        return return_error("unknown root: " .. tostring(root_name), 1)
+    end
+
+    local full_path = root_path .. "/" .. filename
+
+    -- Open file using fibers stream
+    local f, open_err = file.open(full_path, "w")
+    if not f then
+        return return_error("failed to open file for writing: " .. tostring(open_err), 1)
+    end
+
+    local ok, write_err = f:write(opts.data)
+    local _, close_err = f:close()
+
+    if not ok then
+        return return_error("failed to write file: " .. tostring(write_err), 1)
+    end
+
+    if close_err then
+        log.warn("FS Driver", "write: warning closing file:", close_err)
+    end
+
+    -- Emit success event
+    local ok_emit, emit_err = emit(self.cap_emit_ch, root_name, 'event', 'write_success', {
+        filename = filename
+    })
+    if not ok_emit then
+        log.warn("FS Driver", "write: failed to emit success event:", emit_err)
+    end
+
+    return true
+end
+
+--- Validate that a function is implemented
+---@param fn any
+---@return boolean is_valid
+---@return string? error
+local function validate_fn(fn)
+    if fn == nil then
+        return false, tostring(fn) .. " is unimplemented"
+    end
+    if type(fn) ~= "function" then
+        return false, tostring(fn) .. " is not a function"
+    end
+    return true
+end
+
+---- Long Running Fibers ----
+
+function FSDriver:control_manager()
+    if self.cap_emit_ch == nil then
+        log.error("FS Driver", "control_manager: cap_emit_ch is nil")
+        return
+    end
+
+    log.trace("FS Driver", "control_manager: started")
+
+    fibers.current_scope():finally(function()
+        log.trace("FS Driver", "control_manager: exiting")
+    end)
+
+    while true do
+        -- Build named choice over all root control channels
+        local choice_arms = {}
+        for root_name, control_ch in pairs(self.control_chs) do
+            choice_arms[root_name] = control_ch:get_op()
+        end
+
+        -- Wait for a request from any root's control channel
+        local root_name, request, req_err = fibers.perform(op.named_choice(choice_arms))
+
+        if not request then
+            log.error("FS Driver", "control_manager: control channel get error:", req_err)
+            break
+        end
+
+        ---@cast request ControlRequest
+
+        local ok, reason, code
+
+        local fn = self[request.verb]
+        local valid, validation_err = validate_fn(fn)
+        if not valid then
+            ok = false
+            reason = "no function exists for verb: " .. tostring(validation_err)
+        else
+            local call_ok, fn_ok, fn_reason, fn_code = pcall(fn, self, root_name, request.opts)
+            if not call_ok then
+                ok = false
+                reason = "internal error: " .. tostring(fn_ok)
+                code = 1
+            else
+                ok = fn_ok
+                reason = fn_reason
+                code = fn_code
+            end
+        end
+
+        local reply, reply_err = hal_types.new.Reply(ok, reason, code)
+        if not reply then
+            log.error("FS Driver", "control_manager: failed to create reply:", reply_err)
+        else
+            request.reply_ch:put(reply)
+        end
+    end
+end
+
+---- Driver Functions ----
+
+--- Spawn filesystem driver services
+---@return boolean ok
+---@return string error
+function FSDriver:start()
+    if not self.initialised then
+        return false, "filesystem not initialised"
+    end
+    if not self.caps_applied then
+        return false, "capabilities not applied"
+    end
+
+    self.scope:spawn(function() self:control_manager() end)
+
+    return true, ""
+end
+
+--- Closes down the filesystem driver
+---@param timeout number? Timeout in seconds
+---@return boolean ok
+---@return string error
+function FSDriver:stop(timeout)
+    timeout = timeout or DEFAULT_STOP_TIMEOUT
+    self.scope:cancel()
+
+    local source = fibers.perform(op.named_choice {
+        join = self.scope:join_op(),
+        timeout = sleep.sleep_op(timeout)
+    })
+
+    if source == "timeout" then
+        return false, "filesystem stop timeout"
+    end
+    return true, ""
+end
+
+--- Apply capabilities to HAL and start monitoring state
+--- Filesystem must be initialised first
+---@param emit_ch Channel
+---@return Capability[]? capabilities
+---@return string error
+function FSDriver:capabilities(emit_ch)
+    if not self.initialised then
+        return nil, "filesystem not initialised"
+    end
+    if self.caps_applied then
+        return nil, "capabilities already applied"
+    end
+
+    self.cap_emit_ch = emit_ch
+
+    local caps = {}
+
+    for cap_name, _ in pairs(self.roots) do
+        local control_ch = self.control_chs[cap_name]
+        local cap, cap_err = cap_types.new.FilesystemCapability(cap_name, control_ch)
+        if not cap then
+            return nil, "failed to create capability for root " .. cap_name .. ": " .. tostring(cap_err)
+        end
+
+        table.insert(caps, cap)
+    end
+
+    self.caps_applied = true
+
+    return caps, ""
+end
+
+--- Initialize the filesystem driver
+--- Creates missing root directories and validates configuration
+---@return string error
+function FSDriver:init()
+    if self.initialised then
+        return "already initialised"
+    end
+
+    -- Validate roots
+    if type(self.roots) ~= 'table' or next(self.roots) == nil then
+        return "roots must be a non-empty table"
+    end
+
+    -- Create control channels for each root and create missing directories
+    for root_name, root_path in pairs(self.roots) do
+        if type(root_path) ~= 'string' or root_path == '' then
+            return "root path for " .. tostring(root_name) .. " must be a non-empty string"
+        end
+
+        -- Create control channel for this root
+        self.control_chs[root_name] = channel.new(CONTROL_Q_LEN)
+
+        -- Create missing root directory
+        local ok, mkdir_err = file.mkdir_p(root_path)
+        if not ok then
+            local err_msg = "failed to create root directory " .. tostring(root_name) ..
+                            " at " .. tostring(root_path) .. ": " .. tostring(mkdir_err)
+            return err_msg
+        end
+
+        log.trace("FS Driver", "created/verified root", root_name, "at", root_path)
+    end
+
+    self.initialised = true
+    return ""
+end
+
+--- Create a new filesystem driver
+---@param roots table<string, string> A mapping of root names to their paths
+---@return FSDriver?
+---@return string error
+local function new(roots)
+    local self = setmetatable({}, FSDriver)
+    local scope, sc_err = fibers.current_scope():child()
+    if not scope then return nil, sc_err end
+
+    self.scope = scope
+    self.roots = roots or {}
+    self.control_chs = {}
+    self.initialised = false
+    self.caps_applied = false
+
+    return self, ""
+end
+
+return {
+    new = new,
+}

--- a/src/services/hal/drivers/modem.lua
+++ b/src/services/hal/drivers/modem.lua
@@ -52,10 +52,9 @@ local GET_METHODS = list_to_table {
     "imei",
     "device",
     "primary_port",
-    "ports",
     "at_ports",
     "qmi_ports",
-    "gps_ports",
+    -- "gps_ports", -- maybe needed for the future
     "net_ports",
     "access_techs",
     "sim",
@@ -63,7 +62,16 @@ local GET_METHODS = list_to_table {
     "plugin",
     "model",
     "revision",
-    "operator"
+    "operator",
+    "rx_bytes",
+    "tx_bytes",
+    "signal",
+    "mcc",
+    "mnc",
+    "gid1",
+    "active_band_class",
+    "firmware",
+    "iccid"
 }
 
 
@@ -113,14 +121,17 @@ local function emit_kv(emit_ch, imei, kv_data)
     return all_ok, first_err
 end
 
---- Utility function to throw a ControlError
+--- Utility function to return a ControlError
 ---@param err string?
 ---@param code integer?
-local function throw_error(err, code)
+---@return boolean ok
+---@return string reason
+---@return integer? code
+local function return_error(err, code)
     if err == nil then
         err = "unknown error"
     end
-    error(cap_types.new.ControlError(err, code), 2)
+    return false, err, code
 end
 
 --- Emit an event.
@@ -150,30 +161,6 @@ function Modem:_emit_meta(key, data)
     return emit(self.cap_emit_ch, self.imei, 'meta', key, data)
 end
 
---- Emit a set of key-value events.
----@param kv_data table<string, any>
----@return boolean ok
----@return string? error
-function Modem:_emit_kv(kv_data)
-    return emit_kv(self.cap_emit_ch, self.imei, kv_data)
-end
-
---- Emit a set of key-value states.
----@param kv_data table<string, any>
----@return boolean ok
----@return string? error
-function Modem:_emit_kv_state(kv_data)
-    return emit_kv(self.cap_emit_ch, self.imei, kv_data)
-end
-
---- Emit a set of key-value meta information.
----@param kv_data table<string, any>
----@return boolean ok
----@return string? error
-function Modem:_emit_kv_meta(kv_data)
-    return emit_kv(self.cap_emit_ch, self.imei, kv_data)
-end
-
 --- Validate that a function is implemented
 ---@param fn any
 ---@return boolean is_valid
@@ -188,82 +175,116 @@ local function validate_fn(fn)
     return true
 end
 
+--- Trim the traceback from an error message
+---@param err string
+---@return string trimmed_error
+local function trim_error(err)
+    local traceback_start = err:find("\nstack traceback:")
+    if traceback_start then
+        return err:sub(1, traceback_start - 1)
+    end
+    return err
+end
+
 ---- Modem Capabilities ----
 
 --- Get a modem attribute.
 ---@param opts ModemGetOpts?
----@return any value
+---@return boolean ok
+---@return any reason_or_value
+---@return integer? code
 function Modem:get(opts)
     if opts == nil or getmetatable(opts) ~= external_types.ModemGetOpts then
-        throw_error("invalid options")
-        return
+        return return_error("invalid options", 1)
     end
     local field = opts.field
     local timescale = opts.timescale or math.huge
 
     -- Check that the field is supported
     if not GET_METHODS[field] then
-        throw_error("unsupported field: " .. tostring(field))
+        return return_error("unsupported field: " .. tostring(field), 1)
     end
 
     -- Call the corresponding backend function to get the value
     local get_fn = self.backend[field]
     if not get_fn then
-        throw_error("field " .. tostring(field) .. " is not implemented by backend")
+        return return_error("field " .. tostring(field) .. " is not implemented by backend", 1)
     end
     local value, err = get_fn(self.backend, timescale)
     if err ~= "" then
-        throw_error("error getting field " .. tostring(field) .. ": " .. tostring(err))
+        return return_error("error getting field " .. tostring(field) .. ": " .. tostring(err), 1)
     end
-    return value
+    return true, value
 end
 
 --- Enable the modem
+---@return boolean ok
+---@return string? reason
+---@return integer? code
 function Modem:enable()
     local ok, err = self.backend:enable()
     if not ok then
-        throw_error(err)
+        return return_error(err, 1)
     end
+    return true
 end
 
 --- Disable the modem
+---@return boolean ok
+---@return string? reason
+---@return integer? code
 function Modem:disable()
     local ok, err = self.backend:disable()
     if not ok then
-        throw_error(err)
+        return return_error(err, 1)
     end
+    return true
 end
 
 --- Reset the modem
+---@return boolean ok
+---@return string? reason
+---@return integer? code
 function Modem:reset()
     local ok, err = self.backend:reset()
     if not ok then
-        throw_error(err)
+        return return_error(err, 1)
     end
+    return true
 end
 
 --- Connect the modem
 ---@param opts ModemConnectOpts?
+---@return boolean ok
+---@return string? reason
+---@return integer? code
 function Modem:connect(opts)
     if opts == nil or getmetatable(opts) ~= external_types.ModemConnectOpts then
-        throw_error("invalid options")
-        return
+        return return_error("invalid options", 1)
     end
     local ok, err = self.backend:connect(opts.connection_string)
     if not ok then
-        throw_error(err)
+        return return_error(err, 1)
     end
+    return true
 end
 
 --- Disconnect the modem
+---@return boolean ok
+---@return string? reason
+---@return integer? code
 function Modem:disconnect()
     local ok, err = self.backend:disconnect()
     if not ok then
-        throw_error(err)
+        return return_error(err, 1)
     end
+    return true
 end
 
 --- Inhibit the modem
+---@return boolean ok
+---@return string? reason
+---@return integer? code
 function Modem:inhibit()
     local done_ch = channel.new()
 
@@ -273,7 +294,7 @@ function Modem:inhibit()
     end)
 
     if not ok then
-        throw_error("failed to spawn inhibit fiber: " .. tostring(err))
+        return return_error("failed to spawn inhibit fiber: " .. tostring(err), 1)
     end
 
     local source, msg, primary = fibers.perform(op.named_choice {
@@ -283,27 +304,34 @@ function Modem:inhibit()
 
     if source == "done" then
         if not msg.ok then
-            throw_error(msg.err)
+            return return_error(msg.err, 1)
         end
-        return
+        return true
     elseif source == "failed" then
-        throw_error("modem inhibit failed: " .. tostring(primary))
+        return return_error("modem inhibit failed: " .. tostring(primary), 1)
     end
-    throw_error("unexpected error during modem inhibit")
+    return return_error("unexpected error during modem inhibit", 1)
 end
 
 --- Uninhibit the modem
+---@return boolean ok
+---@return string? reason
+---@return integer? code
 function Modem:uninhibit()
     local ok, err = self.backend:uninhibit()
     if not ok then
-        throw_error(err)
+        return return_error(err, 1)
     end
+    return true
 end
 
 --- Start listening for a sim insertion
+---@return boolean ok
+---@return string? reason
+---@return integer? code
 function Modem:listen_for_sim()
     if self.listening_for_sim then
-        throw_error("already listening for SIM")
+        return return_error("already listening for SIM", 1)
     end
     self.listening_for_sim = true
     local ok, err = fibers.current_scope():spawn(function()
@@ -342,39 +370,30 @@ function Modem:listen_for_sim()
         end)
     end)
     if not ok then
-        throw_error("listen_for_sim spawn failed: " .. tostring(err))
+        return return_error("listen_for_sim spawn failed: " .. tostring(err), 1)
     end
+    return true
 end
 
 --- Set the signal update period
 ---@param opts ModemSignalUpdateOpts
+---@return boolean ok
+---@return string? reason
+---@return integer? code
 function Modem:set_signal_update_freq(opts)
     if opts == nil or getmetatable(opts) ~= external_types.ModemSignalUpdateOpts then
-        throw_error("invalid options")
-        return
+        return return_error("invalid options", 1)
     end
     local ok, err = self.backend:set_signal_update_interval(opts.frequency)
     if not ok then
-        throw_error(err)
+        return return_error(err, 1)
     end
+    return true
 end
 
----- Long Running Fibers ----
-
---- Get reason and code from a ControlError
----@param control_err any
----@param verb string
-local function get_reason_and_code(control_err, verb)
-    if getmetatable(control_err) == cap_types.ControlError then
-        ---@cast control_err ControlError
-        return control_err.reason, control_err.code
-    end
-
-    local reason = "function " .. tostring(verb) .. " failed with error: " .. tostring(control_err)
-    return reason, 1
-end
 
 function Modem:emitter()
+    local timeout_buffer = 0.1
     log.trace("Modem Driver", self.imei, "emitter: started")
 
     fibers.current_scope():finally(function()
@@ -383,23 +402,28 @@ function Modem:emitter()
 
     while true do
         self.state_pulse:next() -- wait for a pulse indicating state change
+        sleep.sleep(timeout_buffer) -- we want to put some buffer time in to invalidate any cache
 
         for method, _ in pairs(GET_METHODS) do
-            local st, _, primary = fibers.run_scope(function() self:get(external_types.new.ModemGetOpts(method, 0)) end)
-
-            if st ~= 'ok' then
-                local err_msg = primary
-                if type(err_msg) == "table" and err_msg.reason then
-                    err_msg = err_msg.reason
-                end
+            local opts, opts_err = external_types.new.ModemGetOpts(method, timeout_buffer)
+            if not opts then
                 log.warn("Modem Driver", self.imei,
-                    "emitter: error getting field " .. tostring(method) .. ": " .. tostring(err_msg))
+                    "emitter: failed to build get opts for field " .. tostring(method) .. ": "
+                    .. tostring(opts_err))
             else
-                local ok, emit_err = self:_emit_meta(method, primary)
+                local ok, value_or_err = self:get(opts)
                 if not ok then
+                    local trimmed_err = trim_error(value_or_err)
                     log.warn("Modem Driver", self.imei,
-                        "emitter: failed to emit meta for field " .. tostring(method) .. ": "
-                        .. tostring(emit_err))
+                        "emitter: error getting field " .. tostring(method) .. ": "
+                        .. tostring(trimmed_err))
+                else
+                    local emit_ok, emit_err = self:_emit_meta(method, value_or_err)
+                    if not emit_ok then
+                        log.warn("Modem Driver", self.imei,
+                            "emitter: failed to emit meta for field " .. tostring(method) .. ": "
+                            .. tostring(emit_err))
+                    end
                 end
             end
         end
@@ -464,14 +488,15 @@ function Modem:control_manager()
             ok = false
             reason = "no function exists for verb: " .. tostring(validation_err)
         else
-            local status, _, primary_or_val = fibers.run_scope(fn, self, request.opts)
-            -- reason field holds the error in case of failure, or the return value in case of success
-            if status == 'ok' then
-                ok = true
-                reason = primary_or_val
-            else
-                reason, code = get_reason_and_code(primary_or_val, request.verb)
+            local call_ok, fn_ok, fn_reason, fn_code = pcall(fn, self, request.opts)
+            if not call_ok then
                 ok = false
+                reason = "internal error: " .. tostring(fn_ok)
+                code = 1
+            else
+                ok = fn_ok
+                reason = fn_reason
+                code = fn_code
             end
         end
 
@@ -539,7 +564,6 @@ function Modem:capabilities(emit_ch)
     self.cap_emit_ch = emit_ch
 
     local modem_cap, mod_cap_err = cap_types.new.ModemCapability(
-        'modem',
         self.imei,
         self.control_ch
     )

--- a/src/services/hal/drivers/modem.lua
+++ b/src/services/hal/drivers/modem.lua
@@ -29,7 +29,6 @@ local pulse = require "fibers.pulse"
 ---@field initialised boolean
 ---@field caps_applied boolean
 ---@field state_pulse Pulse
----@field cache Cache
 local Modem = {}
 Modem.__index = Modem
 
@@ -42,6 +41,7 @@ local function list_to_table(list)
 end
 
 ---- Constant Definitions ----
+local D_LOG_EMITTER = false
 
 local DEFAULT_STOP_TIMEOUT = 5
 local DEFAULT_CACHE_TIMEOUT = 10
@@ -71,7 +71,8 @@ local GET_METHODS = list_to_table {
     "gid1",
     "active_band_class",
     "firmware",
-    "iccid"
+    "iccid",
+    "imsi"
 }
 
 
@@ -163,14 +164,15 @@ end
 
 --- Validate that a function is implemented
 ---@param fn any
+---@param verb string
 ---@return boolean is_valid
 ---@return string? error
-local function validate_fn(fn)
+local function validate_fn(fn, verb)
     if fn == nil then
-        return false, tostring(fn) .. " is unimplemented"
+        return false, tostring(verb) .. " is unimplemented"
     end
     if type(fn) ~= "function" then
-        return false, tostring(fn) .. " is not a function"
+        return false, tostring(verb) .. " is not a function"
     end
     return true
 end
@@ -198,7 +200,7 @@ function Modem:get(opts)
         return return_error("invalid options", 1)
     end
     local field = opts.field
-    local timescale = opts.timescale or math.huge
+    local timescale = opts.timescale
 
     -- Check that the field is supported
     if not GET_METHODS[field] then
@@ -331,7 +333,7 @@ end
 ---@return integer? code
 function Modem:listen_for_sim()
     if self.listening_for_sim then
-        return return_error("already listening for SIM", 1)
+        return true
     end
     self.listening_for_sim = true
     local ok, err = fibers.current_scope():spawn(function()
@@ -391,7 +393,6 @@ function Modem:set_signal_update_freq(opts)
     return true
 end
 
-
 function Modem:emitter()
     local timeout_buffer = 0.1
     log.trace("Modem Driver", self.imei, "emitter: started")
@@ -400,9 +401,17 @@ function Modem:emitter()
         log.trace("Modem Driver", self.imei, "emitter: exiting")
     end)
 
+    local seen_version = 0
     while true do
-        self.state_pulse:next() -- wait for a pulse indicating state change
+        log.trace("Modem Driver", self.imei, "emitter: waiting for state change (last seen version:", seen_version, ")")
+        local new_version = self.state_pulse:changed(seen_version)
+        if not new_version then
+            -- Pulse was closed
+            break
+        end
+        seen_version = new_version
         sleep.sleep(timeout_buffer) -- we want to put some buffer time in to invalidate any cache
+        log.trace("Modem Driver", self.imei, "emitter: change detected emitting updates")
 
         for method, _ in pairs(GET_METHODS) do
             local opts, opts_err = external_types.new.ModemGetOpts(method, timeout_buffer)
@@ -412,14 +421,14 @@ function Modem:emitter()
                     .. tostring(opts_err))
             else
                 local ok, value_or_err = self:get(opts)
-                if not ok then
+                if not ok and D_LOG_EMITTER then
                     local trimmed_err = trim_error(value_or_err)
                     log.warn("Modem Driver", self.imei,
                         "emitter: error getting field " .. tostring(method) .. ": "
                         .. tostring(trimmed_err))
                 else
                     local emit_ok, emit_err = self:_emit_meta(method, value_or_err)
-                    if not emit_ok then
+                    if not emit_ok and D_LOG_EMITTER then
                         log.warn("Modem Driver", self.imei,
                             "emitter: failed to emit meta for field " .. tostring(method) .. ": "
                             .. tostring(emit_err))
@@ -446,6 +455,8 @@ function Modem:state_monitor()
         elseif err ~= "" then
             log.error("Modem Driver", self.imei, "state_monitor: error monitoring state:", err)
         elseif state_update then
+            log.trace("Modem Driver", self.imei, "state_monitor: detected state change from",
+                state_update.from, "to", state_update.to, "- signaling pulse")
             self.state_pulse:signal() -- signal that modem state has changed
             local ok, emit_err = self:_emit_state('card', state_update)
             if not ok then
@@ -483,10 +494,10 @@ function Modem:control_manager()
         local ok, reason, code
 
         local fn = self[request.verb]
-        local valid, validation_err = validate_fn(fn)
+        local valid, validation_err = validate_fn(fn, request.verb)
         if not valid then
             ok = false
-            reason = "no function exists for verb: " .. tostring(validation_err)
+            reason = validation_err
         else
             local call_ok, fn_ok, fn_reason, fn_code = pcall(fn, self, request.opts)
             if not call_ok then
@@ -525,6 +536,9 @@ function Modem:start()
     self.scope:spawn(function() self:state_monitor() end)
     self.scope:spawn(function() self:control_manager() end)
     self.scope:spawn(function() self:emitter() end)
+
+    -- Signal initial pulse so emitter emits the initial state
+    self.state_pulse:signal()
 
     return true, ""
 end
@@ -638,13 +652,13 @@ local function new(address)
     end
 
     -- Print out driver stack trace if scope closes on a failure
-    scope:finally(function ()
+    scope:finally(function()
         local st, primary = scope:status()
         if st == 'failed' then
             log.error(("Modem Driver %s: error - %s"):format(tostring(address), tostring(primary)))
-            log.trace("Modem Driver %s: scope exiting with status %s", tostring(address), st)
+            log.trace(("Modem Driver %s: scope exiting with status %s"):format(tostring(address), st))
         end
-        log.trace("Modem Driver %s: stopped", tostring(address))
+        log.trace(("Modem Driver %s: stopped"):format(tostring(address)))
     end)
 
     return setmetatable({

--- a/src/services/hal/drivers/modem.lua
+++ b/src/services/hal/drivers/modem.lua
@@ -1,0 +1,553 @@
+-- Modem modules
+local modem_types = require "services.hal.types.modem"
+local attr_paths = require "services.hal.drivers.modem.attr_paths"
+
+-- HAL modules
+local hal_types = require "services.hal.types.core"
+local cap_types = require "services.hal.types.capabilities"
+local external_types = require "services.hal.types.external"
+
+-- Service modules
+local log = require "services.log"
+
+-- Fibers modules
+local fibers = require "fibers"
+local scope_mod = require "fibers.scope"
+local op = require "fibers.op"
+local channel = require "fibers.channel"
+local sleep = require "fibers.sleep"
+
+-- Other modules
+local cache = require "shared.cache"
+
+---@class Modem
+---@field address ModemAddress
+---@field control_ch Channel
+---@field cap_emit_ch Channel
+---@field scope Scope
+---@field identity ModemIdentity
+---@field model string
+---@field model_variant string
+---@field mode string
+---@field initialised boolean
+---@field caps_applied boolean
+---@field cache Cache
+local Modem = {}
+Modem.__index = Modem
+
+---- Constant Definitions ----
+
+local DEFAULT_STOP_TIMEOUT = 5
+local DEFAULT_CACHE_TIMEOUT = 10
+
+local CONTROL_Q_LEN = 8
+
+local ATTR_ACCESSOR = attr_paths.build_paths {
+    get_modem_info = get_modem_info,
+    get_modem_firmware = get_modem_firmware,
+    get_sim_info = get_sim_info,
+    get_home_network = get_home_network,
+    get_gid1 = get_gid1,
+    get_rf_band_info = get_rf_band_info,
+    get_operator_info = get_operator_info,
+    get_signal_info = get_signal_info,
+    get_net_stats = get_net_stats,
+}
+
+local MODEL_INFO = {
+    quectel = {
+        -- these are ordered, as eg25gl should match before eg25g
+        { mod_string = "UNKNOWN",   rev_string = "eg25gl",   model = "eg25",   model_variant = "gl" },
+        { mod_string = "UNKNOWN",   rev_string = "eg25g",    model = "eg25",   model_variant = "g" },
+        { mod_string = "UNKNOWN",   rev_string = "ec25e",    model = "ec25",   model_variant = "e" },
+        { mod_string = "em06-e",    rev_string = "em06e",    model = "em06",   model_variant = "e" },
+        { mod_string = "rm520n-gl", rev_string = "rm520ngl", model = "rm520n", model_variant = "gl" }
+        -- more quectel models here
+    },
+    fibocom = {}
+}
+
+
+---- Modem Utility Functions ----
+
+--- Emit from the modem capability
+---@param emit_ch Channel
+---@param imei string
+---@param mode EmitMode
+---@param key string
+---@param data any
+---@return boolean ok
+---@return string? error
+local function emit(emit_ch, imei, mode, key, data)
+    local payload, err = hal_types.new.Emit(
+        'modem',
+        imei,
+        mode,
+        key,
+        data
+    )
+    if not payload then
+        return false, err
+    end
+    emit_ch:put(payload)
+    return true
+end
+
+--- Emit a set of key-value pairs from the modem capability
+---@param emit_ch Channel
+---@param imei string
+---@param kv_data table<string, any>
+---@return boolean ok
+---@return string? error
+local function emit_kv(emit_ch, imei, kv_data)
+    local all_ok = true
+    local first_err = nil
+    for key, value in pairs(kv_data) do
+        local ok, err = emit(emit_ch, imei, 'state', key, value)
+        if not ok then
+            all_ok = false
+            if not first_err then
+                first_err = err
+            end
+        end
+    end
+    return all_ok, first_err
+end
+
+--- Utility function to throw a ControlError
+---@param err string?
+---@param code integer?
+local function throw_error(err, code)
+    if err == nil then
+        err = "unknown error"
+    end
+    error(cap_types.new.ControlError(err, code), 2)
+end
+
+--- Emit an event.
+---@param key string
+---@param data any
+---@return boolean ok
+---@return string? error
+function Modem:_emit_event(key, data)
+    return emit(self.cap_emit_ch, self.identity.imei, 'event', key, data)
+end
+
+--- Emit a state.
+---@param key string
+---@param data any
+---@return boolean ok
+---@return string? error
+function Modem:_emit_state(key, data)
+    return emit(self.cap_emit_ch, self.identity.imei, 'state', key, data)
+end
+
+--- Emit meta information.
+---@param key string
+---@param data any
+---@return boolean ok
+---@return string? error
+function Modem:_emit_meta(key, data)
+    return emit(self.cap_emit_ch, self.identity.imei, 'meta', key, data)
+end
+
+--- Emit a set of key-value events.
+---@param kv_data table<string, any>
+---@return boolean ok
+---@return string? error
+function Modem:_emit_kv(kv_data)
+    return emit_kv(self.cap_emit_ch, self.identity.imei, kv_data)
+end
+
+--- Emit a set of key-value states.
+---@param kv_data table<string, any>
+---@return boolean ok
+---@return string? error
+function Modem:_emit_kv_state(kv_data)
+    return emit_kv(self.cap_emit_ch, self.identity.imei, kv_data)
+end
+
+--- Emit a set of key-value meta information.
+---@param kv_data table<string, any>
+---@return boolean ok
+---@return string? error
+function Modem:_emit_kv_meta(kv_data)
+    return emit_kv(self.cap_emit_ch, self.identity.imei, kv_data)
+end
+
+--- Validate that a function is implemented
+---@param fn any
+---@return boolean is_valid
+---@return string? error
+local function validate_fn(fn)
+    if fn == nil then
+        return false, tostring(fn) .. " is unimplemented"
+    end
+    if type(fn) ~= "function" then
+        return false, tostring(fn) .. " is not a function"
+    end
+    return true
+end
+
+---- Modem Capabilities ----
+
+--- Get a modem attribute.
+---@param opts ModemGetOpts?
+---@return any value
+---@return string? error
+function Modem:get(opts)
+    if opts == nil or getmetatable(opts) ~= external_types.ModemGetOpts then
+        return nil, "invalid options"
+    end
+    local field = opts.field
+    local timescale = opts.timescale or math.huge
+
+    local accessor = ATTR_ACCESSOR[field]
+    if not accessor then
+        throw_error("unknown field: " .. tostring(field))
+    end
+
+    -- try to find value in cache
+    local method = accessor.method
+    local key = method
+    if accessor.path ~= '' then
+        key = key .. "." .. accessor.path
+    end
+    local value, err = self.cache:get(key, timescale)
+    if err then throw_error(err) end
+
+    -- if not found in cache, or stale
+    if value == nil then
+        local valid, validation_err = validate_fn(accessor.gettr)
+        if not valid then
+            return throw_error(validation_err)
+        end
+
+        local info, info_err = accessor.gettr(self.identity)
+        if not info then throw_error(info_err) end
+        local values = attr_paths.flatten_table(info)
+        for k, v in pairs(values) do
+            self.cache:set(k, v)
+        end
+
+        local ok, emit_err = self:_emit_kv_meta(values)
+        if not ok then
+            log.debug("Modem Driver", self.identity.imei, "emit_kv_meta error:", emit_err)
+        end
+
+        value = values[key]
+    end
+
+    if value == nil then
+        throw_error("no value for field: " .. tostring(field))
+    end
+
+    return value
+end
+
+---- Long Running Fibers ----
+
+--- Get reason and code from a ControlError
+---@param control_err any
+---@param verb string
+local function get_reason_and_code(control_err, verb)
+    if getmetatable(control_err) == cap_types.ControlError then
+        ---@cast control_err ControlError
+        return control_err.reason, control_err.code
+    end
+
+    local reason = "function " .. tostring(verb) .. " did not return a valid ControlError"
+    return reason, 1
+end
+
+function Modem:state_monitor()
+end
+
+function Modem:control_manager()
+    if self.cap_emit_ch == nil then
+        log.error("Modem Driver", self.identity.imei, "control_manager: cap_emit_ch is nil")
+        return
+    end
+    if self.control_ch == nil then
+        log.error("Modem Driver", self.identity.imei, "control_manager: control_ch is nil")
+        return
+    end
+
+    log.trace("Modem Driver", self.identity.imei, "control_manager: started")
+
+    while true do
+        local request, req_err = self.control_ch:get()
+        if not request then
+            log.error("Modem Driver", self.identity.imei, "control_manager: control_ch get error:", req_err)
+            break
+        end
+
+        ---@cast request ControlRequest
+
+        local ok, reason, code
+
+        local fn = self[request.verb]
+        local valid, validation_err = validate_fn(fn)
+        if not valid then
+            ok = false
+            reason = "no function exists for verb: " .. tostring(validation_err)
+        else
+            local status, _, primary_or_val = fibers.run_scope(fn, self, request.opts)
+            -- reason field holds the error in case of failure, or the return value in case of success
+            if status == 'ok' then
+                ok = true
+                reason = primary_or_val
+            else
+                reason, code = get_reason_and_code(primary_or_val, request.verb)
+                ok = false
+            end
+        end
+
+        local reply, reply_err = hal_types.new.Reply(ok, reason, code)
+        if not reply then
+            log.error("Modem Driver", self.identity.imei, "control_manager: failed to create reply:", reply_err)
+        else
+            request.reply_ch:put(reply)
+        end
+    end
+
+    log.trace("Modem Driver", self.identity.imei, "control_manager: exiting")
+end
+
+---- Driver Functions ----
+
+local function format_ports(ports)
+    local port_list = {}
+
+    -- ports is now a comma-separated string
+    if type(ports) == "string" then
+        for port in ports:gmatch("[^,]+") do
+            port = port:match("^%s*(.-)%s*$") -- trim whitespace
+            local port_name, port_type = string.match(port, "^([%w%-]+)%s*%(([%w%-]+)%)")
+            if port_name and port_type then
+                if port_list[port_type] == nil then
+                    port_list[port_type] = { port_name }
+                else
+                    table.insert(port_list[port_type], port_name)
+                end
+            end
+        end
+    end
+
+    return port_list
+end
+
+--- Utility function to check if a string starts with a given prefix (case-insensitive)
+---@param str string
+---@param start string
+---@return boolean
+local function starts_with(str, start)
+    if str == nil or start == nil then return false end
+    str, start = str:lower(), start:lower()
+    -- Use string.sub to get the prefix of mainString that is equal in length to startString
+    return string.sub(str, 1, string.len(start)) == start
+end
+
+
+--- Get driver identity
+---@return ModemIdentity? identity
+---@return string error
+function Modem:get_identity()
+    if not self.initialised then
+        return nil, "modem not initialised"
+    end
+    return self.identity, ""
+end
+
+--- Spawn driver services
+---@return boolean ok
+---@return string error
+function Modem:start()
+    if not self.initialised then
+        return false, "modem not initialised"
+    end
+    if not self.caps_applied then
+        return false, "capabilities not applied"
+    end
+
+    self.scope:spawn(self.state_monitor, self)
+    self.scope:spawn(self.control_manager, self)
+
+    return true, ""
+end
+
+--- Closes down the modem driver
+---@param timeout number? Timeout in seconds
+---@return boolean ok
+---@return string error
+function Modem:stop(timeout)
+    timeout = timeout or DEFAULT_STOP_TIMEOUT
+    self.scope:cancel()
+
+    local source = fibers.perform(op.named_choice {
+        join = self.scope:join_op(),
+        timeout = sleep.sleep_op(timeout)
+    })
+
+    if source == "timeout" then
+        return false, "modem stop timeout"
+    end
+    return true, ""
+end
+
+--- Apply capabilities to HAL and start monitoring state
+--- Modem must be initialised first
+---@param emit_ch Channel
+---@return Capability[]? capabilities
+---@return string? error
+function Modem:capabilities(emit_ch)
+    if not self.initialised then
+        return nil, "modem not initialised"
+    end
+    if self.caps_applied then
+        return nil, "capabilities already applied"
+    end
+
+    self.cap_emit_ch = emit_ch
+
+    local modem_cap, mod_cap_err = cap_types.new.ModemCapability(
+        'modem',
+        self.identity.imei,
+        self.control_ch
+    )
+    if not modem_cap then
+        return nil, "failed to create modem capability: " .. tostring(mod_cap_err)
+    end
+
+    self.caps_applied = true
+
+    return { modem_cap }
+end
+
+--- Setup modem overrides and long running fibers
+---@return string error
+function Modem:init()
+    if self.initialised then
+        return "already initialised"
+    end
+    -- determine mode (qmi/mbim) from drivers to apply mode-specific overrides
+    local drivers, drivers_err = self:get { field = 'drivers' }
+    if not drivers then
+        return "failed to get drivers: " .. tostring(drivers_err)
+    end
+
+    if drivers:match("qmi_wwan") then
+        self.mode = 'qmi'
+    elseif drivers:match("cdc_mbim") then
+        self.mode = 'mbim'
+    end
+
+    assert(mode_overrides.add_mode_funcs(self))
+
+    -- identify model to apply model-specific overrides
+    local plugin, plugin_err = self:get { field = 'plugin' }
+    if not plugin then
+        return "failed to get plugin: " .. tostring(plugin_err)
+    end
+
+    local model, model_err = self:get { field = 'model' }
+    if not model then
+        return "failed to get model: " .. tostring(model_err)
+    end
+
+    local revision, revision_err = self:get { field = 'revision' }
+    if not revision then
+        return "failed to get revision: " .. tostring(revision_err)
+    end
+
+    for manufacturer, models in pairs(MODEL_INFO) do
+        if string.match(plugin:lower(), manufacturer) then
+            for _, details in ipairs(models) do
+                if details.mod_string == model:lower()
+                    or starts_with(revision, details.rev_string) then
+                    log.info("Modem Driver", self.identity.imei,
+                        "identified model as", details.model,
+                        "variant", details.model_variant)
+                    self.model = details.model
+                    self.model_variant = details.model_variant
+                    break
+                end
+            end
+        end
+    end
+
+    model_overrides.add_model_funcs(self)
+
+    -- obtain essential identity information
+    local imei, imei_err = self:get { field = 'imei' }
+    if not imei then
+        return "failed to get imei: " .. tostring(imei_err)
+    end
+
+    local primary_port, primary_port_err = self:get { field = 'primary_port' }
+    if not primary_port then
+        return "failed to get primary_port: " .. tostring(primary_port_err)
+    end
+
+    local ports, ports_err = self:get { field = 'ports' }
+    if not ports then
+        return "failed to get ports: " .. tostring(ports_err)
+    end
+
+    local fmt_ports = format_ports(ports)
+    if (not fmt_ports.at) or (not fmt_ports.at[1]) then
+        return "no AT port found"
+    end
+
+    local device, device_err = self:get { field = 'device' }
+    if not device then
+        return "failed to get device: " .. tostring(device_err)
+    end
+
+    local id, id_err = modem_types.new.ModemIdentity(
+        imei,
+        self.address,
+        primary_port,
+        fmt_ports.at[1],
+        device
+    )
+
+    if not id then
+        return "failed to create modem identity: " .. tostring(id_err)
+    end
+
+    self.identity = id
+
+    self.initialised = true
+
+    return ""
+end
+
+--- Create a new Modem driver.
+---@param scope Scope
+---@param address ModemAddress
+---@return Modem? modem
+---@return string error
+local function new(scope, address)
+    if getmetatable(scope) ~= scope_mod.Scope then
+        return nil, "invalid scope"
+    end
+    if type(address) ~= 'string' or address == '' then
+        return nil, "invalid address"
+    end
+
+    local control_ch = channel.new(CONTROL_Q_LEN)
+
+    return setmetatable({
+        scope = scope,
+        address = address,
+        initialised = false,  -- modem cannot apply capabilities until initialised
+        caps_applied = false, -- modem cannot start until capabilities applied
+        control_ch = control_ch,
+        cache = cache.new(DEFAULT_CACHE_TIMEOUT, nil, '.')
+    }, Modem), ""
+end
+
+return {
+    new
+}

--- a/src/services/hal/drivers/modem.lua
+++ b/src/services/hal/drivers/modem.lua
@@ -1,6 +1,5 @@
 -- Modem modules
-local modem_types = require "services.hal.types.modem"
-local attr_paths = require "services.hal.drivers.modem.attr_paths"
+local modem_backend_provider = require "services.hal.backends.modem.provider"
 
 -- HAL modules
 local hal_types = require "services.hal.types.core"
@@ -12,28 +11,35 @@ local log = require "services.log"
 
 -- Fibers modules
 local fibers = require "fibers"
-local scope_mod = require "fibers.scope"
 local op = require "fibers.op"
 local channel = require "fibers.channel"
 local sleep = require "fibers.sleep"
-
--- Other modules
-local cache = require "shared.cache"
+local cond = require "fibers.cond"
+local pulse = require "fibers.pulse"
 
 ---@class Modem
 ---@field address ModemAddress
 ---@field control_ch Channel
 ---@field cap_emit_ch Channel
 ---@field scope Scope
----@field identity ModemIdentity
+---@field imei string
 ---@field model string
 ---@field model_variant string
 ---@field mode string
 ---@field initialised boolean
 ---@field caps_applied boolean
+---@field state_pulse Pulse
 ---@field cache Cache
 local Modem = {}
 Modem.__index = Modem
+
+local function list_to_table(list)
+    local t = {}
+    for _, v in ipairs(list) do
+        t[v] = true
+    end
+    return t
+end
 
 ---- Constant Definitions ----
 
@@ -42,29 +48,22 @@ local DEFAULT_CACHE_TIMEOUT = 10
 
 local CONTROL_Q_LEN = 8
 
-local ATTR_ACCESSOR = attr_paths.build_paths {
-    get_modem_info = get_modem_info,
-    get_modem_firmware = get_modem_firmware,
-    get_sim_info = get_sim_info,
-    get_home_network = get_home_network,
-    get_gid1 = get_gid1,
-    get_rf_band_info = get_rf_band_info,
-    get_operator_info = get_operator_info,
-    get_signal_info = get_signal_info,
-    get_net_stats = get_net_stats,
-}
-
-local MODEL_INFO = {
-    quectel = {
-        -- these are ordered, as eg25gl should match before eg25g
-        { mod_string = "UNKNOWN",   rev_string = "eg25gl",   model = "eg25",   model_variant = "gl" },
-        { mod_string = "UNKNOWN",   rev_string = "eg25g",    model = "eg25",   model_variant = "g" },
-        { mod_string = "UNKNOWN",   rev_string = "ec25e",    model = "ec25",   model_variant = "e" },
-        { mod_string = "em06-e",    rev_string = "em06e",    model = "em06",   model_variant = "e" },
-        { mod_string = "rm520n-gl", rev_string = "rm520ngl", model = "rm520n", model_variant = "gl" }
-        -- more quectel models here
-    },
-    fibocom = {}
+local GET_METHODS = list_to_table {
+    "imei",
+    "device",
+    "primary_port",
+    "ports",
+    "at_ports",
+    "qmi_ports",
+    "gps_ports",
+    "net_ports",
+    "access_techs",
+    "sim",
+    "drivers",
+    "plugin",
+    "model",
+    "revision",
+    "operator"
 }
 
 
@@ -130,7 +129,7 @@ end
 ---@return boolean ok
 ---@return string? error
 function Modem:_emit_event(key, data)
-    return emit(self.cap_emit_ch, self.identity.imei, 'event', key, data)
+    return emit(self.cap_emit_ch, self.imei, 'event', key, data)
 end
 
 --- Emit a state.
@@ -139,7 +138,7 @@ end
 ---@return boolean ok
 ---@return string? error
 function Modem:_emit_state(key, data)
-    return emit(self.cap_emit_ch, self.identity.imei, 'state', key, data)
+    return emit(self.cap_emit_ch, self.imei, 'state', key, data)
 end
 
 --- Emit meta information.
@@ -148,7 +147,7 @@ end
 ---@return boolean ok
 ---@return string? error
 function Modem:_emit_meta(key, data)
-    return emit(self.cap_emit_ch, self.identity.imei, 'meta', key, data)
+    return emit(self.cap_emit_ch, self.imei, 'meta', key, data)
 end
 
 --- Emit a set of key-value events.
@@ -156,7 +155,7 @@ end
 ---@return boolean ok
 ---@return string? error
 function Modem:_emit_kv(kv_data)
-    return emit_kv(self.cap_emit_ch, self.identity.imei, kv_data)
+    return emit_kv(self.cap_emit_ch, self.imei, kv_data)
 end
 
 --- Emit a set of key-value states.
@@ -164,7 +163,7 @@ end
 ---@return boolean ok
 ---@return string? error
 function Modem:_emit_kv_state(kv_data)
-    return emit_kv(self.cap_emit_ch, self.identity.imei, kv_data)
+    return emit_kv(self.cap_emit_ch, self.imei, kv_data)
 end
 
 --- Emit a set of key-value meta information.
@@ -172,7 +171,7 @@ end
 ---@return boolean ok
 ---@return string? error
 function Modem:_emit_kv_meta(kv_data)
-    return emit_kv(self.cap_emit_ch, self.identity.imei, kv_data)
+    return emit_kv(self.cap_emit_ch, self.imei, kv_data)
 end
 
 --- Validate that a function is implemented
@@ -194,55 +193,170 @@ end
 --- Get a modem attribute.
 ---@param opts ModemGetOpts?
 ---@return any value
----@return string? error
 function Modem:get(opts)
     if opts == nil or getmetatable(opts) ~= external_types.ModemGetOpts then
-        return nil, "invalid options"
+        throw_error("invalid options")
+        return
     end
     local field = opts.field
     local timescale = opts.timescale or math.huge
 
-    local accessor = ATTR_ACCESSOR[field]
-    if not accessor then
-        throw_error("unknown field: " .. tostring(field))
+    -- Check that the field is supported
+    if not GET_METHODS[field] then
+        throw_error("unsupported field: " .. tostring(field))
     end
 
-    -- try to find value in cache
-    local method = accessor.method
-    local key = method
-    if accessor.path ~= '' then
-        key = key .. "." .. accessor.path
+    -- Call the corresponding backend function to get the value
+    local get_fn = self.backend[field]
+    if not get_fn then
+        throw_error("field " .. tostring(field) .. " is not implemented by backend")
     end
-    local value, err = self.cache:get(key, timescale)
-    if err then throw_error(err) end
-
-    -- if not found in cache, or stale
-    if value == nil then
-        local valid, validation_err = validate_fn(accessor.gettr)
-        if not valid then
-            return throw_error(validation_err)
-        end
-
-        local info, info_err = accessor.gettr(self.identity)
-        if not info then throw_error(info_err) end
-        local values = attr_paths.flatten_table(info)
-        for k, v in pairs(values) do
-            self.cache:set(k, v)
-        end
-
-        local ok, emit_err = self:_emit_kv_meta(values)
-        if not ok then
-            log.debug("Modem Driver", self.identity.imei, "emit_kv_meta error:", emit_err)
-        end
-
-        value = values[key]
+    local value, err = get_fn(self.backend, timescale)
+    if err ~= "" then
+        throw_error("error getting field " .. tostring(field) .. ": " .. tostring(err))
     end
-
-    if value == nil then
-        throw_error("no value for field: " .. tostring(field))
-    end
-
     return value
+end
+
+--- Enable the modem
+function Modem:enable()
+    local ok, err = self.backend:enable()
+    if not ok then
+        throw_error(err)
+    end
+end
+
+--- Disable the modem
+function Modem:disable()
+    local ok, err = self.backend:disable()
+    if not ok then
+        throw_error(err)
+    end
+end
+
+--- Reset the modem
+function Modem:reset()
+    local ok, err = self.backend:reset()
+    if not ok then
+        throw_error(err)
+    end
+end
+
+--- Connect the modem
+---@param opts ModemConnectOpts?
+function Modem:connect(opts)
+    if opts == nil or getmetatable(opts) ~= external_types.ModemConnectOpts then
+        throw_error("invalid options")
+        return
+    end
+    local ok, err = self.backend:connect(opts.connection_string)
+    if not ok then
+        throw_error(err)
+    end
+end
+
+--- Disconnect the modem
+function Modem:disconnect()
+    local ok, err = self.backend:disconnect()
+    if not ok then
+        throw_error(err)
+    end
+end
+
+--- Inhibit the modem
+function Modem:inhibit()
+    local done_ch = channel.new()
+
+    local ok, err = self.scope:spawn(function()
+        local result_ok, result_err = self.backend:inhibit()
+        done_ch:put({ ok = result_ok, err = result_err })
+    end)
+
+    if not ok then
+        throw_error("failed to spawn inhibit fiber: " .. tostring(err))
+    end
+
+    local source, msg, primary = fibers.perform(op.named_choice {
+        done = done_ch:get_op(),
+        failed = self.scope:fault_op(),
+    })
+
+    if source == "done" then
+        if not msg.ok then
+            throw_error(msg.err)
+        end
+        return
+    elseif source == "failed" then
+        throw_error("modem inhibit failed: " .. tostring(primary))
+    end
+    throw_error("unexpected error during modem inhibit")
+end
+
+--- Uninhibit the modem
+function Modem:uninhibit()
+    local ok, err = self.backend:uninhibit()
+    if not ok then
+        throw_error(err)
+    end
+end
+
+--- Start listening for a sim insertion
+function Modem:listen_for_sim()
+    if self.listening_for_sim then
+        throw_error("already listening for SIM")
+    end
+    self.listening_for_sim = true
+    local ok, err = fibers.current_scope():spawn(function()
+        fibers.run_scope(function()
+            self:_emit_state("sim_listener", "open")
+
+            fibers.current_scope():finally(function()
+                self.listening_for_sim = false
+                self:_emit_state("sim_listener", "closed")
+            end)
+
+            while true do
+                --- out returns true if SIM is present, false if not
+                local source, out, err = fibers.perform(op.named_choice {
+                    sim_present = self.backend:wait_for_sim_present_op(),
+                    timeout = sleep.sleep_op(DEFAULT_CACHE_TIMEOUT)
+                })
+                if source == "sim_present" then
+                    if err ~= "" then
+                        log.error("Modem Driver", self.imei,
+                            "listen_for_sim: error waiting for SIM presence:", err)
+                        self:_emit_event("sim_listen_error", err)
+                    end
+                    if out then
+                        self.state_pulse:signal()
+                        break
+                    end
+                elseif source == "timeout" then
+                    local ok, check_err = self.backend:trigger_sim_presence_check()
+                    if not ok then
+                        log.error("Modem Driver", self.imei,
+                            "listen_for_sim: failed to trigger SIM presence check:", check_err)
+                    end
+                end
+            end
+        end)
+    end)
+    if not ok then
+        throw_error("listen_for_sim spawn failed: " .. tostring(err))
+    end
+end
+
+--- Set the signal update period
+---@param opts ModemSignalUpdateOpts
+function Modem:set_signal_update_freq(opts)
+    if opts == nil or getmetatable(opts) ~= external_types.ModemSignalUpdateOpts then
+        throw_error("invalid options")
+        return
+    end
+    local ok, err = self.backend:set_signal_update_interval(opts.frequency)
+    if not ok then
+        throw_error(err)
+    end
 end
 
 ---- Long Running Fibers ----
@@ -256,29 +370,87 @@ local function get_reason_and_code(control_err, verb)
         return control_err.reason, control_err.code
     end
 
-    local reason = "function " .. tostring(verb) .. " did not return a valid ControlError"
+    local reason = "function " .. tostring(verb) .. " failed with error: " .. tostring(control_err)
     return reason, 1
 end
 
+function Modem:emitter()
+    log.trace("Modem Driver", self.imei, "emitter: started")
+
+    fibers.current_scope():finally(function()
+        log.trace("Modem Driver", self.imei, "emitter: exiting")
+    end)
+
+    while true do
+        self.state_pulse:next() -- wait for a pulse indicating state change
+
+        for method, _ in pairs(GET_METHODS) do
+            local st, _, primary = fibers.run_scope(function() self:get(external_types.new.ModemGetOpts(method, 0)) end)
+
+            if st ~= 'ok' then
+                local err_msg = primary
+                if type(err_msg) == "table" and err_msg.reason then
+                    err_msg = err_msg.reason
+                end
+                log.warn("Modem Driver", self.imei,
+                    "emitter: error getting field " .. tostring(method) .. ": " .. tostring(err_msg))
+            else
+                local ok, emit_err = self:_emit_meta(method, primary)
+                if not ok then
+                    log.warn("Modem Driver", self.imei,
+                        "emitter: failed to emit meta for field " .. tostring(method) .. ": "
+                        .. tostring(emit_err))
+                end
+            end
+        end
+    end
+end
+
 function Modem:state_monitor()
+    log.trace("Modem Driver", self.imei, "state_monitor: started")
+
+    fibers.current_scope():finally(function()
+        log.trace("Modem Driver", self.imei, "state_monitor: exiting")
+    end)
+
+    while true do
+        local state_update, err = fibers.perform(self.backend:monitor_state_op())
+        ---@cast state_update ModemStateEvent
+        if err == 'Command closed' then
+            log.error("Modem Driver", self.imei, "state_monitor: backend command closed, exiting monitor")
+            break
+        elseif err ~= "" then
+            log.error("Modem Driver", self.imei, "state_monitor: error monitoring state:", err)
+        elseif state_update then
+            self.state_pulse:signal() -- signal that modem state has changed
+            local ok, emit_err = self:_emit_state('card', state_update)
+            if not ok then
+                log.error("Modem Driver", self.imei, "state_monitor: failed to emit state update:", emit_err)
+            end
+        end
+    end
 end
 
 function Modem:control_manager()
     if self.cap_emit_ch == nil then
-        log.error("Modem Driver", self.identity.imei, "control_manager: cap_emit_ch is nil")
+        log.error("Modem Driver", self.imei, "control_manager: cap_emit_ch is nil")
         return
     end
     if self.control_ch == nil then
-        log.error("Modem Driver", self.identity.imei, "control_manager: control_ch is nil")
+        log.error("Modem Driver", self.imei, "control_manager: control_ch is nil")
         return
     end
 
-    log.trace("Modem Driver", self.identity.imei, "control_manager: started")
+    log.trace("Modem Driver", self.imei, "control_manager: started")
+
+    fibers.current_scope():finally(function()
+        log.trace("Modem Driver", self.imei, "control_manager: exiting")
+    end)
 
     while true do
         local request, req_err = self.control_ch:get()
         if not request then
-            log.error("Modem Driver", self.identity.imei, "control_manager: control_ch get error:", req_err)
+            log.error("Modem Driver", self.imei, "control_manager: control_ch get error:", req_err)
             break
         end
 
@@ -305,59 +477,14 @@ function Modem:control_manager()
 
         local reply, reply_err = hal_types.new.Reply(ok, reason, code)
         if not reply then
-            log.error("Modem Driver", self.identity.imei, "control_manager: failed to create reply:", reply_err)
+            log.error("Modem Driver", self.imei, "control_manager: failed to create reply:", reply_err)
         else
             request.reply_ch:put(reply)
         end
     end
-
-    log.trace("Modem Driver", self.identity.imei, "control_manager: exiting")
 end
 
 ---- Driver Functions ----
-
-local function format_ports(ports)
-    local port_list = {}
-
-    -- ports is now a comma-separated string
-    if type(ports) == "string" then
-        for port in ports:gmatch("[^,]+") do
-            port = port:match("^%s*(.-)%s*$") -- trim whitespace
-            local port_name, port_type = string.match(port, "^([%w%-]+)%s*%(([%w%-]+)%)")
-            if port_name and port_type then
-                if port_list[port_type] == nil then
-                    port_list[port_type] = { port_name }
-                else
-                    table.insert(port_list[port_type], port_name)
-                end
-            end
-        end
-    end
-
-    return port_list
-end
-
---- Utility function to check if a string starts with a given prefix (case-insensitive)
----@param str string
----@param start string
----@return boolean
-local function starts_with(str, start)
-    if str == nil or start == nil then return false end
-    str, start = str:lower(), start:lower()
-    -- Use string.sub to get the prefix of mainString that is equal in length to startString
-    return string.sub(str, 1, string.len(start)) == start
-end
-
-
---- Get driver identity
----@return ModemIdentity? identity
----@return string error
-function Modem:get_identity()
-    if not self.initialised then
-        return nil, "modem not initialised"
-    end
-    return self.identity, ""
-end
 
 --- Spawn driver services
 ---@return boolean ok
@@ -370,8 +497,9 @@ function Modem:start()
         return false, "capabilities not applied"
     end
 
-    self.scope:spawn(self.state_monitor, self)
-    self.scope:spawn(self.control_manager, self)
+    self.scope:spawn(function() self:state_monitor() end)
+    self.scope:spawn(function() self:control_manager() end)
+    self.scope:spawn(function() self:emitter() end)
 
     return true, ""
 end
@@ -412,7 +540,7 @@ function Modem:capabilities(emit_ch)
 
     local modem_cap, mod_cap_err = cap_types.new.ModemCapability(
         'modem',
-        self.identity.imei,
+        self.imei,
         self.control_ch
     )
     if not modem_cap then
@@ -430,124 +558,82 @@ function Modem:init()
     if self.initialised then
         return "already initialised"
     end
-    -- determine mode (qmi/mbim) from drivers to apply mode-specific overrides
-    local drivers, drivers_err = self:get { field = 'drivers' }
-    if not drivers then
-        return "failed to get drivers: " .. tostring(drivers_err)
-    end
 
-    if drivers:match("qmi_wwan") then
-        self.mode = 'qmi'
-    elseif drivers:match("cdc_mbim") then
-        self.mode = 'mbim'
-    end
+    local backend_built_sig = cond.new()
 
-    assert(mode_overrides.add_mode_funcs(self))
+    local ok, err = self.scope:spawn(function()
+        self.backend = modem_backend_provider.new(self.address)
 
-    -- identify model to apply model-specific overrides
-    local plugin, plugin_err = self:get { field = 'plugin' }
-    if not plugin then
-        return "failed to get plugin: " .. tostring(plugin_err)
-    end
+        self.backend:start_sim_presence_monitor()
+        self.backend:start_state_monitor()
 
-    local model, model_err = self:get { field = 'model' }
-    if not model then
-        return "failed to get model: " .. tostring(model_err)
-    end
-
-    local revision, revision_err = self:get { field = 'revision' }
-    if not revision then
-        return "failed to get revision: " .. tostring(revision_err)
-    end
-
-    for manufacturer, models in pairs(MODEL_INFO) do
-        if string.match(plugin:lower(), manufacturer) then
-            for _, details in ipairs(models) do
-                if details.mod_string == model:lower()
-                    or starts_with(revision, details.rev_string) then
-                    log.info("Modem Driver", self.identity.imei,
-                        "identified model as", details.model,
-                        "variant", details.model_variant)
-                    self.model = details.model
-                    self.model_variant = details.model_variant
-                    break
-                end
-            end
+        -- Get IMEI from backend
+        local imei, imei_err = self.backend:imei()
+        if imei_err == "" then
+            self.imei = imei
+        else
+            error("failed to get IMEI: " .. tostring(imei_err))
         end
+
+        backend_built_sig:signal()
+    end)
+
+    if not ok then
+        return "failed to spawn modem backend fiber: " .. tostring(err)
     end
 
-    model_overrides.add_model_funcs(self)
+    local source, _, primary = fibers.perform(op.named_choice {
+        backend_ready = backend_built_sig:wait_op(),
+        failed = self.scope:fault_op()
+    })
 
-    -- obtain essential identity information
-    local imei, imei_err = self:get { field = 'imei' }
-    if not imei then
-        return "failed to get imei: " .. tostring(imei_err)
+    if source == "backend_ready" then
+        self.initialised = true
+        return ""
+    elseif source == "failed" then
+        return "modem init failed: " .. tostring(primary) -- primary is the error from the faulted fiber
+    else
+        return "unexpected error during modem init"
     end
-
-    local primary_port, primary_port_err = self:get { field = 'primary_port' }
-    if not primary_port then
-        return "failed to get primary_port: " .. tostring(primary_port_err)
-    end
-
-    local ports, ports_err = self:get { field = 'ports' }
-    if not ports then
-        return "failed to get ports: " .. tostring(ports_err)
-    end
-
-    local fmt_ports = format_ports(ports)
-    if (not fmt_ports.at) or (not fmt_ports.at[1]) then
-        return "no AT port found"
-    end
-
-    local device, device_err = self:get { field = 'device' }
-    if not device then
-        return "failed to get device: " .. tostring(device_err)
-    end
-
-    local id, id_err = modem_types.new.ModemIdentity(
-        imei,
-        self.address,
-        primary_port,
-        fmt_ports.at[1],
-        device
-    )
-
-    if not id then
-        return "failed to create modem identity: " .. tostring(id_err)
-    end
-
-    self.identity = id
-
-    self.initialised = true
-
-    return ""
 end
 
 --- Create a new Modem driver.
----@param scope Scope
 ---@param address ModemAddress
 ---@return Modem? modem
 ---@return string error
-local function new(scope, address)
-    if getmetatable(scope) ~= scope_mod.Scope then
-        return nil, "invalid scope"
-    end
+local function new(address)
     if type(address) ~= 'string' or address == '' then
         return nil, "invalid address"
     end
 
     local control_ch = channel.new(CONTROL_Q_LEN)
 
+    local scope, err = fibers.current_scope():child()
+    if not scope then
+        return nil, "failed to create child scope: " .. tostring(err)
+    end
+
+    -- Print out driver stack trace if scope closes on a failure
+    scope:finally(function ()
+        local st, primary = scope:status()
+        if st == 'failed' then
+            log.error(("Modem Driver %s: error - %s"):format(tostring(address), tostring(primary)))
+            log.trace("Modem Driver %s: scope exiting with status %s", tostring(address), st)
+        end
+        log.trace("Modem Driver %s: stopped", tostring(address))
+    end)
+
     return setmetatable({
         scope = scope,
         address = address,
         initialised = false,  -- modem cannot apply capabilities until initialised
         caps_applied = false, -- modem cannot start until capabilities applied
-        control_ch = control_ch,
-        cache = cache.new(DEFAULT_CACHE_TIMEOUT, nil, '.')
+        listening_for_sim = false,
+        state_pulse = pulse.new(),
+        control_ch = control_ch
     }, Modem), ""
 end
 
 return {
-    new
+    new = new
 }

--- a/src/services/hal/managers/filesystem.lua
+++ b/src/services/hal/managers/filesystem.lua
@@ -1,0 +1,278 @@
+-- HAL modules
+local fs_driver = require "services.hal.drivers.filesystem"
+local hal_types = require "services.hal.types.core"
+
+-- Fibers modules
+local fibers = require "fibers"
+local op = require "fibers.op"
+local sleep = require "fibers.sleep"
+
+-- Other modules
+local log = require "services.log"
+
+
+-- Constants
+
+local STOP_TIMEOUT = 5.0 -- seconds
+
+---@alias Namespace { name: string, root: string }
+---@alias FSDriver table
+
+---@class FilesystemManager
+---@field scope Scope
+---@field started boolean
+---@field drivers table<string, FSDriver>
+---@field dev_ev_ch Channel
+---@field cap_emit_ch Channel
+---@field last_names string[]
+local FilesystemManager = {
+    started = false,
+    drivers = {},
+    dev_ev_ch = nil,
+    cap_emit_ch = nil,
+    last_names = {},
+}
+
+---@param namespaces string[]
+local function emit_removed_device(namespaces)
+    local removed_event, removed_err = hal_types.new.DeviceEvent(
+        "removed",
+        "fs",
+        "main",
+        { namespaces = namespaces }
+    )
+    if not removed_event then
+        log.error("Filesystem Manager: failed to create removed device event:", removed_err)
+        return
+    end
+    FilesystemManager.dev_ev_ch:put(removed_event)
+end
+
+---@param driver FSDriver
+local function stop_driver(driver)
+    log.trace("Filesystem Manager: stopping previous driver")
+    local stop_ok, stop_err = driver:stop(STOP_TIMEOUT)
+    if not stop_ok then
+        log.warn("Filesystem Manager: failed to stop previous driver:", stop_err)
+    end
+end
+
+local function stop_previous_driver_and_emit()
+    local prev_driver = FilesystemManager.drivers["main"]
+    if not prev_driver then
+        return
+    end
+
+    stop_driver(prev_driver)
+
+    emit_removed_device(FilesystemManager.last_names)
+    FilesystemManager.drivers["main"] = nil
+end
+
+---@param namespaces Namespace[]
+---@return table<string, string> roots
+---@return string[] names
+---@return string error
+local function build_roots(namespaces)
+    local roots = {}
+    local names = {}
+    for _, ns in ipairs(namespaces) do
+        if type(ns.name) ~= 'string' or type(ns.root) ~= 'string' then
+            return {}, {}, "invalid namespace config"
+        end
+        roots[ns.name] = ns.root
+        names[#names + 1] = ns.name
+    end
+    return roots, names, ""
+end
+
+---@param roots table<string, string>
+---@return FSDriver? driver
+---@return string error
+local function init_driver(roots)
+    local driver, drv_err = fs_driver.new(roots)
+    if not driver then
+        return nil, "failed to create filesystem driver: " .. tostring(drv_err)
+    end
+
+    local init_err = driver:init()
+    if init_err ~= "" then
+        return nil, "failed to init filesystem driver: " .. tostring(init_err)
+    end
+
+    return driver, ""
+end
+
+---@param driver FSDriver
+---@return Capability[]? capabilities
+---@return string error
+local function apply_driver_capabilities(driver)
+    local capabilities, cap_err = driver:capabilities(FilesystemManager.cap_emit_ch)
+    if cap_err ~= "" then
+        return nil, "failed to apply capabilities: " .. tostring(cap_err)
+    end
+
+    return capabilities, ""
+end
+
+---@param driver FSDriver
+---@return string error
+local function start_driver(driver)
+    local ok, start_err = driver:start()
+    if not ok then
+        return "failed to start driver: " .. tostring(start_err)
+    end
+
+    return ""
+end
+
+---@param namespaces string[]
+---@param capabilities Capability[]
+local function emit_added_device(namespaces, capabilities)
+    local device_event, ev_err = hal_types.new.DeviceEvent(
+        "added",
+        "fs",
+        "main",
+        { namespaces = namespaces },
+        capabilities
+    )
+    if not device_event then
+        log.error("Filesystem Manager: failed to create device event:", ev_err)
+        return
+    end
+
+    FilesystemManager.dev_ev_ch:put(device_event)
+end
+
+
+---Starts the Filesystem Manager.
+---@param dev_ev_ch Channel
+---@param cap_emit_ch Channel
+---@return string error
+function FilesystemManager.start(dev_ev_ch, cap_emit_ch)
+    if FilesystemManager.started then
+        return "Already started"
+    end
+
+    local scope, err = fibers.current_scope():child()
+    if not scope then
+        return "Failed to create child scope: " .. tostring(err)
+    end
+    FilesystemManager.scope = scope
+    FilesystemManager.dev_ev_ch = dev_ev_ch
+    FilesystemManager.cap_emit_ch = cap_emit_ch
+
+    -- Print out manager stack trace if scope closes on a failure
+    scope:finally(function()
+        local st, primary = scope:status()
+        if st == 'failed' then
+            log.error(("Filesystem Manager: error - %s"):format(tostring(primary)))
+            log.trace("Filesystem Manager: scope exiting with status", st)
+        end
+        log.trace("Filesystem Manager: stopped")
+    end)
+
+    FilesystemManager.started = true
+    log.trace("Filesystem Manager: started")
+    return ""
+end
+
+---Stops the Filesystem Manager.
+---@param timeout number? Timeout in seconds
+---@return boolean ok
+---@return string error
+function FilesystemManager.stop(timeout)
+    if not FilesystemManager.started then
+        return false, "Not started"
+    end
+    timeout = timeout or STOP_TIMEOUT
+    FilesystemManager.scope:cancel()
+
+    local source = fibers.perform(op.named_choice {
+        join = FilesystemManager.scope:join_op(),
+        timeout = sleep.sleep_op(timeout)
+    })
+
+    if source == "timeout" then
+        return false, "filesystem manager stop timeout"
+    end
+    FilesystemManager.started = false
+    return true, ""
+end
+
+--- Check that config is a set of name-root pairs and that paths are valid
+---@param namespaces Namespace[]
+local function validate_config(namespaces)
+    if type(namespaces) ~= 'table' then
+        return false, "config must be a table of namespaces"
+    end
+    for _, ns in ipairs(namespaces) do
+        if type(ns.name) ~= 'string' or type(ns.root) ~= 'string' then
+            return false, "each namespace must have a name and root string"
+        end
+    end
+    return true, ""
+end
+
+---Apply filesystem configuration by creating a driver with the given namespaces.
+---This function is non-blocking and spawns a fiber to initialize the driver.
+---Stored channels from start() are used. Must be called after start().
+---@param namespaces Namespace[] List of {name, root} namespace configs
+---@return boolean ok
+---@return string error
+function FilesystemManager.apply_config(namespaces)
+    local valid, validate_err = validate_config(namespaces)
+    if not valid then
+        return false, validate_err
+    end
+
+    if not FilesystemManager.started then
+        return false, "filesystem manager not started"
+    end
+
+    if FilesystemManager.dev_ev_ch == nil or FilesystemManager.cap_emit_ch == nil then
+        return false, "channels not initialized (start must be called first)"
+    end
+
+    -- Spawn non-blocking fiber to create and initialize driver
+    local ok, spawn_err = FilesystemManager.scope:spawn(function()
+        stop_previous_driver_and_emit()
+
+        local roots, names, roots_err = build_roots(namespaces)
+        if roots_err ~= "" then
+            log.error("Filesystem Manager: " .. roots_err)
+            return
+        end
+
+        local driver, init_err = init_driver(roots)
+        if not driver then
+            log.error("Filesystem Manager: " .. tostring(init_err))
+            return
+        end
+
+        local capabilities, cap_err = apply_driver_capabilities(driver)
+        if not capabilities then
+            log.error("Filesystem Manager: " .. tostring(cap_err))
+            return
+        end
+
+        local start_err = start_driver(driver)
+        if start_err ~= "" then
+            log.error("Filesystem Manager: " .. tostring(start_err))
+            return
+        end
+
+        FilesystemManager.drivers["main"] = driver
+        FilesystemManager.last_names = names
+        emit_added_device(names, capabilities)
+        log.trace("Filesystem Manager: applied config and created driver")
+    end)
+
+    if not ok then
+        return false, "failed to spawn driver initialization: " .. tostring(spawn_err)
+    end
+
+    return true, ""
+end
+
+return FilesystemManager

--- a/src/services/hal/managers/modemcard.lua
+++ b/src/services/hal/managers/modemcard.lua
@@ -108,7 +108,12 @@ local function on_remove(dev_ev_ch, address)
 
     -- Get device, no need to have a fresh value so set cache lifetime to infinity
     -- Also asking for a fresh value when the modem may have disconnected could cause errors
-    local device = driver:get(external_types.new.ModemGetOpts("device", math.huge))
+    local get_ok, primary = driver:get(external_types.new.ModemGetOpts("device", math.huge))
+    if not get_ok then
+        log.error(("Modemcard Manager: failed to get device: %s"):format(primary))
+        return
+    end
+    local device = primary
 
     fibers.current_scope():spawn(function()
         local ok, stop_err = driver:stop(STOP_TIMEOUT)
@@ -168,7 +173,12 @@ end
 local function on_driver(dev_ev_ch, cap_emit_ch, driver)
     local address = driver.address
     -- Get device, no need to have a fresh value so set cache lifetime to infinity
-    local device = driver:get(external_types.new.ModemGetOpts("device", math.huge))
+    local get_ok, primary = driver:get(external_types.new.ModemGetOpts("device", math.huge))
+    if not get_ok then
+        log.error(("Modemcard Manager: failed to get device: %s"):format(primary))
+        return
+    end
+    local device = primary
 
     ModemcardManager.modems[driver.address] = driver
 
@@ -308,6 +318,15 @@ function ModemcardManager.stop(timeout)
         return false, "modemcard manager stop timeout"
     end
     ModemcardManager.started = false
+    return true, ""
+end
+
+---Apply configuration for modemcard manager (no-op, kept for interface consistency).
+---@param namespaces table
+---@return boolean ok
+---@return string error
+function ModemcardManager.apply_config(namespaces) -- luacheck: ignore
+    -- No-op: modemcard manager does not support dynamic configuration
     return true, ""
 end
 

--- a/src/services/hal/managers/modemcard.lua
+++ b/src/services/hal/managers/modemcard.lua
@@ -1,12 +1,11 @@
 -- HAL modules
 local mmcli = require "services.hal.backends.mmcli"
 local hal_types = require "services.hal.types.core"
-local modem_types = require "services.hal.types.modem"
+local external_types = require "services.hal.types.external"
 local modem_driver = require "services.hal.drivers.modem"
 
 -- Fiber modules
 local fibers = require "fibers"
-local scope_mod = require "fibers.scope"
 local op = require "fibers.op"
 local channel = require "fibers.channel"
 local sleep = require "fibers.sleep"
@@ -22,13 +21,14 @@ local STOP_TIMEOUT = 5.0 -- seconds
 ---@class ModemDriver
 
 ---@class ModemcardManager
----@field spawned boolean
+---@field scope Scope
+---@field started boolean
 ---@field modem_remove_ch Channel
 ---@field modem_detect_ch Channel
 ---@field driver_ch Channel
 ---@field modems table<ModemAddress, Modem>
 local ModemcardManager = {
-    spawned = false,
+    started = false,
     modem_remove_ch = channel.new(),
     modem_detect_ch = channel.new(),
     driver_ch = channel.new(),
@@ -51,15 +51,18 @@ end
 
 ---Continuously monitors modem add/remove events and publishes them onto
 ---`ModemcardManager.modem_detect_ch` and `ModemcardManager.modem_remove_ch`.
-local function detector()
+---@param scope Scope
+local function detector(scope)
     log.trace("Modem Detector: started")
+
+    scope:finally(function ()
+        log.trace("Modem Detector: closed")
+    end)
 
     local monitor_cmd = mmcli.monitor_modems()
     local stdout, err = monitor_cmd:stdout_stream()
     if not stdout then
-        log.error("Modem Detector: failed to open stdout stream:", err)
-        log.trace("Modem Detector: closed")
-        return
+        error("Modem Detector: failed to get stdout stream: " .. err)
     end
 
     while true do
@@ -84,8 +87,6 @@ local function detector()
             ModemcardManager.modem_remove_ch:put(address)
         end
     end
-
-    log.trace("Modem Detector: closed")
 end
 
 ---Handle modem removal.
@@ -105,14 +106,11 @@ local function on_remove(dev_ev_ch, address)
         return
     end
 
-    local identity, id_err = driver:get_identity()
-    if not identity then
-        log.error("Modemcard Manager: failed to get identity for removal at", address, id_err)
-        return
-    end
-    local device = identity.device
+    -- Get device, no need to have a fresh value so set cache lifetime to infinity
+    -- Also asking for a fresh value when the modem may have disconnected could cause errors
+    local device = driver:get(external_types.new.ModemGetOpts("device", math.huge))
 
-    fibers.spawn(function()
+    fibers.current_scope():spawn(function()
         local ok, stop_err = driver:stop(STOP_TIMEOUT)
         if not ok then
             log.error("Modemcard Manager: failed to stop driver:", stop_err)
@@ -145,18 +143,16 @@ local function on_detection(address)
 
     log.info("Modemcard Manager: creating modem at", address)
 
-    -- Create a child scope for the driver
-    local child_scope = fibers.current_scope():child()
-    local driver, drv_err = modem_driver.new(child_scope, address)
+    local driver, drv_err = modem_driver.new(address)
     if not driver then
         log.error("Modemcard Manager: failed to create modem driver:", drv_err)
         return
     end
 
-    fibers.spawn(function()
+    fibers.current_scope():spawn(function()
         local init_err = driver:init()
         if init_err ~= "" then
-            log.error("Modemcard Manager: failed to init modem driver:", init_err)
+            log.error(("Modemcard Manager: failed to init modem driver %s: %s"):format(address, init_err))
             return
         end
         ModemcardManager.driver_ch:put(driver)
@@ -170,18 +166,11 @@ end
 ---@param driver Modem
 ---@return nil
 local function on_driver(dev_ev_ch, cap_emit_ch, driver)
-    if getmetatable(driver) ~= modem_driver.ModemDriver then
-        log.error("Modemcard Manager: invalid driver received")
-        return
-    end
+    local address = driver.address
+    -- Get device, no need to have a fresh value so set cache lifetime to infinity
+    local device = driver:get(external_types.new.ModemGetOpts("device", math.huge))
 
-    local identity, id_err = driver:get_identity()
-    if not identity then
-        log.error("Modemcard Manager: failed to get driver identity:", id_err)
-        return
-    end
-
-    ModemcardManager.modems[identity.address] = driver
+    ModemcardManager.modems[driver.address] = driver
 
     -- Build capabilities
     local capabilities, cap_err = driver:capabilities(cap_emit_ch)
@@ -200,10 +189,10 @@ local function on_driver(dev_ev_ch, cap_emit_ch, driver)
     local device_event, ev_err = hal_types.new.DeviceEvent(
         "added",
         "modemcard",
-        identity.device,
+        device,
         {
-            address = identity.address,
-            port = identity.device -- the device field holds the usb or pcie port info
+            address = address,
+            port = device -- the device field holds the usb or pcie port info
         },
         capabilities
     )
@@ -217,16 +206,33 @@ local function on_driver(dev_ev_ch, cap_emit_ch, driver)
 end
 
 ---Modemcard Manager notifies HAL of modem additions/removals.
+---@param scope Scope
 ---@param dev_ev_ch Channel Device event channel (DeviceEvent messages)
 ---@param cap_emit_ch Channel Capability emit channel (Emit messages)
 ---@return nil
-local function manager(dev_ev_ch, cap_emit_ch)
+local function manager(scope, dev_ev_ch, cap_emit_ch)
     log.trace("Modemcard Manager: started")
+
+    scope:finally(function ()
+        log.trace("Modemcard Manager: closed")
+    end)
+
     while true do
-        local source, msg, err = fibers.perform(op.named_choice {
+        local fault_ops = {}
+        for address, driver in pairs(ModemcardManager.modems) do
+            table.insert(fault_ops, driver.scope:fault_op():wrap(function () return address end))
+        end
+
+        local fault_op = op.never()
+        if #fault_ops > 0 then
+            fault_op = op.choice(unpack(fault_ops))
+        end
+
+        local source, msg, err = fibers.perform(op.named_choice{
             detect = ModemcardManager.modem_detect_ch:get_op(),
             remove = ModemcardManager.modem_remove_ch:get_op(),
             driver = ModemcardManager.driver_ch:get_op(),
+            driver_fault = fault_op,
         })
 
         if not msg then
@@ -240,29 +246,46 @@ local function manager(dev_ev_ch, cap_emit_ch)
             on_remove(dev_ev_ch, msg)
         elseif source == "driver" then
             on_driver(dev_ev_ch, cap_emit_ch, msg)
+        elseif source == "driver_fault" then
+            log.error("Modemcard Manager: driver fault detected for modem at", msg)
+            on_remove(dev_ev_ch, msg)
+        else
+            log.error("Modemcard Manager: unknown operation source:", source)
         end
     end
-
-    log.trace("Modemcard Manager: closed")
 end
 
 ---Starts the Modemcard Manager's detector and manager fibers.
----@param scope Scope
 ---@param dev_ev_ch Channel
 ---@param cap_emit_ch Channel
-function ModemcardManager.start(scope, dev_ev_ch, cap_emit_ch)
-    if ModemcardManager.spawned then
-        log.warn("Modemcard Manager: already spawned")
-        return
+---@return string error
+function ModemcardManager.start(dev_ev_ch, cap_emit_ch)
+    if ModemcardManager.started then
+        return "Already started"
     end
 
+    local scope, err = fibers.current_scope():child()
+    if not scope then
+        return "Failed to create child scope: " .. tostring(err)
+    end
     ModemcardManager.scope = scope
 
-    scope:spawn(detector)
-    scope:spawn(manager, dev_ev_ch, cap_emit_ch)
+    -- Print out manager stack trace if scope closes on a failure
+    scope:finally(function ()
+        local st, primary = scope:status()
+        if st == 'failed' then
+            log.error(("Modem Manager: error - %s"):format(tostring(primary)))
+            log.trace("Modem Manager: scope exiting with status", st)
+        end
+        log.trace("Modem Manager: stopped")
+    end)
 
-    ModemcardManager.spawned = true
-    log.trace("Modemcard Manager: spawned")
+    ModemcardManager.scope:spawn(detector)
+    ModemcardManager.scope:spawn(manager, dev_ev_ch, cap_emit_ch)
+
+    ModemcardManager.started = true
+    log.trace("Modemcard Manager: started")
+    return ""
 end
 
 ---Stops the Modemcard Manager.
@@ -270,6 +293,9 @@ end
 ---@return boolean ok
 ---@return string error
 function ModemcardManager.stop(timeout)
+    if not ModemcardManager.started then
+        return false, "Not started"
+    end
     timeout = timeout or STOP_TIMEOUT
     ModemcardManager.scope:cancel()
 
@@ -281,5 +307,8 @@ function ModemcardManager.stop(timeout)
     if source == "timeout" then
         return false, "modemcard manager stop timeout"
     end
+    ModemcardManager.started = false
     return true, ""
 end
+
+return ModemcardManager

--- a/src/services/hal/managers/modemcard.lua
+++ b/src/services/hal/managers/modemcard.lua
@@ -1,5 +1,5 @@
 -- HAL modules
-local mmcli = require "services.hal.backends.mmcli"
+local modem_provider = require "services.hal.backends.modem.provider"
 local hal_types = require "services.hal.types.core"
 local external_types = require "services.hal.types.external"
 local modem_driver = require "services.hal.drivers.modem"
@@ -35,20 +35,6 @@ local ModemcardManager = {
     modems = {},
 }
 
----Get a modem status and address from a monitor line
----@param line string
----@return boolean? is_added
----@return string? address
----@return string? err
-local function parse_monitor(line)
-    local status, address = line:match("^(.-)(/org%S+)")
-    if address then
-        return not status:match("-"), address, nil
-    else
-        return nil, nil, 'line could not be parsed'
-    end
-end
-
 ---Continuously monitors modem add/remove events and publishes them onto
 ---`ModemcardManager.modem_detect_ch` and `ModemcardManager.modem_remove_ch`.
 ---@param scope Scope
@@ -59,32 +45,26 @@ local function detector(scope)
         log.trace("Modem Detector: closed")
     end)
 
-    local monitor_cmd = mmcli.monitor_modems()
-    local stdout, err = monitor_cmd:stdout_stream()
-    if not stdout then
-        error("Modem Detector: failed to get stdout stream: " .. err)
+    local monitor, err = modem_provider.new_monitor()
+    if not monitor then
+        error("Modem Detector: failed to create monitor: " .. tostring(err))
     end
 
     while true do
-        local line, rerr = stdout:read_line()
-        if rerr then
-            log.error("Modem Detector: stdout read error:", rerr)
+        local event, mon_err = fibers.perform(monitor:next_event_op())
+        if mon_err == "Command closed" then
             break
-        end
-        if line == nil then
-            break
-        end
-
-        local is_added, address, parse_err = parse_monitor(line)
-
-        if is_added == nil or address == nil then
-            log.error("Modem Detector: failed to parse line:", parse_err)
-        elseif is_added == true then
-            log.info("Modem Detector: detected at", address)
-            ModemcardManager.modem_detect_ch:put(address)
-        elseif is_added == false then
-            log.info("Modem Detector: removed at", address)
-            ModemcardManager.modem_remove_ch:put(address)
+        elseif mon_err and mon_err ~= "" then
+            log.warn("Modem Detector: skipping unparseable line:", mon_err)
+        elseif event then
+            ---@cast event ModemMonitorEvent
+            if event.is_added then
+                log.info("Modem Detector: detected at", event.address)
+                ModemcardManager.modem_detect_ch:put(event.address)
+            else
+                log.info("Modem Detector: removed at", event.address)
+                ModemcardManager.modem_remove_ch:put(event.address)
+            end
         end
     end
 end

--- a/src/services/hal/managers/modemcard.lua
+++ b/src/services/hal/managers/modemcard.lua
@@ -1,0 +1,285 @@
+-- HAL modules
+local mmcli = require "services.hal.backends.mmcli"
+local hal_types = require "services.hal.types.core"
+local modem_types = require "services.hal.types.modem"
+local modem_driver = require "services.hal.drivers.modem"
+
+-- Fiber modules
+local fibers = require "fibers"
+local scope_mod = require "fibers.scope"
+local op = require "fibers.op"
+local channel = require "fibers.channel"
+local sleep = require "fibers.sleep"
+
+-- Other modules
+local log = require "services.log"
+
+
+-- Constants
+
+local STOP_TIMEOUT = 5.0 -- seconds
+
+---@class ModemDriver
+
+---@class ModemcardManager
+---@field spawned boolean
+---@field modem_remove_ch Channel
+---@field modem_detect_ch Channel
+---@field driver_ch Channel
+---@field modems table<ModemAddress, Modem>
+local ModemcardManager = {
+    spawned = false,
+    modem_remove_ch = channel.new(),
+    modem_detect_ch = channel.new(),
+    driver_ch = channel.new(),
+    modems = {},
+}
+
+---Get a modem status and address from a monitor line
+---@param line string
+---@return boolean? is_added
+---@return string? address
+---@return string? err
+local function parse_monitor(line)
+    local status, address = line:match("^(.-)(/org%S+)")
+    if address then
+        return not status:match("-"), address, nil
+    else
+        return nil, nil, 'line could not be parsed'
+    end
+end
+
+---Continuously monitors modem add/remove events and publishes them onto
+---`ModemcardManager.modem_detect_ch` and `ModemcardManager.modem_remove_ch`.
+local function detector()
+    log.trace("Modem Detector: started")
+
+    local monitor_cmd = mmcli.monitor_modems()
+    local stdout, err = monitor_cmd:stdout_stream()
+    if not stdout then
+        log.error("Modem Detector: failed to open stdout stream:", err)
+        log.trace("Modem Detector: closed")
+        return
+    end
+
+    while true do
+        local line, rerr = stdout:read_line()
+        if rerr then
+            log.error("Modem Detector: stdout read error:", rerr)
+            break
+        end
+        if line == nil then
+            break
+        end
+
+        local is_added, address, parse_err = parse_monitor(line)
+
+        if is_added == nil or address == nil then
+            log.error("Modem Detector: failed to parse line:", parse_err)
+        elseif is_added == true then
+            log.info("Modem Detector: detected at", address)
+            ModemcardManager.modem_detect_ch:put(address)
+        elseif is_added == false then
+            log.info("Modem Detector: removed at", address)
+            ModemcardManager.modem_remove_ch:put(address)
+        end
+    end
+
+    log.trace("Modem Detector: closed")
+end
+
+---Handle modem removal.
+---@param dev_ev_ch Channel Device event channel (DeviceEvent messages)
+---@param address ModemAddress
+local function on_remove(dev_ev_ch, address)
+    if type(address) ~= 'string' or address == '' then
+        log.error("Modemcard Manager: invalid address on removal")
+        return
+    end
+
+    log.info("Modemcard Manager: removing modem at", address)
+
+    local driver = ModemcardManager.modems[address]
+    if driver == nil then
+        log.error("Modemcard Manager: modem not found for removal at", address)
+        return
+    end
+
+    local identity, id_err = driver:get_identity()
+    if not identity then
+        log.error("Modemcard Manager: failed to get identity for removal at", address, id_err)
+        return
+    end
+    local device = identity.device
+
+    fibers.spawn(function()
+        local ok, stop_err = driver:stop(STOP_TIMEOUT)
+        if not ok then
+            log.error("Modemcard Manager: failed to stop driver:", stop_err)
+        end
+    end)
+
+    ModemcardManager.modems[address] = nil
+
+    local device_event, ev_err = hal_types.new.DeviceEvent(
+        "removed",
+        "modemcard",
+        device
+    )
+    if not device_event then
+        log.error("Modemcard Manager: failed to create device event:", ev_err)
+        return
+    end
+
+    dev_ev_ch:put(device_event)
+end
+
+---Handle modem detection by creating and initializing a driver.
+---@param address ModemAddress
+---@return nil
+local function on_detection(address)
+    if type(address) ~= 'string' or address == '' then
+        log.error("Modemcard Manager: invalid address on detection")
+        return
+    end
+
+    log.info("Modemcard Manager: creating modem at", address)
+
+    -- Create a child scope for the driver
+    local child_scope = fibers.current_scope():child()
+    local driver, drv_err = modem_driver.new(child_scope, address)
+    if not driver then
+        log.error("Modemcard Manager: failed to create modem driver:", drv_err)
+        return
+    end
+
+    fibers.spawn(function()
+        local init_err = driver:init()
+        if init_err ~= "" then
+            log.error("Modemcard Manager: failed to init modem driver:", init_err)
+            return
+        end
+        ModemcardManager.driver_ch:put(driver)
+    end)
+end
+
+---Handle a fully initialized driver by creating the modem device, applying
+---capabilities, and emitting a HAL device event.
+---@param dev_ev_ch Channel Device event channel (DeviceEvent messages)
+---@param cap_emit_ch Channel Capability emit channel (Emit messages)
+---@param driver Modem
+---@return nil
+local function on_driver(dev_ev_ch, cap_emit_ch, driver)
+    if getmetatable(driver) ~= modem_driver.ModemDriver then
+        log.error("Modemcard Manager: invalid driver received")
+        return
+    end
+
+    local identity, id_err = driver:get_identity()
+    if not identity then
+        log.error("Modemcard Manager: failed to get driver identity:", id_err)
+        return
+    end
+
+    ModemcardManager.modems[identity.address] = driver
+
+    -- Build capabilities
+    local capabilities, cap_err = driver:capabilities(cap_emit_ch)
+    if cap_err then
+        log.error("Modemcard Manager: failed to apply capabilities:", cap_err)
+        return
+    end
+
+    -- Start the driver
+    local ok, start_err = driver:start()
+    if not ok then
+        log.error("Modemcard Manager: failed to start driver:", start_err)
+        return
+    end
+
+    local device_event, ev_err = hal_types.new.DeviceEvent(
+        "added",
+        "modemcard",
+        identity.device,
+        {
+            address = identity.address,
+            port = identity.device -- the device field holds the usb or pcie port info
+        },
+        capabilities
+    )
+    if not device_event then
+        log.error("Modemcard Manager: failed to create device event:", ev_err)
+        return
+    end
+
+    -- Notify HAL of new modem device
+    dev_ev_ch:put(device_event)
+end
+
+---Modemcard Manager notifies HAL of modem additions/removals.
+---@param dev_ev_ch Channel Device event channel (DeviceEvent messages)
+---@param cap_emit_ch Channel Capability emit channel (Emit messages)
+---@return nil
+local function manager(dev_ev_ch, cap_emit_ch)
+    log.trace("Modemcard Manager: started")
+    while true do
+        local source, msg, err = fibers.perform(op.named_choice {
+            detect = ModemcardManager.modem_detect_ch:get_op(),
+            remove = ModemcardManager.modem_remove_ch:get_op(),
+            driver = ModemcardManager.driver_ch:get_op(),
+        })
+
+        if not msg then
+            log.error("Modemcard Manager: operation failed:", err)
+            break
+        end
+
+        if source == "detect" then
+            on_detection(msg)
+        elseif source == "remove" then
+            on_remove(dev_ev_ch, msg)
+        elseif source == "driver" then
+            on_driver(dev_ev_ch, cap_emit_ch, msg)
+        end
+    end
+
+    log.trace("Modemcard Manager: closed")
+end
+
+---Starts the Modemcard Manager's detector and manager fibers.
+---@param scope Scope
+---@param dev_ev_ch Channel
+---@param cap_emit_ch Channel
+function ModemcardManager.start(scope, dev_ev_ch, cap_emit_ch)
+    if ModemcardManager.spawned then
+        log.warn("Modemcard Manager: already spawned")
+        return
+    end
+
+    ModemcardManager.scope = scope
+
+    scope:spawn(detector)
+    scope:spawn(manager, dev_ev_ch, cap_emit_ch)
+
+    ModemcardManager.spawned = true
+    log.trace("Modemcard Manager: spawned")
+end
+
+---Stops the Modemcard Manager.
+---@param timeout number? Timeout in seconds
+---@return boolean ok
+---@return string error
+function ModemcardManager.stop(timeout)
+    timeout = timeout or STOP_TIMEOUT
+    ModemcardManager.scope:cancel()
+
+    local source = fibers.perform(op.named_choice {
+        join = ModemcardManager.scope:join_op(),
+        timeout = sleep.sleep_op(timeout)
+    })
+
+    if source == "timeout" then
+        return false, "modemcard manager stop timeout"
+    end
+    return true, ""
+end

--- a/src/services/hal/types/capabilities.lua
+++ b/src/services/hal/types/capabilities.lua
@@ -95,8 +95,7 @@ function new.ModemCapability(id, control_ch)
         'restart',
         'connect',
         'disconnect',
-        'sim_detect',
-        'fix_failure',
+        'listen_for_sim',
         'set_signal_update_freq',
     }
     return new.Capability('modem', id, control_ch, offerings)
@@ -199,6 +198,17 @@ function new.FilesystemCapability(id, control_ch)
         'write'
     }
     return new.Capability('fs', id, control_ch, offerings)
+end
+
+---@param id CapabilityId
+---@param control_ch Channel
+---@return Capability?
+---@return string error
+function new.UARTCapability(id, control_ch)
+    local offerings = {
+        'open', 'close', 'write'
+    }
+    return new.Capability('uart', id, control_ch, offerings)
 end
 
 ---@class ControlError

--- a/src/services/hal/types/capabilities.lua
+++ b/src/services/hal/types/capabilities.lua
@@ -1,0 +1,220 @@
+---@param list string[]
+---@return table<string, boolean>
+local function list_to_map(list)
+    local map = {}
+    for _, v in ipairs(list) do
+        map[v] = true
+    end
+    return map
+end
+
+local function valid_class(class)
+    return type(class) == 'string' and class ~= ''
+end
+
+local function valid_id(id)
+    return (type(id) == 'string' and id ~= '') or (type(id) == 'number' and id >= 0)
+end
+
+local function valid_offerings(offerings)
+    if type(offerings) ~= 'table' then
+        return false
+    end
+    for _, v in ipairs(offerings) do
+        if type(v) ~= 'string' or v == '' then
+            return false
+        end
+    end
+    return true
+end
+
+---@alias CapabilityClass string
+---@alias CapabilityId string|integer
+---@alias CapabilityOffering string
+---@alias CapabilityOfferingMap table<string, boolean>
+
+---@class CapabilityConstructors
+local new = {}
+
+
+---@class Capability
+---@field class CapabilityClass
+---@field id CapabilityId
+---@field offerings CapabilityOfferingMap
+---@field control_ch Channel
+local Capability = {}
+Capability.__index = Capability
+
+---@param class CapabilityClass
+---@param id CapabilityId
+---@param control_ch Channel
+---@param offerings CapabilityOffering[]
+---@return Capability?
+---@return string error
+function new.Capability(class, id, control_ch, offerings)
+    if not valid_class(class) then
+        return nil, "invalid capability class"
+    end
+
+    if not valid_id(id) then
+        return nil, "invalid capability id"
+    end
+
+    if getmetatable(control_ch) ~= "Channel" then
+        return nil, "invalid capability control_ch"
+    end
+
+    if not valid_offerings(offerings) then
+        return nil, "invalid capability offerings"
+    end
+
+    local offerings_map = list_to_map(offerings)
+    offerings_map['get'] = true -- all capabilities support 'get'
+    offerings_map['set'] = true -- all capabilities support 'set'
+
+    local capability = setmetatable({
+        class = class,
+        id = id,
+        offerings = offerings_map,
+        control_ch = control_ch,
+    }, Capability)
+
+    return capability, ""
+end
+
+---@param class CapabilityClass
+---@param id CapabilityId
+---@param control_ch Channel
+---@return Capability?
+---@return string error
+function new.ModemCapability(class, id, control_ch)
+    local offerings = {
+        'enable',
+        'disable',
+        'restart',
+        'connect',
+        'disconnect',
+        'sim_detect',
+        'fix_failure',
+        'set_signal_update_freq',
+    }
+    return new.Capability(class, id, control_ch, offerings)
+end
+
+---@param class CapabilityClass
+---@param id CapabilityId
+---@param control_ch Channel
+---@return Capability?
+---@return string error
+function new.GeoCapability(class, id, control_ch)
+    local offerings = {}
+    return new.Capability(class, id, control_ch, offerings)
+end
+
+---@param class CapabilityClass
+---@param id CapabilityId
+---@param control_ch Channel
+---@return Capability?
+---@return string error
+function new.TimeCapability(class, id, control_ch)
+    local offerings = {}
+    return new.Capability(class, id, control_ch, offerings)
+end
+
+---@param class CapabilityClass
+---@param id CapabilityId
+---@param control_ch Channel
+---@return Capability?
+---@return string error
+function new.NetworkCapability(class, id, control_ch)
+    local offerings = {}
+    return new.Capability(class, id, control_ch, offerings)
+end
+
+---@param class CapabilityClass
+---@param id CapabilityId
+---@param control_ch Channel
+---@return Capability?
+---@return string error
+function new.WirelessCapability(class, id, control_ch)
+    local offerings = {
+        'set_channels',
+        'set_country',
+        'set_txpower',
+        'set_type',
+        'set_enabled',
+        'add_interface',
+        'delete_interface',
+        'clear_radio_config',
+        'apply'
+    }
+    return new.Capability(class, id, control_ch, offerings)
+end
+
+---@param class CapabilityClass
+---@param id CapabilityId
+---@param control_ch Channel
+---@return Capability?
+---@return string error
+function new.BandCapability(class, id, control_ch)
+    local offerings = {
+        'set_log_level',
+        'set_kicking',
+        'set_station_counting',
+        'set_rrm_mode',
+        'set_neighbour_reports',
+        'set_legacy_options',
+        'set_band_priority',
+        'set_band_kicking',
+        'set_support_bonus',
+        'set_update_freq',
+        'set_client_inactive_kickoff',
+        'set_cleanup',
+        'set_networking',
+        'apply'
+    }
+    return new.Capability(class, id, control_ch, offerings)
+end
+
+---@param class CapabilityClass
+---@param id CapabilityId
+---@param control_ch Channel
+---@return Capability?
+---@return string error
+function new.SerialCapability(class, id, control_ch)
+    local offerings = {
+        'open', 'close', 'write'
+    }
+    return new.Capability(class, id, control_ch, offerings)
+end
+
+---@class ControlError
+---@field reason string
+---@field code integer
+local ControlError = {}
+ControlError.__index = ControlError
+
+---@param reason string
+---@param code integer?
+---@return ControlError
+function new.ControlError(reason, code)
+    if type(reason) ~= 'string' then
+        reason = tostring(reason)
+    end
+
+    if type(code) ~= 'number' or code < 0 then
+        code = 1
+    end
+
+    local control_error = setmetatable({
+        reason = reason,
+        code = code,
+    }, ControlError)
+    return control_error
+end
+
+return {
+    Capability = Capability,
+    ControlError = ControlError,
+    new = new,
+}

--- a/src/services/hal/types/capabilities.lua
+++ b/src/services/hal/types/capabilities.lua
@@ -83,12 +83,11 @@ function new.Capability(class, id, control_ch, offerings)
     return capability, ""
 end
 
----@param class CapabilityClass
 ---@param id CapabilityId
 ---@param control_ch Channel
 ---@return Capability?
 ---@return string error
-function new.ModemCapability(class, id, control_ch)
+function new.ModemCapability(id, control_ch)
     local offerings = {
         'get',
         'enable',
@@ -100,7 +99,7 @@ function new.ModemCapability(class, id, control_ch)
         'fix_failure',
         'set_signal_update_freq',
     }
-    return new.Capability(class, id, control_ch, offerings)
+    return new.Capability('modem', id, control_ch, offerings)
 end
 
 ---@param class CapabilityClass
@@ -188,6 +187,18 @@ function new.SerialCapability(class, id, control_ch)
         'open', 'close', 'write'
     }
     return new.Capability(class, id, control_ch, offerings)
+end
+
+---@param id CapabilityId
+---@param control_ch Channel
+---@return Capability?
+---@return string error
+function new.FilesystemCapability(id, control_ch)
+    local offerings = {
+        'read',
+        'write'
+    }
+    return new.Capability('fs', id, control_ch, offerings)
 end
 
 ---@class ControlError

--- a/src/services/hal/types/capabilities.lua
+++ b/src/services/hal/types/capabilities.lua
@@ -8,6 +8,9 @@ local function list_to_map(list)
     return map
 end
 
+local channel = require "fibers.channel"
+local ChannelMT = getmetatable(channel.new())
+
 local function valid_class(class)
     return type(class) == 'string' and class ~= ''
 end
@@ -60,7 +63,7 @@ function new.Capability(class, id, control_ch, offerings)
         return nil, "invalid capability id"
     end
 
-    if getmetatable(control_ch) ~= "Channel" then
+    if getmetatable(control_ch) ~= ChannelMT then
         return nil, "invalid capability control_ch"
     end
 
@@ -69,8 +72,6 @@ function new.Capability(class, id, control_ch, offerings)
     end
 
     local offerings_map = list_to_map(offerings)
-    offerings_map['get'] = true -- all capabilities support 'get'
-    offerings_map['set'] = true -- all capabilities support 'set'
 
     local capability = setmetatable({
         class = class,
@@ -89,6 +90,7 @@ end
 ---@return string error
 function new.ModemCapability(class, id, control_ch)
     local offerings = {
+        'get',
         'enable',
         'disable',
         'restart',

--- a/src/services/hal/types/core.lua
+++ b/src/services/hal/types/core.lua
@@ -1,0 +1,239 @@
+---@alias DeviceClass string
+---@alias DeviceId string|integer
+
+---@alias Meta table<string, any>
+
+---@alias CapList Capability[]
+
+local cap_types = require "hal.types.capabilities"
+
+---@class TypeConstructors
+local new = {}
+
+
+---@class ControlRequest
+---@field verb string
+---@field opts table<string, any>
+---@field reply_ch Channel
+local ControlRequest = {}
+ControlRequest.__index = ControlRequest
+
+---Create a new ControlRequest.
+---@param verb string
+---@param opts table<string, any>
+---@param reply_ch Channel
+---@return ControlRequest?
+---@return string error
+function new.ControlRequest(verb, opts, reply_ch)
+    if type(verb) ~= 'string' or verb == '' then
+        return nil, "invalid verb"
+    end
+
+    if type(opts) ~= 'table' then
+        return nil, "opts must be a table"
+    end
+
+    if getmetatable(reply_ch) ~= "Channel" then
+        return nil, "invalid reply_ch"
+    end
+
+    return setmetatable({
+        verb = verb,
+        opts = opts,
+        reply_ch = reply_ch,
+    }, ControlRequest), ""
+end
+
+---@class Reply
+---@field ok boolean
+---@field reason any
+---@field code integer?
+local Reply = {}
+Reply.__index = Reply
+
+---Create a new Reply.
+---@param ok boolean
+---@param reason string?
+---@param code integer?
+---@return Reply?
+---@return string error
+function new.Reply(ok, reason, code)
+    if type(ok) ~= 'boolean' then
+        return nil, "invalid ok"
+    end
+
+    return setmetatable({
+        ok = ok,
+        reason = reason,
+        code = code,
+    }, Reply), ""
+end
+
+---@alias EmitMode 'event'|'state'|'meta'
+
+---@class Emit
+---@field class CapabilityClass
+---@field id CapabilityId
+---@field mode EmitMode
+---@field key string
+---@field data any
+local Emit = {}
+Emit.__index = Emit
+
+---Create a new Emit.
+---@param class CapabilityClass
+---@param id CapabilityId
+---@param mode EmitMode
+---@param key string
+---@param data any
+---@return Emit?
+---@return string error
+function new.Emit(class, id, mode, key, data)
+    if type(class) ~= 'string' or class == '' then
+        return nil, "invalid class"
+    end
+
+    if type(id) ~= 'string' and type(id) ~= 'number' then
+        return nil, "invalid id"
+    end
+
+    if mode ~= 'event' and mode ~= 'state' and mode ~= 'meta' then
+        return nil, "invalid mode"
+    end
+
+    if type(key) ~= 'string' or key == '' then
+        return nil, "invalid key"
+    end
+
+    if type(data) == 'nil' then
+        return nil, "data cannot be nil"
+    end
+
+    return setmetatable({
+        class = class,
+        id = id,
+        mode = mode,
+        key = key,
+        data = data,
+    }, Emit), ""
+end
+
+---@alias EventType 'added'|'removed'
+
+---@class DeviceEvent
+---@field event_type EventType
+---@field class DeviceClass
+---@field id DeviceId
+---@field meta Meta
+---@field capabilities CapList
+local DeviceEvent = {}
+DeviceEvent.__index = DeviceEvent
+
+---Create a new DeviceEvent.
+---@param event_type EventType
+---@param class DeviceClass
+---@param id DeviceId
+---@param meta Meta?
+---@param capabilities CapList?
+---@return DeviceEvent?
+---@return string error
+function new.DeviceEvent(event_type, class, id, meta, capabilities)
+    meta = meta or {}
+    capabilities = capabilities or {}
+
+    if event_type ~= 'added' and event_type ~= 'removed' then
+        return nil, "invalid event_type"
+    end
+
+    if type(class) ~= 'string' or class == '' then
+        return nil, "invalid class"
+    end
+
+    if type(id) ~= 'string' and type(id) ~= 'number' then
+        return nil, "invalid id"
+    end
+
+    if type(meta) ~= 'table' then
+        return nil, "invalid meta"
+    end
+
+    if type(capabilities) ~= 'table' then
+        return nil, "invalid capabilities"
+    end
+    for _, cap in ipairs(capabilities) do
+        if getmetatable(cap) ~= cap_types.Capability then
+            return nil, "invalid capability in capabilities"
+        end
+    end
+
+    local ev = setmetatable({
+        event_type = event_type,
+        class = class,
+        id = id,
+        meta = meta,
+        capabilities = capabilities,
+    }, DeviceEvent)
+
+    return ev, ""
+end
+
+---@class Device
+---@field class DeviceClass
+---@field id DeviceId
+---@field meta Meta
+---@field capabilities Capability[]
+local Device = {}
+Device.__index = Device
+
+---Create a new Device.
+---@param class DeviceClass
+---@param id DeviceId
+---@param meta Meta
+---@param capabilities CapList
+---@return Device?
+---@return string error
+function new.Device(class, id, meta, capabilities)
+    meta = meta or {}
+    capabilities = capabilities or {}
+
+    if type(class) ~= 'string' or class == '' then
+        return nil, "invalid class"
+    end
+
+    if type(id) ~= 'string' and type(id) ~= 'number' then
+        return nil, "invalid id"
+    end
+
+    if type(meta) ~= 'table' then
+        return nil, "invalid meta"
+    end
+
+    if type(capabilities) ~= 'table' then
+        return nil, "invalid capabilities"
+    end
+    for _, cap in ipairs(capabilities) do
+        if getmetatable(cap) ~= cap_types.Capability then
+            return nil, "invalid capability in capabilities"
+        end
+    end
+
+    local dev = setmetatable({
+        class = class,
+        id = id,
+        meta = meta,
+        capabilities = capabilities,
+    }, Device)
+    return dev, ""
+end
+
+-- Todo types:
+---@class Manager
+
+return {
+    ControlRequest = ControlRequest,
+    Reply = Reply,
+    Emit = Emit,
+    DeviceEvent = DeviceEvent,
+    Device = Device,
+    new = new,
+}

--- a/src/services/hal/types/core.lua
+++ b/src/services/hal/types/core.lua
@@ -233,6 +233,7 @@ end
 ---@field scope Scope
 ---@field start fun(dev_ev_ch: Channel, cap_emit_ch: Channel): string error
 ---@field stop fun(): string error
+---@field apply_config fun(config: table): boolean ok, string error
 
 return {
     ControlRequest = ControlRequest,

--- a/src/services/hal/types/core.lua
+++ b/src/services/hal/types/core.lua
@@ -5,7 +5,9 @@
 
 ---@alias CapList Capability[]
 
-local cap_types = require "hal.types.capabilities"
+local cap_types = require "services.hal.types.capabilities"
+local channel = require "fibers.channel"
+local ChannelMT = getmetatable(channel.new())
 
 ---@class TypeConstructors
 local new = {}
@@ -33,7 +35,7 @@ function new.ControlRequest(verb, opts, reply_ch)
         return nil, "opts must be a table"
     end
 
-    if getmetatable(reply_ch) ~= "Channel" then
+    if getmetatable(reply_ch) ~= ChannelMT then
         return nil, "invalid reply_ch"
     end
 
@@ -228,6 +230,9 @@ end
 
 -- Todo types:
 ---@class Manager
+---@field scope Scope
+---@field start fun(dev_ev_ch: Channel, cap_emit_ch: Channel): string error
+---@field stop fun(): string error
 
 return {
     ControlRequest = ControlRequest,

--- a/src/services/hal/types/external.lua
+++ b/src/services/hal/types/external.lua
@@ -16,7 +16,7 @@ function new.ModemGetOpts(field, timescale)
         return nil, "invalid field"
     end
 
-    if timescale ~= nil and (type(timescale) ~= 'number' or timescale <= 0) then
+    if timescale ~= nil and (type(timescale) ~= 'number' or timescale < 0) then
         return nil, "invalid timescale"
     end
 
@@ -62,8 +62,74 @@ function new.ModemSignalUpdateOpts(frequency)
     }, ModemSignalUpdateOpts), ""
 end
 
+---@class FilesystemReadOpts
+---@field filename string
+local FilesystemReadOpts = {}
+FilesystemReadOpts.__index = FilesystemReadOpts
+
+--- Validate that a filename contains no path separators or .. segments
+---@param filename string
+---@return boolean valid
+---@return string? error
+local function validate_filename(filename)
+    if type(filename) ~= 'string' or filename == '' then
+        return false, "filename must be a non-empty string"
+    end
+
+    if filename:find('/') or filename:find('\\') then
+        return false, "filename cannot contain path separators"
+    end
+
+    if filename == '..' or filename:find('^%.%.') or filename:find('%.%.') then
+        return false, "filename cannot contain .. segments"
+    end
+
+    return true, nil
+end
+
+---Create a new FilesystemReadOpts
+---@param filename string
+---@return FilesystemReadOpts?
+---@return string error
+function new.FilesystemReadOpts(filename)
+    local valid, err = validate_filename(filename)
+    if not valid then
+        return nil, err
+    end
+    return setmetatable({
+        filename = filename,
+    }, FilesystemReadOpts), ""
+end
+
+---@class FilesystemWriteOpts
+---@field filename string
+---@field data string
+local FilesystemWriteOpts = {}
+FilesystemWriteOpts.__index = FilesystemWriteOpts
+
+---Create a new FilesystemWriteOpts
+---@param filename string
+---@param data string
+---@return FilesystemWriteOpts?
+---@return string error
+function new.FilesystemWriteOpts(filename, data)
+    local valid, err = validate_filename(filename)
+    if not valid then
+        return nil, err
+    end
+    if type(data) ~= 'string' then
+        return nil, "invalid data"
+    end
+    return setmetatable({
+        filename = filename,
+        data = data,
+    }, FilesystemWriteOpts), ""
+end
+
 return {
     ModemGetOpts = ModemGetOpts,
     ModemConnectOpts = ModemConnectOpts,
+    FilesystemReadOpts = FilesystemReadOpts,
+    FilesystemWriteOpts = FilesystemWriteOpts,
     new = new,
 }

--- a/src/services/hal/types/external.lua
+++ b/src/services/hal/types/external.lua
@@ -126,10 +126,56 @@ function new.FilesystemWriteOpts(filename, data)
     }, FilesystemWriteOpts), ""
 end
 
+---@class UARTOpenOpts
+---@field read boolean
+---@field write boolean
+local UARTOpenOpts = {}
+UARTOpenOpts.__index = UARTOpenOpts
+
+---Create a new UARTOpenOpts.
+---At least one of read or write must be true.
+---@param read boolean
+---@param write boolean
+---@return UARTOpenOpts?
+---@return string error
+function new.UARTOpenOpts(read, write)
+    if type(read) ~= 'boolean' or type(write) ~= 'boolean' then
+        return nil, "read and write must be booleans"
+    end
+    if not read and not write then
+        return nil, "at least one of read or write must be true"
+    end
+    return setmetatable({
+        read  = read,
+        write = write,
+    }, UARTOpenOpts), ""
+end
+
+---@class UARTWriteOpts
+---@field data string
+local UARTWriteOpts = {}
+UARTWriteOpts.__index = UARTWriteOpts
+
+---Create a new UARTWriteOpts.
+---@param data string
+---@return UARTWriteOpts?
+---@return string error
+function new.UARTWriteOpts(data)
+    if type(data) ~= 'string' or data == '' then
+        return nil, "data must be a non-empty string"
+    end
+    return setmetatable({
+        data = data,
+    }, UARTWriteOpts), ""
+end
+
 return {
     ModemGetOpts = ModemGetOpts,
     ModemConnectOpts = ModemConnectOpts,
+    ModemSignalUpdateOpts = ModemSignalUpdateOpts,
     FilesystemReadOpts = FilesystemReadOpts,
     FilesystemWriteOpts = FilesystemWriteOpts,
+    UARTOpenOpts = UARTOpenOpts,
+    UARTWriteOpts = UARTWriteOpts,
     new = new,
 }

--- a/src/services/hal/types/external.lua
+++ b/src/services/hal/types/external.lua
@@ -26,7 +26,44 @@ function new.ModemGetOpts(field, timescale)
     }, ModemGetOpts), ""
 end
 
+---@class ModemConnectOpts
+---@field connection_string string
+local ModemConnectOpts = {}
+ModemConnectOpts.__index = ModemConnectOpts
+
+---Create a new ModemConnectOpts.
+---@param connection_string string
+---@return ModemConnectOpts?
+---@return string error
+function new.ModemConnectOpts(connection_string)
+    if type(connection_string) ~= 'string' or connection_string == '' then
+        return nil, "invalid connection string"
+    end
+    return setmetatable({
+        connection_string = connection_string,
+    }, ModemConnectOpts), ""
+end
+
+---@class ModemSignalUpdateOpts
+---@field frequency number
+local ModemSignalUpdateOpts = {}
+ModemSignalUpdateOpts.__index = ModemSignalUpdateOpts
+
+---Create a new ModemSignalUpdateOpts.
+---@param frequency number
+---@return ModemSignalUpdateOpts?
+---@return string error
+function new.ModemSignalUpdateOpts(frequency)
+    if type(frequency) ~= 'number' or frequency <= 0 then
+        return nil, "invalid frequency"
+    end
+    return setmetatable({
+        frequency = frequency,
+    }, ModemSignalUpdateOpts), ""
+end
+
 return {
     ModemGetOpts = ModemGetOpts,
+    ModemConnectOpts = ModemConnectOpts,
     new = new,
 }

--- a/src/services/hal/types/external.lua
+++ b/src/services/hal/types/external.lua
@@ -1,0 +1,32 @@
+local new = {}
+
+---@class ModemGetOpts
+---@field field string
+---@field timescale? number
+local ModemGetOpts = {}
+ModemGetOpts.__index = ModemGetOpts
+
+---Create a new ModemGetOpts.
+---@param field string
+---@param timescale? number
+---@return ModemGetOpts?
+---@return string error
+function new.ModemGetOpts(field, timescale)
+    if type(field) ~= 'string' or field == '' then
+        return nil, "invalid field"
+    end
+
+    if timescale ~= nil and (type(timescale) ~= 'number' or timescale <= 0) then
+        return nil, "invalid timescale"
+    end
+
+    return setmetatable({
+        field = field,
+        timescale = timescale,
+    }, ModemGetOpts), ""
+end
+
+return {
+    ModemGetOpts = ModemGetOpts,
+    new = new,
+}

--- a/src/services/hal/types/modem.lua
+++ b/src/services/hal/types/modem.lua
@@ -32,8 +32,9 @@ end
 ---@class ModemIdentity
 ---@field imei string
 ---@field address ModemAddress
----@field primary_port string
+---@field mode_port string
 ---@field at_port string
+---@field net_port string
 ---@field device string
 local ModemIdentity = {}
 ModemIdentity.__index = ModemIdentity
@@ -41,12 +42,13 @@ ModemIdentity.__index = ModemIdentity
 ---Create a new ModemIdentity.
 ---@param imei string
 ---@param address ModemAddress
----@param primary_port string
+---@param mode_port string
 ---@param at_port string
+---@param net_port string
 ---@param device string
 ---@return ModemIdentity?
 ---@return string error
-function new.ModemIdentity(imei, address, primary_port, at_port, device)
+function new.ModemIdentity(imei, address, mode_port, at_port, net_port, device)
 	if type(imei) ~= 'string' or imei == '' then
 		return nil, "invalid imei"
 	end
@@ -55,12 +57,16 @@ function new.ModemIdentity(imei, address, primary_port, at_port, device)
 		return nil, "invalid address"
 	end
 
-	if type(primary_port) ~= 'string' or primary_port == '' then
-		return nil, "invalid primary_port"
+	if type(mode_port) ~= 'string' or mode_port == '' then
+		return nil, "invalid mode_port"
 	end
 
 	if type(at_port) ~= 'string' or at_port == '' then
 		return nil, "invalid at_port"
+	end
+
+	if type(net_port) ~= 'string' or net_port == '' then
+		return nil, "invalid net_port"
 	end
 
 	if type(device) ~= 'string' or device == '' then
@@ -70,8 +76,9 @@ function new.ModemIdentity(imei, address, primary_port, at_port, device)
 	local identity = setmetatable({
 		imei = imei,
 		address = address,
-		primary_port = primary_port,
+		mode_port = mode_port,
 		at_port = at_port,
+		net_port = net_port,
 		device = device,
 	}, ModemIdentity)
 	return identity, ""
@@ -133,6 +140,50 @@ end
 function new.ModemStateRemovedEvent(reason)
 	return new.ModemStateEvent("removed", "removed", "removed", reason)
 end
+
+---@class ModemBackend
+---@field identity ModemIdentity
+---@field cache Cache
+---@field base string
+---@field inhibit_cmd Command?
+---@field state_monitor table?
+---@field sim_present table?
+---@field imei fun(self: ModemBackend, timeout: number?): string, string
+---@field device fun(self: ModemBackend, timeout: number?): string, string
+---@field primary_port fun(self: ModemBackend, timeout: number?): string, string
+---@field at_ports fun(self: ModemBackend, timeout: number?): table, string
+---@field qmi_ports fun(self: ModemBackend, timeout: number?): table, string
+---@field gps_ports fun(self: ModemBackend, timeout: number?): table, string
+---@field net_ports fun(self: ModemBackend, timeout: number?): table, string
+---@field access_techs fun(self: ModemBackend, timeout: number?): table, string
+---@field sim fun(self: ModemBackend, timeout: number?): string, string
+---@field drivers fun(self: ModemBackend, timeout: number?): table, string
+---@field plugin fun(self: ModemBackend, timeout: number?): string, string
+---@field model fun(self: ModemBackend, timeout: number?): string, string
+---@field revision fun(self: ModemBackend, timeout: number?): string, string
+---@field operator fun(self: ModemBackend, timeout: number?): string, string
+---@field rx_bytes fun(self: ModemBackend): integer, string
+---@field tx_bytes fun(self: ModemBackend): integer, string
+---@field signal fun(self: ModemBackend, timeout: number?): table, string
+---@field mcc fun(self: ModemBackend, timeout: number?): string, string
+---@field mnc fun(self: ModemBackend, timeout: number?): string, string
+---@field gid1 fun(self: ModemBackend, timeout: number?): string, string
+---@field active_band_class fun(self: ModemBackend, timeout: number?): string, string
+---@field start_state_monitor fun(self: ModemBackend): boolean, string
+---@field monitor_state_op fun(self: ModemBackend): Op
+---@field start_sim_presence_monitor fun(self: ModemBackend): boolean, string
+---@field wait_for_sim_present_op fun(self: ModemBackend): Op
+---@field wait_for_sim_present fun(self: ModemBackend): boolean, string
+---@field is_sim_present fun(self: ModemBackend): boolean, string
+---@field trigger_sim_presence_check fun(self: ModemBackend, cooldown: number?): boolean, string
+---@field enable fun(self: ModemBackend): boolean, string
+---@field disable fun(self: ModemBackend): boolean, string
+---@field reset fun(self: ModemBackend): boolean, string
+---@field connect fun(self: ModemBackend, conn_string: string): boolean, string
+---@field disconnect fun(self: ModemBackend): boolean, string
+---@field inhibit fun(self: ModemBackend): boolean, string
+---@field uninhibit fun(self: ModemBackend): boolean, string
+---@field set_signal_update_interval fun(self: ModemBackend, interval: number): boolean, string
 
 return {
 	ModemDevice = ModemDevice,

--- a/src/services/hal/types/modem.lua
+++ b/src/services/hal/types/modem.lua
@@ -1,0 +1,142 @@
+---@alias ModemAddress string
+
+---@class ModemDevice
+---@field driver Modem
+---@field device string
+local ModemDevice = {}
+ModemDevice.__index = ModemDevice
+
+---@class ModemTypeConstructors
+local new = {}
+
+---Create a new ModemDevice.
+---@param driver Modem
+---@param device string
+---@return ModemDevice?
+---@return string error
+function new.ModemDevice(driver, device)
+	if driver == nil then
+		return nil, "invalid driver"
+	end
+
+	if type(device) ~= 'string' or device == '' then
+		return nil, "invalid device"
+	end
+
+	return setmetatable({
+		driver = driver,
+		device = device,
+	}, ModemDevice), ""
+end
+
+---@class ModemIdentity
+---@field imei string
+---@field address ModemAddress
+---@field primary_port string
+---@field at_port string
+---@field device string
+local ModemIdentity = {}
+ModemIdentity.__index = ModemIdentity
+
+---Create a new ModemIdentity.
+---@param imei string
+---@param address ModemAddress
+---@param primary_port string
+---@param at_port string
+---@param device string
+---@return ModemIdentity?
+---@return string error
+function new.ModemIdentity(imei, address, primary_port, at_port, device)
+	if type(imei) ~= 'string' or imei == '' then
+		return nil, "invalid imei"
+	end
+
+	if type(address) ~= 'string' or address == '' then
+		return nil, "invalid address"
+	end
+
+	if type(primary_port) ~= 'string' or primary_port == '' then
+		return nil, "invalid primary_port"
+	end
+
+	if type(at_port) ~= 'string' or at_port == '' then
+		return nil, "invalid at_port"
+	end
+
+	if type(device) ~= 'string' or device == '' then
+		return nil, "invalid device"
+	end
+
+	local identity = setmetatable({
+		imei = imei,
+		address = address,
+		primary_port = primary_port,
+		at_port = at_port,
+		device = device,
+	}, ModemIdentity)
+	return identity, ""
+end
+
+---@alias ModemStateEventType "initial"|"changed"|"removed"
+---@alias ModemState string
+
+---@class ModemStateEvent
+---@field ev_type ModemStateEventType
+---@field from ModemState
+---@field to ModemState
+---@field reason string?
+local ModemStateEvent = {}
+ModemStateEvent.__index = ModemStateEvent
+
+--- Creates a new ModemStateEvent.
+---@param ev_type ModemStateEventType
+---@param from ModemState
+---@param to ModemState
+---@param reason string?
+---@return ModemStateEvent?
+---@return string error
+function new.ModemStateEvent(ev_type, from, to, reason)
+	if ev_type ~= "initial" and ev_type ~= "changed" and ev_type ~= "removed" then
+		return nil, "invalid event type"
+	end
+
+	if type(from) ~= 'string' or from == '' then
+		return nil, "invalid from state"
+	end
+
+	if type(to) ~= 'string' or to == '' then
+		return nil, "invalid to state"
+	end
+
+	reason = reason or "unknown"
+	if (type(reason) ~= 'string' or reason == '') then
+		return nil, "invalid reason"
+	end
+
+	local event = setmetatable({
+		ev_type = ev_type,
+		from = from,
+		to = to,
+		reason = reason,
+	}, { __index = ModemStateEvent })
+	return event, ""
+end
+
+function new.ModemStateInitialEvent(state, reason)
+	return new.ModemStateEvent("initial", state, state, reason)
+end
+
+function new.ModemStateChangeEvent(from, to, reason)
+	return new.ModemStateEvent("changed", from, to, reason)
+end
+
+function new.ModemStateRemovedEvent(reason)
+	return new.ModemStateEvent("removed", "removed", "removed", reason)
+end
+
+return {
+	ModemDevice = ModemDevice,
+	ModemIdentity = ModemIdentity,
+	ModemStateEvent = ModemStateEvent,
+	new = new,
+}

--- a/src/services/hal/types/modem.lua
+++ b/src/services/hal/types/modem.lua
@@ -141,6 +141,33 @@ function new.ModemStateRemovedEvent(reason)
 	return new.ModemStateEvent("removed", "removed", "removed", reason)
 end
 
+---@class ModemMonitorEvent
+---@field is_added boolean
+---@field address ModemAddress
+local ModemMonitorEvent = {}
+ModemMonitorEvent.__index = ModemMonitorEvent
+
+---Create a new ModemMonitorEvent.
+---@param is_added boolean
+---@param address ModemAddress
+---@return ModemMonitorEvent?
+---@return string error
+function new.ModemMonitorEvent(is_added, address)
+	if type(is_added) ~= 'boolean' then
+		return nil, "invalid is_added: expected boolean"
+	end
+	if type(address) ~= 'string' or address == '' then
+		return nil, "invalid address"
+	end
+	return setmetatable({
+		is_added = is_added,
+		address = address,
+	}, ModemMonitorEvent), ""
+end
+
+---@class ModemMonitor
+---@field next_event_op fun(self: ModemMonitor): Op
+
 ---@class ModemBackend
 ---@field identity ModemIdentity
 ---@field cache Cache
@@ -189,5 +216,6 @@ return {
 	ModemDevice = ModemDevice,
 	ModemIdentity = ModemIdentity,
 	ModemStateEvent = ModemStateEvent,
+	ModemMonitorEvent = ModemMonitorEvent,
 	new = new,
 }

--- a/src/services/log.lua
+++ b/src/services/log.lua
@@ -1,0 +1,33 @@
+local rxilog = require 'rxilog'
+local new_msg = require 'bus'.new_msg
+
+local log_service = {
+    name = "log",
+}
+log_service.__index = log_service
+
+for _, mode in ipairs(rxilog.modes) do
+    local level = mode.name
+    log_service[level] = function(...)
+        local msg = rxilog.tostring(...)
+        rxilog[level](msg)
+
+        if log_service.conn then
+            local info = debug.getinfo(2, "Sl")
+            local lineinfo = info.short_src .. ":" .. info.currentline
+            local formatted_msg = rxilog.format_log_message(level:upper(), lineinfo, msg)
+
+            log_service.conn:publish(new_msg({ "logs", level }, formatted_msg))
+        end
+    end
+end
+
+function log_service:start(ctx, conn)
+    self.ctx = ctx
+    self.conn = conn
+    log_service.trace("Starting Log Service")
+end
+
+-- Make singleton
+package.loaded["services.log"] = log_service
+return log_service

--- a/src/services/metrics.lua
+++ b/src/services/metrics.lua
@@ -34,7 +34,7 @@ local conf           = require 'services.metrics.config'
 local types          = require 'services.metrics.types'
 
 
-local unpack = unpack or table.unpack
+local unpack = unpack or rawget(table, 'unpack')
 
 local NAME = 'metrics'
 

--- a/src/services/metrics.lua
+++ b/src/services/metrics.lua
@@ -10,8 +10,8 @@
 -- Topics consumed:
 --   {'obs', 'v1', '+', 'metric', '+'}  - incoming metric values
 --   {'cfg', 'metrics'}                  - metrics config (retained)
---   {'time', 'ntp_synced'}              - NTP sync status (retained)
---   {'cap', 'fs', 'config', 'state'}    - HAL filesystem capability readiness
+--   {'svc', 'time', 'synced'}           - NTP sync status (retained)
+--   {'cap', 'fs', 'configs', 'state'}   - HAL filesystem capability readiness
 --
 -- Topics produced:
 --   {'svc', 'metrics', 'status'}        - service lifecycle status (retained)
@@ -95,14 +95,17 @@ end
 ---@param topic any
 ---@return boolean
 local function validate_topic(topic)
-	if type(topic) ~= 'table' or #topic == 0 then return false end
+	if type(topic) ~= 'table' then return false end
 	local count = 0
-	for k, v in pairs(topic) do
-		count = count + 1
+	for k in pairs(topic) do
 		if type(k) ~= 'number' or k < 1 or k ~= math.floor(k) then return false end
-		if v == nil then return false end
+		count = count + 1
 	end
-	return count == #topic
+	if count == 0 then return false end
+	for i = 1, count do
+		if topic[i] == nil then return false end
+	end
+	return true
 end
 
 --- Shift per-endpoint metric timestamps from monotonic to real-time milliseconds.

--- a/src/services/metrics.lua
+++ b/src/services/metrics.lua
@@ -1,0 +1,576 @@
+-- services/metrics.lua
+--
+-- Metrics service:
+--  - subscribes to {'obs', 'v1', '+', 'metric', '+'} for all observable metrics
+--  - applies per-pipeline processing (DiffTrigger, DeltaValue, etc.)
+--  - maintains per-endpoint processing state (shared pipeline logic, isolated state)
+--  - periodically publishes accumulated metrics via http, log, or bus protocol
+--  - fetches Mainflux cloud credentials from the HAL filesystem capability
+--
+-- Topics consumed:
+--   {'obs', 'v1', '+', 'metric', '+'}  - incoming metric values
+--   {'cfg', 'metrics'}                  - metrics config (retained)
+--   {'time', 'ntp_synced'}              - NTP sync status (retained)
+--   {'cap', 'fs', 'config', 'state'}    - HAL filesystem capability readiness
+--
+-- Topics produced:
+--   {'svc', 'metrics', 'status'}        - service lifecycle status (retained)
+--   {'svc', 'metrics', ...}             - per-metric bus publications (bus protocol)
+
+local fibers         = require 'fibers'
+local op             = require 'fibers.op'
+local sleep          = require 'fibers.sleep'
+local runtime        = require 'fibers.runtime'
+local time           = require 'fibers.utils.time'
+local perform        = fibers.perform
+
+local json           = require 'cjson.safe'
+local log            = require 'services.log'
+local external_types = require 'services.hal.types.external'
+
+local senml          = require 'services.metrics.senml'
+local http_m         = require 'services.metrics.http'
+local conf           = require 'services.metrics.config'
+local types          = require 'services.metrics.types'
+
+
+local unpack = unpack or table.unpack
+
+local NAME = 'metrics'
+
+-------------------------------------------------------------------------------
+-- Topic helpers
+-------------------------------------------------------------------------------
+
+---@param name string
+---@return table
+local function t_svc_status(name) return { 'svc', name, 'status' } end
+
+---@param service string
+---@param name string
+---@return table
+local function t_obs_metric(service, name) return { 'obs', 'v1', service, 'metric', name } end
+
+---@param name string
+---@return table
+local function t_cfg(name) return { 'cfg', name } end
+
+---@return table
+local function t_time_ntp_synced() return { 'time', 'ntp_synced' } end
+
+---@return table
+local function t_cap_fs_state() return { 'cap', 'fs', 'configs', 'state' } end
+
+---@param method string
+---@return table
+local function t_cap_fs_rpc(method) return { 'cap', 'fs', 'configs', 'rpc', method } end
+
+---@param tokens table
+---@return table
+local function t_svc_metrics_bus(tokens) return { 'svc', 'metrics', unpack(tokens) } end
+
+---@return number
+local function now() return runtime.now() end
+
+---@return number
+local function now_real() return time.realtime() end
+
+---@param conn Connection
+---@param name string
+---@param state string
+---@param extra table?
+local function publish_status(conn, name, state, extra)
+	local payload = { state = state, ts = now() }
+	if type(extra) == 'table' then
+		for k, v in pairs(extra) do payload[k] = v end
+	end
+	conn:retain(t_svc_status(name), payload)
+end
+
+-------------------------------------------------------------------------------
+-- Metric helpers
+-------------------------------------------------------------------------------
+
+--- Validate a topic array (no gaps, no nils, at least one element).
+---@param topic any
+---@return boolean
+local function validate_topic(topic)
+	if type(topic) ~= 'table' or #topic == 0 then return false end
+	local count = 0
+	for k, v in pairs(topic) do
+		count = count + 1
+		if type(k) ~= 'number' or k < 1 or k ~= math.floor(k) then return false end
+		if v == nil then return false end
+	end
+	return count == #topic
+end
+
+--- Shift per-endpoint metric timestamps from monotonic to real-time milliseconds.
+--- base_time = { real = wall_clock_at_mono_base, mono = mono_at_base }
+---@param base_time BaseTime
+---@param metrics table
+---@return table
+local function set_timestamps_realtime_millis(base_time, metrics)
+	for _, metric in pairs(metrics) do
+		metric.time = math.floor((base_time.real + (metric.time - base_time.mono)) * 1000)
+	end
+	return metrics
+end
+
+-------------------------------------------------------------------------------
+-- Config warnings (pure: no service state)
+-------------------------------------------------------------------------------
+
+--- Log config warnings and prune invalid entries from the raw config in-place.
+---@param warns table
+---@param config table
+local function process_config_warnings(warns, config)
+	if #warns == 0 then return end
+
+	local warn_msgs         = {}
+	local dropped_metrics   = {}
+	local dropped_templates = {}
+
+	for _, warn in ipairs(warns) do
+		table.insert(warn_msgs, warn.msg)
+		if warn.endpoint then
+			if warn.type == 'metric' then
+				config.pipelines[warn.endpoint] = nil
+				dropped_metrics[warn.endpoint]  = true
+			elseif warn.type == 'template' then
+				if config.templates then
+					config.templates[warn.endpoint] = nil
+				end
+				dropped_templates[warn.endpoint] = true
+			end
+		end
+	end
+
+	local summary_parts = {}
+
+	local dm_list = {}
+	for ep in pairs(dropped_metrics) do dm_list[#dm_list + 1] = ep end
+	if #dm_list > 0 then
+		table.insert(summary_parts, string.format(
+			'Dropped %d metric(s): %s', #dm_list, table.concat(dm_list, ', ')))
+	end
+
+	local dt_list = {}
+	for ep in pairs(dropped_templates) do dt_list[#dt_list + 1] = ep end
+	if #dt_list > 0 then
+		table.insert(summary_parts, string.format(
+			'Dropped %d template(s): %s', #dt_list, table.concat(dt_list, ', ')))
+	end
+
+	log.warn(string.format(
+		'metrics: config warnings (invalid entries will be dropped):\n\t%s\n\nSummary: %s',
+		table.concat(warn_msgs, '\n\t'),
+		table.concat(summary_parts, '; ')))
+end
+
+-------------------------------------------------------------------------------
+-- Service state
+-------------------------------------------------------------------------------
+
+---@type ServiceState
+local State = {
+	conn             = nil,
+	name             = nil,
+	http_send_ch     = nil,
+	pipelines_map    = {},
+	metric_states    = {},
+	endpoint_to_pipe = {},
+	metric_values    = {},
+	publish_period   = nil,
+	cloud_url        = nil,
+	mainflux_config  = nil,
+	cloud_config     = nil,
+	base_time        = nil,
+}
+
+-------------------------------------------------------------------------------
+-- Cloud config
+-------------------------------------------------------------------------------
+
+local function rebuild_cloud_config()
+	local mf = State.mainflux_config
+	if not mf or not State.cloud_url or not mf.thing_key or not mf.channels then
+		State.cloud_config = nil
+		return
+	end
+	local cfg, cfg_err = types.new.CloudConfig(State.cloud_url, mf.thing_key, mf.channels)
+	if not cfg then
+		log.warn('metrics: failed to build cloud config: ' .. tostring(cfg_err))
+		State.cloud_config = nil
+		return
+	end
+	State.cloud_config = cfg
+end
+
+local function fetch_mainflux_config()
+	local read_opts, opts_err = external_types.new.FilesystemReadOpts('mainflux.cfg')
+	if not read_opts then
+		log.warn('metrics: failed to build mainflux.cfg read opts:', tostring(opts_err))
+		return
+	end
+
+	local reply, err = State.conn:call(t_cap_fs_rpc('read'), read_opts)
+	if not reply then
+		log.warn('metrics: failed to read mainflux.cfg:', tostring(err))
+		return
+	end
+	if reply.ok ~= true then
+		log.warn('metrics: mainflux.cfg read failed:', tostring(reply.reason))
+		return
+	end
+
+	local raw, decode_err = json.decode(reply.reason)
+	if not raw then
+		log.warn('metrics: failed to decode mainflux.cfg:', tostring(decode_err))
+		return
+	end
+
+	State.mainflux_config = conf.standardise_config(raw)
+	rebuild_cloud_config()
+end
+
+-------------------------------------------------------------------------------
+-- Protocol publish handlers
+-------------------------------------------------------------------------------
+
+---@param data table<string, MetricSample>
+local function bus_publish(data)
+	for endpoint_str, metric in pairs(data) do
+		local tokens = {}
+		for part in endpoint_str:gmatch('[^.]+') do
+			tokens[#tokens + 1] = part
+		end
+		State.conn:publish(t_svc_metrics_bus(tokens), { value = metric.value, time = metric.time })
+	end
+end
+
+---@param data table<string, MetricSample>
+local function log_publish(data)
+	for endpoint_str, metric in pairs(data) do
+		log.info(string.format('metrics: %s = %s (t=%s)',
+			endpoint_str, tostring(metric.value), tostring(metric.time)))
+	end
+end
+
+---@param data table<string, MetricSample>
+local function http_publish(data)
+	local senml_list, encode_err = senml.encode_r('', data)
+	if encode_err then
+		log.error('metrics: SenML encode failed: ' .. tostring(encode_err))
+		return
+	end
+	if #senml_list == 0 then return end
+
+	local body = json.encode(senml_list)
+
+	local valid, config_err = conf.validate_http_config(State.cloud_config)
+	if not valid then
+		log.error('metrics: HTTP publish skipped, invalid cloud config: ' .. tostring(config_err))
+		return
+	end
+
+	local channel_id
+	for _, ch in ipairs(State.cloud_config.channels) do
+		if ch.metadata and ch.metadata.channel_type == 'data' then
+			channel_id = ch.id
+			break
+		end
+	end
+	if channel_id == nil then
+		log.error('metrics: HTTP publish failed, no data channel id found')
+		return
+	end
+
+	local uri   = string.format('%s/http/channels/%s/messages',
+		State.cloud_config.url, channel_id)
+	local auth  = 'Thing ' .. State.cloud_config.thing_key
+
+	-- Non-blocking enqueue: drop and log if the channel is at capacity.
+	local sent = perform(State.http_send_ch:put_op({ uri = uri, auth = auth, body = body })
+		:or_else(function() return false end))
+	if not sent then
+		log.error('metrics: HTTP send queue full, dropping publish payload')
+	end
+end
+
+local publish_fns = { bus = bus_publish, log = log_publish, http = http_publish }
+
+---@param values table<string, table<string, MetricSample>>
+local function publish_all(values)
+	for protocol, pv in pairs(values) do
+		-- Reset per-endpoint pipeline states for published endpoints.
+		for endpoint_str, _ in pairs(pv) do
+			local metric_name = State.endpoint_to_pipe[endpoint_str]
+			if metric_name then
+				local pipe_cfg = State.pipelines_map[metric_name]
+				if pipe_cfg and State.metric_states[endpoint_str] then
+					pipe_cfg.pipeline:reset(State.metric_states[endpoint_str])
+				end
+			end
+		end
+
+		pv = set_timestamps_realtime_millis(State.base_time, pv)
+
+		local fn = publish_fns[protocol]
+		if fn == nil then
+			log.error('metrics: no publish function for protocol: ' .. tostring(protocol))
+		else
+			fn(pv)
+		end
+	end
+end
+
+-------------------------------------------------------------------------------
+-- Metric handling
+-------------------------------------------------------------------------------
+
+---@param msg Message?
+local function handle_metric(msg)
+	if not msg then return end
+
+	-- Topic layout: {'obs', 'v1', <service>, 'metric', <metric_name>}
+	local metric_name = msg.topic and msg.topic[5]
+	if not metric_name then return end
+
+	local pipe_cfg = State.pipelines_map[metric_name]
+	if not pipe_cfg then return end -- no matching pipeline, drop silently
+
+	local payload = msg.payload
+	if type(payload) ~= 'table' then return end
+
+	local value = payload.value
+	if value == nil then return end
+
+	-- Optional namespace overrides the topic used as the SenML name and state key.
+	local topic = payload.namespace or msg.topic
+	if not validate_topic(topic) then
+		log.warn('metrics: received metric with invalid topic array, skipping')
+		return
+	end
+
+	local endpoint_str = table.concat(topic, '.')
+
+	-- Get-or-create per-endpoint processing state.
+	if not State.metric_states[endpoint_str] then
+		State.metric_states[endpoint_str]    = pipe_cfg.pipeline:new_state()
+		State.endpoint_to_pipe[endpoint_str] = metric_name
+	end
+
+	local ret, short, err = pipe_cfg.pipeline:run(value, State.metric_states[endpoint_str])
+	if err then
+		log.error(string.format(
+			'metrics: pipeline error for [%s]: %s', endpoint_str, tostring(err)))
+		return
+	end
+
+	if not short then
+		State.metric_values[pipe_cfg.protocol] = State.metric_values[pipe_cfg.protocol] or {}
+		State.metric_values[pipe_cfg.protocol][endpoint_str] = types.new.MetricSample(ret, now())
+	end
+end
+
+-------------------------------------------------------------------------------
+-- Config handling
+-------------------------------------------------------------------------------
+
+---@param payload table?
+---@return number next_publish_time
+local function handle_config(payload)
+	if not payload then return math.huge end
+
+	local valid, warns, err = conf.validate_config(payload)
+	if not valid then
+		log.error('metrics: invalid config received: ' .. tostring(err))
+		return math.huge
+	end
+
+	process_config_warnings(warns, payload)
+
+	local new_pipelines_map, new_publish_period = conf.apply_config(payload)
+
+	if next(new_pipelines_map) == nil then
+		log.warn('metrics: no valid pipelines after config apply; service will be idle')
+	end
+
+	-- Cache cloud_url from the metrics config and rebuild cloud_config.
+	State.cloud_url = payload.cloud_url
+	rebuild_cloud_config()
+
+	-- Replace all pipeline state (logic may have changed).
+	State.pipelines_map    = new_pipelines_map
+	State.metric_states    = {}
+	State.endpoint_to_pipe = {}
+	State.publish_period   = new_publish_period
+
+	if State.base_time.synced and State.publish_period then
+		return now() + State.publish_period
+	end
+	return math.huge
+end
+
+---@param synced boolean
+---@return boolean first_sync
+local function handle_time_sync(synced)
+	if synced == true then
+		if not State.base_time.synced then
+			State.base_time.synced = true
+			local real = now_real()
+			local mono = now()
+			-- Compute the wall-clock time that corresponds to base_time.mono.
+			State.base_time.real = real - (mono - State.base_time.mono)
+			return true -- first sync
+		end
+	else
+		State.base_time.synced = false
+	end
+	return false
+end
+
+-------------------------------------------------------------------------------
+-- Main loop
+-------------------------------------------------------------------------------
+
+---@return boolean ok
+local function wait_for_fs_capability()
+	local sub = State.conn:subscribe(
+		t_cap_fs_state(),
+		{ queue_len = 10, full = 'drop_oldest' })
+
+	while true do
+		local msg, err = perform(sub:recv_op())
+		if not msg then
+			log.warn('metrics: filesystem capability subscription closed:', tostring(err))
+			sub:unsubscribe()
+			return false
+		end
+		if msg.payload == 'added' then
+			sub:unsubscribe()
+			return true
+		end
+	end
+end
+
+local function main()
+	-- Subscribe to all observable metrics.
+	local obs_sub = State.conn:subscribe(
+		t_obs_metric('+', '+'),
+		{ queue_len = 100, full = 'drop_oldest' })
+
+	-- Subscribe to the metrics config (retained; first message is current config).
+	local cfg_sub = State.conn:subscribe(
+		t_cfg(NAME),
+		{ queue_len = 10, full = 'drop_oldest' })
+
+	-- Subscribe to NTP sync status.
+	local time_sub = State.conn:subscribe(
+		t_time_ntp_synced(),
+		{ queue_len = 5, full = 'drop_oldest' })
+
+	local next_publish_time = math.huge
+
+	while true do
+		local which, a, b = perform(op.named_choice({
+			config   = cfg_sub:recv_op(),
+			metric   = obs_sub:recv_op(),
+			-- timesync = time_sub:recv_op(),
+			timesync = State.base_time.synced and op.never() or op.always({ payload = true }),
+			tick     = sleep.sleep_until_op(next_publish_time),
+		}))
+
+
+		if which == 'config' then
+			local msg, err = a, b
+			if not msg then
+				log.warn('metrics: config subscription closed:', tostring(err))
+				break
+			end
+			next_publish_time = handle_config(msg.payload)
+			-- Re-read mainflux.cfg in case cloud_url or credentials changed.
+			fetch_mainflux_config()
+		elseif which == 'metric' then
+			local msg = a
+			if msg then
+				handle_metric(msg)
+			end
+		elseif which == 'timesync' then
+			local msg = a
+			if msg then
+				local first_sync = handle_time_sync(msg.payload)
+				if first_sync and State.publish_period then
+					next_publish_time = now() + State.publish_period
+				elseif not State.base_time.synced then
+					next_publish_time = math.huge
+				end
+			end
+		elseif which == 'tick' then
+			local values        = State.metric_values
+			State.metric_values = {}
+
+			if State.base_time.synced and State.publish_period then
+				next_publish_time = now() + State.publish_period
+			else
+				next_publish_time = math.huge
+			end
+
+			publish_all(values)
+		end
+	end
+
+	obs_sub:unsubscribe()
+	cfg_sub:unsubscribe()
+	time_sub:unsubscribe()
+	log.info('metrics: service stopping')
+end
+
+-------------------------------------------------------------------------------
+-- Module entry point
+-------------------------------------------------------------------------------
+
+local M = {}
+
+---@param conn Connection
+---@param opts table?
+function M.start(conn, opts)
+	opts = opts or {}
+	local name = opts.name or NAME
+
+	publish_status(conn, name, 'starting')
+
+	State.conn             = conn
+	State.name             = name
+	State.http_send_ch     = http_m.start_http_publisher()
+	State.pipelines_map    = {}
+	State.metric_states    = {}
+	State.endpoint_to_pipe = {}
+	State.metric_values    = {}
+	State.publish_period   = nil
+	State.cloud_url        = nil
+	State.mainflux_config  = nil
+	State.cloud_config     = nil
+	State.base_time        = types.new.BaseTime(now_real(), now())
+
+	fibers.current_scope():finally(function(_, st, primary)
+		local reason = primary or st
+		log.info(('metrics: scope closed (status: %s, reason: %s)'):format(tostring(st), tostring(primary)))
+		publish_status(conn, name, 'stopped', reason and { reason = tostring(reason) } or nil)
+	end)
+
+	local fs_ok = wait_for_fs_capability()
+	if not fs_ok then
+		publish_status(conn, name, 'error', { reason = 'filesystem capability unavailable' })
+		return
+	end
+
+	fetch_mainflux_config()
+
+	publish_status(conn, name, 'running')
+
+	main()
+end
+
+return M

--- a/src/services/metrics.lua
+++ b/src/services/metrics.lua
@@ -56,7 +56,7 @@ local function t_obs_metric(service, name) return { 'obs', 'v1', service, 'metri
 local function t_cfg(name) return { 'cfg', name } end
 
 ---@return table
-local function t_time_ntp_synced() return { 'time', 'ntp_synced' } end
+local function t_time_ntp_synced() return { 'svc', 'time', 'synced' } end
 
 ---@return table
 local function t_cap_fs_state() return { 'cap', 'fs', 'configs', 'state' } end
@@ -478,8 +478,8 @@ local function main()
 		local which, a, b = perform(op.named_choice({
 			config   = cfg_sub:recv_op(),
 			metric   = obs_sub:recv_op(),
-			-- timesync = time_sub:recv_op(),
-			timesync = State.base_time.synced and op.never() or op.always({ payload = true }),
+			timesync = time_sub:recv_op(),
+			-- timesync = State.base_time.synced and op.never() or op.always({ payload = true }),
 			tick     = sleep.sleep_until_op(next_publish_time),
 		}))
 

--- a/src/services/metrics.lua
+++ b/src/services/metrics.lua
@@ -291,9 +291,10 @@ local function http_publish(data)
 	local auth  = 'Thing ' .. State.cloud_config.thing_key
 
 	-- Non-blocking enqueue: drop and log if the channel is at capacity.
-	local sent = perform(State.http_send_ch:put_op({ uri = uri, auth = auth, body = body })
-		:or_else(function() return false end))
-	if not sent then
+	local full = perform(State.http_send_ch:put_op({ uri = uri, auth = auth, body = body })
+		:or_else(function() return true end))
+
+	if full then
 		log.error('metrics: HTTP send queue full, dropping publish payload')
 	end
 end

--- a/src/services/metrics/config.lua
+++ b/src/services/metrics/config.lua
@@ -39,10 +39,15 @@ local VALID_METRIC_FIELDS   = {
 ---@return boolean
 local function is_array(t)
     if type(t) ~= 'table' then return false end
-    local i = 1
+    local count = 0
     for k in pairs(t) do
-        if k ~= i then return false end
-        i = i + 1
+        if type(k) ~= 'number' or math.floor(k) ~= k or k < 1 then
+            return false
+        end
+        count = count + 1
+    end
+    for i = 1, count do
+        if t[i] == nil then return false end
     end
     return true
 end
@@ -76,10 +81,12 @@ local function standardise_config(config)
     for _, channel in ipairs(out.channels or {}) do
         channel.metadata = channel.metadata or {}
         if type(channel.metadata) == 'userdata' then channel.metadata = {} end
-        if string.find(channel.name, 'data') then
-            channel.metadata.channel_type = 'data'
-        elseif string.find(channel.name, 'control') then
-            channel.metadata.channel_type = 'events'
+        if type(channel.name) == 'string' then
+            if string.find(channel.name, 'data') then
+                channel.metadata.channel_type = 'data'
+            elseif string.find(channel.name, 'control') then
+                channel.metadata.channel_type = 'events'
+            end
         end
     end
     out.content = config.content

--- a/src/services/metrics/config.lua
+++ b/src/services/metrics/config.lua
@@ -1,0 +1,443 @@
+-- services/metrics/config.lua
+--
+-- Configuration validation and application for the metrics service.
+--
+-- validate_config(config)
+--   Returns (ok, warnings, error).  Validates structure, protocols, process
+--   blocks, templates and pipelines.  Invalid templates and any pipelines that
+--   reference them are collected as warnings rather than hard failures so that
+--   the service can continue with the valid subset.
+--
+-- apply_config(config)
+--   Returns (pipelines_map, publish_period).
+--   pipelines_map[metric_name] = { pipeline, protocol }
+--   The pipeline object contains only logic; per-endpoint state is created
+--   externally with pipeline:new_state().
+
+local log                   = require 'services.log'
+local processing            = require 'services.metrics.processing'
+local _types                = require 'services.metrics.types' -- luacheck: ignore (imported for annotations)
+
+local VALID_PROTOCOLS       = { http = true, log = true, bus = true }
+local VALID_PROCESS_TYPES   = { DiffTrigger = true, TimeTrigger = true, DeltaValue = true }
+
+local VALID_TEMPLATE_FIELDS = {
+    protocol = true,
+    process  = true,
+}
+local VALID_METRIC_FIELDS   = {
+    protocol = true,
+    process  = true,
+    template = true,
+}
+
+-------------------------------------------------------------------------------
+-- Helpers
+-------------------------------------------------------------------------------
+
+---@param t any
+---@return boolean
+local function is_array(t)
+    if type(t) ~= 'table' then return false end
+    local i = 1
+    for k in pairs(t) do
+        if k ~= i then return false end
+        i = i + 1
+    end
+    return true
+end
+
+---@param base table?
+---@param override table?
+---@return table
+local function merge_config(base, override)
+    if not base then return override or {} end
+    if not override then return base end
+    local result = {}
+    for k, v in pairs(base) do result[k] = v end
+    for k, v in pairs(override) do
+        if type(v) == 'table' and type(result[k]) == 'table' then
+            result[k] = merge_config(result[k], v)
+        else
+            result[k] = v
+        end
+    end
+    return result
+end
+
+--- Normalise a raw mainflux config table to a consistent field set.
+--- Accepts both legacy (`mainflux_*`) and current (`thing_*`) naming.
+---@param config table
+---@return table
+local function standardise_config(config)
+    local out     = {}
+    out.thing_key = config.mainflux_key or config.thing_key
+    out.channels  = config.mainflux_channels or config.channels
+    for _, channel in ipairs(out.channels or {}) do
+        channel.metadata = channel.metadata or {}
+        if type(channel.metadata) == 'userdata' then channel.metadata = {} end
+        if string.find(channel.name, 'data') then
+            channel.metadata.channel_type = 'data'
+        elseif string.find(channel.name, 'control') then
+            channel.metadata.channel_type = 'events'
+        end
+    end
+    out.content = config.content
+    return out
+end
+
+--- Basic sanity-check for the cloud (Mainflux) config used for HTTP publish.
+---@param config CloudConfig?
+---@return boolean ok
+---@return string? error
+local function validate_http_config(config)
+    if not config then
+        return false, 'No cloud config set'
+    end
+    if not config.url then
+        return false, 'No cloud url set'
+    end
+    if type(config.url) ~= 'string' then
+        return false, 'Cloud url is not a string'
+    end
+    if not config.thing_key or not config.channels then
+        return false, 'Cloud thing_key / channels missing'
+    end
+    return true, nil
+end
+
+-------------------------------------------------------------------------------
+-- Internal validation helpers
+-------------------------------------------------------------------------------
+
+---@param process_block any
+---@param endpoint string
+---@param index number
+---@return string? error
+local function validate_process_block(process_block, endpoint, index)
+    if type(process_block) ~= 'table' then
+        return string.format('Metric config [%s] process block %d is not a table',
+            tostring(endpoint), index)
+    end
+    if process_block.type == nil then
+        return string.format('Metric config [%s] process block %d has no type field',
+            tostring(endpoint), index)
+    end
+    if not VALID_PROCESS_TYPES[process_block.type] then
+        return string.format(
+            "Metric config [%s] process block %d has invalid type '%s' (valid: %s)",
+            tostring(endpoint), index, tostring(process_block.type),
+            table.concat({ 'DiffTrigger', 'TimeTrigger', 'DeltaValue' }, ', '))
+    end
+    return nil
+end
+
+---@param name any
+---@param template_config any
+---@return table warnings
+local function validate_template(name, template_config)
+    local warnings = {}
+
+    if type(name) ~= 'string' then
+        table.insert(warnings, {
+            msg      = 'Template name is not a string',
+            endpoint = name,
+            type     = 'template',
+        })
+    end
+    if type(template_config) ~= 'table' then
+        table.insert(warnings, {
+            msg      = string.format('Template config [%s] is not a table', tostring(name)),
+            endpoint = name,
+            type     = 'template',
+        })
+        return warnings
+    end
+
+    for field in pairs(template_config) do
+        if not VALID_TEMPLATE_FIELDS[field] then
+            table.insert(warnings, {
+                msg      = string.format("Template config [%s] has invalid field '%s'",
+                    tostring(name), tostring(field)),
+                endpoint = name,
+                type     = 'template',
+            })
+        end
+    end
+
+    if template_config.protocol and not VALID_PROTOCOLS[template_config.protocol] then
+        table.insert(warnings, {
+            msg      = string.format(
+                "Template config [%s] has invalid protocol '%s' (valid: http, log, bus)",
+                tostring(name), tostring(template_config.protocol)),
+            endpoint = name,
+            type     = 'template',
+        })
+    end
+
+    if template_config.process ~= nil then
+        if not is_array(template_config.process) then
+            table.insert(warnings, {
+                msg      = string.format('Template config [%s] process must be an array', tostring(name)),
+                endpoint = name,
+                type     = 'template',
+            })
+        else
+            for i, blk in ipairs(template_config.process) do
+                local err = validate_process_block(blk, name, i)
+                if err then
+                    table.insert(warnings, { msg = err, endpoint = name, type = 'template' })
+                end
+            end
+        end
+    end
+
+    return warnings
+end
+
+---@param endpoint any
+---@param metric_config any
+---@return table warnings
+local function validate_metric(endpoint, metric_config)
+    local warnings = {}
+
+    if type(endpoint) ~= 'string' then
+        table.insert(warnings, {
+            msg      = 'Metric endpoint is not a string',
+            endpoint = endpoint,
+            type     = 'metric',
+        })
+    end
+    if type(metric_config) ~= 'table' then
+        table.insert(warnings, {
+            msg      = string.format('Metric config [%s] is not a table', tostring(endpoint)),
+            endpoint = endpoint,
+            type     = 'metric',
+        })
+        return warnings
+    end
+
+    for field in pairs(metric_config) do
+        if not VALID_METRIC_FIELDS[field] then
+            table.insert(warnings, {
+                msg      = string.format("Metric config [%s] has invalid field '%s'",
+                    tostring(endpoint), tostring(field)),
+                endpoint = endpoint,
+                type     = 'metric',
+            })
+        end
+    end
+
+    if metric_config.protocol == nil then
+        table.insert(warnings, {
+            msg      = string.format('Metric config [%s] has no defined protocol', tostring(endpoint)),
+            endpoint = endpoint,
+            type     = 'metric',
+        })
+    elseif not VALID_PROTOCOLS[metric_config.protocol] then
+        table.insert(warnings, {
+            msg      = string.format(
+                "Metric config [%s] has invalid protocol '%s' (valid: http, log, bus)",
+                tostring(endpoint), tostring(metric_config.protocol)),
+            endpoint = endpoint,
+            type     = 'metric',
+        })
+    end
+
+    if metric_config.process ~= nil then
+        if not is_array(metric_config.process) then
+            table.insert(warnings, {
+                msg      = string.format('Metric config [%s] process must be an array', tostring(endpoint)),
+                endpoint = endpoint,
+                type     = 'metric',
+            })
+        else
+            for i, blk in ipairs(metric_config.process) do
+                local err = validate_process_block(blk, endpoint, i)
+                if err then
+                    table.insert(warnings, { msg = err, endpoint = endpoint, type = 'metric' })
+                end
+            end
+        end
+    end
+
+    return warnings
+end
+
+-------------------------------------------------------------------------------
+-- Pipeline builder
+-------------------------------------------------------------------------------
+
+--- Build a ProcessPipeline from a process_config array.
+---@param endpoint string
+---@param process_config table
+---@return ProcessPipeline?
+---@return string? error
+local function build_metric_pipeline(endpoint, process_config)
+    local pipeline, pipeline_err = processing.new_process_pipeline()
+    if not pipeline then
+        return nil, string.format('Metric config [%s] failed to create pipeline: %s', endpoint, tostring(pipeline_err))
+    end
+
+    if process_config == nil then
+        -- An empty pipeline (pass-through) is valid.
+        return pipeline, nil
+    end
+
+    for _, blk_cfg in ipairs(process_config) do
+        local ptype = blk_cfg.type
+        if ptype == nil then
+            return nil, string.format('Metric config [%s] has process block with no type', endpoint)
+        end
+
+        local proc_class = processing[ptype]
+        if proc_class == nil then
+            return nil, string.format('Metric config [%s] has invalid process block type [%s]',
+                endpoint, tostring(ptype))
+        end
+
+        local proc, proc_err = proc_class.new(blk_cfg)
+        if not proc or proc_err then
+            return nil, string.format(
+                'Metric config [%s] failed to create process block [%s]: %s',
+                endpoint, tostring(ptype), tostring(proc_err))
+        end
+
+        local add_err = pipeline:add(proc)
+        if add_err then
+            return nil, add_err
+        end
+    end
+
+    return pipeline, nil
+end
+
+-------------------------------------------------------------------------------
+-- Public: validate_config
+-------------------------------------------------------------------------------
+
+--- Validate a raw metrics config table.
+---@param config table
+---@return boolean ok
+---@return table   warnings
+---@return string? error
+local function validate_config(config)
+    local warnings = {}
+
+    if type(config) ~= 'table' then
+        return false, warnings, 'Invalid configuration message'
+    end
+
+    if type(config.publish_period) ~= 'number' then
+        return false, warnings,
+            'Publish period must be of number type, found ' .. type(config.publish_period)
+    end
+    if config.publish_period <= 0 then
+        return false, warnings, 'Publish period must be greater than 0'
+    end
+
+    if type(config.pipelines) ~= 'table' then
+        return false, warnings, 'No metric pipelines defined in config'
+    end
+
+    local dropped_templates = {}
+    for name, tmpl in pairs(config.templates or {}) do
+        local tmpl_warns = validate_template(name, tmpl)
+        if #tmpl_warns > 0 then
+            for _, w in ipairs(tmpl_warns) do
+                table.insert(warnings, w)
+            end
+            dropped_templates[name] = true
+        end
+    end
+
+    for endpoint, metric_config in pairs(config.pipelines) do
+        -- Check template existence
+        if metric_config.template then
+            if (not config.templates) or (not config.templates[metric_config.template]) then
+                table.insert(warnings, {
+                    msg      = string.format(
+                        'Metric config [%s] uses template [%s] that does not exist',
+                        tostring(endpoint), tostring(metric_config.template)),
+                    endpoint = endpoint,
+                    type     = 'metric',
+                })
+            end
+            if dropped_templates[metric_config.template] then
+                table.insert(warnings, {
+                    msg      = string.format(
+                        'Metric config [%s] uses invalid template [%s]',
+                        tostring(endpoint), tostring(metric_config.template)),
+                    endpoint = endpoint,
+                    type     = 'metric',
+                })
+            end
+        end
+
+        -- Merge template then validate the resulting config
+        local full_cfg = merge_config(
+            (config.templates and metric_config.template
+                and config.templates[metric_config.template]) or {},
+            metric_config
+        )
+        local metric_warns = validate_metric(endpoint, full_cfg)
+        for _, w in ipairs(metric_warns) do
+            table.insert(warnings, w)
+        end
+    end
+
+    return true, warnings, nil
+end
+
+-------------------------------------------------------------------------------
+-- Public: apply_config
+-------------------------------------------------------------------------------
+
+--- Apply a validated config and return a pipelines_map.
+--- Does not create any bus subscriptions.
+---
+---@param config table
+---@return PipelineMap pipelines_map  keyed by metric_name
+---@return number      publish_period
+local function apply_config(config)
+    local publish_period = config.publish_period
+    local pipelines_map  = {}
+
+    for metric_name, metric_config in pairs(config.pipelines) do
+        local resolved = metric_config
+        if resolved.template and config.templates and config.templates[resolved.template] then
+            resolved = merge_config(config.templates[resolved.template], resolved)
+        end
+
+        local protocol = resolved.protocol
+        if not protocol or not VALID_PROTOCOLS[protocol] then
+            log.warn(string.format(
+                'metrics/config: skipping pipeline [%s] — invalid or missing protocol',
+                tostring(metric_name)))
+        else
+            local pipeline, pipeline_err = build_metric_pipeline(
+                metric_name, resolved.process or {})
+            if pipeline_err then
+                log.error(string.format(
+                    'metrics/config: skipping pipeline [%s] — %s',
+                    tostring(metric_name), pipeline_err))
+            else
+                pipelines_map[metric_name] = {
+                    pipeline = pipeline,
+                    protocol = protocol,
+                }
+            end
+        end
+    end
+
+    return pipelines_map, publish_period
+end
+
+return {
+    merge_config          = merge_config,
+    standardise_config    = standardise_config,
+    validate_http_config  = validate_http_config,
+    validate_config       = validate_config,
+    apply_config          = apply_config,
+    build_metric_pipeline = build_metric_pipeline,
+}

--- a/src/services/metrics/http.lua
+++ b/src/services/metrics/http.lua
@@ -1,0 +1,98 @@
+-- services/metrics/http.lua
+--
+-- HTTP publisher for the metrics service.
+--
+-- Starts a dedicated fiber that drains a bounded channel of HTTP payloads and
+-- sends them to the Mainflux cloud endpoint with exponential-backoff retry on
+-- network failure.
+--
+-- Public API:
+--   start_http_publisher() -> channel
+--     Must be called from inside a running fiber scope.  Returns the send
+--     channel (capacity QUEUE_SIZE).  The caller enqueues payloads with a
+--     non-blocking put; if the channel is full the payload is dropped and an
+--     error is logged.
+
+local fibers     = require 'fibers'
+local op         = require 'fibers.op'
+local sleep      = require 'fibers.sleep'
+local channel    = require 'fibers.channel'
+local request    = require 'http.request'
+local log        = require 'services.log'
+
+local QUEUE_SIZE = 10
+
+--- Send a single HTTP payload to the cloud, retrying with exponential backoff
+--- on network failure.  Returns only when the send succeeds or the enclosing
+--- scope is cancelled.
+---
+---@param data table  { uri: string, auth: string, body: string }
+local function send_http(data)
+    local uri            = data.uri
+    local body           = data.body
+    local auth           = data.auth
+
+    local sleep_duration = 1
+    local response_headers
+
+    while not response_headers do
+        local req = request.new_from_uri(uri)
+        req.headers:upsert(':method', 'POST')
+        req.headers:upsert('authorization', auth)
+        req.headers:upsert('content-type', 'application/senml+json')
+        req.headers:delete('expect')
+        req:set_body(body)
+
+        local headers = req:go(10)
+        response_headers = headers
+
+        if not response_headers then
+            log.debug(string.format(
+                'metrics/http: HTTP publish failed, retrying in %s seconds',
+                sleep_duration))
+            sleep.sleep(sleep_duration)
+            sleep_duration = math.min(sleep_duration * 2, 60)
+        end
+    end
+
+    local status = response_headers:get(':status')
+    if status ~= '202' then
+        local parts = {}
+        for k, v in response_headers:each() do
+            table.insert(parts, string.format('\t%s: %s', k, v))
+        end
+        log.debug(string.format(
+            'metrics/http: HTTP publish failed, response headers:\n%s',
+            table.concat(parts, '\n')))
+    else
+        log.info('metrics/http: HTTP publish success, status: ' .. status)
+    end
+end
+
+--- Start the HTTP publisher fiber in the current scope.
+--- Returns the send channel.  Payloads must be enqueued with a non-blocking
+--- select (see _http_publish in metrics.lua); if the channel is full the
+--- payload should be dropped by the caller.
+---
+---@return table channel
+local function start_http_publisher()
+    local send_ch = channel.new(QUEUE_SIZE)
+
+    local scope = fibers.current_scope()
+    scope:spawn(function()
+        while true do
+            local which, payload = fibers.perform(op.named_choice({
+                msg = send_ch:get_op(),
+            }))
+            if which == 'msg' and payload ~= nil then
+                send_http(payload)
+            end
+        end
+    end)
+
+    return send_ch
+end
+
+return {
+    start_http_publisher = start_http_publisher,
+}

--- a/src/services/metrics/processing.lua
+++ b/src/services/metrics/processing.lua
@@ -1,0 +1,293 @@
+-- services/metrics/processing.lua
+--
+-- Processing pipeline blocks for the metrics service.
+--
+-- Each block class holds only configuration (logic). Runtime state is kept in a
+-- separate table created by :new_state() and passed explicitly to :run() and
+-- :reset().  This allows a single pipeline object to be shared across many
+-- metric endpoints while maintaining fully isolated per-endpoint state.
+--
+-- Block interface:
+--   block:new_state()               -> state_table
+--   block:run(value, state)         -> value, short_circuit, error
+--   block:reset(state)              -> nil
+--
+-- ProcessPipeline wraps a list of blocks and exposes the same interface:
+--   pipeline:new_state()            -> state_table  {full_run, blocks={...}}
+--   pipeline:run(value, state)      -> value, short_circuit, error
+--   pipeline:reset(state)           -> nil   (only resets when full_run == true)
+--   pipeline:force_reset(state)     -> nil   (reset unconditionally)
+--   pipeline:add(block)             -> error?
+
+local runtime = require 'fibers.runtime'
+
+-------------------------------------------------------------------------------
+-- Base Process (documentation only; not used at runtime)
+-------------------------------------------------------------------------------
+
+---@class Process
+---@field new_state  fun(self: Process): table
+---@field run        fun(self: Process, value: any, state: table): any, boolean, string?
+---@field reset      fun(self: Process, state: table)
+
+-------------------------------------------------------------------------------
+-- DiffTrigger
+-------------------------------------------------------------------------------
+
+--- Passes a value only when the change from the last-published value exceeds a
+--- threshold.  Three diff methods are supported:
+---   "absolute"   - abs(curr - last) >= threshold
+---   "percent"    - abs((curr - last) / last) * 100 >= threshold
+---   "any-change" - curr ~= last
+---
+---@class DiffTrigger
+---@field threshold  number
+---@field diff_fn    function
+---@field config     table
+local DiffTrigger = {}
+DiffTrigger.__index = DiffTrigger
+
+local function check_diff_args_valid(config)
+    if config.initial_val and type(config.initial_val) ~= 'number' then
+        return 'Initial value must be a number'
+    end
+    if config.diff_method ~= 'any-change' and type(config.threshold) ~= 'number' then
+        return 'Threshold must be a number'
+    end
+end
+
+---@param config table
+---@return DiffTrigger?
+---@return string? error
+function DiffTrigger.new(config)
+    local valid_err = check_diff_args_valid(config)
+    if valid_err then return nil, valid_err end
+
+    local self = setmetatable({}, DiffTrigger)
+    self.config = config
+    self.threshold = config.threshold
+
+    local dm = config.diff_method
+    if dm == 'absolute' then
+        self.diff_fn = function(curr, last, threshold)
+            return math.abs(curr - last) >= threshold
+        end
+    elseif dm == 'percent' then
+        self.diff_fn = function(curr, last, threshold)
+            return (math.abs((curr - last) / last) * 100) >= threshold
+        end
+    elseif dm == 'any-change' then
+        self.diff_fn = function(curr, last)
+            return curr ~= last
+        end
+    else
+        return nil, "Diff method must be 'absolute', 'percent' or 'any-change'"
+    end
+    return self, nil
+end
+
+---@return table
+function DiffTrigger:new_state()
+    return {
+        empty    = (self.config.initial_val == nil),
+        last_val = self.config.initial_val or 0,
+        curr_val = nil,
+    }
+end
+
+---@param value any
+---@param state table
+---@return any
+---@return boolean short_circuit
+---@return string? error
+function DiffTrigger:run(value, state)
+    state.curr_val = value
+    if state.empty or self.diff_fn(state.curr_val, state.last_val, self.threshold) then
+        state.last_val = value
+        state.empty = false
+        return value, false, nil
+    end
+    return nil, true, nil
+end
+
+--- No-op: DiffTrigger does not reset last_val on publish.
+---@param state table
+function DiffTrigger:reset(state) end -- luacheck: ignore
+
+-------------------------------------------------------------------------------
+-- TimeTrigger
+-------------------------------------------------------------------------------
+
+--- Passes a value only when the elapsed time since the last pass exceeds
+--- `duration` seconds.
+---
+---@class TimeTrigger
+---@field duration number
+---@field config   table
+local TimeTrigger = {}
+TimeTrigger.__index = TimeTrigger
+
+---@param config table
+---@return TimeTrigger?
+---@return string? error
+function TimeTrigger.new(config)
+    if type(config.duration) ~= 'number' then
+        return nil, 'Duration must be a number'
+    end
+    local self    = setmetatable({}, TimeTrigger)
+    self.duration = config.duration
+    self.config   = config
+    return self, nil
+end
+
+---@return table
+function TimeTrigger:new_state()
+    return { timeout = runtime.now() + self.duration }
+end
+
+---@param value any
+---@param state table
+---@return any
+---@return boolean short_circuit
+---@return string? error
+function TimeTrigger:run(value, state)
+    if runtime.now() >= state.timeout then
+        state.timeout = runtime.now() + self.duration
+        return value, false, nil
+    end
+    return nil, true, nil
+end
+
+---@param state table
+function TimeTrigger:reset(state) end -- luacheck: ignore
+
+-------------------------------------------------------------------------------
+-- DeltaValue
+-------------------------------------------------------------------------------
+
+--- Replaces the raw value with the difference from the last-published value.
+--- Requires numeric input.
+---
+---@class DeltaValue
+---@field config table
+local DeltaValue = {}
+DeltaValue.__index = DeltaValue
+
+---@param config table
+---@return DeltaValue
+function DeltaValue.new(config)
+    local self = setmetatable({}, DeltaValue)
+    self.config = config
+    return self
+end
+
+---@return table
+function DeltaValue:new_state()
+    return {
+        last_val = self.config.initial_val or 0,
+        curr_val = nil,
+    }
+end
+
+---@param value any
+---@param state table
+---@return any
+---@return boolean short_circuit
+---@return string? error
+function DeltaValue:run(value, state)
+    if type(value) ~= 'number' then
+        return nil, false, 'Value must be a number'
+    end
+    local difference = value - state.last_val
+    state.curr_val = value
+    return difference, false, nil
+end
+
+--- On reset, advance last_val to curr_val so the next delta is computed from
+--- the most-recently-published sample.
+---@param state table
+function DeltaValue:reset(state)
+    state.last_val = state.curr_val or 0
+end
+
+-------------------------------------------------------------------------------
+-- ProcessPipeline
+-------------------------------------------------------------------------------
+
+---@class ProcessPipeline
+---@field process_blocks table
+local ProcessPipeline = {}
+ProcessPipeline.__index = ProcessPipeline
+
+---@return ProcessPipeline
+local function new_process_pipeline()
+    return setmetatable({ process_blocks = {} }, ProcessPipeline)
+end
+
+--- Append a processing block to the pipeline.
+---@param block any
+---@return string? error
+function ProcessPipeline:add(block)
+    if block == nil then return 'processing block cannot be nil' end
+    table.insert(self.process_blocks, block)
+end
+
+--- Create a fresh state table for this pipeline (and all its blocks).
+---@return table
+function ProcessPipeline:new_state()
+    local state = { full_run = false, blocks = {} }
+    for i, block in ipairs(self.process_blocks) do
+        state.blocks[i] = block:new_state()
+    end
+    return state
+end
+
+--- Run the pipeline, passing value through each block sequentially.
+--- Stops early if any block short-circuits or returns an error.
+---@param value any
+---@param state table
+---@return any
+---@return boolean short_circuit
+---@return string? error
+function ProcessPipeline:run(value, state)
+    local val   = value
+    local short = false
+    local err   = nil
+
+    for i, block in ipairs(self.process_blocks) do
+        val, short, err = block:run(val, state.blocks[i])
+        if err or short then break end
+    end
+
+    if not short and not err then
+        state.full_run = true
+    end
+
+    return val, short, err
+end
+
+--- Reset block states, but only when the pipeline produced a published value
+--- (i.e. ran to completion without short-circuiting).
+---@param state table
+function ProcessPipeline:reset(state)
+    if state.full_run then
+        for i, block in ipairs(self.process_blocks) do
+            block:reset(state.blocks[i])
+        end
+        state.full_run = false
+    end
+end
+
+--- Reset regardless of whether the pipeline produced a published value.
+---@param state table
+function ProcessPipeline:force_reset(state)
+    state.full_run = true
+    self:reset(state)
+end
+
+return {
+    DiffTrigger          = DiffTrigger,
+    TimeTrigger          = TimeTrigger,
+    DeltaValue           = DeltaValue,
+    new_process_pipeline = new_process_pipeline,
+}

--- a/src/services/metrics/processing.lua
+++ b/src/services/metrics/processing.lua
@@ -48,7 +48,7 @@ local DiffTrigger = {}
 DiffTrigger.__index = DiffTrigger
 
 local function check_diff_args_valid(config)
-    if config.initial_val and type(config.initial_val) ~= 'number' then
+    if config.initial_val ~= nil and type(config.initial_val) ~= 'number' then
         return 'Initial value must be a number'
     end
     if config.diff_method ~= 'any-change' and type(config.threshold) ~= 'number' then
@@ -174,11 +174,15 @@ local DeltaValue = {}
 DeltaValue.__index = DeltaValue
 
 ---@param config table
----@return DeltaValue
+---@return DeltaValue?
+---@return string? error
 function DeltaValue.new(config)
+    if config.initial_val ~= nil and type(config.initial_val) ~= 'number' then
+        return nil, 'Initial value must be a number'
+    end
     local self = setmetatable({}, DeltaValue)
     self.config = config
-    return self
+    return self, nil
 end
 
 ---@return table

--- a/src/services/metrics/senml.lua
+++ b/src/services/metrics/senml.lua
@@ -1,0 +1,80 @@
+-- services/metrics/senml.lua
+--
+-- SenML (Sensor Markup Language) encoder for the metrics service.
+-- Converts a nested metric-values table into a flat array of SenML objects
+-- ready for JSON encoding and HTTP publication.
+
+--- Encode a single (name, value, time) triple as a SenML record.
+---@param topic string
+---@param value  number|string|boolean
+---@param time   number?  milliseconds since epoch (optional)
+---@return SenMLRecord? senml_obj
+---@return string? error
+local function encode(topic, value, time)
+    local vtype = type(value)
+    if vtype ~= 'number' and vtype ~= 'string' and vtype ~= 'boolean' then
+        return nil, 'value must be number, string or boolean, found ' .. vtype
+    end
+
+    local obj = { n = topic }
+
+    if vtype == 'number' then
+        obj.v = value
+    elseif vtype == 'string' then
+        obj.vs = value
+    elseif vtype == 'boolean' then
+        obj.vb = value
+    end
+
+    if time and type(time) == 'number' then
+        obj.t = time
+    end
+
+    return obj, nil
+end
+
+--- Recursively encode a nested values table into a flat SenML array.
+---
+--- Each leaf may be either:
+---   {value = v, time = t}  - a metric sample
+---   a plain value           - treated as {value = v}
+---
+--- Tables without both 'value' and 'time' fields are recursed into with the
+--- key appended to the topic (dot-separated).  The special key '__value' does
+--- not append anything to the topic.
+---
+---@param base_topic string
+---@param values     table
+---@param output     table   accumulator array (created automatically on top call)
+---@return table? output
+---@return string? error
+local function encode_r(base_topic, values, output)
+    for k, v in pairs(values) do
+        local topic = base_topic
+        if k ~= '__value' then
+            if base_topic == '' then
+                topic = k
+            else
+                topic = topic .. '.' .. k
+            end
+        end
+
+        if type(v) == 'table' and not (v.value and v.time) then
+            local _, err = encode_r(topic, v, output)
+            if err then return nil, err end
+        else
+            if type(v) ~= 'table' then
+                v = { value = v }
+            end
+            local obj, err = encode(topic, v.value, v.time)
+            if err then return nil, err end
+            table.insert(output, obj)
+        end
+    end
+    return output, nil
+end
+
+return {
+    encode   = encode,
+    encode_r = function(base_topic, values) return encode_r(base_topic, values, {}) end,
+}

--- a/src/services/metrics/senml.lua
+++ b/src/services/metrics/senml.lua
@@ -11,6 +11,9 @@
 ---@return SenMLRecord? senml_obj
 ---@return string? error
 local function encode(topic, value, time)
+    if type(topic) ~= 'string' or topic == '' then
+        return nil, 'topic must be a non-empty string'
+    end
     local vtype = type(value)
     if vtype ~= 'number' and vtype ~= 'string' and vtype ~= 'boolean' then
         return nil, 'value must be number, string or boolean, found ' .. vtype

--- a/src/services/metrics/types.lua
+++ b/src/services/metrics/types.lua
@@ -147,7 +147,7 @@ end
 -- ServiceState  (the live mutable state table held in metrics.lua)
 -------------------------------------------------------------------------------
 
----@alias PipelineEntry { pipeline: ProcessPipeline, protocol: string, field: string|number|nil, rename: table? }
+---@alias PipelineEntry { pipeline: ProcessPipeline, protocol: string }
 ---@alias PipelineMap   table<string, PipelineEntry>
 ---@alias MetricStates  table<string, table>
 ---@alias MetricValues  table<string, table<string, MetricSample>>

--- a/src/services/metrics/types.lua
+++ b/src/services/metrics/types.lua
@@ -1,0 +1,175 @@
+-- services/metrics/types.lua
+--
+-- Shared type definitions and constructors for the metrics service.
+-- Follows the same pattern as services/hal/types/external.lua.
+
+---@class TypeConstructors
+local new = {}
+
+-------------------------------------------------------------------------------
+-- BaseTime
+-------------------------------------------------------------------------------
+
+---@class BaseTime
+---@field synced boolean
+---@field real   number  wall-clock seconds at the monotonic base
+---@field mono   number  monotonic seconds at the base
+local BaseTime = {}
+BaseTime.__index = BaseTime
+
+---Create a new BaseTime anchored to the supplied real/monotonic pair.
+---@param real   number
+---@param mono   number
+---@return BaseTime?
+---@return string error
+function new.BaseTime(real, mono)
+    if type(real) ~= 'number' then
+        return nil, "real must be a number"
+    end
+    if type(mono) ~= 'number' then
+        return nil, "mono must be a number"
+    end
+    return setmetatable({
+        synced = false,
+        real   = real,
+        mono   = mono,
+    }, BaseTime), ""
+end
+
+-------------------------------------------------------------------------------
+-- CloudConfig
+-------------------------------------------------------------------------------
+
+---@class CloudChannel
+---@field id       string
+---@field name     string
+---@field metadata table<string, string>
+
+---@class CloudConfig
+---@field url       string
+---@field thing_key string
+---@field channels  CloudChannel[]
+local CloudConfig = {}
+CloudConfig.__index = CloudConfig
+
+---Create a new CloudConfig.
+---@param url       string
+---@param thing_key string
+---@param channels  CloudChannel[]
+---@return CloudConfig?
+---@return string error
+function new.CloudConfig(url, thing_key, channels)
+    if type(url) ~= 'string' or url == '' then
+        return nil, "url must be a non-empty string"
+    end
+    if type(thing_key) ~= 'string' or thing_key == '' then
+        return nil, "thing_key must be a non-empty string"
+    end
+    if type(channels) ~= 'table' then
+        return nil, "channels must be a table"
+    end
+    return setmetatable({
+        url       = url,
+        thing_key = thing_key,
+        channels  = channels,
+    }, CloudConfig), ""
+end
+
+-------------------------------------------------------------------------------
+-- MetricSample  (per-endpoint cache entry)
+-------------------------------------------------------------------------------
+
+---@class MetricSample
+---@field value number|string|boolean
+---@field time  number  monotonic seconds when the value was recorded
+local MetricSample = {}
+MetricSample.__index = MetricSample
+
+---Create a new MetricSample.
+---@param value number|string|boolean
+---@param time  number
+---@return MetricSample?
+---@return string error
+function new.MetricSample(value, time)
+    local vt = type(value)
+    if vt ~= 'number' and vt ~= 'string' and vt ~= 'boolean' then
+        return nil, "value must be number, string or boolean"
+    end
+    if type(time) ~= 'number' then
+        return nil, "time must be a number"
+    end
+    return setmetatable({
+        value = value,
+        time  = time,
+    }, MetricSample), ""
+end
+
+-------------------------------------------------------------------------------
+-- SenMLRecord  (single SenML object ready for JSON encoding)
+-------------------------------------------------------------------------------
+
+---@class SenMLRecord
+---@field n  string           SenML name
+---@field v  number?          numeric value
+---@field vs string?          string value
+---@field vb boolean?         boolean value
+---@field t  number?          time in milliseconds since epoch
+local SenMLRecord = {}
+SenMLRecord.__index = SenMLRecord
+
+---Create a new SenMLRecord.
+---@param name  string
+---@param value number|string|boolean
+---@param time  number?  milliseconds since epoch
+---@return SenMLRecord?
+---@return string? error
+function new.SenMLRecord(name, value, time)
+    if type(name) ~= 'string' or name == '' then
+        return nil, "name must be a non-empty string"
+    end
+    local vt = type(value)
+    if vt ~= 'number' and vt ~= 'string' and vt ~= 'boolean' then
+        return nil, "value must be number, string or boolean, found " .. vt
+    end
+    if time ~= nil and type(time) ~= 'number' then
+        return nil, "time must be a number"
+    end
+
+    local obj = setmetatable({ n = name }, SenMLRecord)
+    if vt == 'number' then obj.v = value end
+    if vt == 'string' then obj.vs = value end
+    if vt == 'boolean' then obj.vb = value end
+    if time then obj.t = time end
+    return obj, nil
+end
+
+-------------------------------------------------------------------------------
+-- ServiceState  (the live mutable state table held in metrics.lua)
+-------------------------------------------------------------------------------
+
+---@alias PipelineEntry { pipeline: ProcessPipeline, protocol: string, field: string|number|nil, rename: table? }
+---@alias PipelineMap   table<string, PipelineEntry>
+---@alias MetricStates  table<string, table>
+---@alias MetricValues  table<string, table<string, MetricSample>>
+
+---@class ServiceState
+---@field conn             Connection?   nil before M.start() is called
+---@field name             string?       nil before M.start() is called
+---@field http_send_ch     Channel?      nil before M.start() is called
+---@field pipelines_map    PipelineMap
+---@field metric_states    MetricStates
+---@field endpoint_to_pipe table<string, string>
+---@field metric_values    MetricValues
+---@field publish_period   number?
+---@field cloud_url        string?
+---@field mainflux_config  table?
+---@field cloud_config     CloudConfig?
+---@field base_time        BaseTime?     nil before M.start() is called
+
+return {
+    new          = new,
+    BaseTime     = BaseTime,
+    CloudConfig  = CloudConfig,
+    MetricSample = MetricSample,
+    SenMLRecord  = SenMLRecord,
+}

--- a/src/shared/binser.lua
+++ b/src/shared/binser.lua
@@ -1,0 +1,752 @@
+-- binser.lua
+
+--[[
+Copyright (c) 2016-2019 Calvin Rose
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+]]
+
+local fiber_file = require "fibers.io.file"
+
+local assert = assert
+local error = error
+local select = select
+local pairs = pairs
+local getmetatable = getmetatable
+local setmetatable = setmetatable
+local type = type
+local loadstring = loadstring or load
+local concat = table.concat
+local char = string.char
+local byte = string.byte
+local format = string.format
+local sub = string.sub
+local dump = string.dump
+local floor = math.floor
+local frexp = math.frexp
+local unpack = unpack or table.unpack
+
+-- Lua 5.3 frexp polyfill
+-- From https://github.com/excessive/cpml/blob/master/modules/utils.lua
+if not frexp then
+    local log, abs, floor = math.log, math.abs, math.floor
+    local log2 = log(2)
+    frexp = function(x)
+        if x == 0 then return 0, 0 end
+        local e = floor(log(abs(x)) / log2 + 1)
+        return x / 2 ^ e, e
+    end
+end
+
+local function pack(...)
+    return {...}, select("#", ...)
+end
+
+local function not_array_index(x, len)
+    return type(x) ~= "number" or x < 1 or x > len or x ~= floor(x)
+end
+
+local function type_check(x, tp, name)
+    assert(type(x) == tp,
+        format("Expected parameter %q to be of type %q.", name, tp))
+end
+
+local bigIntSupport = false
+local isInteger
+if math.type then -- Detect Lua 5.3
+    local mtype = math.type
+    bigIntSupport = loadstring[[
+    local char = string.char
+    return function(n)
+        local nn = n < 0 and -(n + 1) or n
+        local b1 = nn // 0x100000000000000
+        local b2 = nn // 0x1000000000000 % 0x100
+        local b3 = nn // 0x10000000000 % 0x100
+        local b4 = nn // 0x100000000 % 0x100
+        local b5 = nn // 0x1000000 % 0x100
+        local b6 = nn // 0x10000 % 0x100
+        local b7 = nn // 0x100 % 0x100
+        local b8 = nn % 0x100
+        if n < 0 then
+            b1, b2, b3, b4 = 0xFF - b1, 0xFF - b2, 0xFF - b3, 0xFF - b4
+            b5, b6, b7, b8 = 0xFF - b5, 0xFF - b6, 0xFF - b7, 0xFF - b8
+        end
+        return char(212, b1, b2, b3, b4, b5, b6, b7, b8)
+    end]]()
+    isInteger = function(x)
+        return mtype(x) == 'integer'
+    end
+else
+    isInteger = function(x)
+        return floor(x) == x
+    end
+end
+
+-- Copyright (C) 2012-2015 Francois Perrad.
+-- number serialization code modified from https://github.com/fperrad/lua-MessagePack
+-- Encode a number as a big-endian ieee-754 double, big-endian signed 64 bit integer, or a small integer
+local function number_to_str(n)
+    if isInteger(n) then -- int
+        if n <= 100 and n >= -27 then -- 1 byte, 7 bits of data
+            return char(n + 27)
+        elseif n <= 8191 and n >= -8192 then -- 2 bytes, 14 bits of data
+            n = n + 8192
+            return char(128 + (floor(n / 0x100) % 0x100), n % 0x100)
+        elseif bigIntSupport then
+            return bigIntSupport(n)
+        end
+    end
+    local sign = 0
+    if n < 0.0 then
+        sign = 0x80
+        n = -n
+    end
+    local m, e = frexp(n) -- mantissa, exponent
+    if m ~= m then
+        return char(203, 0xFF, 0xF8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00)
+    elseif m == 1/0 then
+        if sign == 0 then
+            return char(203, 0x7F, 0xF0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00)
+        else
+            return char(203, 0xFF, 0xF0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00)
+        end
+    end
+    e = e + 0x3FE
+    if e < 1 then -- denormalized numbers
+        m = m * 2 ^ (52 + e)
+        e = 0
+    else
+        m = (m * 2 - 1) * 2 ^ 52
+    end
+    return char(203,
+                sign + floor(e / 0x10),
+                (e % 0x10) * 0x10 + floor(m / 0x1000000000000),
+                floor(m / 0x10000000000) % 0x100,
+                floor(m / 0x100000000) % 0x100,
+                floor(m / 0x1000000) % 0x100,
+                floor(m / 0x10000) % 0x100,
+                floor(m / 0x100) % 0x100,
+                m % 0x100)
+end
+
+-- Copyright (C) 2012-2015 Francois Perrad.
+-- number deserialization code also modified from https://github.com/fperrad/lua-MessagePack
+local function number_from_str(str, index)
+    local b = byte(str, index)
+    if not b then error("Expected more bytes of input.") end
+    if b < 128 then
+        return b - 27, index + 1
+    elseif b < 192 then
+        local b2 = byte(str, index + 1)
+        if not b2 then error("Expected more bytes of input.") end
+        return b2 + 0x100 * (b - 128) - 8192, index + 2
+    end
+    local b1, b2, b3, b4, b5, b6, b7, b8 = byte(str, index + 1, index + 8)
+    if (not b1) or (not b2) or (not b3) or (not b4) or
+        (not b5) or (not b6) or (not b7) or (not b8) then
+        error("Expected more bytes of input.")
+    end
+    if b == 212 then
+        local flip = b1 >= 128
+        if flip then -- negative
+            b1, b2, b3, b4 = 0xFF - b1, 0xFF - b2, 0xFF - b3, 0xFF - b4
+            b5, b6, b7, b8 = 0xFF - b5, 0xFF - b6, 0xFF - b7, 0xFF - b8
+        end
+        local n = ((((((b1 * 0x100 + b2) * 0x100 + b3) * 0x100 + b4) *
+            0x100 + b5) * 0x100 + b6) * 0x100 + b7) * 0x100 + b8
+        if flip then
+            return (-n) - 1, index + 9
+        else
+            return n, index + 9
+        end
+    end
+    if b ~= 203 then
+        error("Expected number")
+    end
+    local sign = b1 > 0x7F and -1 or 1
+    local e = (b1 % 0x80) * 0x10 + floor(b2 / 0x10)
+    local m = ((((((b2 % 0x10) * 0x100 + b3) * 0x100 + b4) * 0x100 + b5) * 0x100 + b6) * 0x100 + b7) * 0x100 + b8
+    local n
+    if e == 0 then
+        if m == 0 then
+            n = sign * 0.0
+        else
+            n = sign * (m / 2 ^ 52) * 2 ^ -1022
+        end
+    elseif e == 0x7FF then
+        if m == 0 then
+            n = sign * (1/0)
+        else
+            n = 0.0/0.0
+        end
+    else
+        n = sign * (1.0 + m / 2 ^ 52) * 2 ^ (e - 0x3FF)
+    end
+    return n, index + 9
+end
+
+
+local function newbinser()
+
+    -- unique table key for getting next value
+    local NEXT = {}
+    local CTORSTACK = {}
+
+    -- NIL = 202
+    -- FLOAT = 203
+    -- TRUE = 204
+    -- FALSE = 205
+    -- STRING = 206
+    -- TABLE = 207
+    -- REFERENCE = 208
+    -- CONSTRUCTOR = 209
+    -- FUNCTION = 210
+    -- RESOURCE = 211
+    -- INT64 = 212
+    -- TABLE WITH META = 213
+
+    local mts = {}
+    local ids = {}
+    local serializers = {}
+    local deserializers = {}
+    local resources = {}
+    local resources_by_name = {}
+    local types = {}
+
+    types["nil"] = function(x, visited, accum)
+        accum[#accum + 1] = "\202"
+    end
+
+    function types.number(x, visited, accum)
+        accum[#accum + 1] = number_to_str(x)
+    end
+
+    function types.boolean(x, visited, accum)
+        accum[#accum + 1] = x and "\204" or "\205"
+    end
+
+    function types.string(x, visited, accum)
+        local alen = #accum
+        if visited[x] then
+            accum[alen + 1] = "\208"
+            accum[alen + 2] = number_to_str(visited[x])
+        else
+            visited[x] = visited[NEXT]
+            visited[NEXT] =  visited[NEXT] + 1
+            accum[alen + 1] = "\206"
+            accum[alen + 2] = number_to_str(#x)
+            accum[alen + 3] = x
+        end
+    end
+
+    local function check_custom_type(x, visited, accum)
+        local res = resources[x]
+        if res then
+            accum[#accum + 1] = "\211"
+            types[type(res)](res, visited, accum)
+            return true
+        end
+        local mt = getmetatable(x)
+        local id = mt and ids[mt]
+        if id then
+            local constructing = visited[CTORSTACK]
+            if constructing[x] then
+                error("Infinite loop in constructor.")
+            end
+            constructing[x] = true
+            accum[#accum + 1] = "\209"
+            types[type(id)](id, visited, accum)
+            local args, len = pack(serializers[id](x))
+            accum[#accum + 1] = number_to_str(len)
+            for i = 1, len do
+                local arg = args[i]
+                types[type(arg)](arg, visited, accum)
+            end
+            visited[x] = visited[NEXT]
+            visited[NEXT] = visited[NEXT] + 1
+            -- We finished constructing
+            constructing[x] = nil
+            return true
+        end
+    end
+
+    function types.userdata(x, visited, accum)
+        if visited[x] then
+            accum[#accum + 1] = "\208"
+            accum[#accum + 1] = number_to_str(visited[x])
+        else
+            if check_custom_type(x, visited, accum) then return end
+            error("Cannot serialize this userdata.")
+        end
+    end
+
+    function types.table(x, visited, accum)
+        if visited[x] then
+            accum[#accum + 1] = "\208"
+            accum[#accum + 1] = number_to_str(visited[x])
+        else
+            if check_custom_type(x, visited, accum) then return end
+            visited[x] = visited[NEXT]
+            visited[NEXT] =  visited[NEXT] + 1
+            local xlen = #x
+            local mt = getmetatable(x)
+            if mt then
+                accum[#accum + 1] = "\213"
+                types.table(mt, visited, accum)
+            else
+                accum[#accum + 1] = "\207"
+            end
+            accum[#accum + 1] = number_to_str(xlen)
+            for i = 1, xlen do
+                local v = x[i]
+                types[type(v)](v, visited, accum)
+            end
+            local key_count = 0
+            for k in pairs(x) do
+                if not_array_index(k, xlen) then
+                    key_count = key_count + 1
+                end
+            end
+            accum[#accum + 1] = number_to_str(key_count)
+            for k, v in pairs(x) do
+                if not_array_index(k, xlen) then
+                    types[type(k)](k, visited, accum)
+                    types[type(v)](v, visited, accum)
+                end
+            end
+        end
+    end
+
+    types["function"] = function(x, visited, accum)
+        if visited[x] then
+            accum[#accum + 1] = "\208"
+            accum[#accum + 1] = number_to_str(visited[x])
+        else
+            if check_custom_type(x, visited, accum) then return end
+            visited[x] = visited[NEXT]
+            visited[NEXT] =  visited[NEXT] + 1
+            local str = dump(x)
+            accum[#accum + 1] = "\210"
+            accum[#accum + 1] = number_to_str(#str)
+            accum[#accum + 1] = str
+        end
+    end
+
+    types.cdata = function(x, visited, accum)
+        if visited[x] then
+            accum[#accum + 1] = "\208"
+            accum[#accum + 1] = number_to_str(visited[x])
+        else
+            if check_custom_type(x, visited, #accum) then return end
+            error("Cannot serialize this cdata.")
+        end
+    end
+
+    types.thread = function() error("Cannot serialize threads.") end
+
+    local function deserialize_value(str, index, visited)
+        local t = byte(str, index)
+        if not t then return nil, index end
+        if t < 128 then
+            return t - 27, index + 1
+        elseif t < 192 then
+            local b2 = byte(str, index + 1)
+            if not b2 then error("Expected more bytes of input.") end
+            return b2 + 0x100 * (t - 128) - 8192, index + 2
+        elseif t == 202 then
+            return nil, index + 1
+        elseif t == 203 or t == 212 then
+            return number_from_str(str, index)
+        elseif t == 204 then
+            return true, index + 1
+        elseif t == 205 then
+            return false, index + 1
+        elseif t == 206 then
+            local length, dataindex = number_from_str(str, index + 1)
+            local nextindex = dataindex + length
+            if not (length >= 0) then error("Bad string length") end
+            if #str < nextindex - 1 then error("Expected more bytes of string") end
+            local substr = sub(str, dataindex, nextindex - 1)
+            visited[#visited + 1] = substr
+            return substr, nextindex
+        elseif t == 207 or t == 213 then
+            local mt, count, nextindex
+            local ret = {}
+            visited[#visited + 1] = ret
+            nextindex = index + 1
+            if t == 213 then
+                mt, nextindex = deserialize_value(str, nextindex, visited)
+                if type(mt) ~= "table" then error("Expected table metatable") end
+            end
+            count, nextindex = number_from_str(str, nextindex)
+            for i = 1, count do
+                local oldindex = nextindex
+                ret[i], nextindex = deserialize_value(str, nextindex, visited)
+                if nextindex == oldindex then error("Expected more bytes of input.") end
+            end
+            count, nextindex = number_from_str(str, nextindex)
+            for i = 1, count do
+                local k, v
+                local oldindex = nextindex
+                k, nextindex = deserialize_value(str, nextindex, visited)
+                if nextindex == oldindex then error("Expected more bytes of input.") end
+                oldindex = nextindex
+                v, nextindex = deserialize_value(str, nextindex, visited)
+                if nextindex == oldindex then error("Expected more bytes of input.") end
+                if k == nil then error("Can't have nil table keys") end
+                ret[k] = v
+            end
+            if mt then setmetatable(ret, mt) end
+            return ret, nextindex
+        elseif t == 208 then
+            local ref, nextindex = number_from_str(str, index + 1)
+            return visited[ref], nextindex
+        elseif t == 209 then
+            local count
+            local name, nextindex = deserialize_value(str, index + 1, visited)
+            count, nextindex = number_from_str(str, nextindex)
+            local args = {}
+            for i = 1, count do
+                local oldindex = nextindex
+                args[i], nextindex = deserialize_value(str, nextindex, visited)
+                if nextindex == oldindex then error("Expected more bytes of input.") end
+            end
+            if not name or not deserializers[name] then
+                error(("Cannot deserialize class '%s'"):format(tostring(name)))
+            end
+            local ret = deserializers[name](unpack(args))
+            visited[#visited + 1] = ret
+            return ret, nextindex
+        elseif t == 210 then
+            local length, dataindex = number_from_str(str, index + 1)
+            local nextindex = dataindex + length
+            if not (length >= 0) then error("Bad string length") end
+            if #str < nextindex - 1 then error("Expected more bytes of string") end
+            local ret = loadstring(sub(str, dataindex, nextindex - 1))
+            visited[#visited + 1] = ret
+            return ret, nextindex
+        elseif t == 211 then
+            local resname, nextindex = deserialize_value(str, index + 1, visited)
+            if resname == nil then error("Got nil resource name") end
+            local res = resources_by_name[resname]
+            if res == nil then
+                error(("No resources found for name '%s'"):format(tostring(resname)))
+            end
+            return res, nextindex
+        else
+            error("Could not deserialize type byte " .. t .. ".")
+        end
+    end
+
+    local function serialize(...)
+        local visited = {[NEXT] = 1, [CTORSTACK] = {}}
+        local accum = {}
+        for i = 1, select("#", ...) do
+            local x = select(i, ...)
+            types[type(x)](x, visited, accum)
+        end
+        return concat(accum)
+    end
+
+    local function make_file_writer(file)
+        return setmetatable({}, {
+            __newindex = function(_, _, v)
+                file:write(v)
+            end
+        })
+    end
+
+    local function serialize_to_file(path, mode, ...)
+        local file, err = io.open(path, mode)
+        assert(file, err)
+        local visited = {[NEXT] = 1, [CTORSTACK] = {}}
+        local accum = make_file_writer(file)
+        for i = 1, select("#", ...) do
+            local x = select(i, ...)
+            types[type(x)](x, visited, accum)
+        end
+        -- flush the writer
+        file:flush()
+        file:close()
+    end
+
+    local function writeFile(path, ...)
+        return serialize_to_file(path, "wb", ...)
+    end
+
+    local function appendFile(path, ...)
+        return serialize_to_file(path, "ab", ...)
+    end
+
+    local function deserialize(str, index)
+        assert(type(str) == "string", "Expected string to deserialize.")
+        local vals = {}
+        index = index or 1
+        local visited = {}
+        local len = 0
+        local val
+        while true do
+            local nextindex
+            val, nextindex = deserialize_value(str, index, visited)
+            if nextindex > index then
+                len = len + 1
+                vals[len] = val
+                index = nextindex
+            else
+                break
+            end
+        end
+        return vals, len
+    end
+
+    local function deserializeN(str, n, index)
+        assert(type(str) == "string", "Expected string to deserialize.")
+        n = n or 1
+        assert(type(n) == "number", "Expected a number for parameter n.")
+        assert(n > 0 and floor(n) == n, "N must be a poitive integer.")
+        local vals = {}
+        index = index or 1
+        local visited = {}
+        local len = 0
+        local val
+        while len < n do
+            local nextindex
+            val, nextindex = deserialize_value(str, index, visited)
+            if nextindex > index then
+                len = len + 1
+                vals[len] = val
+                index = nextindex
+            else
+                break
+            end
+        end
+        vals[len + 1] = index
+        return unpack(vals, 1, n + 1)
+    end
+
+    local function readFile(path)
+        local file, err = fiber_file.open(path, "rb")
+        assert(file, err)
+        local file_chars = file:read("*a")
+        file:close()
+        return deserialize(file_chars)
+    end
+
+    -- Resources
+
+    local function registerResource(resource, name)
+        type_check(name, "string", "name")
+        assert(not resources[resource],
+            "Resource already registered.")
+        assert(not resources_by_name[name],
+            format("Resource %q already exists.", name))
+        resources_by_name[name] = resource
+        resources[resource] = name
+        return resource
+    end
+
+    local function unregisterResource(name)
+        type_check(name, "string", "name")
+        assert(resources_by_name[name], format("Resource %q does not exist.", name))
+        local resource = resources_by_name[name]
+        resources_by_name[name] = nil
+        resources[resource] = nil
+        return resource
+    end
+
+    -- Templating
+
+    local function normalize_template(template)
+        local ret = {}
+        for i = 1, #template do
+            ret[i] = template[i]
+        end
+        local non_array_part = {}
+        -- The non-array part of the template (nested templates) have to be deterministic, so they are sorted.
+        -- This means that inherently non deterministicly sortable keys (tables, functions) should NOT be used
+        -- in templates. Looking for way around this.
+        for k in pairs(template) do
+            if not_array_index(k, #template) then
+                non_array_part[#non_array_part + 1] = k
+            end
+        end
+        table.sort(non_array_part)
+        for i = 1, #non_array_part do
+            local name = non_array_part[i]
+            ret[#ret + 1] = {name, normalize_template(template[name])}
+        end
+        return ret
+    end
+
+    local function templatepart_serialize(part, argaccum, x, len)
+        local extras = {}
+        local extracount = 0
+        for k, v in pairs(x) do
+            extras[k] = v
+            extracount = extracount + 1
+        end
+        for i = 1, #part do
+            local name
+            if type(part[i]) == "table" then
+                name = part[i][1]
+                len = templatepart_serialize(part[i][2], argaccum, x[name], len)
+            else
+                name = part[i]
+                len = len + 1
+                argaccum[len] = x[part[i]]
+            end
+            if extras[name] ~= nil then
+                extracount = extracount - 1
+                extras[name] = nil
+            end
+        end
+        if extracount > 0 then
+            argaccum[len + 1] = extras
+        else
+            argaccum[len + 1] = nil
+        end
+        return len + 1
+    end
+
+    local function templatepart_deserialize(ret, part, values, vindex)
+        for i = 1, #part do
+            local name = part[i]
+            if type(name) == "table" then
+                local newret = {}
+                ret[name[1]] = newret
+                vindex = templatepart_deserialize(newret, name[2], values, vindex)
+            else
+                ret[name] = values[vindex]
+                vindex = vindex + 1
+            end
+        end
+        local extras = values[vindex]
+        if extras then
+            for k, v in pairs(extras) do
+                ret[k] = v
+            end
+        end
+        return vindex + 1
+    end
+
+    local function template_serializer_and_deserializer(metatable, template)
+        return function(x)
+            local argaccum = {}
+            local len = templatepart_serialize(template, argaccum, x, 0)
+            return unpack(argaccum, 1, len)
+        end, function(...)
+            local ret = {}
+            local args = {...}
+            templatepart_deserialize(ret, template, args, 1)
+            return setmetatable(ret, metatable)
+        end
+    end
+
+    -- Used to serialize classes withh custom serializers and deserializers.
+    -- If no _serialize or _deserialize (or no _template) value is found in the
+    -- metatable, then the metatable is registered as a resources.
+    local function register(metatable, name, serialize, deserialize)
+        if type(metatable) == "table" then
+            name = name or metatable.name
+            serialize = serialize or metatable._serialize
+            deserialize = deserialize or metatable._deserialize
+            if (not serialize) or (not deserialize) then
+                if metatable._template then
+                    -- Register as template
+                    local t = normalize_template(metatable._template)
+                    serialize, deserialize = template_serializer_and_deserializer(metatable, t)
+                else
+                    -- Register the metatable as a resource. This is semantically
+                    -- similar and more flexible (handles cycles).
+                    registerResource(metatable, name)
+                    return
+                end
+            end
+        elseif type(metatable) == "string" then
+            name = name or metatable
+        end
+        type_check(name, "string", "name")
+        type_check(serialize, "function", "serialize")
+        type_check(deserialize, "function", "deserialize")
+        assert((not ids[metatable]) and (not resources[metatable]),
+            "Metatable already registered.")
+        assert((not mts[name]) and (not resources_by_name[name]),
+            ("Name %q already registered."):format(name))
+        mts[name] = metatable
+        ids[metatable] = name
+        serializers[name] = serialize
+        deserializers[name] = deserialize
+        return metatable
+    end
+
+    local function unregister(item)
+        local name, metatable
+        if type(item) == "string" then -- assume name
+            name, metatable = item, mts[item]
+        else -- assume metatable
+            name, metatable = ids[item], item
+        end
+        type_check(name, "string", "name")
+        mts[name] = nil
+        if (metatable) then
+            resources[metatable] = nil
+            ids[metatable] = nil
+        end
+        serializers[name] = nil
+        deserializers[name] = nil
+        resources_by_name[name] = nil;
+        return metatable
+    end
+
+    local function registerClass(class, name)
+        name = name or class.name
+        if class.__instanceDict then -- middleclass
+            register(class.__instanceDict, name)
+        else -- assume 30log or similar library
+            register(class, name)
+        end
+        return class
+    end
+
+    return {
+        VERSION = "0.0-8",
+        -- aliases
+        s = serialize,
+        d = deserialize,
+        dn = deserializeN,
+        r = readFile,
+        w = writeFile,
+        a = appendFile,
+
+        serialize = serialize,
+        deserialize = deserialize,
+        deserializeN = deserializeN,
+        readFile = readFile,
+        writeFile = writeFile,
+        appendFile = appendFile,
+        register = register,
+        unregister = unregister,
+        registerResource = registerResource,
+        unregisterResource = unregisterResource,
+        registerClass = registerClass,
+
+        newbinser = newbinser
+    }
+end
+
+return newbinser()

--- a/src/shared/cache.lua
+++ b/src/shared/cache.lua
@@ -42,7 +42,7 @@ function Cache:set(key, value, timeout)
     timeout = timeout or self.default_timeout
     if type(value) == 'table' then
         if is_array(value) then
-            self.store[key] = {value=value, timestamp=self.time_func() + timeout}
+            self.store[key] = {value=value, timestamp=self.time_func() + timeout, timeout = timeout}
         else
             for k, v in pairs(value) do
                 self:set(key .. self.separator .. k, v, timeout)
@@ -58,7 +58,6 @@ end
 ---@param timeout number?
 ---@return any
 function Cache:get(key, timeout)
-    if stale == nil then stale = false end
     if type(key) ~= 'string' then
         key = table.concat(key, self.separator)
     end

--- a/src/shared/cache.lua
+++ b/src/shared/cache.lua
@@ -40,17 +40,18 @@ end
 ---@param timeout number?
 function Cache:set(key, value, timeout)
     timeout = timeout or self.default_timeout
-    if type(value) == 'table' then
-        if is_array(value) then
-            self.store[key] = {value=value, timestamp=self.time_func() + timeout, timeout = timeout}
-        else
-            for k, v in pairs(value) do
-                self:set(key .. self.separator .. k, v, timeout)
-            end
-        end
-    else
-        self.store[key] = {value = value, timestamp=self.time_func(), timeout = timeout}
-    end
+    -- if type(value) == 'table' then
+    --     if is_array(value) then
+    --         self.store[key] = {value=value, timestamp=self.time_func() + timeout, timeout = timeout}
+    --     else
+    --         for k, v in pairs(value) do
+    --             self:set(key .. self.separator .. k, v, timeout)
+    --         end
+    --     end
+    -- else
+    --     self.store[key] = {value = value, timestamp=self.time_func(), timeout = timeout}
+    -- end
+    self.store[key] = {value = value, timestamp=self.time_func(), timeout = timeout}
 end
 
 --- Getting a value from the cache

--- a/src/shared/cache.lua
+++ b/src/shared/cache.lua
@@ -1,0 +1,78 @@
+---@alias CacheKey string|string[]
+---@alias CacheEntry {value: any, timestamp: number, timeout: number}
+
+---@class Cache
+---@field default_timeout number
+---@field time_func function
+---@field separator string
+---@field store table<string, CacheEntry>
+local Cache = {}
+Cache.__index = Cache
+
+--- Cache constructor
+---@param default_timeout number?
+---@param custom_time_func function?
+---@param separator string?
+---@return Cache
+local function new(default_timeout, custom_time_func, separator)
+    local self = setmetatable({}, Cache)
+    self.default_timeout = default_timeout or 10
+    self.time_func = custom_time_func or os.time
+    self.separator = separator or string.char(31)
+    self.store = {}
+    return self
+end
+
+--- Utility function to check if a table is an array
+---@param table table
+local function is_array(table)
+    local i = 0
+    for _ in pairs(table) do
+        i = i + 1
+        if table[i] == nil then return false end
+    end
+    return true
+end
+
+--- Setting a value in the cache
+---@param key string
+---@param value any
+---@param timeout number?
+function Cache:set(key, value, timeout)
+    timeout = timeout or self.default_timeout
+    if type(value) == 'table' then
+        if is_array(value) then
+            self.store[key] = {value=value, timestamp=self.time_func() + timeout}
+        else
+            for k, v in pairs(value) do
+                self:set(key .. self.separator .. k, v, timeout)
+            end
+        end
+    else
+        self.store[key] = {value = value, timestamp=self.time_func(), timeout = timeout}
+    end
+end
+
+--- Getting a value from the cache
+---@param key CacheKey
+---@param timeout number?
+---@return any
+function Cache:get(key, timeout)
+    if stale == nil then stale = false end
+    if type(key) ~= 'string' then
+        key = table.concat(key, self.separator)
+    end
+    local item = self.store[key]
+    if item then
+        timeout = timeout or item.timeout
+        if self.time_func() < (item.timestamp + timeout) then
+            return item.value
+        end
+    end
+    return nil -- or a default value
+end
+
+return {
+    new = new,
+    Cache = Cache
+}

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,1 +1,12 @@
-This folder will contain tests for `devicecode`
+This folder will contain tests for `devicecode`.
+
+Deterministic async test helpers live in `tests/test_utils/`.
+
+- `virtual_time.lua` installs a test-controlled monotonic and realtime clock for fibers-based tests.
+- `time_harness.lua` provides general op helpers:
+	- `try_op_now(op_or_factory)` for non-blocking op probes,
+	- `wait_op_ticks(op_or_factory, { max_ticks = ... })` for bounded scheduler-turn waits,
+	- `wait_op_within(clock, timeout_s, op_or_factory, ...)` for virtual-time bounded waits,
+	plus compatibility helpers for metrics subscriptions.
+
+For fibers service tests, prefer advancing virtual time and flushing a bounded number of scheduler turns over wall-clock sleeps. This keeps tests focused on logic and avoids timing-dependent flakes across different environments.

--- a/tests/test_metrics.lua
+++ b/tests/test_metrics.lua
@@ -565,10 +565,22 @@ end
 
 TestMetricsService = {}
 
+function TestMetricsService:setUp()
+    self.clock = nil
+end
+
+function TestMetricsService:tearDown()
+    if self.clock then
+        self.clock:restore()
+        self.clock = nil
+    end
+end
+
 -- Publish a metric config as a retained message and a raw metric, then verify
 -- the processed value is re-published on the bus topic.
 function TestMetricsService:test_metric_published_via_bus()
     local clock = new_test_clock()
+    self.clock = clock
     local root      = fibers.current_scope()
     local bus       = make_bus()
     local test_conn = bus:connect()
@@ -576,6 +588,7 @@ function TestMetricsService:test_metric_published_via_bus()
     -- Signal HAL filesystem capability ready (retained).
     test_conn:retain({ 'cap', 'fs', 'configs', 'state' }, 'added')
     start_mock_hal(test_conn, root)
+    test_conn:retain({ 'svc', 'time', 'synced' }, true)
 
     -- Subscribe to bus-protocol metric output before starting the service.
     local result_sub = test_conn:subscribe(
@@ -606,12 +619,14 @@ end
 -- the SenML key and the output topic.
 function TestMetricsService:test_namespace_overrides_topic_key()
     local clock = new_test_clock()
+    self.clock = clock
     local root      = fibers.current_scope()
     local bus       = make_bus()
     local test_conn = bus:connect()
 
     test_conn:retain({ 'cap', 'fs', 'configs', 'state' }, 'added')
     start_mock_hal(test_conn, root)
+    test_conn:retain({ 'svc', 'time', 'synced' }, true)
 
     local result_sub = test_conn:subscribe(
         { 'svc', 'metrics', '#' },
@@ -641,12 +656,14 @@ end
 -- A metric whose name has no matching pipeline must be silently dropped.
 function TestMetricsService:test_unknown_metric_dropped()
     local clock = new_test_clock()
+    self.clock = clock
     local root      = fibers.current_scope()
     local bus       = make_bus()
     local test_conn = bus:connect()
 
     test_conn:retain({ 'cap', 'fs', 'configs', 'state' }, 'added')
     start_mock_hal(test_conn, root)
+    test_conn:retain({ 'svc', 'time', 'synced' }, true)
 
     local result_sub = test_conn:subscribe(
         { 'svc', 'metrics', '#' },
@@ -675,12 +692,14 @@ end
 -- does not change between publish cycles.
 function TestMetricsService:test_difftrigger_suppresses_unchanged_value()
     local clock = new_test_clock()
+    self.clock = clock
     local root      = fibers.current_scope()
     local bus       = make_bus()
     local test_conn = bus:connect()
 
     test_conn:retain({ 'cap', 'fs', 'configs', 'state' }, 'added')
     start_mock_hal(test_conn, root)
+    test_conn:retain({ 'svc', 'time', 'synced' }, true)
 
     local result_sub = test_conn:subscribe(
         { 'svc', 'metrics', '#' },
@@ -723,12 +742,14 @@ end
 -- DeltaValue transforms a cumulative counter into a per-period delta.
 function TestMetricsService:test_delta_value_pipeline()
     local clock = new_test_clock()
+    self.clock = clock
     local root      = fibers.current_scope()
     local bus       = make_bus()
     local test_conn = bus:connect()
 
     test_conn:retain({ 'cap', 'fs', 'configs', 'state' }, 'added')
     start_mock_hal(test_conn, root)
+    test_conn:retain({ 'svc', 'time', 'synced' }, true)
 
     local result_sub = test_conn:subscribe(
         { 'svc', 'metrics', '#' },
@@ -765,12 +786,14 @@ end
 -- HTTP protocol pipelines should enqueue a well-formed Mainflux request.
 function TestMetricsService:test_http_pipeline_enqueues_request_payload()
     local clock = new_test_clock()
+    self.clock = clock
     local root      = fibers.current_scope()
     local bus       = make_bus()
     local test_conn = bus:connect()
 
     test_conn:retain({ 'cap', 'fs', 'configs', 'state' }, 'added')
     start_mock_hal(test_conn, root)
+    test_conn:retain({ 'svc', 'time', 'synced' }, true)
 
     local captured = nil
     local original_http_mod = package.loaded['services.metrics.http']
@@ -836,12 +859,14 @@ end
 -- Receiving a new config replaces pipelines; old metric names are dropped.
 function TestMetricsService:test_config_update_replaces_pipelines()
     local clock = new_test_clock()
+    self.clock = clock
     local root      = fibers.current_scope()
     local bus       = make_bus()
     local test_conn = bus:connect()
 
     test_conn:retain({ 'cap', 'fs', 'configs', 'state' }, 'added')
     start_mock_hal(test_conn, root)
+    test_conn:retain({ 'svc', 'time', 'synced' }, true)
 
     local result_sub = test_conn:subscribe(
         { 'svc', 'metrics', '#' },
@@ -882,12 +907,14 @@ end
 -- state (DeltaValue counters don't bleed across endpoints).
 function TestMetricsService:test_per_endpoint_state_isolation()
     local clock = new_test_clock()
+    self.clock = clock
     local root      = fibers.current_scope()
     local bus       = make_bus()
     local test_conn = bus:connect()
 
     test_conn:retain({ 'cap', 'fs', 'configs', 'state' }, 'added')
     start_mock_hal(test_conn, root)
+    test_conn:retain({ 'svc', 'time', 'synced' }, true)
 
     local result_sub = test_conn:subscribe(
         { 'svc', 'metrics', '#' },

--- a/tests/test_metrics.lua
+++ b/tests/test_metrics.lua
@@ -1,535 +1,937 @@
--- Detect if this file is being run as the entry point
+-- test_metrics.lua
+--
+-- Service-level tests for the metrics service.
+--
+-- Each test spins up the full metrics service in a child scope, interacts with
+-- it via the bus, and asserts on bus-published results.
+--
+-- Run standalone: luajit test_metrics.lua
+
 local this_file = debug.getinfo(1, "S").source:match("@?([^/]+)$")
 local is_entry_point = arg and arg[0] and arg[0]:match("[^/]+$") == this_file
 
 if is_entry_point then
-    package.path = "../src/lua-fibers/?.lua;" -- fibers submodule src
-        .. "../src/lua-trie/src/?.lua;"       -- trie submodule src
-        .. "../src/lua-bus/src/?.lua;"        -- bus submodule src
+    package.path = "../vendor/lua-fibers/src/?.lua;"
+        .. "../vendor/lua-trie/src/?.lua;"
+        .. "../vendor/lua-bus/src/?.lua;"
         .. "../src/?.lua;"
         .. "./test_utils/?.lua;"
         .. package.path
         .. ";/usr/lib/lua/?.lua;/usr/lib/lua/?/init.lua"
 
-    _G._TEST = true -- Enable test exports in source code
+    _G._TEST = true
 end
 
 local luaunit = require 'luaunit'
+local fibers  = require 'fibers'
+local perform = fibers.perform
+local op      = require 'fibers.op'
+local busmod  = require 'bus'
+local json    = require 'cjson.safe'
+local virtual_time = require 'virtual_time'
+local time_harness = require 'time_harness'
+
 local processing = require 'services.metrics.processing'
-local conf = require 'services.metrics.config'
-local sc = require "fibers.utils.syscall"
-local sleep = require "fibers.sleep"
-local fiber = require "fibers.fiber"
-local senml = require "services.metrics.senml"
+local conf       = require 'services.metrics.config'
+local senml      = require 'services.metrics.senml'
+
+-------------------------------------------------------------------------------
+-- Helpers
+-------------------------------------------------------------------------------
+
+-- A sample mainflux.cfg payload returned by the mock HAL RPC.
+local MAINFLUX_CFG = json.encode({
+    thing_key = 'test-thing-key',
+    channels  = {
+        { id = 'ch-data',    name = 'test_data',    metadata = { channel_type = 'data' } },
+        { id = 'ch-control', name = 'test_control', metadata = { channel_type = 'control' } },
+    },
+})
+
+-- Build a fresh bus and test connection for each test.
+local function make_bus()
+    return busmod.new({ q_length = 100, s_wild = '+', m_wild = '#' })
+end
+
+local function new_test_clock()
+    return virtual_time.install({
+        monotonic = 0,
+        realtime  = 1700000000,
+    })
+end
+
+local function flush_ticks(max_ticks)
+    time_harness.flush_ticks(max_ticks or 20)
+end
+
+-- The tests subscribe to {'svc', 'metrics', '#'} so they can match
+-- dynamically-keyed output topics such as 'svc.metrics.wan.rx_bytes'.
+-- The '#' wildcard also captures the service's own lifecycle messages
+-- retained at {'svc', 'metrics', 'status'} (e.g. 'starting', 'running',
+-- 'stopped').  The helpers below skip those status messages so assertions
+-- only see metric payload publishes.
+local function recv_timeout(clock, sub, timeout_s)
+    local step = 0.05
+    local max_ticks = 20
+    local elapsed = 0
+    while true do
+        while true do
+            local ok, msg = time_harness.try_op_now(function() return sub:recv_op() end)
+            if not ok then break end
+            if msg.topic[3] ~= 'status' then return msg end
+        end
+        if elapsed >= timeout_s then return nil end
+        local advance = math.min(step, timeout_s - elapsed)
+        clock:advance(advance)
+        time_harness.flush_ticks(max_ticks)
+        elapsed = elapsed + advance
+    end
+end
+
+local function drain_non_status(sub, max_ticks)
+    max_ticks = max_ticks or 20
+    local messages = {}
+    for tick = 1, max_ticks do
+        local saw_message = false
+        while true do
+            local ok, msg = time_harness.try_op_now(function() return sub:recv_op() end)
+            if not ok then break end
+            saw_message = true
+            if msg.topic[3] ~= 'status' then
+                messages[#messages + 1] = msg
+            end
+        end
+        if not saw_message or tick == max_ticks then break end
+        time_harness.flush_ticks(1)
+    end
+    return messages
+end
+
+-- Start a mock handler for the HAL filesystem read RPC on `bus`.
+-- The handler responds with `mainflux_cfg_json` to every request then loops.
+-- Returns the child scope so the caller can cancel it after the test.
+local function start_mock_hal(test_conn, root_scope)
+    local ep = test_conn:bind(
+        { 'cap', 'fs', 'configs', 'rpc', 'read' },
+        { queue_len = 5 })
+
+    root_scope:spawn(function()
+        while true do
+            local req, err = perform(ep:recv_op())
+            if not req then break end
+            -- call_op binds a reply endpoint; deliver to it with publish_one.
+            test_conn:publish_one(req.reply_to, { ok = true, reason = MAINFLUX_CFG })
+        end
+    end)
+end
+
+-- Convenience: start the metrics service in its own child scope.
+-- Returns the scope so the caller can cancel/join it.
+local function start_metrics(bus, root_scope, opts)
+    local svc_scope = root_scope:child()
+    svc_scope:spawn(function()
+        -- Each test needs a fresh require to reset module-level State.
+        package.loaded['services.metrics'] = nil
+        local metrics = require 'services.metrics'
+        local svc_conn = bus:connect()
+        metrics.start(svc_conn, opts or { name = 'metrics' })
+    end)
+    return svc_scope
+end
+
+-- Cancel a scope and wait for it to finish.
+local function stop_scope(svc_scope)
+    svc_scope:cancel('test done')
+    perform(svc_scope:join_op())
+end
+
+-- A minimal valid metrics config with one bus-protocol pipeline.
+local function bus_pipeline_config(metric_name, publish_period, process)
+    return {
+        publish_period = publish_period or 0.1,
+        pipelines = {
+            [metric_name] = {
+                protocol = 'bus',
+                process  = process or {},
+            },
+        },
+    }
+end
+
+-- A minimal valid metrics config with one log-protocol pipeline.
+local function log_pipeline_config(metric_name, publish_period, process)
+    return {
+        publish_period = publish_period or 0.1,
+        pipelines = {
+            [metric_name] = {
+                protocol = 'log',
+                process  = process or {},
+            },
+        },
+    }
+end
+
+-------------------------------------------------------------------------------
+-- Unit tests: processing blocks
+-------------------------------------------------------------------------------
 
 TestProcessing = {}
 
 function TestProcessing:test_diff_trigger_absolute()
-    local config = {
-        threshold = 5,
-        diff_method = "absolute",
-        initial_val = 10
-    }
+    local trigger = processing.DiffTrigger.new({
+        threshold   = 5,
+        diff_method = 'absolute',
+        initial_val = 10,
+    })
+    local state = trigger:new_state()
 
-    local trigger, trig_err = processing.DiffTrigger.new(config)
-    luaunit.assertNil(trig_err)
-    local val, short, err = trigger:run(12)
+    local val, short, err = trigger:run(12, state)
     luaunit.assertNil(err)
-    luaunit.assertEquals(short, true) -- Should short circuit as diff < threshold
+    luaunit.assertTrue(short)  -- diff = 2 < threshold 5, short-circuits
 
-    val, short, err = trigger:run(16)
+    val, short, err = trigger:run(16, state)
     luaunit.assertNil(err)
-    luaunit.assertEquals(short, false) -- Should pass as diff >= threshold
+    luaunit.assertFalse(short) -- diff = 6 >= threshold 5
     luaunit.assertEquals(val, 16)
 end
 
 function TestProcessing:test_diff_trigger_percent()
-    local config = {
-        threshold = 10, -- 10% threshold
-        diff_method = "percent",
-        initial_val = 100
-    }
+    local trigger = processing.DiffTrigger.new({
+        threshold   = 10,
+        diff_method = 'percent',
+        initial_val = 100,
+    })
+    local state = trigger:new_state()
 
-    local trigger, trig_err = processing.DiffTrigger.new(config)
-    luaunit.assertNil(trig_err)
-
-    -- 5% change - should short circuit
-    local val, short, err = trigger:run(105)
+    local val, short, err = trigger:run(105, state)
     luaunit.assertNil(err)
-    luaunit.assertEquals(short, true)
+    luaunit.assertTrue(short)  -- 5% < 10% threshold
 
-    -- 15% change - should pass
-    val, short, err = trigger:run(115)
+    val, short, err = trigger:run(115, state)
     luaunit.assertNil(err)
-    luaunit.assertEquals(short, false)
+    luaunit.assertFalse(short) -- 15% >= 10% threshold
     luaunit.assertEquals(val, 115)
 end
 
 function TestProcessing:test_diff_trigger_any_change()
-    local config = {
-        diff_method = "any-change",
-        initial_val = 10
-    }
+    local trigger = processing.DiffTrigger.new({
+        diff_method = 'any-change',
+        initial_val = 10,
+    })
+    local state = trigger:new_state()
 
-    local trigger, trig_err = processing.DiffTrigger.new(config)
-    luaunit.assertNil(trig_err)
-
-    -- Same value - should short circuit
-    local val, short, err = trigger:run(10)
+    local val, short, err = trigger:run(10, state)
     luaunit.assertNil(err)
-    luaunit.assertEquals(short, true)
+    luaunit.assertTrue(short)   -- same value
 
-    -- Any change - should pass
-    val, short, err = trigger:run(10.1)
+    val, short, err = trigger:run(10.1, state)
     luaunit.assertNil(err)
-    luaunit.assertEquals(short, false)
+    luaunit.assertFalse(short)  -- changed
     luaunit.assertEquals(val, 10.1)
 end
 
-function TestProcessing:test_time_trigger()
-    local config = { duration = 0.1 }
-    local trigger = processing.TimeTrigger.new(config)
-
-    local val, short, err = trigger:run(123)
-    luaunit.assertNil(err)
-    luaunit.assertEquals(short, true) -- Should short circuit initially
-
-    sleep.sleep(0.2)
-    val, short, err = trigger:run(123)
-    luaunit.assertNil(err)
-    luaunit.assertEquals(short, false) -- Should pass after duration
-    luaunit.assertEquals(val, 123)
-end
-
 function TestProcessing:test_delta_value()
-    local delta = processing.DeltaValue.new({ initial_val = 10 })
+    local block = processing.DeltaValue.new({ initial_val = 10 })
+    local state = block:new_state()
 
-    local val, short, err = delta:run(15)
+    local val, short, err = block:run(15, state)
     luaunit.assertNil(err)
-    luaunit.assertEquals(short, false)
-    luaunit.assertEquals(val, 5) -- Should return difference
+    luaunit.assertFalse(short)
+    luaunit.assertEquals(val, 5)  -- 15 - 10
 
-    delta:reset()
-    val, short, err = delta:run(20)
+    block:reset(state)            -- simulate publish: last_val = 15
+
+    val, short, err = block:run(20, state)
     luaunit.assertNil(err)
-    luaunit.assertEquals(short, false)
-    luaunit.assertEquals(val, 5)
+    luaunit.assertEquals(val, 5) -- 20 - 15
 end
 
-function TestProcessing:test_clone_process()
-    local config = {
-        threshold = 5,
-        diff_method = "absolute",
-        initial_val = 10
-    }
+function TestProcessing:test_pipeline_run_and_reset()
+    local pipeline, err = processing.new_process_pipeline()
+    luaunit.assertNil(err)
+    pipeline:add(processing.DeltaValue.new({ initial_val = 10 }))
 
-    local trigger, trig_err = processing.DiffTrigger.new(config)
-    luaunit.assertNil(trig_err)
+    local state = pipeline:new_state()
 
-    local clone, clone_err = trigger:clone()
-    luaunit.assertNil(clone_err)
-    luaunit.assertNotNil(clone)
+    local val, short
+    val, short, err = pipeline:run(20, state)
+    luaunit.assertNil(err)
+    luaunit.assertFalse(short)
+    luaunit.assertEquals(val, 10) -- 20 - 10
 
-    -- Test that clone behaves the same as original
-    local val1, short1, err1 = trigger:run(16)
-    local val2, short2, err2 = clone:run(16)
+    pipeline:reset(state)         -- last_val = 20
 
-    luaunit.assertEquals(val1, val2)
-    luaunit.assertEquals(short1, short2)
-    luaunit.assertEquals(err1, err2)
+    val, short, err = pipeline:run(25, state)
+    luaunit.assertNil(err)
+    luaunit.assertEquals(val, 5)  -- 25 - 20
 end
 
-function TestProcessing:test_process_pipeline()
-    local pipeline = processing.new_process_pipeline()
-
-    -- Create a pipeline with DiffTrigger and DeltaValue
-    local diff_trigger = processing.DiffTrigger.new({
-        threshold = 5,
-        diff_method = "absolute",
-        initial_val = 10
-    })
-    local delta_value = processing.DeltaValue.new({ initial_val = 10 })
-
-    pipeline:add(diff_trigger)
-    pipeline:add(delta_value)
-
-    -- First run should pass through both processes
-    local val, short, err = pipeline:run(20)
+function TestProcessing:test_pipeline_short_circuit()
+    local pipeline, err = processing.new_process_pipeline()
     luaunit.assertNil(err)
-    luaunit.assertEquals(short, false)
-    luaunit.assertEquals(val, 10) -- DeltaValue should return difference from initial
+    pipeline:add(processing.DiffTrigger.new({
+        diff_method = 'absolute', threshold = 5, initial_val = 10,
+    }))
+    pipeline:add(processing.DeltaValue.new({ initial_val = 10 }))
 
-    -- Second run should short circuit at DiffTrigger
-    val, short, err = pipeline:run(22)
+    local state = pipeline:new_state()
+
+    local val, short
+    val, short, err = pipeline:run(20, state)  -- diff=10, passes DiffTrigger
     luaunit.assertNil(err)
-    luaunit.assertEquals(short, true)
+    luaunit.assertFalse(short)
+    luaunit.assertEquals(val, 10) -- DeltaValue: 20-10
+
+    val, short, err = pipeline:run(22, state)  -- diff=2 from last(20), short-circuits
+    luaunit.assertNil(err)
+    luaunit.assertTrue(short)
 end
 
-function TestProcessing:test_pipeline_reset()
-    local pipeline = processing.new_process_pipeline()
-    local delta_value = processing.DeltaValue.new({ initial_val = 10 })
-    pipeline:add(delta_value)
-
-    -- Run once to get delta
-    local val, short, err = pipeline:run(20)
-    luaunit.assertNil(err)
-    luaunit.assertEquals(val, 10)
-
-    -- Reset pipeline
-    pipeline:reset()
-
-    -- Next run should use the last value as new base
-    val, short, err = pipeline:run(25)
-    luaunit.assertNil(err)
-    luaunit.assertEquals(val, 5) -- 25 - 20
-end
+-------------------------------------------------------------------------------
+-- Unit tests: config module
+-------------------------------------------------------------------------------
 
 TestConfig = {}
 
-function TestConfig:test_build_metric_pipeline_via_apply_config()
-    -- Test pipeline building indirectly through apply_config
-    -- which is the main way pipelines are created
-    local mock_conn = {
-        subscribe = function(self, topic)
-            return {
-                next_msg_op = function() end,
-                unsubscribe = function() end
-            }
-        end
-    }
-
-    local config = {
-        templates = {},
-        collections = {
-            ["test/endpoint"] = {
-                protocol = "log",
-                process = {
-                    {
-                        type = "DiffTrigger",
-                        threshold = 5,
-                        diff_method = "absolute"
-                    }
-                }
-            }
-        },
-        publish_period = 60
-    }
-
-    local metrics, period, cloud_config = conf.apply_config(mock_conn, config, {})
-    luaunit.assertEquals(#metrics, 1)
-    luaunit.assertEquals(period, 60)
-    luaunit.assertNotNil(metrics[1].base_pipeline)
+function TestConfig:test_validate_http_config_valid()
+    local ok, err = conf.validate_http_config({
+        url       = 'http://cloud.example.com',
+        thing_key = 'key',
+        channels  = { { id = 'ch1', name = 'data' } },
+    })
+    luaunit.assertTrue(ok)
+    luaunit.assertNil(err)
 end
 
-function TestConfig:test_validate_http_config()
-    -- Valid config
-    local valid_config = {
-        url = "http://example.com",
-        thing_key = "test_key",
-        channels = {
-            { id = "ch1", name = "data", metadata = { channel_type = "data" } }
-        }
-    }
-    local valid, err = conf.validate_http_config(valid_config)
-    luaunit.assertTrue(valid)
-    luaunit.assertNil(err)
-
-    -- Missing url
-    local invalid_config = {
-        thing_key = "test_key",
-        channels = {}
-    }
-    valid, err = conf.validate_http_config(invalid_config)
-    luaunit.assertFalse(valid)
+function TestConfig:test_validate_http_config_nil()
+    local ok, err = conf.validate_http_config(nil)
+    luaunit.assertFalse(ok)
     luaunit.assertNotNil(err)
+end
 
-    -- Nil config
-    valid, err = conf.validate_http_config(nil)
-    luaunit.assertFalse(valid)
+function TestConfig:test_validate_http_config_missing_url()
+    local ok, err = conf.validate_http_config({ thing_key = 'k', channels = {} })
+    luaunit.assertFalse(ok)
     luaunit.assertNotNil(err)
 end
 
 function TestConfig:test_merge_config()
-    local base = {
-        url = "http://base.com",
-        thing_key = "base_key",
-        nested = {
-            field1 = "value1",
-            field2 = "value2"
-        }
-    }
-
-    local override = {
-        thing_key = "override_key",
-        nested = {
-            field2 = "override_value2",
-            field3 = "value3"
-        }
-    }
-
-    local merged = conf.merge_config(base, override)
-    luaunit.assertEquals(merged.url, "http://base.com")
-    luaunit.assertEquals(merged.thing_key, "override_key")
-    luaunit.assertEquals(merged.nested.field1, "value1")
-    luaunit.assertEquals(merged.nested.field2, "override_value2")
-    luaunit.assertEquals(merged.nested.field3, "value3")
+    local merged = conf.merge_config(
+        { a = 1, nested = { x = 10, y = 20 } },
+        { b = 2, nested = { y = 99, z = 30 } }
+    )
+    luaunit.assertEquals(merged.a, 1)
+    luaunit.assertEquals(merged.b, 2)
+    luaunit.assertEquals(merged.nested.x, 10)
+    luaunit.assertEquals(merged.nested.y, 99) -- overridden
+    luaunit.assertEquals(merged.nested.z, 30) -- added
 end
 
-function TestConfig:test_validate_topic_with_nil()
-    -- Test the actual metrics service validate_topic logic by directly calling _handle_metric
-    local metrics_service = require 'services.metrics'
-    local bus_pkg = require 'bus'
-    local context = require "fibers.context"
-
-    -- Create a bus and connection (but don't start the service)
-    local test_bus = bus_pkg.new()
-    local conn = test_bus:connect()
-
-    -- Create a context for the metrics service (needed for logging)
-    local bg_ctx = context.background()
-    local service_ctx = context.with_value(bg_ctx, "service_name", "metrics_test")
-    service_ctx = context.with_value(service_ctx, "fiber_name", "test_fiber")
-
-    -- Set up metrics service state manually without starting it
-    metrics_service.ctx = service_ctx
-    metrics_service.metric_values = {}
-    metrics_service.pipelines = {}
-
-    -- Create a pipeline for a test metric
-    local base_pipeline = processing.new_process_pipeline()
-    local diff_trigger = processing.DiffTrigger.new({
-        threshold = 5,
-        diff_method = "absolute",
-        initial_val = 10
+function TestConfig:test_apply_config_builds_pipeline()
+    local map, period = conf.apply_config({
+        publish_period = 30,
+        pipelines = {
+            rx_bytes = {
+                protocol = 'log',
+                process  = { { type = 'DeltaValue' } },
+            },
+        },
     })
-    base_pipeline:add(diff_trigger)
-
-    -- Create a metric definition
-    local metric = {
-        protocol = "log",
-        field = nil,
-        rename = nil,
-        base_pipeline = base_pipeline
-    }
-
-    -- Test 1: Valid topic should work and add value to metric_values
-    local valid_msg = bus_pkg.new_msg({"test", "metric"}, 100)
-    metrics_service:_handle_metric(metric, valid_msg)
-    luaunit.assertNotNil(metrics_service.metric_values.log)
-    luaunit.assertNotNil(metrics_service.metric_values.log["test.metric"])
-    luaunit.assertEquals(metrics_service.metric_values.log["test.metric"].value, 100)
-
-    -- Reset for next test
-    metrics_service.metric_values = {}
-
-    -- Test 2: Invalid topic with nil in the middle should be rejected (not added)
-    local invalid_msg_nil = bus_pkg.new_msg({"test", nil, "metric"}, 200)
-    metrics_service:_handle_metric(metric, invalid_msg_nil)
-    -- Should not create any metric values because topic is invalid
-    luaunit.assertTrue((not metrics_service.metric_values.log) or (not metrics_service.metric_values.log["test..metric"]))
-
-    -- Test 3: Invalid topic with gap (sparse array) should be rejected
-    local sparse_topic = {}
-    sparse_topic[1] = "test"
-    sparse_topic[3] = "metric"  -- index 2 is missing
-    local sparse_msg = bus_pkg.new_msg(sparse_topic, 300)
-    metrics_service:_handle_metric(metric, sparse_msg)
-    -- Should not create any metric values because topic is invalid
-    luaunit.assertTrue((not metrics_service.metric_values.log) or (not metrics_service.metric_values.log["test.metric"]))
-
-    -- Test 4: Another valid topic should work
-    metrics_service.metric_values = {}
-    local valid_msg2 = bus_pkg.new_msg({"another", "valid", "topic"}, 50)
-    metrics_service:_handle_metric(metric, valid_msg2)
-    luaunit.assertNotNil(metrics_service.metric_values.log)
-    luaunit.assertNotNil(metrics_service.metric_values.log["another.valid.topic"])
-
-    -- Test 5: Empty topic should be rejected
-    metrics_service.metric_values = {}
-    local empty_msg = bus_pkg.new_msg({}, 400)
-    metrics_service:_handle_metric(metric, empty_msg)
-    luaunit.assertNil(metrics_service.metric_values.log)
-
-    -- Clean up
-    conn:disconnect()
+    luaunit.assertEquals(period, 30)
+    luaunit.assertNotNil(map.rx_bytes)
+    luaunit.assertEquals(map.rx_bytes.protocol, 'log')
+    luaunit.assertNotNil(map.rx_bytes.pipeline)
 end
+
+function TestConfig:test_validate_config_rejects_bad_period()
+    local ok, _, err = conf.validate_config({
+        publish_period = -1,
+        pipelines      = { sim = { protocol = 'log', process = {} } },
+    })
+    luaunit.assertFalse(ok)
+    luaunit.assertNotNil(err)
+end
+
+function TestConfig:test_validate_config_warns_bad_protocol()
+    local ok, warns = conf.validate_config({
+        publish_period = 10,
+        pipelines      = { sim = { protocol = 'invalid' } },
+    })
+    luaunit.assertTrue(ok)
+    luaunit.assertTrue(#warns > 0)
+end
+
+function TestConfig:test_validate_config_propagates_invalid_template_to_pipeline()
+    local ok, warns, err = conf.validate_config({
+        publish_period = 10,
+        templates = {
+            bad_template = {
+                protocol = 'invalid',
+            },
+        },
+        pipelines = {
+            sim = {
+                template = 'bad_template',
+            },
+        },
+    })
+
+    luaunit.assertTrue(ok)
+    luaunit.assertNil(err)
+
+    local saw_template_invalid = false
+    local saw_metric_uses_invalid_template = false
+    local saw_metric_invalid_protocol = false
+
+    for _, w in ipairs(warns) do
+        if w.type == 'template'
+            and w.endpoint == 'bad_template'
+            and string.find(w.msg, "invalid protocol 'invalid'", 1, true)
+        then
+            saw_template_invalid = true
+        end
+
+        if w.type == 'metric'
+            and w.endpoint == 'sim'
+            and string.find(w.msg, 'uses invalid template [bad_template]', 1, true)
+        then
+            saw_metric_uses_invalid_template = true
+        end
+
+        if w.type == 'metric'
+            and w.endpoint == 'sim'
+            and string.find(w.msg, "invalid protocol 'invalid'", 1, true)
+        then
+            saw_metric_invalid_protocol = true
+        end
+    end
+
+    luaunit.assertTrue(saw_template_invalid)
+    luaunit.assertTrue(saw_metric_uses_invalid_template)
+    luaunit.assertTrue(saw_metric_invalid_protocol)
+end
+
+-------------------------------------------------------------------------------
+-- Unit tests: SenML encoder
+-------------------------------------------------------------------------------
 
 TestSenML = {}
 
-function TestSenML:test_encode_basic()
-    -- Test encoding a string
-    local result, err = senml.encode("test/topic", "string_value")
+function TestSenML:test_encode_number()
+    local rec, err = senml.encode('cpu', 42.5)
     luaunit.assertNil(err)
-    luaunit.assertEquals(result.n, "test/topic")
-    luaunit.assertEquals(result.vs, "string_value")
-
-    -- Test encoding a number
-    result, err = senml.encode("test/topic", 42.5)
-    luaunit.assertNil(err)
-    luaunit.assertEquals(result.n, "test/topic")
-    luaunit.assertEquals(result.v, 42.5)
-
-    -- Test encoding a boolean
-    result, err = senml.encode("test/topic", true)
-    luaunit.assertNil(err)
-    luaunit.assertEquals(result.n, "test/topic")
-    luaunit.assertEquals(result.vb, true)
-
-    -- Test encoding with timestamp
-    result, err = senml.encode("test/topic", 42, 1234567890)
-    luaunit.assertNil(err)
-    luaunit.assertEquals(result.t, 1234567890)
+    luaunit.assertEquals(rec.n, 'cpu')
+    luaunit.assertEquals(rec.v, 42.5)
 end
 
-function TestSenML:test_encode_invalid_types()
-    -- Test encoding with invalid type
-    local result, err = senml.encode("test/topic", {})
-    luaunit.assertNotNil(err)
-    luaunit.assertNil(result)
+function TestSenML:test_encode_string()
+    local rec, err = senml.encode('status', 'ok')
+    luaunit.assertNil(err)
+    luaunit.assertEquals(rec.vs, 'ok')
+end
 
-    -- Test encoding with nil
-    result, err = senml.encode("test/topic", nil)
+function TestSenML:test_encode_boolean()
+    local rec, err = senml.encode('flag', true)
+    luaunit.assertNil(err)
+    luaunit.assertEquals(rec.vb, true)
+end
+
+function TestSenML:test_encode_with_time()
+    local rec, err = senml.encode('t', 1, 1000)
+    luaunit.assertNil(err)
+    luaunit.assertEquals(rec.t, 1000)
+end
+
+function TestSenML:test_encode_invalid_value()
+    local rec, err = senml.encode('k', {})
+    luaunit.assertNil(rec)
     luaunit.assertNotNil(err)
-    luaunit.assertNil(result)
 end
 
 function TestSenML:test_encode_r_flat()
-    -- Test encoding a flat table
-    local values = {
-        temperature = 23.5,
-        humidity = 60,
-        status = "online"
-    }
-
-    local result, err = senml.encode_r("device/sensors", values)
+    local recs, err = senml.encode_r('dev', { temp = 23.5, status = 'on' })
     luaunit.assertNil(err)
-    luaunit.assertEquals(#result, 3)
-
-    -- Check each entry
-    local found = { temp = false, humid = false, status = false }
-    for _, entry in ipairs(result) do
-        if entry.n == "device/sensors.temperature" and entry.v == 23.5 then
-            found.temp = true
-        elseif entry.n == "device/sensors.humidity" and entry.v == 60 then
-            found.humid = true
-        elseif entry.n == "device/sensors.status" and entry.vs == "online" then
-            found.status = true
-        end
-    end
-
-    luaunit.assertTrue(found.temp)
-    luaunit.assertTrue(found.humid)
-    luaunit.assertTrue(found.status)
+    luaunit.assertEquals(#recs, 2)
+    local names = {}
+    for _, r in ipairs(recs) do names[r.n] = r end
+    luaunit.assertEquals(names['dev.temp'].v,   23.5)
+    luaunit.assertEquals(names['dev.status'].vs, 'on')
 end
 
-function TestSenML:test_encode_r_nested()
-    -- Test encoding a nested table
-    local values = {
-        system = {
-            memory = 8192,
-            cpu = 45.6
-        },
-        network = {
-            status = "connected",
-            speed = 100
-        }
+-------------------------------------------------------------------------------
+-- Unit tests: HTTP publisher module
+-------------------------------------------------------------------------------
+
+TestHttpModule = {}
+
+function TestHttpModule:test_start_http_publisher_builds_expected_request()
+    local original_http_request = package.loaded['http.request']
+    local original_http_module  = package.loaded['services.metrics.http']
+
+    local captured = {
+        uri = nil,
+        method = nil,
+        auth = nil,
+        content_type = nil,
+        expect_header = 'present',
+        body = nil,
+        timeout = nil,
     }
 
-    local result, err = senml.encode_r("device", values)
-    luaunit.assertNil(err)
-    luaunit.assertEquals(#result, 4)
+    package.loaded['http.request'] = {
+        new_from_uri = function(uri)
+            captured.uri = uri
 
-    -- Check specific entries
-    local found = { memory = false, cpu = false, net_status = false, speed = false }
-    for _, entry in ipairs(result) do
-        if entry.n == "device.system.memory" and entry.v == 8192 then
-            found.memory = true
-        elseif entry.n == "device.system.cpu" and entry.v == 45.6 then
-            found.cpu = true
-        elseif entry.n == "device.network.status" and entry.vs == "connected" then
-            found.net_status = true
-        elseif entry.n == "device.network.speed" and entry.v == 100 then
-            found.speed = true
-        end
-    end
-
-    luaunit.assertTrue(found.memory)
-    luaunit.assertTrue(found.cpu)
-    luaunit.assertTrue(found.net_status)
-    luaunit.assertTrue(found.speed)
-end
-
-function TestSenML:test_encode_r_with_value_field()
-    -- Test encoding a table with __value field and a subtable
-    local values = {
-        system = {
-            __value = "active", -- This should be at the base topic
-            memory = {
-                __value = "healthy",
-                used = 4096,
-                free = 4096
+            local hdr = {}
+            local req = {
+                headers = {
+                    upsert = function(_, k, v) hdr[k] = v end,
+                    delete = function(_, k) hdr[k] = nil end,
+                },
+                set_body = function(_, body)
+                    captured.body = body
+                end,
+                go = function(_, timeout)
+                    captured.timeout = timeout
+                    captured.method = hdr[':method']
+                    captured.auth = hdr['authorization']
+                    captured.content_type = hdr['content-type']
+                    captured.expect_header = hdr['expect']
+                    return {
+                        get = function(_, key)
+                            if key == ':status' then return '202' end
+                            return nil
+                        end,
+                        each = function()
+                            return function() return nil end
+                        end,
+                    }
+                end,
             }
-        }
+
+            return req
+        end,
     }
 
-    local result, err = senml.encode_r("device", values)
-    luaunit.assertNil(err)
+    package.loaded['services.metrics.http'] = nil
 
-    -- Check for all expected entries
-    local found = { system = false, memory = false, used = false, free = false }
-    for _, entry in ipairs(result) do
-        if entry.n == "device.system" and entry.vs == "active" then
-            found.system = true
-        elseif entry.n == "device.system.memory" and entry.vs == "healthy" then
-            found.memory = true
-        elseif entry.n == "device.system.memory.used" and entry.v == 4096 then
-            found.used = true
-        elseif entry.n == "device.system.memory.free" and entry.v == 4096 then
-            found.free = true
-        end
-    end
+    local st, _, test_err = fibers.run_scope(function(s)
+        local http_mod = require 'services.metrics.http'
 
-    luaunit.assertTrue(found.system)
-    luaunit.assertTrue(found.memory)
-    luaunit.assertTrue(found.used)
-    luaunit.assertTrue(found.free)
-    luaunit.assertEquals(#result, 4)
-end
+        local worker_scope, worker_err = s:child()
+        luaunit.assertNotNil(worker_scope, tostring(worker_err))
 
-function TestSenML:test_encode_r_with_value_and_time()
-    -- Test encoding values with explicit value and time fields
-    local values = {
-        temperature = {
-            value = 23.5,
-            time = 1234567890
-        },
-        status = "online"
-    }
+        local spawn_ok, spawn_err = worker_scope:spawn(function()
+            local ch = http_mod.start_http_publisher()
 
-    local result, err = senml.encode_r("sensor", values)
-    luaunit.assertNil(err)
-    luaunit.assertEquals(#result, 2)
+            perform(ch:put_op({
+                uri = 'http://localhost:18080/http/channels/ch-data/messages',
+                auth = 'Thing test-thing-key',
+                body = '[{"n":"sim","vs":"present"}]',
+            }))
+        end)
+        luaunit.assertTrue(spawn_ok, tostring(spawn_err))
 
-    -- Check entries
-    local found = { temp = false, status = false }
-    for _, entry in ipairs(result) do
-        if entry.n == "sensor.temperature" and entry.v == 23.5 and entry.t == 1234567890 then
-            found.temp = true
-        elseif entry.n == "sensor.status" and entry.vs == "online" then
-            found.status = true
-        end
-    end
+        flush_ticks(20)
 
-    luaunit.assertTrue(found.temp)
-    luaunit.assertTrue(found.status)
-end
+        luaunit.assertEquals(captured.uri,
+            'http://localhost:18080/http/channels/ch-data/messages')
+        luaunit.assertEquals(captured.method, 'POST')
+        luaunit.assertEquals(captured.auth, 'Thing test-thing-key')
+        luaunit.assertEquals(captured.content_type, 'application/senml+json')
+        luaunit.assertNil(captured.expect_header)
+        luaunit.assertEquals(captured.body, '[{"n":"sim","vs":"present"}]')
+        luaunit.assertEquals(captured.timeout, 10)
 
--- Only run tests if this file is executed directly (not via dofile)
-if is_entry_point then
-    fiber.spawn(function ()
-        luaunit.LuaUnit.run()
-        fiber.stop()
+        worker_scope:cancel('test done')
+        perform(worker_scope:join_op())
     end)
 
-    fiber.main()
+    package.loaded['http.request'] = original_http_request
+    package.loaded['services.metrics.http'] = original_http_module
+
+    if st ~= 'ok' then
+        error(test_err or ('http module scope failed: ' .. tostring(st)))
+    end
+end
+
+-------------------------------------------------------------------------------
+-- Service-level tests
+--
+-- These tests run the full metrics service in a child scope and exercise it
+-- end-to-end via the bus.  Because they call perform() / sleep, they must run
+-- inside a fiber (i.e. inside fibers.run or another existing scope+spawn).
+-------------------------------------------------------------------------------
+
+TestMetricsService = {}
+
+-- Publish a metric config as a retained message and a raw metric, then verify
+-- the processed value is re-published on the bus topic.
+function TestMetricsService:test_metric_published_via_bus()
+    local clock = new_test_clock()
+    local root      = fibers.current_scope()
+    local bus       = make_bus()
+    local test_conn = bus:connect()
+
+    -- Signal HAL filesystem capability ready (retained).
+    test_conn:retain({ 'cap', 'fs', 'configs', 'state' }, 'added')
+    start_mock_hal(test_conn, root)
+
+    -- Subscribe to bus-protocol metric output before starting the service.
+    local result_sub = test_conn:subscribe(
+        { 'svc', 'metrics', '#' },
+        { queue_len = 10, full = 'drop_oldest' })
+
+    -- Publish config: simple pass-through pipeline, publish every 0.1 s.
+    test_conn:retain({ 'cfg', 'metrics' }, bus_pipeline_config('sim', 0.1))
+
+    local svc_scope = start_metrics(bus, root)
+    flush_ticks()
+
+    -- topic[5] = 'sim' must match the pipeline name.
+    test_conn:publish(
+        { 'obs', 'v1', 'modem', 'metric', 'sim' },
+        { value = 'present', namespace = { 'modem', 1, 'sim' } })
+
+    local msg = recv_timeout(clock, result_sub, 0.5)
+
+    luaunit.assertNotNil(msg, 'expected bus publish of sim metric')
+    luaunit.assertEquals(msg.payload.value, 'present')
+
+    stop_scope(svc_scope)
+    clock:restore()
+end
+
+-- When the payload has a `namespace` field it overrides the bus topic used as
+-- the SenML key and the output topic.
+function TestMetricsService:test_namespace_overrides_topic_key()
+    local clock = new_test_clock()
+    local root      = fibers.current_scope()
+    local bus       = make_bus()
+    local test_conn = bus:connect()
+
+    test_conn:retain({ 'cap', 'fs', 'configs', 'state' }, 'added')
+    start_mock_hal(test_conn, root)
+
+    local result_sub = test_conn:subscribe(
+        { 'svc', 'metrics', '#' },
+        { queue_len = 10, full = 'drop_oldest' })
+
+    test_conn:retain({ 'cfg', 'metrics' }, bus_pipeline_config('rx_bytes', 0.1))
+    local svc_scope = start_metrics(bus, root)
+    flush_ticks()
+
+    -- Publish with a namespace override: topic key becomes 'wan.rx_bytes'.
+    test_conn:publish(
+        { 'obs', 'v1', 'network', 'metric', 'rx_bytes' },
+        { value = 1024, namespace = { 'wan', 'rx_bytes' } })
+
+    local msg = recv_timeout(clock, result_sub, 0.5)
+
+    luaunit.assertNotNil(msg, 'expected bus publish with namespace key')
+    -- Output topic should be {'svc', 'metrics', 'wan', 'rx_bytes'}
+    luaunit.assertEquals(msg.topic[3], 'wan')
+    luaunit.assertEquals(msg.topic[4], 'rx_bytes')
+    luaunit.assertEquals(msg.payload.value, 1024)
+
+    stop_scope(svc_scope)
+    clock:restore()
+end
+
+-- A metric whose name has no matching pipeline must be silently dropped.
+function TestMetricsService:test_unknown_metric_dropped()
+    local clock = new_test_clock()
+    local root      = fibers.current_scope()
+    local bus       = make_bus()
+    local test_conn = bus:connect()
+
+    test_conn:retain({ 'cap', 'fs', 'configs', 'state' }, 'added')
+    start_mock_hal(test_conn, root)
+
+    local result_sub = test_conn:subscribe(
+        { 'svc', 'metrics', '#' },
+        { queue_len = 10, full = 'drop_oldest' })
+
+    -- Config only knows about 'sim'; we will publish 'rx_bytes'.
+    test_conn:retain({ 'cfg', 'metrics' }, bus_pipeline_config('sim', 0.1))
+    local svc_scope = start_metrics(bus, root)
+    flush_ticks()
+
+    test_conn:publish(
+        { 'obs', 'v1', 'network', 'metric', 'rx_bytes' },
+        { value = 9999 })
+
+    clock:advance(0.25)
+    time_harness.flush_ticks(20)
+    local messages = drain_non_status(result_sub)
+
+    luaunit.assertEquals(#messages, 0, 'unexpected publish for unknown metric')
+
+    stop_scope(svc_scope)
+    clock:restore()
+end
+
+-- A DiffTrigger with any-change suppresses the second publish when the value
+-- does not change between publish cycles.
+function TestMetricsService:test_difftrigger_suppresses_unchanged_value()
+    local clock = new_test_clock()
+    local root      = fibers.current_scope()
+    local bus       = make_bus()
+    local test_conn = bus:connect()
+
+    test_conn:retain({ 'cap', 'fs', 'configs', 'state' }, 'added')
+    start_mock_hal(test_conn, root)
+
+    local result_sub = test_conn:subscribe(
+        { 'svc', 'metrics', '#' },
+        { queue_len = 10, full = 'drop_oldest' })
+
+    test_conn:retain({ 'cfg', 'metrics' }, bus_pipeline_config('sim', 0.1, {
+        { type = 'DiffTrigger', diff_method = 'any-change' },
+    }))
+    local svc_scope = start_metrics(bus, root)
+    flush_ticks()
+
+    -- First publish: value 'present' — should pass DiffTrigger.
+    test_conn:publish(
+        { 'obs', 'v1', 'modem', 'metric', 'sim' },
+        { value = 'present' })
+
+    local msg1 = recv_timeout(clock, result_sub, 0.4)
+    luaunit.assertNotNil(msg1, 'expected first publish')
+    luaunit.assertEquals(msg1.payload.value, 'present')
+
+    -- Second publish: same value — DiffTrigger must suppress it.
+    test_conn:publish(
+        { 'obs', 'v1', 'modem', 'metric', 'sim' },
+        { value = 'present' })
+
+    clock:advance(0.25)
+    time_harness.flush_ticks(20)
+    local msg2 = nil
+    while true do
+        local ok, m = time_harness.try_op_now(function() return result_sub:recv_op() end)
+        if not ok then break end
+        if m.topic[3] ~= 'status' then msg2 = m; break end
+    end
+    luaunit.assertNil(msg2, 'second publish should be suppressed by DiffTrigger')
+
+    stop_scope(svc_scope)
+    clock:restore()
+end
+
+-- DeltaValue transforms a cumulative counter into a per-period delta.
+function TestMetricsService:test_delta_value_pipeline()
+    local clock = new_test_clock()
+    local root      = fibers.current_scope()
+    local bus       = make_bus()
+    local test_conn = bus:connect()
+
+    test_conn:retain({ 'cap', 'fs', 'configs', 'state' }, 'added')
+    start_mock_hal(test_conn, root)
+
+    local result_sub = test_conn:subscribe(
+        { 'svc', 'metrics', '#' },
+        { queue_len = 10, full = 'drop_oldest' })
+
+    test_conn:retain({ 'cfg', 'metrics' }, bus_pipeline_config('rx_bytes', 0.1, {
+        { type = 'DeltaValue', initial_val = 0 },
+    }))
+    local svc_scope = start_metrics(bus, root)
+    flush_ticks()
+
+    -- First reading: 1000 bytes; delta from initial 0 = 1000.
+    test_conn:publish(
+        { 'obs', 'v1', 'network', 'metric', 'rx_bytes' },
+        { value = 1000 })
+
+    local msg1 = recv_timeout(clock, result_sub, 0.4)
+    luaunit.assertNotNil(msg1, 'expected first delta publish')
+    luaunit.assertEquals(msg1.payload.value, 1000)
+
+    -- Second reading: 1500 bytes; delta from 1000 = 500.
+    test_conn:publish(
+        { 'obs', 'v1', 'network', 'metric', 'rx_bytes' },
+        { value = 1500 })
+
+    local msg2 = recv_timeout(clock, result_sub, 0.4)
+    luaunit.assertNotNil(msg2, 'expected second delta publish')
+    luaunit.assertEquals(msg2.payload.value, 500)
+
+    stop_scope(svc_scope)
+    clock:restore()
+end
+
+-- HTTP protocol pipelines should enqueue a well-formed Mainflux request.
+function TestMetricsService:test_http_pipeline_enqueues_request_payload()
+    local clock = new_test_clock()
+    local root      = fibers.current_scope()
+    local bus       = make_bus()
+    local test_conn = bus:connect()
+
+    test_conn:retain({ 'cap', 'fs', 'configs', 'state' }, 'added')
+    start_mock_hal(test_conn, root)
+
+    local captured = nil
+    local original_http_mod = package.loaded['services.metrics.http']
+    package.loaded['services.metrics.http'] = {
+        start_http_publisher = function()
+            return {
+                put_op = function(_, data)
+                    captured = data
+                    return op.always(true)
+                end,
+            }
+        end,
+    }
+
+    local svc_scope = nil
+    local st, _, test_err = fibers.run_scope(function()
+        test_conn:retain({ 'cfg', 'metrics' }, {
+            publish_period = 0.1,
+            cloud_url = 'http://localhost:18080',
+            pipelines = {
+                sim = {
+                    protocol = 'http',
+                    process  = {},
+                },
+            },
+        })
+
+        svc_scope = start_metrics(bus, root)
+        flush_ticks()
+
+        test_conn:publish(
+            { 'obs', 'v1', 'modem', 'metric', 'sim' },
+            { value = 'present', namespace = { 'modem', 1, 'sim' } })
+
+        clock:advance(0.3)
+        time_harness.flush_ticks(20)
+
+        luaunit.assertNotNil(captured, 'expected HTTP payload to be enqueued')
+        luaunit.assertEquals(captured.uri,
+            'http://localhost:18080/http/channels/ch-data/messages')
+        luaunit.assertEquals(captured.auth, 'Thing test-thing-key')
+        luaunit.assertNotNil(captured.body)
+
+        local recs, decode_err = json.decode(captured.body)
+        luaunit.assertNil(decode_err)
+        luaunit.assertEquals(type(recs), 'table')
+        luaunit.assertEquals(#recs, 1)
+        luaunit.assertEquals(recs[1].n, 'modem.1.sim')
+        luaunit.assertEquals(recs[1].vs, 'present')
+    end)
+
+    if svc_scope then
+        stop_scope(svc_scope)
+    end
+    package.loaded['services.metrics.http'] = original_http_mod
+    clock:restore()
+
+    if st ~= 'ok' then
+        error(test_err or ('metrics http scope failed: ' .. tostring(st)))
+    end
+end
+
+-- Receiving a new config replaces pipelines; old metric names are dropped.
+function TestMetricsService:test_config_update_replaces_pipelines()
+    local clock = new_test_clock()
+    local root      = fibers.current_scope()
+    local bus       = make_bus()
+    local test_conn = bus:connect()
+
+    test_conn:retain({ 'cap', 'fs', 'configs', 'state' }, 'added')
+    start_mock_hal(test_conn, root)
+
+    local result_sub = test_conn:subscribe(
+        { 'svc', 'metrics', '#' },
+        { queue_len = 20, full = 'drop_oldest' }
+    )
+
+    -- Initial config: pipeline for 'sim'.
+    test_conn:retain({ 'cfg', 'metrics' }, bus_pipeline_config('sim', 0.1))
+    local svc_scope = start_metrics(bus, root)
+    flush_ticks()
+
+    -- Confirm 'sim' publishes under the initial config.
+    test_conn:publish(
+        { 'obs', 'v1', 'modem', 'metric', 'sim' },
+        { value = 'present' }
+    )
+    local msg1 = recv_timeout(clock, result_sub, 0.4)
+    luaunit.assertNotNil(msg1, 'expected sim metric before config update')
+
+    -- Update config: replace 'sim' pipeline with 'rx_bytes'.
+    test_conn:retain({ 'cfg', 'metrics' }, bus_pipeline_config('rx_bytes', 0.1))
+    flush_ticks()
+
+    -- 'rx_bytes' must publish after the config update.
+    test_conn:publish(
+        { 'obs', 'v1', 'network', 'metric', 'rx_bytes' },
+        { value = 42 }
+    )
+    local msg2 = recv_timeout(clock, result_sub, 0.4)
+    luaunit.assertNotNil(msg2, 'expected rx_bytes metric after config update')
+    luaunit.assertEquals(msg2.payload.value, 42)
+
+    stop_scope(svc_scope)
+    clock:restore()
+end
+
+-- Two endpoints sharing the same pipeline name maintain isolated processing
+-- state (DeltaValue counters don't bleed across endpoints).
+function TestMetricsService:test_per_endpoint_state_isolation()
+    local clock = new_test_clock()
+    local root      = fibers.current_scope()
+    local bus       = make_bus()
+    local test_conn = bus:connect()
+
+    test_conn:retain({ 'cap', 'fs', 'configs', 'state' }, 'added')
+    start_mock_hal(test_conn, root)
+
+    local result_sub = test_conn:subscribe(
+        { 'svc', 'metrics', '#' },
+        { queue_len = 20, full = 'drop_oldest' })
+
+    test_conn:retain({ 'cfg', 'metrics' }, bus_pipeline_config('rx_bytes', 0.1, {
+        { type = 'DeltaValue', initial_val = 0 },
+    }))
+    local svc_scope = start_metrics(bus, root)
+    flush_ticks()
+
+    -- WAN endpoint: 500 bytes → delta = 500.
+    test_conn:publish(
+        { 'obs', 'v1', 'network', 'metric', 'rx_bytes' },
+        { value = 500, namespace = { 'wan', 'rx_bytes' } })
+
+    -- LAN endpoint: 200 bytes → delta = 200 (independent state).
+    test_conn:publish(
+        { 'obs', 'v1', 'network', 'metric', 'rx_bytes' },
+        { value = 200, namespace = { 'lan', 'rx_bytes' } })
+
+    -- Collect both publishes within one tick window.
+    local received = {}
+    for _ = 1, 2 do
+        local msg = recv_timeout(clock, result_sub, 0.4)
+        if msg then
+            local key = table.concat(msg.topic, '.')
+            received[key] = msg.payload.value
+        end
+    end
+
+    luaunit.assertEquals(received['svc.metrics.wan.rx_bytes'], 500)
+    luaunit.assertEquals(received['svc.metrics.lan.rx_bytes'], 200)
+
+    stop_scope(svc_scope)
+    clock:restore()
+end
+
+-------------------------------------------------------------------------------
+-- Entry point
+-------------------------------------------------------------------------------
+
+if is_entry_point then
+    fibers.run(function()
+        os.exit(luaunit.LuaUnit.run())
+    end)
 end

--- a/tests/test_utils/time_harness.lua
+++ b/tests/test_utils/time_harness.lua
@@ -1,0 +1,113 @@
+local fibers  = require 'fibers'
+local runtime = require 'fibers.runtime'
+
+local perform = fibers.perform
+local pack    = rawget(table, 'pack') or function(...)
+    return { n = select('#', ...), ... }
+end
+local unpack  = rawget(table, 'unpack') or unpack
+
+---@class VirtualClock
+---@field advance fun(self: VirtualClock, dt: number): number
+
+---@class TimeHarnessTickOpts
+---@field max_ticks? integer
+
+---@class TimeHarnessWaitTicksOpts
+---@field max_ticks? integer
+---@field on_miss? fun(tick: integer)
+
+---@class TimeHarnessWaitWithinOpts
+---@field step? number
+---@field max_ticks? integer
+
+local M = {}
+local NOT_READY = {}
+
+---@param op_or_factory any|fun(): any
+---@return any
+local function resolve_op(op_or_factory)
+    if type(op_or_factory) == 'function' then
+        return op_or_factory()
+    end
+    return op_or_factory
+end
+
+---@param op_or_factory any|fun(): any
+---@return boolean
+---@return ...
+function M.try_op_now(op_or_factory)
+    local op = resolve_op(op_or_factory)
+    local out = pack(perform(op:or_else(function() return NOT_READY end)))
+    if out.n == 1 and out[1] == NOT_READY then
+        return false
+    end
+    return true, unpack(out, 1, out.n)
+end
+
+---@param max_ticks? integer
+function M.flush_ticks(max_ticks)
+    max_ticks = max_ticks or 1
+    for _ = 1, max_ticks do
+        runtime.yield()
+    end
+end
+
+---@param op_or_factory any|fun(): any
+---@param opts? TimeHarnessWaitTicksOpts
+---@return boolean
+---@return ...
+function M.wait_op_ticks(op_or_factory, opts)
+    opts = opts or {}
+
+    local max_ticks = opts.max_ticks or 1
+    local on_miss = opts.on_miss
+
+    for tick = 0, max_ticks do
+        local out = pack(M.try_op_now(op_or_factory))
+        if out[1] then
+            return unpack(out, 1, out.n)
+        end
+
+        if tick == max_ticks then break end
+
+        if on_miss then
+            on_miss(tick + 1)
+        else
+            runtime.yield()
+        end
+    end
+
+    return false
+end
+
+---@param clock VirtualClock
+---@param timeout_s number
+---@param op_or_factory any|fun(): any
+---@param opts? TimeHarnessWaitWithinOpts
+---@return boolean
+---@return ...
+function M.wait_op_within(clock, timeout_s, op_or_factory, opts)
+    opts = opts or {}
+
+    local step = opts.step or timeout_s
+    local max_ticks = opts.max_ticks or 1
+    local elapsed = 0
+
+    while true do
+        local out = pack(M.try_op_now(op_or_factory))
+        if out[1] then
+            return unpack(out, 1, out.n)
+        end
+        if elapsed >= timeout_s then
+            return false
+        end
+
+        local advance = math.min(step, timeout_s - elapsed)
+        clock:advance(advance)
+        M.flush_ticks(max_ticks)
+        elapsed = elapsed + advance
+    end
+end
+
+return M

--- a/tests/test_utils/virtual_time.lua
+++ b/tests/test_utils/virtual_time.lua
@@ -1,0 +1,127 @@
+local runtime = require 'fibers.runtime'
+local time    = require 'fibers.utils.time'
+
+---@class VirtualTimeInstallOpts
+---@field monotonic? number
+---@field realtime? number
+---@field follow_realtime? boolean
+
+---@class VirtualClock
+---@field monotonic fun(self: VirtualClock): number
+---@field realtime fun(self: VirtualClock): number
+---@field set_monotonic fun(self: VirtualClock, value: number): number
+---@field set_realtime fun(self: VirtualClock, value: number): number
+---@field advance fun(self: VirtualClock, dt: number): number
+---@field restore fun(self: VirtualClock)
+
+local M = {}
+
+---@type VirtualClock|nil
+local active_clock = nil
+
+---@param value number|nil
+---@param fallback number
+---@return number
+local function now_or(value, fallback)
+    if value ~= nil then return value end
+    return fallback
+end
+
+---@param opts? VirtualTimeInstallOpts
+---@return VirtualClock
+function M.install(opts)
+    if active_clock then
+        error('virtual_time.install: a clock is already installed')
+    end
+
+    opts = opts or {}
+
+    local scheduler = runtime.current_scheduler
+    local original = {
+        monotonic      = time.monotonic,
+        realtime       = time.realtime,
+        block          = time._block,
+        scheduler_time = scheduler.get_time,
+    }
+
+    local state = {
+        scheduler       = scheduler,
+        original        = original,
+        monotonic       = now_or(opts.monotonic, scheduler:now()),
+        realtime        = now_or(opts.realtime, time.realtime()),
+        follow_realtime = opts.follow_realtime ~= false,
+        restored        = false,
+    }
+
+    local function monotonic_now()
+        return state.monotonic
+    end
+
+    local function realtime_now()
+        return state.realtime
+    end
+
+    time.monotonic = monotonic_now
+    time.realtime = realtime_now
+    time._block = function()
+        return true
+    end
+
+    scheduler.get_time = monotonic_now
+    scheduler.wheel.now = state.monotonic
+
+    local clock = {}
+
+    function clock:monotonic()
+        return state.monotonic
+    end
+
+    function clock:realtime()
+        return state.realtime
+    end
+
+    function clock:set_monotonic(value)
+        assert(type(value) == 'number', 'virtual_time.set_monotonic: value must be a number')
+        assert(value >= state.monotonic, 'virtual_time.set_monotonic: cannot move time backwards')
+        state.monotonic = value
+        return state.monotonic
+    end
+
+    function clock:set_realtime(value)
+        assert(type(value) == 'number', 'virtual_time.set_realtime: value must be a number')
+        state.realtime = value
+        return state.realtime
+    end
+
+    function clock:advance(dt)
+        assert(type(dt) == 'number', 'virtual_time.advance: dt must be a number')
+        assert(dt >= 0, 'virtual_time.advance: dt must be non-negative')
+        state.monotonic = state.monotonic + dt
+        if state.follow_realtime then
+            state.realtime = state.realtime + dt
+        end
+        return state.monotonic
+    end
+
+    function clock:restore()
+        if state.restored then return end
+        if active_clock ~= clock then
+            error('virtual_time.restore: attempted to restore a non-active clock')
+        end
+
+        scheduler.get_time = original.scheduler_time
+        scheduler.wheel.now = scheduler.get_time()
+        time.monotonic = original.monotonic
+        time.realtime = original.realtime
+        time._block = original.block
+
+        state.restored = true
+        active_clock = nil
+    end
+
+    ---@cast clock VirtualClock
+    active_clock = clock
+    return clock
+end
+
+return M

--- a/tests/test_utils/virtual_time.lua
+++ b/tests/test_utils/virtual_time.lua
@@ -42,6 +42,7 @@ function M.install(opts)
         realtime       = time.realtime,
         block          = time._block,
         scheduler_time = scheduler.get_time,
+        wheel_now      = scheduler.wheel.now,
     }
 
     local state = {
@@ -110,7 +111,7 @@ function M.install(opts)
         end
 
         scheduler.get_time = original.scheduler_time
-        scheduler.wheel.now = scheduler.get_time()
+        scheduler.wheel.now = original.wheel_now
         time.monotonic = original.monotonic
         time.realtime = original.realtime
         time._block = original.block


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [x] 📝 Documentation Update
- [ ] 🎨 Style
- [x] 🧑‍💻 Code Refactor
- [x] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description
- Migrated the metrics service to use the new version of fibers
- Metrics now has annotations for functions and types
- Logic and state is now separate from pipelines to reduce pipeline cloning
- Metrics configs are now done via metric name rather than endpoint, cutting down on pipeline reuse
- Changed bus API to fit new runtime proposal
- Added test utils
- - Fibers clock can now be manually moved forwards instead of sleeping for time dependent tests
- - A time harness uses ticks (instances of a yield) as a timeout instead of actual time, this removes system specific failures due to timeout being missed and makes time based tests deterministic
- I have tests for cases where manual testing is either not possible or would take more time than just making the tests (verifying filter logic for example)

## Manual test
<!-- Have you manually tested this code and confirmed it is working? -->
- [x] 👍 yes
- [ ] 🙅 no

## Manual test description
Add the correct cloud url into the config.json
Comment line 481 and un-comment line 482 to make sure the metrics service does not lock due to missing time service
Run new devicecode with 
`DEVICECODE_CONFIG_DIR=./configs/ DEVICECODE_SERVICES=config,hal,gsm,metrics luajit main.lua`
Check grafana for metrics being sent up

## Added tests?
- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?
- [x] 📜 docs/specs/metrics.md
- [ ] 🙅 no documentation needed


