### PR TITLE
Fabric chris

### DIFF
--- a/src/configs/mcu-dev.json
+++ b/src/configs/mcu-dev.json
@@ -1,0 +1,64 @@
+{
+  "hal": {
+    "managers": {
+      "uart": {
+        "serial_ports": [
+          {
+            "name": "uart-0",
+            "path": "/dev/ttyAMA0",
+            "baud": 115200
+          }
+        ]
+      }
+    }
+  },
+  "fabric": {
+    "schema": "devicecode.fabric/1",
+    "links": {
+      "mcu0": {
+        "peer_id": "mcu-1",
+        "keepalive": {
+          "hello_retry_s": 1.0,
+          "idle_ping_s": 15.0,
+          "stale_after_s": 45.0
+        },
+        "transport": {
+          "kind": "uart",
+          "serial_ref": "uart-0"
+        },
+        "export": {
+          "publish": [
+            {
+              "src": ["config", "mcu"],
+              "dst": ["config", "device"],
+              "retain": true
+            }
+          ]
+        },
+        "import": {
+          "publish": [
+            {
+              "src": ["state", "#"],
+              "dst": ["peer", "mcu-1", "state", "#"],
+              "retain": true
+            }
+          ],
+          "call": [
+            {
+              "src": ["rpc", "hal", "read_state"],
+              "dst": ["rpc", "hal", "read_state"],
+              "timeout_s": 0.5
+            }
+          ]
+        },
+        "proxy_calls": [
+          {
+            "src": ["rpc", "peer", "mcu-1", "hal", "dump"],
+            "dst": ["rpc", "hal", "dump"],
+            "timeout_s": 0.5
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/devicecode/config_bootstrap.lua
+++ b/src/devicecode/config_bootstrap.lua
@@ -1,0 +1,234 @@
+-- devicecode/config_bootstrap.lua
+--
+-- Optional startup bootstrap for legacy checked-in config files under
+-- src/configs/. This only seeds the pieces needed by the current runtime:
+--   * config/hal    (serial refs for HAL-backed UART access)
+--   * config/fabric (minimal UART fabric link, when fabric is enabled)
+
+local cjson = require 'cjson.safe'
+
+local M = {}
+
+local function copy_plain(v, seen)
+	if type(v) ~= 'table' then
+		return v
+	end
+	if getmetatable(v) ~= nil then
+		error('config bootstrap only supports plain tables', 2)
+	end
+	seen = seen or {}
+	if seen[v] then
+		return seen[v]
+	end
+	local out = {}
+	seen[v] = out
+	for k, val in pairs(v) do
+		out[copy_plain(k, seen)] = copy_plain(val, seen)
+	end
+	return out
+end
+
+local function read_file(path)
+	local f = io.open(path, 'rb')
+	if not f then return nil end
+	local s = f:read('*a')
+	f:close()
+	return s
+end
+
+local function strip_comment_lines(s)
+	local out = {}
+	for line in tostring(s):gmatch('([^\n]*)\n?') do
+		if line == '' and #out > 0 and out[#out] == '' then
+			break
+		end
+		if not line:match('^%s*//') then
+			out[#out + 1] = line
+		end
+	end
+	return table.concat(out, '\n')
+end
+
+local function resolve_path(name)
+	if type(name) ~= 'string' or name == '' then
+		return nil, 'config name must be a non-empty string'
+	end
+
+	local candidates = {}
+	if name:find('/', 1, true) or name:sub(-5) == '.json' then
+		candidates = {
+			name,
+			'./' .. name,
+		}
+	else
+		candidates = {
+			('./configs/%s.json'):format(name),
+			('./src/configs/%s.json'):format(name),
+		}
+	end
+
+	for i = 1, #candidates do
+		local path = candidates[i]
+		local data = read_file(path)
+		if data ~= nil then
+			return path, data
+		end
+	end
+
+	return nil, ('config file not found for %s'):format(name)
+end
+
+local function load_selected(name)
+	local path, data_or_err = resolve_path(name)
+	if not path then
+		return nil, nil, data_or_err
+	end
+
+	local decoded, err = cjson.decode(data_or_err)
+	if type(decoded) ~= 'table' then
+		decoded, err = cjson.decode(strip_comment_lines(data_or_err))
+	end
+	if type(decoded) ~= 'table' then
+		return nil, nil, ('invalid JSON in %s: %s'):format(path, tostring(err or 'root must be an object'))
+	end
+
+	return decoded, path, nil
+end
+
+local function has_service(names, wanted)
+	for i = 1, #names do
+		if names[i] == wanted then
+			return true
+		end
+	end
+	return false
+end
+
+local function normalise_hal_cfg(raw)
+	if type(raw) ~= 'table' then
+		return nil
+	end
+
+	if type(raw.serial) == 'table' then
+		return copy_plain(raw)
+	end
+
+	local managers = raw.managers
+	local uart = type(managers) == 'table' and managers.uart or nil
+	local serial_ports = type(uart) == 'table' and uart.serial_ports or nil
+	if type(serial_ports) ~= 'table' then
+		return nil
+	end
+
+	local out = {
+		serial = {},
+	}
+
+	for i = 1, #serial_ports do
+		local rec = serial_ports[i]
+		if type(rec) == 'table' then
+			local ref = rec.name
+			local device = rec.device or rec.path
+			if type(ref) == 'string' and ref ~= '' and type(device) == 'string' and device ~= '' then
+				out.serial[ref] = {
+					device = device,
+					baud   = rec.baud,
+					mode   = rec.mode,
+				}
+			end
+		end
+	end
+
+	if next(out.serial) == nil then
+		return nil
+	end
+
+	return out
+end
+
+local function first_serial_ref(hal_cfg)
+	if type(hal_cfg) ~= 'table' or type(hal_cfg.serial) ~= 'table' then
+		return nil
+	end
+
+	local best = nil
+	for ref in pairs(hal_cfg.serial) do
+		if best == nil or tostring(ref) < tostring(best) then
+			best = ref
+		end
+	end
+	return best
+end
+
+local function normalise_fabric_cfg(raw, opts, hal_cfg)
+	if type(raw) == 'table' and type(raw.schema) == 'string' and type(raw.links) == 'table' then
+		return copy_plain(raw)
+	end
+
+	local serial_ref = opts.fabric_serial_ref or first_serial_ref(hal_cfg)
+	if type(serial_ref) ~= 'string' or serial_ref == '' then
+		return nil, 'cannot derive fabric serial_ref from selected config'
+	end
+
+	local link_id = opts.fabric_link_id or 'mcu0'
+	local peer_id = opts.fabric_peer_id or 'mcu-1'
+
+	return {
+		schema = 'devicecode.fabric/1',
+		links = {
+			[link_id] = {
+				peer_id = peer_id,
+				transport = {
+					kind       = 'uart',
+					serial_ref = serial_ref,
+				},
+				export = {
+					publish = {},
+				},
+				import = {
+					publish = {},
+					call    = {},
+				},
+				proxy_calls = {},
+			},
+		},
+	}, nil
+end
+
+function M.seed(conn, opts)
+	opts = opts or {}
+
+	local name = opts.name
+	if type(name) ~= 'string' or name == '' then
+		return nil, nil
+	end
+
+	local selected, path, err = load_selected(name)
+	if not selected then
+		return nil, err
+	end
+
+	local topics = {}
+	local hal_cfg = normalise_hal_cfg(selected.hal)
+	if hal_cfg ~= nil then
+		conn:retain({ 'config', 'hal' }, hal_cfg)
+		topics[#topics + 1] = 'config/hal'
+	end
+
+	if has_service(opts.service_names or {}, 'fabric') then
+		local fabric_cfg, ferr = normalise_fabric_cfg(selected.fabric, opts, hal_cfg)
+		if not fabric_cfg then
+			return nil, ferr
+		end
+		conn:retain({ 'config', 'fabric' }, fabric_cfg)
+		topics[#topics + 1] = 'config/fabric'
+	end
+
+	return {
+		name   = name,
+		path   = path,
+		topics = topics,
+	}, nil
+end
+
+return M

--- a/src/devicecode/main.lua
+++ b/src/devicecode/main.lua
@@ -7,6 +7,7 @@ local op     = require 'fibers.op'
 local sleep  = require 'fibers.sleep'
 local authz  = require 'devicecode.authz'
 local busmod = require 'bus'
+local config_bootstrap = require 'devicecode.config_bootstrap'
 
 local safe = require 'coxpcall'
 
@@ -171,6 +172,7 @@ function M.run(scope, params)
 	params = params or {}
 
 	local env = params.env or (os.getenv('DEVICECODE_ENV') or 'dev')
+	local config_name = params.config_name or os.getenv('DEVICECODE_CONFIG')
 
 	local service_names = parse_csv(params.services_csv or require_env('DEVICECODE_SERVICES'))
 	if #service_names == 0 then
@@ -196,6 +198,28 @@ function M.run(scope, params)
 		env      = env,
 		services = service_names,
 	})
+
+	if config_name then
+		local seeded, serr = config_bootstrap.seed(main_conn, {
+			name             = config_name,
+			service_names    = service_names,
+			fabric_link_id   = params.fabric_link_id or os.getenv('DEVICECODE_FABRIC_LINK_ID'),
+			fabric_peer_id   = params.fabric_peer_id or os.getenv('DEVICECODE_FABRIC_PEER_ID'),
+			fabric_serial_ref = params.fabric_serial_ref or os.getenv('DEVICECODE_FABRIC_SERIAL_REF'),
+		})
+		if not seeded then
+			fail_boot(main_conn, nil, 'config_bootstrap_failed', serr, {
+				config_name = config_name,
+			})
+		end
+
+		main_conn:publish({ 'obs', 'log', 'main', 'info' }, {
+			what        = 'config_bootstrap_loaded',
+			config_name = seeded.name,
+			path        = seeded.path,
+			topics      = seeded.topics,
+		})
+	end
 
 	main_conn:publish({ 'obs', 'log', 'main', 'info' }, {
 		what = 'starting',

--- a/src/main.lua
+++ b/src/main.lua
@@ -8,26 +8,39 @@
 --
 -- Optional env:
 --   DEVICECODE_ENV        "dev" | "prod" (default: dev)
+--   DEVICECODE_CONFIG     selected config name (same effect as argv[1])
 
 local function add_path(prefix)
 	package.path = prefix .. '?.lua;' .. prefix .. '?/init.lua;' .. package.path
 end
 
+local function script_dir()
+	local script = arg and arg[0] or ''
+	local dir = script:match('^(.*[/\\])')
+	if dir then
+		return dir
+	end
+	return './'
+end
+
+local root = script_dir() .. '../'
 local env = os.getenv('DEVICECODE_ENV') or 'dev'
 if env == 'prod' then
-	add_path('./lib/')
+	add_path(root .. 'lib/')
 else
-	add_path('../vendor/lua-fibers/src/')
-	add_path('../vendor/lua-bus/src/')
-	add_path('../vendor/lua-trie/src/')
-	add_path('./')
+	add_path(root .. 'vendor/lua-fibers/src/')
+	add_path(root .. 'vendor/lua-bus/src/')
+	add_path(root .. 'vendor/lua-trie/src/')
+	add_path(script_dir())
 end
 
 local fibers = require 'fibers'
 local mainmod = require 'devicecode.main'
+local config_name = arg and arg[1] or nil
 
 fibers.run(function(scope)
 	return mainmod.run(scope, {
-		env = env,
+		env         = env,
+		config_name = config_name,
 	})
 end)

--- a/src/services/fabric.lua
+++ b/src/services/fabric.lua
@@ -78,13 +78,21 @@ function M.start(conn, opts)
 				})
 			else
 				local ok_spawn, serr = child:spawn(function()
-					return session.run(conn, svc, {
+					local ok_run, run_err = pcall(session.run, conn, svc, {
 						gen      = gen,
 						link_id  = link_id,
 						link     = link_cfg,
 						connect  = opts.connect,
 						node_id  = opts.node_id,
 					})
+					if not ok_run then
+						svc:obs_log('error', {
+							what    = 'link_session_failed',
+							link_id = link_id,
+							err     = tostring(run_err),
+						})
+						error(run_err, 0)
+					end
 				end)
 
 				if not ok_spawn then
@@ -95,6 +103,13 @@ function M.start(conn, opts)
 						err     = tostring(serr),
 					})
 				else
+					svc:obs_log('info', {
+						what    = 'link_session_spawned',
+						link_id = link_id,
+						gen     = gen,
+						peer_id = link_cfg.peer_id,
+						kind    = ((link_cfg.transport or {}).kind) or 'uart',
+					})
 					children[link_id] = {
 						scope = child,
 						cfg   = link_cfg,

--- a/src/services/fabric/config.lua
+++ b/src/services/fabric/config.lua
@@ -54,6 +54,37 @@ local function norm_transport(t, path)
     return nil, path .. '.kind is unsupported: ' .. tostring(kind)
 end
 
+local function norm_keepalive(t, path)
+    if t == nil then
+        return nil, nil
+    end
+    if not is_plain_table(t) then
+        return nil, path .. ' must be a table'
+    end
+
+    local out = {}
+    local keys = {
+        'hello_retry_s',
+        'idle_ping_s',
+        'stale_after_s',
+    }
+    for i = 1, #keys do
+        local key = keys[i]
+        local v = t[key]
+        if v ~= nil then
+            if type(v) ~= 'number' or v <= 0 then
+                return nil, path .. '.' .. key .. ' must be a positive number'
+            end
+            out[key] = v
+        end
+    end
+
+    if next(out) == nil then
+        return nil, nil
+    end
+    return out, nil
+end
+
 local function is_concrete_topic(t)
     for i = 1, #t do
         if t[i] == '+' or t[i] == '#' then
@@ -181,6 +212,10 @@ function M.normalise(payload)
         if not transport then
             return nil, terr
         end
+        local keepalive, kerr = norm_keepalive(rec.keepalive, ('links.%s.keepalive'):format(link_id))
+        if kerr then
+            return nil, kerr
+        end
         if type(rec.peer_id) ~= 'string' or rec.peer_id == '' then
             return nil, ('links.%s.peer_id must be a non-empty string'):format(link_id)
         end
@@ -201,6 +236,9 @@ function M.normalise(payload)
             },
             proxy_calls = {},
         }
+        if keepalive ~= nil then
+            link.keepalive = keepalive
+        end
 
         local exp_pub    = type(export_cfg.publish) == 'table' and export_cfg.publish or {}
         for i = 1, #exp_pub do

--- a/src/services/fabric/session.lua
+++ b/src/services/fabric/session.lua
@@ -52,12 +52,13 @@ local function choose_transport(svc, link_cfg)
 	error('fabric: unsupported transport kind ' .. tostring(k), 0)
 end
 
-local function max2(a, b)
-	if a == nil then return b end
-	if b == nil then return a end
-	return (a > b) and a or b
-end
-
+-- Keepalive timing relationships:
+--   stale_after_s (45) > idle_ping_s (15) > hello_retry_s (10)
+--
+-- idle_ping_s drives TX-idle pings so the remote peer's stale timer
+-- stays alive. stale_after_s is RX-only — if nothing is received for
+-- this long, the peer is declared stale. The margin between them
+-- (45 - 15 = 30s) is the grace window for lost pings.
 local function keepalive_cfg(link_cfg)
 	local ka = (type(link_cfg.keepalive) == 'table') and link_cfg.keepalive or {}
 	return {
@@ -561,10 +562,6 @@ function M.run(conn, svc, opts)
 		publish_session()
 	end
 
-	local function last_activity()
-		return max2(state.last_rx_at, state.last_tx_at)
-	end
-
 	local function next_deadline(tnow)
 		local best = math.huge
 
@@ -573,12 +570,18 @@ function M.run(conn, svc, opts)
 			if hello_due < best then best = hello_due end
 		end
 
-		local act = last_activity()
-		if act ~= nil then
-			local ping_due = act + ka.idle_ping_s
+		-- Ping deadline uses TX time only — we ping when WE haven't sent
+		-- anything, regardless of incoming traffic. This keeps the remote
+		-- peer's stale timer alive. Using max(rx, tx) here would suppress
+		-- pings during one-way receive, causing the peer to go stale.
+		local tx_at = state.last_tx_at
+		if tx_at ~= nil then
+			local ping_due = tx_at + ka.idle_ping_s
 			if ping_due < best then best = ping_due end
 		end
 
+		-- Stale deadline uses RX time only — if WE haven't received
+		-- anything, the peer may be dead.
 		if state.last_rx_at ~= nil then
 			local stale_due = state.last_rx_at + ka.stale_after_s
 			if stale_due < best then best = stale_due end
@@ -680,8 +683,8 @@ function M.run(conn, svc, opts)
 					})
 				end
 			else
-				local act = last_activity()
-				if act ~= nil and (now2 - act) >= ka.idle_ping_s then
+				local tx_at = state.last_tx_at
+				if tx_at ~= nil and (now2 - tx_at) >= ka.idle_ping_s then
 					local ok2, err2 = send_frame(protocol.ping({ sid = state.local_sid }))
 					if ok2 ~= true then
 						svc:obs_log('warn', {

--- a/src/services/hal/backends/hosttest.lua
+++ b/src/services/hal/backends/hosttest.lua
@@ -19,8 +19,19 @@ local function read_file(path)
 	return s, nil
 end
 
+local function module_dir()
+	local source = debug.getinfo(1, 'S').source or ''
+	if source:sub(1, 1) == '@' then
+		local dir = source:sub(2):match('^(.*[/\\])')
+		if dir then
+			return dir
+		end
+	end
+	return './'
+end
+
 local function default_seed_path()
-	return './services/hal/backends/hosttest/services.json'
+	return module_dir() .. 'hosttest/services.json'
 end
 
 local function shallow_copy(t)

--- a/src/services/hal/backends/openwrt/serial.lua
+++ b/src/services/hal/backends/openwrt/serial.lua
@@ -199,23 +199,27 @@ function M.open_serial_stream(self, req, _msg)
 		return { ok = false, err = tostring(aerr) }
 	end
 
-	-- Best-effort device configuration.
+	-- Configure the serial device. All stty variants failing is fatal —
+	-- an unconfigured TTY will not match the expected baud/mode and the
+	-- link will produce decode errors or timeouts.
 	do
 		local ok_cfg, cfg_errs, cfg_cmd = try_serial_config(self, args)
 		if not ok_cfg then
+			local parts = {}
+			for i = 1, #(cfg_errs or {}) do
+				local rec_err = cfg_errs[i]
+				parts[#parts + 1] = tostring(rec_err.cmd) .. ': ' .. tostring(rec_err.err)
+			end
+			local msg = table.concat(parts, ' | ')
 			if self._host and type(self._host.log) == 'function' then
-				local parts = {}
-				for i = 1, #(cfg_errs or {}) do
-					local rec_err = cfg_errs[i]
-					parts[#parts + 1] = tostring(rec_err.cmd) .. ': ' .. tostring(rec_err.err)
-				end
 				self._host.log('warn', {
 					what   = 'serial_stty_failed',
 					ref    = ref,
 					device = rec.device,
-					err    = table.concat(parts, ' | '),
+					err    = msg,
 				})
 			end
+			return { ok = false, err = 'serial config failed: ' .. msg }
 		elseif self._host and type(self._host.log) == 'function' and cfg_cmd ~= 'stty' then
 			self._host.log('info', {
 				what   = 'serial_stty_fallback_used',

--- a/src/services/hal/backends/openwrt/serial.lua
+++ b/src/services/hal/backends/openwrt/serial.lua
@@ -15,7 +15,37 @@ local op     = require 'fibers.op'
 local common = require 'services.hal.backends.openwrt.common'
 local hcfg   = require 'services.hal.config'
 
+local unpack_ = table.unpack or unpack
+
 local M = {}
+
+local function try_serial_config(self, args)
+	local commands = {
+		{ 'stty' },
+		{ '/bin/busybox', 'stty' },
+		{ '/usr/bin/stty' },
+		{ '/bin/stty' },
+	}
+
+	local errs = {}
+	for i = 1, #commands do
+		local cmd = commands[i]
+		local argv = {}
+		for j = 1, #cmd do argv[#argv + 1] = cmd[j] end
+		for j = 1, #args do argv[#argv + 1] = args[j] end
+
+		local ok_cfg, cfg_err = common.cmd_ok(unpack_(argv))
+		if ok_cfg then
+			return true, nil, argv[1]
+		end
+		errs[#errs + 1] = {
+			cmd = table.concat(cmd, ' '),
+			err = tostring(cfg_err),
+		}
+	end
+
+	return nil, errs, nil
+end
 
 local function parse_mode(mode)
 	mode = mode or '8N1'
@@ -171,11 +201,28 @@ function M.open_serial_stream(self, req, _msg)
 
 	-- Best-effort device configuration.
 	do
-		local cmd = { 'stty' }
-		for i = 1, #args do cmd[#cmd + 1] = args[i] end
-		local ok_cfg, cfg_err = common.cmd_ok(table.unpack(cmd))
+		local ok_cfg, cfg_errs, cfg_cmd = try_serial_config(self, args)
 		if not ok_cfg then
-			return { ok = false, err = 'stty failed: ' .. tostring(cfg_err) }
+			if self._host and type(self._host.log) == 'function' then
+				local parts = {}
+				for i = 1, #(cfg_errs or {}) do
+					local rec_err = cfg_errs[i]
+					parts[#parts + 1] = tostring(rec_err.cmd) .. ': ' .. tostring(rec_err.err)
+				end
+				self._host.log('warn', {
+					what   = 'serial_stty_failed',
+					ref    = ref,
+					device = rec.device,
+					err    = table.concat(parts, ' | '),
+				})
+			end
+		elseif self._host and type(self._host.log) == 'function' and cfg_cmd ~= 'stty' then
+			self._host.log('info', {
+				what   = 'serial_stty_fallback_used',
+				ref    = ref,
+				device = rec.device,
+				cmd    = cfg_cmd,
+			})
 		end
 	end
 

--- a/src/services/monitor.lua
+++ b/src/services/monitor.lua
@@ -1,13 +1,14 @@
 -- services/monitor.lua
 --
 -- Monitor service:
---   * subscribes to obs/# and prints messages
+--   * subscribes to obs/# and peer/# and prints messages
 --   * bounded, drop-oldest
 
 local fibers  = require 'fibers'
 local runtime = require 'fibers.runtime'
 local file    = require 'fibers.io.file'
 local sleep   = require 'fibers.sleep'
+local cjson   = require 'cjson'
 
 local perform      = fibers.perform
 local named_choice = fibers.named_choice
@@ -15,6 +16,254 @@ local named_choice = fibers.named_choice
 local base = require 'devicecode.service_base'
 
 local M = {}
+local topic_to_string
+
+local AUTO_PROBE_START_DELAY_S = 1.0
+local AUTO_PROBE_RETRY_DELAY_S = 0.75
+local AUTO_PROBE_MAX_ATTEMPTS = 3
+
+local function t(...) return { ... } end
+
+local function reply_best_effort(conn, msg, payload)
+	if msg.reply_to == nil then
+		return false, 'no_reply_to'
+	end
+	return conn:publish_one(msg.reply_to, payload, { id = msg.id })
+end
+
+local function empty_array()
+	return setmetatable({}, cjson.array_mt)
+end
+
+local function normalise_probe_req(req)
+	if req == nil then
+		return {}, nil
+	end
+	if type(req) ~= 'table' then
+		return nil, 'request payload must be a table or nil'
+	end
+	return req, nil
+end
+
+local function publish_config_mcu(conn, svc, req)
+	local payload = req.payload
+	if payload == nil then
+		payload = {
+			source = 'monitor',
+			ts = svc:now(),
+		}
+	elseif type(payload) ~= 'table' then
+		return {
+			ok = false,
+			err = 'payload must be a table when provided',
+		}
+	end
+
+	local topic = t('config', 'mcu')
+	conn:retain(topic, payload)
+	svc:obs_event('fabric_probe_publish', {
+		topic = topic_to_string(topic),
+	})
+
+	return {
+		ok = true,
+		topic = topic,
+		retain = true,
+		payload = payload,
+	}
+end
+
+local function call_peer_hal_dump(conn, svc, req)
+	local peer_id = req.peer_id
+	if peer_id == nil or peer_id == '' then
+		peer_id = 'mcu-1'
+	elseif type(peer_id) ~= 'string' then
+		return {
+			ok = false,
+			err = 'peer_id must be a string when provided',
+		}
+	end
+
+	local payload = req.payload
+	if payload == nil then
+		payload = {}
+	elseif type(payload) ~= 'table' then
+		return {
+			ok = false,
+			err = 'payload must be a table when provided',
+		}
+	end
+
+	local timeout_s = req.timeout_s
+	if timeout_s == nil then
+		timeout_s = 5.0
+	elseif type(timeout_s) ~= 'number' or timeout_s <= 0 then
+		return {
+			ok = false,
+			err = 'timeout_s must be a positive number when provided',
+		}
+	end
+
+	local topic = t('rpc', 'peer', peer_id, 'hal', 'dump')
+	local reply, err = conn:call(topic, payload, { timeout = timeout_s })
+	svc:obs_event('fabric_probe_call', {
+		topic = topic_to_string(topic),
+		peer_id = peer_id,
+		ok = (reply ~= nil),
+	})
+
+	if reply == nil then
+		return {
+			ok = false,
+			err = tostring(err or 'rpc_failed'),
+			topic = topic,
+			peer_id = peer_id,
+		}
+	end
+
+	return {
+		ok = true,
+		topic = topic,
+		peer_id = peer_id,
+		reply = reply,
+	}
+end
+
+local function spawn_rpc_endpoint(conn, svc, method, handler)
+	local topic = t('rpc', svc.name, method)
+	local ep = conn:bind(topic, { queue_len = 8 })
+
+	fibers.spawn(function()
+		while true do
+			local msg, err = perform(ep:recv_op())
+			if not msg then
+				svc:obs_log('warn', {
+					what = 'rpc_endpoint_closed',
+					method = method,
+					err = tostring(err),
+				})
+				return
+			end
+
+			local req, rerr = normalise_probe_req(msg.payload)
+			local out
+			if req == nil then
+				out = { ok = false, err = rerr }
+			else
+				out = handler(conn, svc, req)
+			end
+
+			local ok, reason = reply_best_effort(conn, msg, out)
+			if not ok then
+				svc:obs_log('warn', {
+					what = 'rpc_reply_failed',
+					method = method,
+					reason = tostring(reason),
+				})
+			end
+		end
+	end)
+end
+
+local function auto_probe_enabled()
+	local v = os.getenv('DEVICECODE_MONITOR_FABRIC_AUTO_PROBE')
+	if v == nil or v == '' then
+		return (os.getenv('DEVICECODE_ENV') or 'dev') ~= 'prod'
+	end
+	v = tostring(v):lower()
+	return not (v == '0' or v == 'false' or v == 'no' or v == 'off')
+end
+
+local function spawn_auto_fabric_probe(conn, svc)
+	if not auto_probe_enabled() then
+		return
+	end
+
+	local sub_link = conn:subscribe({ 'state', 'fabric', 'link', '#' }, {
+		queue_len = 32,
+		full = 'drop_oldest',
+	})
+
+	local seen = {}
+
+	local function dump_reply_applied(dump)
+		if type(dump) ~= 'table' or dump.ok ~= true then
+			return false
+		end
+		local reply = dump.reply
+		if type(reply) ~= 'table' then
+			return false
+		end
+		if reply.applied == true then
+			return true
+		end
+		return type(reply.config_count) == 'number' and reply.config_count > 0
+	end
+
+	fibers.spawn(function()
+		while true do
+			local msg, err = perform(sub_link:recv_op())
+			if not msg then
+				svc:obs_log('warn', {
+					what = 'fabric_auto_probe_stopped',
+					err = tostring(err),
+				})
+				return
+			end
+
+				local payload = msg.payload
+				if type(payload) == 'table' and payload.ready == true then
+					local link_id = payload.link_id or msg.topic[4] or 'unknown'
+					local peer_id = payload.peer_id or 'mcu-1'
+					local peer_sid = payload.peer_sid or ''
+					local key = tostring(link_id) .. '|' .. tostring(peer_id) .. '|' .. tostring(peer_sid)
+
+					if not seen[key] then
+						seen[key] = true
+
+						fibers.spawn(function()
+							svc:obs_event('fabric_auto_probe_started', {
+								link_id = link_id,
+								peer_id = peer_id,
+								peer_sid = peer_sid,
+							})
+
+							fibers.perform(sleep.sleep_op(AUTO_PROBE_START_DELAY_S))
+
+							local pub = publish_config_mcu(conn, svc, {
+								payload = {
+									devices = empty_array(),
+									pollers = empty_array(),
+								},
+							})
+							svc:obs_event('fabric_auto_probe_publish', pub)
+
+							local dump
+							local attempts = 0
+							for attempt = 1, AUTO_PROBE_MAX_ATTEMPTS do
+								attempts = attempt
+								dump = call_peer_hal_dump(conn, svc, {
+									peer_id = peer_id,
+									timeout_s = 1.0,
+									payload = { ask = 'status', source = 'monitor_auto_probe' },
+								})
+								if dump_reply_applied(dump) then
+									break
+								end
+								if attempt < AUTO_PROBE_MAX_ATTEMPTS then
+									fibers.perform(sleep.sleep_op(AUTO_PROBE_RETRY_DELAY_S))
+								end
+							end
+							if type(dump) == 'table' then
+								dump.attempts = attempts
+							end
+							svc:obs_event('fabric_auto_probe_dump', dump)
+						end)
+					end
+				end
+			end
+		end)
+end
 
 -- pretty printer kept as-is (it is purely a dev/operator tool)
 
@@ -90,7 +339,7 @@ local function pretty(v, opts, depth, seen)
 	return table.concat(out, ' ')
 end
 
-local function topic_to_string(topic)
+function topic_to_string(topic)
 	local parts = {}
 	for i = 1, #topic do parts[#parts + 1] = tostring(topic[i]) end
 	return table.concat(parts, '/')
@@ -166,20 +415,42 @@ function M.start(conn, ctx)
 		end
 	end
 
-	svc:status('running', { subscribed = 'obs/#' })
+	local rpc_methods = {
+		'fabric_publish_config_mcu',
+		'fabric_dump_peer_hal',
+	}
 
-	local sub = conn:subscribe({ 'obs', '#' }, { queue_len = 500, full = 'drop_oldest' })
+	svc:status('running', {
+		subscribed = { 'obs/#', 'peer/#' },
+		rpc_root = 'rpc/' .. name,
+		rpc_methods = rpc_methods,
+	})
+
+	local sub_obs = conn:subscribe({ 'obs', '#' }, { queue_len = 500, full = 'drop_oldest' })
+	local sub_peer = conn:subscribe({ 'peer', '#' }, { queue_len = 500, full = 'drop_oldest' })
+
+	spawn_rpc_endpoint(conn, svc, 'fabric_publish_config_mcu', publish_config_mcu)
+	spawn_rpc_endpoint(conn, svc, 'fabric_dump_peer_hal', call_peer_hal_dump)
+	spawn_auto_fabric_probe(conn, svc)
 
 	write_line(string.format('%s  STA  %-10s %-12s  %s',
-		fmt_time(), name, 'start', 'subscribed to obs/#'))
+		fmt_time(), name, 'start',
+		'subscribed to obs/# and peer/#; rpc on rpc/' .. name .. '/{fabric_publish_config_mcu,fabric_dump_peer_hal}'))
 
-	for msg in sub:iter() do
+	while true do
+		local which, msg, err = perform(named_choice {
+			obs  = sub_obs:recv_op(),
+			peer = sub_peer:recv_op(),
+		})
+
+		if msg == nil then
+			write_line(string.format('%s  STA  %-10s %-12s  %s',
+				fmt_time(), name, 'stop', ('subscription ended: %s (%s)'):format(tostring(err), tostring(which))))
+			return
+		end
+
 		write_line(format_line(msg))
 	end
-
-	local why = tostring(sub:why() or 'closed')
-	write_line(string.format('%s  STA  %-10s %-12s  %s',
-		fmt_time(), name, 'stop', 'subscription ended: ' .. why))
 end
 
 return M

--- a/src/services/ui/http_transport.lua
+++ b/src/services/ui/http_transport.lua
@@ -413,7 +413,11 @@ local function handle_api(svc, api, stream, req_method, req_path, req_headers)
 		end
 
 		local sid = session_id_from_headers(req_headers)
-		local body = read_json_body(stream)
+		local body, jerr = read_json_body(stream)
+		if not body then
+			write_json(stream, 400, { ok = false, err = jerr })
+			return true
+		end
 		if type(body) == 'table' and body.session_id then
 			sid = body.session_id
 		end
@@ -473,10 +477,12 @@ local function handle_api(svc, api, stream, req_method, req_path, req_headers)
 
 		local sid = session_id_from_headers(req_headers) or body.session_id
 		local out, cerr = api.config_set(sid, parts[3], body.data)
-		write_json(stream, out and 200 or 400, {
-			ok   = (out ~= nil),
+		local ok = (out ~= nil) and (type(out) ~= 'table' or out.ok ~= false)
+		write_json(stream, ok and 200 or 400, {
+			ok   = ok,
 			data = out,
-			err  = (out == nil) and tostring(cerr) or nil,
+			err  = (out == nil) and tostring(cerr)
+				or ((type(out) == 'table' and out.ok == false) and tostring(out.err) or nil),
 		})
 		return true
 	end

--- a/tests/run.lua
+++ b/tests/run.lua
@@ -1,21 +1,32 @@
 -- tests/run.lua
 
--- look one level up
-package.path = "../src/?.lua;" .. package.path
-package.path = '../?.lua;../?/init.lua;./?.lua;./?/init.lua;' .. package.path
-
 local function add_path(prefix)
 	package.path = prefix .. '?.lua;' .. prefix .. '?/init.lua;' .. package.path
 end
 
+local function script_dir()
+	local script = arg and arg[0] or ''
+	local dir = script:match('^(.*[/\\])')
+	if dir then
+		return dir
+	end
+	return './'
+end
+
+local root = script_dir() .. '../'
+
+-- look one level up
+package.path = root .. 'src/?.lua;' .. package.path
+package.path = root .. '?.lua;' .. root .. '?/init.lua;' .. script_dir() .. '?.lua;' .. script_dir() .. '?/init.lua;' .. package.path
+
 local env = os.getenv('DEVICECODE_ENV') or 'dev'
 if env == 'prod' then
-	add_path('./lib/')
+	add_path(root .. 'lib/')
 else
-	add_path('../vendor/lua-fibers/src/')
-	add_path('../vendor/lua-bus/src/')
-	add_path('../vendor/lua-trie/src/')
-	add_path('./')
+	add_path(root .. 'vendor/lua-fibers/src/')
+	add_path(root .. 'vendor/lua-bus/src/')
+	add_path(root .. 'vendor/lua-trie/src/')
+	add_path(script_dir())
 end
 
 local safe = require 'coxpcall'
@@ -28,12 +39,12 @@ local files = {
 	'unit.main.service_spec',
 	'unit.config.service_spec',
 	'unit.net.service_spec',
+	'unit.monitor.service_spec',
 	'unit.ui.service_spec',
 	'unit.ui.http_transport_spec',
 	'unit.ui.cqueues_bridge_spec',
 	'unit.fabric.config_spec',
 	'unit.fabric.topicmap_spec',
-	'unit.fabric.protocol_spec',
 	'unit.fabric.service_spec',
 	'integration.devhost.stack_spec',
 	'integration.devhost.main_stack_spec',

--- a/tests/unit/fabric/config_spec.lua
+++ b/tests/unit/fabric/config_spec.lua
@@ -97,4 +97,30 @@ function T.normalise_rejects_wild_proxy_call_topic()
 	assert(err:find('concrete', 1, true) ~= nil)
 end
 
+function T.normalise_preserves_keepalive()
+	local out, err = cfg.normalise({
+		schema = 'devicecode.fabric/1',
+		links = {
+			mcu0 = {
+				peer_id = 'mcu-1',
+				transport = {
+					kind       = 'uart',
+					serial_ref = 'uart-0',
+				},
+				keepalive = {
+					hello_retry_s = 1.0,
+					idle_ping_s = 12.5,
+					stale_after_s = 30.0,
+				},
+			},
+		},
+	})
+
+	assert(out ~= nil, tostring(err))
+	assert(type(out.links.mcu0.keepalive) == 'table')
+	assert(out.links.mcu0.keepalive.hello_retry_s == 1.0)
+	assert(out.links.mcu0.keepalive.idle_ping_s == 12.5)
+	assert(out.links.mcu0.keepalive.stale_after_s == 30.0)
+end
+
 return T

--- a/tests/unit/fabric/service_spec.lua
+++ b/tests/unit/fabric/service_spec.lua
@@ -627,8 +627,15 @@ function T.fabric_accepts_symmetric_peer_hello_and_imports_remote_publish()
 		cfg_conn:retain({ 'config', 'fabric' }, base_fabric_cfg())
 
 		local which, msg, err = recv_with_timeout(sub:recv_op(), 0.75)
-		assert(which == 'value', explain('timed out waiting for imported remote publish after symmetric hello', diag, fake_hal, wire))
-		assert(msg ~= nil, explain('subscription ended waiting for imported remote publish after symmetric hello: ' .. tostring(err), diag, fake_hal, wire))
+		assert(which == 'value', explain(
+			'timed out waiting for imported remote publish after symmetric hello',
+			diag, fake_hal, wire
+		))
+		assert(msg ~= nil, explain(
+			'subscription ended waiting for imported remote publish after symmetric hello: '
+				.. tostring(err),
+			diag, fake_hal, wire
+		))
 
 		assert(msg.topic[1] == 'peer')
 		assert(msg.topic[2] == 'mcu-1')
@@ -637,6 +644,238 @@ function T.fabric_accepts_symmetric_peer_hello_and_imports_remote_publish()
 		assert(type(msg.payload) == 'table')
 		assert(msg.payload.ok == true)
 		assert(msg.payload.source == 'mcu')
+	end, { timeout = 1.5 })
+end
+
+function T.fabric_drops_invalid_frame_before_handshake_and_accepts_following_hello_ack()
+	runfibers.run(function(scope)
+		local bus = busmod.new()
+		local cfg_conn = bus:connect()
+		local probe_conn = bus:connect()
+
+		local diag = stack_diag.start(scope, bus, {
+			{ label = 'svc',   topic = { 'svc', '#' } },
+			{ label = 'cfg',   topic = { 'config', '#' } },
+			{ label = 'state', topic = { 'state', '#' } },
+			{ label = 'obs',   topic = { 'obs', '#' } },
+		}, { max_records = 300 })
+
+		local sub = probe_conn:subscribe({ 'peer', 'mcu-1', 'state', '#' }, {
+			queue_len = 8,
+			full      = 'drop_oldest',
+		})
+
+		local hal_side, peer_side = fake_stream_mod.new_pair()
+		local wire = new_wire_trace()
+
+		local fake_hal = fake_hal_mod.new({
+			scripted = {
+				open_serial_stream = function(req, _msg)
+					return {
+						ok     = true,
+						stream = hal_side,
+						info   = {
+							ref  = req.ref,
+							baud = 115200,
+							mode = '8N1',
+						},
+					}
+				end,
+			},
+		})
+		fake_hal:start(bus:connect(), { name = 'hal' })
+
+		local ok_peer, perr = scope:spawn(function()
+			local which1, line1, err1 = recv_with_timeout(peer_side:read_line_op(), 0.5)
+			assert(which1 == 'value', explain('timed out waiting for hello', diag, fake_hal, wire))
+			assert(line1 ~= nil, explain('peer read error waiting for hello: ' .. tostring(err1), diag, fake_hal, wire))
+
+			local hello, derr1 = protocol.decode_line(line1)
+			wire_add(wire, 'rx', line1, hello)
+			assert(hello ~= nil, explain('failed to decode hello: ' .. tostring(derr1), diag, fake_hal, wire))
+			assert_hello_frame(hello, diag, fake_hal, wire)
+
+			wire_add(wire, 'tx', ':true}', { raw = ':true}' })
+			assert(fibers.perform(peer_side:write_op(':true}', '\n')))
+
+			local ack_msg = protocol.hello_ack('mcu-1', {
+				sid = 'peer-sid-1',
+			})
+			local ack_line = assert(protocol.encode_line(ack_msg))
+			wire_add(wire, 'tx', ack_line, ack_msg)
+			assert(fibers.perform(peer_side:write_op(ack_line, '\n')))
+
+			local pub_msg = protocol.pub({ 'state', 'health' }, { ok = true, source = 'mcu' }, true)
+			local pub_line = assert(protocol.encode_line(pub_msg))
+			wire_add(wire, 'tx', pub_line, pub_msg)
+			assert(fibers.perform(peer_side:write_op(pub_line, '\n')))
+		end)
+		assert(ok_peer, tostring(perr))
+
+		spawn_fabric(scope, bus)
+		cfg_conn:retain({ 'config', 'fabric' }, base_fabric_cfg())
+
+		local which, msg, err = recv_with_timeout(sub:recv_op(), 0.75)
+		assert(which == 'value', explain(
+			'timed out waiting for imported remote publish after invalid frame',
+			diag, fake_hal, wire
+		))
+		assert(msg ~= nil, explain(
+			'subscription ended waiting for imported remote publish after invalid frame: '
+				.. tostring(err),
+			diag, fake_hal, wire
+		))
+
+		assert(msg.topic[1] == 'peer')
+		assert(msg.topic[2] == 'mcu-1')
+		assert(msg.topic[3] == 'state')
+		assert(msg.topic[4] == 'health')
+		assert(type(msg.payload) == 'table')
+		assert(msg.payload.ok == true)
+		assert(msg.payload.source == 'mcu')
+
+		local saw_invalid_drop = wait_until_trace_has(diag, function(rec)
+			return rec.label == 'obs'
+				and type(rec.payload) == 'table'
+				and rec.payload.what == 'invalid_frame_dropped'
+				and rec.payload.link_id == 'mcu0'
+				and tostring(rec.payload.raw) == ':true}'
+		end, 0.5, 0.01)
+		assert(saw_invalid_drop == true, explain(
+			'expected invalid_frame_dropped log before handshake recovery',
+			diag, fake_hal, wire
+		))
+
+		local saw_ack = wait_until_trace_has(diag, function(rec)
+			return rec.label == 'obs'
+				and type(rec.payload) == 'table'
+				and rec.payload.what == 'hello_ack_received'
+				and rec.payload.link_id == 'mcu0'
+		end, 0.5, 0.01)
+		assert(saw_ack == true, explain(
+			'expected hello_ack_received after invalid frame',
+			diag, fake_hal, wire
+		))
+	end, { timeout = 1.5 })
+end
+
+function T.fabric_drops_invalid_frame_after_handshake_and_processes_following_ping()
+	runfibers.run(function(scope)
+		local bus = busmod.new()
+		local cfg_conn = bus:connect()
+
+		local diag = stack_diag.start(scope, bus, {
+			{ label = 'svc',   topic = { 'svc', '#' } },
+			{ label = 'cfg',   topic = { 'config', '#' } },
+			{ label = 'state', topic = { 'state', '#' } },
+			{ label = 'obs',   topic = { 'obs', '#' } },
+		}, { max_records = 300 })
+
+		local hal_side, peer_side = fake_stream_mod.new_pair()
+		local wire = new_wire_trace()
+
+		local fake_hal = fake_hal_mod.new({
+			scripted = {
+				open_serial_stream = function(req, _msg)
+					return {
+						ok     = true,
+						stream = hal_side,
+						info   = {
+							ref  = req.ref,
+							baud = 115200,
+							mode = '8N1',
+						},
+					}
+				end,
+			},
+		})
+		fake_hal:start(bus:connect(), { name = 'hal' })
+
+		local ok_peer, perr = scope:spawn(function()
+			local which1, line1, err1 = recv_with_timeout(peer_side:read_line_op(), 0.5)
+			assert(which1 == 'value', explain('timed out waiting for hello', diag, fake_hal, wire))
+			assert(line1 ~= nil, explain('peer read error waiting for hello: ' .. tostring(err1), diag, fake_hal, wire))
+
+			local hello, derr1 = protocol.decode_line(line1)
+			wire_add(wire, 'rx', line1, hello)
+			assert(hello ~= nil, explain('failed to decode hello: ' .. tostring(derr1), diag, fake_hal, wire))
+			assert_hello_frame(hello, diag, fake_hal, wire)
+
+			local ack_msg = protocol.hello_ack('mcu-1', {
+				sid = 'peer-sid-1',
+			})
+			local ack_line = assert(protocol.encode_line(ack_msg))
+			wire_add(wire, 'tx', ack_line, ack_msg)
+			assert(fibers.perform(peer_side:write_op(ack_line, '\n')))
+
+			wire_add(wire, 'tx', ':true}', { raw = ':true}' })
+			assert(fibers.perform(peer_side:write_op(':true}', '\n')))
+
+			local ping_msg = protocol.ping({ sid = 'peer-sid-1' })
+			local ping_line = assert(protocol.encode_line(ping_msg))
+			wire_add(wire, 'tx', ping_line, ping_msg)
+			assert(fibers.perform(peer_side:write_op(ping_line, '\n')))
+
+			local which2, line2, err2 = recv_with_timeout(peer_side:read_line_op(), 0.75)
+			assert(which2 == 'value', explain(
+				'timed out waiting for pong after invalid frame',
+				diag, fake_hal, wire
+			))
+			assert(line2 ~= nil, explain(
+				'peer read error waiting for pong after invalid frame: ' .. tostring(err2),
+				diag, fake_hal, wire
+			))
+
+			local pong, derr2 = protocol.decode_line(line2)
+			wire_add(wire, 'rx', line2, pong)
+			assert(pong ~= nil, explain(
+				'failed to decode pong after invalid frame: ' .. tostring(derr2),
+				diag, fake_hal, wire
+			))
+			assert(pong.t == 'pong', explain('expected pong after invalid frame', diag, fake_hal, wire))
+		end)
+		assert(ok_peer, tostring(perr))
+
+		spawn_fabric(scope, bus)
+		cfg_conn:retain({ 'config', 'fabric' }, base_fabric_cfg())
+
+		local saw_invalid_drop = wait_until_trace_has(diag, function(rec)
+			return rec.label == 'obs'
+				and type(rec.payload) == 'table'
+				and rec.payload.what == 'invalid_frame_dropped'
+				and rec.payload.link_id == 'mcu0'
+				and tostring(rec.payload.raw) == ':true}'
+		end, 0.5, 0.01)
+		assert(saw_invalid_drop == true, explain(
+			'expected invalid_frame_dropped log after handshake',
+			diag, fake_hal, wire
+		))
+
+		local saw_pong = wait_until_trace_has(diag, function(rec)
+			return rec.label == 'obs'
+				and type(rec.payload) == 'table'
+				and rec.payload.what == 'pong_sent'
+				and rec.payload.link_id == 'mcu0'
+		end, 0.5, 0.01)
+		assert(saw_pong == true, explain(
+			'expected pong_sent after invalid frame',
+			diag, fake_hal, wire
+		))
+
+		local went_down = wait_until_trace_has(diag, function(rec)
+			return rec.label == 'state'
+				and type(rec.payload) == 'table'
+				and rec.topic
+				and rec.topic[1] == 'state'
+				and rec.topic[2] == 'fabric'
+				and rec.topic[3] == 'link'
+				and rec.topic[4] == 'mcu0'
+				and rec.payload.status == 'down'
+		end, 0.2, 0.01)
+		assert(went_down ~= true, explain(
+			'link should not transition to down after malformed frame',
+			diag, fake_hal, wire
+		))
 	end, { timeout = 1.5 })
 end
 

--- a/tests/unit/monitor/service_spec.lua
+++ b/tests/unit/monitor/service_spec.lua
@@ -1,0 +1,178 @@
+local busmod          = require 'bus'
+local fibers          = require 'fibers'
+local sleep           = require 'fibers.sleep'
+local cjson           = require 'cjson'
+
+local runfibers       = require 'tests.support.run_fibers'
+local monitor_service = require 'services.monitor'
+
+local T = {}
+
+local function recv_with_timeout(ev, timeout_s)
+	local which, a, b = fibers.perform(fibers.named_choice({
+		value = ev,
+		timer = sleep.sleep_op(timeout_s):wrap(function() return true end),
+	}))
+	return which, a, b
+end
+
+local function spawn_monitor(scope, bus)
+	local ok, err = scope:spawn(function()
+		monitor_service.start(bus:connect(), {
+			name = 'monitor',
+			env = 'dev',
+		})
+	end)
+	assert(ok, tostring(err))
+end
+
+function T.monitor_can_publish_config_mcu_probe()
+	runfibers.run(function(scope)
+		local bus = busmod.new()
+		local caller = bus:connect()
+		local sub = caller:subscribe({ 'config', 'mcu' }, {
+			queue_len = 4,
+			full = 'drop_oldest',
+		})
+
+		spawn_monitor(scope, bus)
+		fibers.perform(sleep.sleep_op(0.01))
+
+		local reply, err = caller:call(
+			{ 'rpc', 'monitor', 'fabric_publish_config_mcu' },
+			{ payload = { mode = 'probe', answer = 42 } },
+			{ timeout = 0.5 }
+		)
+
+		assert(reply ~= nil, tostring(err))
+		assert(reply.ok == true)
+		assert(reply.topic[1] == 'config')
+		assert(reply.topic[2] == 'mcu')
+
+		local which, msg, rerr = recv_with_timeout(sub:recv_op(), 0.5)
+		assert(which == 'value', tostring(rerr))
+		assert(msg ~= nil, tostring(rerr))
+		assert(msg.topic[1] == 'config')
+		assert(msg.topic[2] == 'mcu')
+		assert(type(msg.payload) == 'table')
+		assert(msg.payload.mode == 'probe')
+		assert(msg.payload.answer == 42)
+	end, { timeout = 1.5 })
+end
+
+function T.monitor_can_call_peer_hal_dump_probe()
+	runfibers.run(function(scope)
+		local bus = busmod.new()
+		local caller = bus:connect()
+		local peer = bus:connect()
+		local ep = peer:bind({ 'rpc', 'peer', 'mcu-1', 'hal', 'dump' }, {
+			queue_len = 4,
+		})
+
+		local ok_peer, perr = scope:spawn(function()
+			local which, msg, err = recv_with_timeout(ep:recv_op(), 0.5)
+			assert(which == 'value', tostring(err))
+			assert(msg ~= nil, tostring(err))
+			assert(type(msg.payload) == 'table')
+			assert(msg.payload.ask == 'status')
+			local ok, reason = peer:publish_one(msg.reply_to, {
+				ok = true,
+				source = 'peer-hal-dump',
+			}, {
+				id = msg.id,
+			})
+			assert(ok == true, tostring(reason))
+		end)
+		assert(ok_peer, tostring(perr))
+
+		spawn_monitor(scope, bus)
+		fibers.perform(sleep.sleep_op(0.01))
+
+		local reply, err = caller:call(
+			{ 'rpc', 'monitor', 'fabric_dump_peer_hal' },
+			{ payload = { ask = 'status' }, timeout_s = 0.5 },
+			{ timeout = 0.75 }
+		)
+
+		assert(reply ~= nil, tostring(err))
+		assert(reply.ok == true)
+		assert(reply.peer_id == 'mcu-1')
+		assert(type(reply.reply) == 'table')
+		assert(reply.reply.ok == true)
+		assert(reply.reply.source == 'peer-hal-dump')
+	end, { timeout = 1.5 })
+end
+
+function T.monitor_auto_probes_when_fabric_link_becomes_ready()
+	runfibers.run(function(scope)
+		local bus = busmod.new()
+		local feeder = bus:connect()
+		local watcher = bus:connect()
+		local peer = bus:connect()
+
+		local sub_cfg = watcher:subscribe({ 'config', 'mcu' }, {
+			queue_len = 4,
+			full = 'drop_oldest',
+		})
+		local sub_dump = watcher:subscribe({ 'obs', 'event', 'monitor', 'fabric_auto_probe_dump' }, {
+			queue_len = 4,
+			full = 'drop_oldest',
+		})
+		local ep = peer:bind({ 'rpc', 'peer', 'mcu-1', 'hal', 'dump' }, {
+			queue_len = 4,
+		})
+
+		local ok_peer, perr = scope:spawn(function()
+			for attempt = 1, 2 do
+				local which, msg, err = recv_with_timeout(ep:recv_op(), 2.0)
+				assert(which == 'value', tostring(err))
+				assert(msg ~= nil, tostring(err))
+				assert(type(msg.payload) == 'table')
+				assert(msg.payload.source == 'monitor_auto_probe')
+				local ok, reason = peer:publish_one(msg.reply_to, {
+					ok = true,
+					applied = (attempt >= 2),
+					config_count = (attempt >= 2) and 1 or 0,
+					source = 'auto-probe-reply',
+				}, {
+					id = msg.id,
+				})
+				assert(ok == true, tostring(reason))
+			end
+		end)
+		assert(ok_peer, tostring(perr))
+
+		spawn_monitor(scope, bus)
+		fibers.perform(sleep.sleep_op(0.01))
+
+		feeder:retain({ 'state', 'fabric', 'link', 'mcu0' }, {
+			link_id = 'mcu0',
+			peer_id = 'mcu-1',
+			peer_sid = 'peer-sid-1',
+			ready = true,
+		})
+
+		local which_cfg, msg_cfg, err_cfg = recv_with_timeout(sub_cfg:recv_op(), 2.0)
+		assert(which_cfg == 'value', tostring(err_cfg))
+		assert(msg_cfg ~= nil, tostring(err_cfg))
+		assert(type(msg_cfg.payload) == 'table')
+		assert(type(msg_cfg.payload.devices) == 'table')
+		assert(#msg_cfg.payload.devices == 0)
+		assert(type(msg_cfg.payload.pollers) == 'table')
+		assert(#msg_cfg.payload.pollers == 0)
+		local encoded = cjson.encode(msg_cfg.payload)
+		assert(encoded == '{"devices":[],"pollers":[]}' or encoded == '{"pollers":[],"devices":[]}')
+
+		local which_dump, msg_dump, err_dump = recv_with_timeout(sub_dump:recv_op(), 3.5)
+		assert(which_dump == 'value', tostring(err_dump))
+		assert(msg_dump ~= nil, tostring(err_dump))
+		assert(type(msg_dump.payload) == 'table')
+		assert(msg_dump.payload.ok == true)
+		assert(msg_dump.payload.attempts == 2)
+		assert(type(msg_dump.payload.reply) == 'table')
+		assert(msg_dump.payload.reply.applied == true)
+		assert(msg_dump.payload.reply.config_count == 1)
+	end, { timeout = 4.0 })
+end
+
+return T

--- a/tests/unit/ui/http_transport_spec.lua
+++ b/tests/unit/ui/http_transport_spec.lua
@@ -230,6 +230,39 @@ function T.http_logout_clears_cookie()
 	assert(calls[1].session_id == 'sess-logout')
 end
 
+function T.http_logout_rejects_malformed_json()
+	local calls = {}
+
+	local api = {
+		logout = function(session_id)
+			calls[#calls + 1] = {
+				op = 'logout',
+				session_id = session_id,
+			}
+			return true, nil
+		end,
+	}
+
+	local handler = transport.build_handler(fake_svc(), api, {})
+	local stream = new_stream(
+		make_req_headers('POST', '/api/logout', {
+			cookie = 'devicecode_session=sess-logout',
+		}),
+		'{'
+	)
+
+	handler({}, stream)
+
+	assert(stream:response_status() == '400')
+
+	local body = decode_json_body(stream)
+	assert(body.ok == false)
+	assert(type(body.err) == 'string')
+	assert(body.err:match('json_decode_failed') ~= nil)
+
+	assert(#calls == 0)
+end
+
 function T.http_config_route_uses_cookie_session()
 	local calls = {}
 
@@ -276,6 +309,41 @@ function T.http_config_route_uses_cookie_session()
 	assert(calls[1].service_name == 'net')
 	assert(type(calls[1].data) == 'table')
 	assert(calls[1].data.answer == 42)
+end
+
+function T.http_config_route_surfaces_rejected_writes()
+	local api = {
+		config_set = function(_session_id, service_name, _data)
+			return {
+				ok = false,
+				err = 'validation failed',
+				service = service_name,
+			}, nil
+		end,
+	}
+
+	local handler = transport.build_handler(fake_svc(), api, {})
+	local stream = new_stream(
+		make_req_headers('POST', '/api/config/net', {
+			cookie = 'devicecode_session=sess-net',
+		}),
+		cjson.encode({
+			data = {
+				schema = 'devicecode.net/1',
+			},
+		})
+	)
+
+	handler({}, stream)
+
+	assert(stream:response_status() == '400')
+
+	local body = decode_json_body(stream)
+	assert(body.ok == false)
+	assert(body.err == 'validation failed')
+	assert(type(body.data) == 'table')
+	assert(body.data.ok == false)
+	assert(body.data.err == 'validation failed')
 end
 
 function T.http_rpc_route_prefers_cookie_then_body()


### PR DESCRIPTION
### What type of PR is this?
- [x] Feature
- [x] Bug Fix

### Description

Adds OpenWrt UART bring-up, keepalive fix, and monitor auto-probe for the CM5 fabric link.

- mcu-dev.json config with explicit keepalive parameters
- Keepalive config validation in `fabric/config.lua`
- Ping scheduling fix: use TX-idle time only, so incoming MCU traffic no longer suppresses pings
- Invalid frame handling: structured errors instead of session teardown
- UART trace logging gated on `DEVICECODE_FABRIC_TRACE=1`
- Monitor auto-probe: publishes config and calls `hal/dump` on link ready, retries up to 3x
- OpenWrt serial backend with busybox stty fallback
- Lua bootstrap path fixes, HAL hosttest support, UI error handling

### CM5 UART RX Reliability Issue

The CM5's PL011 UART at `1f00030000` (RP1 UART0) intermittently drops bytes on RX, corrupting fabric protocol frames. The MCU always sends correct data (confirmed via USB console), but the CM5 occasionally receives garbled or truncated JSON. This may be related to using a prototype board — production hardware with a proper carrier board and cleaner signal routing could behave differently.

#### Evidence

Corrupted frames observed on CM5:
```
# 70-byte hello_ack sent by MCU, 38 bytes received (32 bytes dropped mid-frame):
{"t":"hello_ack"","proto":1,"ok":true}

# Same frame, different run, 22 bytes received (48 bytes dropped):
{"t":"hello_ack":true}
```

dmesg confirms PIO mode and overruns:
```
pl011-axi 1f00030000.serial: no DMA platform data
ttyAMA ttyAMA10: 7 input overrun(s)
```

| Condition | Result |
| --- | --- |
| Fresh power cycle + first boot | Usually works |
| Lua restart, MCU keeps running | Sometimes fails |
| Device rested after being off | Reliable |
| Lowering baud to 57600 | No improvement |

#### Root cause

The RP1 UART0 PL011 has a 16-byte hardware FIFO. At 115200 baud the FIFO fills in ~1.4ms. When the CM5 kernel can't service the RX interrupt in time, bytes are dropped mid-frame.

#### Why DMA is not the fix

The RPi kernel team [intentionally disabled DMA for RP1 UART0](https://github.com/raspberrypi/linux/pull/6371) due to data loss and aborted transfers. DMA properties were [present in rpi-6.6.y](https://github.com/raspberrypi/linux/blob/rpi-6.6.y/arch/arm64/boot/dts/broadcom/rp1.dtsi) but [commented out in rpi-6.12.y](https://github.com/raspberrypi/linux/blob/rpi-6.12.y/arch/arm64/boot/dts/broadcom/rp1.dtsi).

#### Current mitigation

The protocol handles byte drops gracefully:
- Invalid JSON frames are logged and dropped (not fatal)
- Hello retries every 1s until a clean hello_ack arrives
- Session self-heals after a few attempts

#### Possible solutions (to investigate)

1. **Hardware flow control (RTS/CTS)** — PL011 supports it natively. Requires two additional GPIO wires and MCU-side support.
2. **Inter-byte spacing on MCU TX** — Small delays in the reactor's `TryWrite` to keep the FIFO from filling too fast.
3. **Use a different UART instance** — If another RP1 UART has better interrupt characteristics.
4. **Kernel IRQ priority tuning** — Increase PL011 interrupt priority on the CM5.
5. **Wait for upstream fix** — Monitor [raspberrypi/linux](https://github.com/raspberrypi/linux) for RP1 DMA reliability improvements.
6. **Production hardware** — Test on final carrier board to see if the issue persists outside the prototype setup.

### Manual test
- [x] yes

### Manual test description

Proven on hardware (2026-04-02):
- `ping_sent` log entries appear every ~15s during die-temp streaming
- MCU does not show `link down reason peer_stale`
- Auto-probe shows `applied=true` in dump reply
- Session stable for >60s

### Added tests?
- [x] yes

### Added to documentation?
- [x] `fabric-alignment-review.md` updated
- [x] Keepalive timing relationships documented in session.lua