### PR TITLE
Wifi migration

### DIFF
--- a/docs/specs/hal/band_driver.md
+++ b/docs/specs/hal/band_driver.md
@@ -1,0 +1,432 @@
+# Band Driver (HAL)
+
+## Description
+
+The Band Driver is a HAL component that exposes DAWN (Distributed Access point with No-manager) band steering daemon configuration to the rest of the system via a single `band` capability. It:
+
+1. **Holds staged configuration** — all `set_*` calls accumulate changes in-memory. No config system is touched until `apply()` is called.
+2. **Applies staged config on demand** — `apply()` passes the staged table to `backend:apply(staged)`. The backend is responsible for writing to the underlying config system (e.g. UCI) and restarting the daemon.
+3. **Clears backend state on demand** — `clear()` calls `backend:clear()` to reset the backend's config to a known base state, ready for a fresh set of staged calls.
+
+The driver never touches UCI or any OS config system. All writes are delegated to the active backend. A future non-OpenWrt backend can implement the same interface without any UCI involvement.
+
+## Dependencies
+
+- `backends/band/provider.lua` — selects the active backend at driver creation.
+- DAWN must be installed on the target device. If `backend:clear()` fails on startup (e.g. DAWN config absent), the WLAN Manager logs the error and does not emit a device-added event for the band capability.
+
+## Initialisation
+
+On creation by the WLAN Manager:
+
+1. Resolve the band backend via `provider.get_backend()`. If no supported backend is found, creation fails with an error.
+2. Call `backend:clear()`. The backend is responsible for resetting the DAWN config to a clean base state. If `clear` fails, creation fails with an error.
+3. Publish capability `meta`.
+4. Start the RPC handler fiber.
+
+## Capability
+
+Class: `band`
+Id: `'1'`
+
+### Meta (retained)
+
+Topic: `{'cap', 'band', '1', 'meta'}`
+
+```lua
+{
+  provider = 'hal',
+  version  = 1,
+}
+```
+
+### Offerings
+
+All offerings return `{ ok = true }` on success or `{ ok = false, reason = <string> }` on validation failure or internal error. Changes are staged in-memory until `apply` is called.
+
+---
+
+#### set_log_level
+
+Topic: `{'cap', 'band', '1', 'rpc', 'set_log_level'}`
+
+Stages the daemon log level.
+
+Input:
+
+```lua
+{
+  level = <number>,  -- required: non-negative integer
+}
+```
+
+---
+
+#### set_kicking
+
+Topic: `{'cap', 'band', '1', 'rpc', 'set_kicking'}`
+
+Stages the global client-kicking policy.
+
+Input:
+
+```lua
+{
+  mode                = <string>,  -- required: "none"|"compare"|"absolute"|"both"
+  bandwidth_threshold = <number>,  -- required: non-negative
+  kicking_threshold   = <number>,  -- required: non-negative
+  evals_before_kick   = <number>,  -- required: non-negative integer
+}
+```
+
+Mode-to-integer mapping (used by the backend): `none=0`, `compare=1`, `absolute=2`, `both=3`.
+
+---
+
+#### set_station_counting
+
+Topic: `{'cap', 'band', '1', 'rpc', 'set_station_counting'}`
+
+Stages the station-counting policy.
+
+Input:
+
+```lua
+{
+  use_station_count = <boolean>,  -- required
+  max_station_diff  = <number>,   -- required: non-negative integer
+}
+```
+
+---
+
+#### set_rrm_mode
+
+Topic: `{'cap', 'band', '1', 'rpc', 'set_rrm_mode'}`
+
+Stages the RRM (Radio Resource Management) mode.
+
+Input:
+
+```lua
+{
+  mode = <string>,  -- required: one of "PAT"
+}
+```
+
+---
+
+#### set_neighbour_reports
+
+Topic: `{'cap', 'band', '1', 'rpc', 'set_neighbour_reports'}`
+
+Stages neighbour report parameters.
+
+Input:
+
+```lua
+{
+  dyn_report_num      = <number>,  -- required: non-negative integer (coerced with tonumber)
+  disassoc_report_len = <number>,  -- required: non-negative integer (coerced with tonumber)
+}
+```
+
+---
+
+#### set_legacy_options
+
+Topic: `{'cap', 'band', '1', 'rpc', 'set_legacy_options'}`
+
+Input:
+
+```lua
+{
+  opts = <table>,  -- required: key-value table; valid keys: "eval_probe_req", "eval_assoc_req", "eval_auth_req", "min_probe_count", "deny_assoc_reason", "deny_auth_reason"
+}
+```
+
+Each key-value pair is staged in the driver's in-memory config table under the global section. The backend maps driver-level keys to the appropriate config system entries. Unknown keys or nil values return `ok = false`.
+
+---
+
+#### set_band_priority
+
+Topic: `{'cap', 'band', '1', 'rpc', 'set_band_priority'}`
+
+Stages the initial score (priority) for a frequency band.
+
+Input:
+
+```lua
+{
+  band     = <string>,  -- required: "2G" or "5G" (case-insensitive, normalised to upper)
+  priority = <number>,  -- required: non-negative number
+}
+```
+
+The backend maps `2G`/`5G` to the appropriate config section names.
+
+---
+
+#### set_band_kicking
+
+Topic: `{'cap', 'band', '1', 'rpc', 'set_band_kicking'}`
+
+Stages per-band RSSI and channel-utilisation scoring parameters.
+
+Input:
+
+```lua
+{
+  band    = <string>,   -- required: "2G" or "5G"
+  options = <table>,    -- required: key-value table of scoring parameters
+}
+```
+
+Valid option keys and their descriptions (all values must be numbers). The backend maps these to the appropriate config system keys:
+
+| Option key                       | Description                                    |
+|----------------------------------|------------------------------------------------|
+| `rssi_center`                    | RSSI centre value                              |
+| `rssi_reward_threshold`          | RSSI good threshold                            |
+| `rssi_reward`                    | RSSI good reward                               |
+| `rssi_penalty_threshold`         | RSSI bad threshold                             |
+| `rssi_penalty`                   | RSSI bad penalty                               |
+| `rssi_weight`                    | RSSI weight                                    |
+| `channel_util_reward_threshold`  | Channel utilisation good threshold             |
+| `channel_util_reward`            | Channel utilisation good reward                |
+| `channel_util_penalty_threshold` | Channel utilisation bad threshold              |
+| `channel_util_penalty`           | Channel utilisation bad penalty                |
+
+Unknown keys return `ok = false`. Values that cannot be coerced to a number return `ok = false`.
+
+---
+
+#### set_support_bonus
+
+Topic: `{'cap', 'band', '1', 'rpc', 'set_support_bonus'}`
+
+Input:
+
+```lua
+{
+  band    = <string>,   -- required: "2G" or "5G"
+  support = <string>,   -- required: "ht" or "vht"
+  reward  = <number>,   -- required
+}
+```
+
+The backend maps driver-level keys to the appropriate config entries. Unknown keys return `ok = false`.
+
+Topic: `{'cap', 'band', '1', 'rpc', 'set_update_freq'}`
+
+Stages update frequencies for internal DAWN polling loops.
+
+Input:
+
+```lua
+{
+  updates = <table>,   -- required: key-value table; valid keys: "client","chan_util","hostapd","beacon_reports","tcp_con"
+}
+```
+
+Values must be non-negative numbers. Unknown keys return `ok = false`.
+
+---
+
+#### set_client_inactive_kickoff
+
+Topic: `{'cap', 'band', '1', 'rpc', 'set_client_inactive_kickoff'}`
+
+Stages the inactive client kickoff timeout.
+
+Input:
+
+```lua
+{
+  timeout = <number>,  -- required: non-negative integer (coerced with tonumber)
+}
+```
+
+---
+
+#### set_cleanup
+
+Topic: `{'cap', 'band', '1', 'rpc', 'set_cleanup'}`
+
+Stages cleanup timeouts for probes, clients, and APs.
+
+Input:
+
+```lua
+{
+  timeouts = <table>,  -- required: key-value table; valid keys: "probe","client","ap"
+}
+```
+
+Values must be non-negative numbers. Unknown keys return `ok = false`.
+
+---
+
+#### set_networking
+
+Topic: `{'cap', 'band', '1', 'rpc', 'set_networking'}`
+
+Stages the DAWN inter-AP networking method and options.
+
+Input:
+
+```lua
+{
+  method  = <string>,  -- required: "broadcast"|"tcp+umdns"|"multicast"|"tcp"
+  options = <table>,   -- required: key-value table of optional networking settings
+}
+```
+
+Valid option keys (the backend maps these to the appropriate config entries):
+
+| Key                  | Type      |
+|----------------------|-----------|
+| `ip`                 | string    |
+| `port`               | number    |
+| `broadcast_port`     | number    |
+| `enable_encryption`  | boolean   |
+
+Unknown keys or type mismatches return `ok = false`.
+
+---
+
+#### apply
+
+Topic: `{'cap', 'band', '1', 'rpc', 'apply'}`
+
+Passes the full staged config table to `backend:apply(staged)`. The backend is responsible for writing to the config system and triggering a daemon restart. The backend coalesces rapid successive restarts with a 1-second debounce window.
+
+Input: none (empty object `{}`).
+
+---
+
+#### clear
+
+Topic: `{'cap', 'band', '1', 'rpc', 'clear'}`
+
+Calls `backend:clear()` to reset the backend's DAWN config to a known base state. The in-memory staged config is also reset to empty. This should be called before beginning a new configuration sequence.
+
+Input: none (empty object `{}`).
+
+---
+
+#### rollback
+
+Topic: `{'cap', 'band', '1', 'rpc', 'rollback'}`
+
+Discards all staged changes without any backend call. The staged config is reset to empty (same state as after `clear`).
+
+Input: none (empty object `{}`).
+
+---
+
+## Types
+
+All capability arg and reply types follow the conventions in `src/services/hal/types/`.
+
+### `BandSetKickingOpts`
+
+```lua
+---@class BandSetKickingOpts
+---@field mode string              -- "none"|"compare"|"absolute"|"both"
+---@field bandwidth_threshold number
+---@field kicking_threshold number
+---@field evals_before_kick number
+```
+
+### `BandSetStationCountingOpts`
+
+```lua
+---@class BandSetStationCountingOpts
+---@field use_station_count boolean
+---@field max_station_diff number
+```
+
+### `BandSetNeighbourReportsOpts`
+
+```lua
+---@class BandSetNeighbourReportsOpts
+---@field dyn_report_num number
+---@field disassoc_report_len number
+```
+
+### `BandSetBandPriorityOpts`
+
+```lua
+---@class BandSetBandPriorityOpts
+---@field band string    -- "2G" or "5G"
+---@field priority number
+```
+
+### `BandSetBandKickingOpts`
+
+```lua
+---@class BandSetBandKickingOpts
+---@field band string    -- "2G" or "5G"
+---@field options table  -- see set_band_kicking valid option keys
+```
+
+### `BandSetSupportBonusOpts`
+
+```lua
+---@class BandSetSupportBonusOpts
+---@field band string    -- "2G" or "5G"
+---@field support string -- "ht" or "vht"
+---@field reward number
+```
+
+### `BandSetNetworkingOpts`
+
+```lua
+---@class BandSetNetworkingOpts
+---@field method string   -- "broadcast"|"tcp+umdns"|"multicast"|"tcp"
+---@field options table
+```
+
+### `BandCapabilityReply`
+
+```lua
+---@class BandCapabilityReply
+---@field ok boolean
+---@field reason string|nil  -- present on failure
+```
+
+## Backend Contract
+
+The OpenWrt-DAWN band backend (`backends/band/providers/openwrt-dawn/impl.lua`) must implement:
+
+| Function          | Description                                                                                                    |
+|-------------------|----------------------------------------------------------------------------------------------------------------|
+| `is_supported()`  | Returns `true` if DAWN is installed (checks `/etc/config/dawn` exists and is readable)                        |
+| `clear()`         | Deletes non-`hostapd` DAWN UCI sections; creates required fixed sections (`global`, `802_11g`, `802_11a`, `gbltime`, `gblnet`, `localcfg`) with default values; commits. Leaves the daemon in a clean state ready for fresh staged config. |
+| `apply(staged)`   | Writes the staged config table to the config system and triggers `service dawn restart`. The 1-second debounce coalescing is an internal backend concern. |
+
+Band section name mapping (`2G → 802_11g`, `5G → 802_11a`) is a detail of the backend, not the driver. The driver passes band identifiers as-is in the staged table.
+
+The driver has no import of or dependency on `backends/common/uci.lua`.
+
+## Service Flow
+
+1. Resolve backend; if unsupported, stop with error.
+2. Call `backend:clear()`; if it fails, stop with error.
+3. Publish meta.
+4. Enter `named_choice` loop on `control_ch` and scope cancellation.
+5. On each RPC: validate inputs; update staged config table; reply `{ ok = true }` or `{ ok = false, reason = ... }`.
+6. On `apply`: pass staged config table to `backend:apply(staged)`.
+7. On `clear`: call `backend:clear()`; reset in-memory staged config.
+8. On `rollback`: discard staged config table.
+9. On scope cancelled: exit loop.
+
+## Architecture
+
+- The driver runs a single RPC handler fiber. There is no autonomous emission from the band driver.
+- Staged config is a plain Lua table local to the driver. It is only ever accessed by the single RPC handler fiber (no concurrent access).
+- `apply` passes the staged config table to `backend:apply(staged)`. The driver has no knowledge of how the backend writes the config.
+- The clear sequence on startup is fully owned by the backend via `backend:clear()`. If it fails, the driver stops without advertising the capability.
+- A `finally` block on the driver scope logs the reason for shutdown.

--- a/docs/specs/hal/radio_driver.md
+++ b/docs/specs/hal/radio_driver.md
@@ -1,0 +1,370 @@
+# Radio Driver (HAL)
+
+## Description
+
+The Radio Driver is a HAL component that exposes wireless radio configuration and interface statistics to the rest of the system via a single `radio` capability. It:
+
+1. **Holds staged configuration** — all `set_*` calls accumulate changes in-memory. Changes are not applied until `apply()` is called.
+2. **Applies staged config on demand** — `apply()` delegates the staged config table to the active backend, which is responsible for writing it to the underlying OS config system (e.g. UCI) and triggering a reload.
+3. **Emits interface stats** — a stats loop calls backend methods to detect client connect/disconnect events and collect per-interface counters, emitting them via the capability `emit_ch` for HAL to publish on the bus.
+
+The driver never touches UCI or any OS config system directly. All config writes are delegated to the active backend via `backend:apply(staged)`. A future non-OpenWrt backend can implement the same backend interface without any UCI involvement.
+
+## Dependencies
+
+- `backends/radio/provider.lua` — selects the active backend at driver creation.
+
+## Initialisation
+
+On creation by the WLAN Manager:
+
+1. Resolve the radio backend via `provider.get_backend()`. If no supported backend is found, creation fails with an error; the manager logs the error and does not emit a device-added event.
+2. Fetch initial radio metadata via `backend:get_meta(name)` to populate the capability meta (path, type).
+3. Initialise the staged config table (empty).
+4. Publish capability `meta`.
+5. Start the RPC handler fiber.
+6. Start the stats loop fiber.
+
+## Capability
+
+Class: `radio`
+Id: UCI radio section name (e.g. `'radio0'`, `'radio1'`)
+
+### Meta (retained)
+
+Topic: `{'cap', 'radio', <id>, 'meta'}`
+
+```lua
+{
+  provider = 'hal',
+  version  = 1,
+  name     = <string>,   -- UCI radio section name
+  path     = <string>,   -- PCI/AHB device path, e.g. "platform/ahb/18100000.wmac"
+  type     = <string>,   -- radio chipset type, e.g. "mac80211"
+}
+```
+
+### Offerings
+
+All offerings return `{ ok = true }` on success or `{ ok = false, reason = <string> }` on validation failure or internal error.
+
+---
+
+#### set_channels
+
+Topic: `{'cap', 'radio', <id>, 'rpc', 'set_channels'}`
+
+Stages the radio frequency parameters in the driver's staged config. No UCI write occurs until `apply` is called.
+
+Input:
+
+```lua
+{
+  band     = <string>,         -- required: "2g" or "5g"
+  channel  = <number|string>,  -- required: channel number or "auto"
+  htmode   = <string>,         -- required: one of "HE20","HE40+","HE40-","HE80","HE160","HT20","HT40+","HT40-","VHT20","VHT40+","VHT40-","VHT80","VHT160"
+  channels = <table|nil>,      -- required when channel == "auto": list of numbers or strings
+}
+```
+
+Validation:
+- `band` must be `"2g"` or `"5g"`.
+- `htmode` must be one of the listed valid values.
+- When `channel == "auto"`, `channels` must be a non-empty list of numbers or strings.
+- When `channel ~= "auto"`, `channel` must be a number or string.
+
+---
+
+#### set_txpower
+
+Topic: `{'cap', 'radio', <id>, 'rpc', 'set_txpower'}`
+
+Input:
+
+```lua
+{
+  txpower = <number|string>,  -- required
+}
+```
+
+Validation: `txpower` must be a number or a string.
+
+---
+
+#### set_country
+
+Topic: `{'cap', 'radio', <id>, 'rpc', 'set_country'}`
+
+Input:
+
+```lua
+{
+  country = <string>,  -- required: 2-letter ISO country code (normalised to uppercase)
+}
+```
+
+Validation: must be a 2-character string.
+
+---
+
+#### set_enabled
+
+Topic: `{'cap', 'radio', <id>, 'rpc', 'set_enabled'}`
+
+Input:
+
+```lua
+{
+  enabled = <boolean>,  -- required
+}
+```
+
+Stages the enabled/disabled state for the radio. Validation: must be boolean.
+
+---
+
+#### add_interface
+
+Topic: `{'cap', 'radio', <id>, 'rpc', 'add_interface'}`
+
+Stages a new wireless interface entry for this radio. The interface name is generated as `<radio_name>_i<N>` where N is an auto-incrementing counter.
+
+Input:
+
+```lua
+{
+  ssid           = <string>,   -- required: SSID string, non-empty
+  encryption     = <string>,   -- required: one of "none","wep","psk","psk2","psk-mixed","sae","sae-mixed","owe","wpa","wpa2","wpa3"
+  password       = <string>,   -- required: may be empty string for open networks
+  network        = <string>,   -- required: network interface name, non-empty
+  mode           = <string>,   -- required: one of "ap","sta","adhoc","mesh","monitor"
+  enable_steering = <boolean>, -- required: if true, enables 802.11k/v BSS transition flags
+}
+```
+
+Reply on success:
+
+```lua
+{ ok = true, result = <string> }  -- result is the generated interface name e.g. "radio0_i0"
+```
+
+When `enable_steering = true`, the staged interface entry includes BSS transition and 802.11k flags. The backend is responsible for mapping these to the appropriate config system keys (e.g. `bss_transition`, `ieee80211k`, `rrm_neighbor_report`, `rrm_beacon_report` in UCI).
+
+---
+
+#### delete_interface
+
+Topic: `{'cap', 'radio', <id>, 'rpc', 'delete_interface'}`
+
+Marks an interface entry for removal in the staged config. The removal is applied by the backend on the next `apply` call.
+
+Input:
+
+```lua
+{
+  interface = <string>,  -- required: interface name to delete, non-empty
+}
+```
+
+---
+
+#### clear_radio_config
+
+Topic: `{'cap', 'radio', <id>, 'rpc', 'clear_radio_config'}`
+
+Resets the in-memory staged config to the base state: only the radio's fixed identity fields (`name`, `path`, `type`). All previously staged option changes and all staged interface entries are discarded. No backend call is made — this is a purely in-memory operation.
+
+Input: none (empty object `{}`).
+
+---
+
+#### set_report_period
+
+Topic: `{'cap', 'radio', <id>, 'rpc', 'set_report_period'}`
+
+Sets the metrics loop publish interval. Takes effect on the next sleep in the metrics loop.
+
+Input:
+
+```lua
+{
+  period = <number>,  -- required: interval in seconds, must be > 0
+}
+```
+
+---
+
+#### apply
+
+Topic: `{'cap', 'radio', <id>, 'rpc', 'apply'}`
+
+Passes the full staged config table to `backend:apply(staged)`. The backend is responsible for writing to UCI (or equivalent) and triggering a reload. The backend coalesces rapid successive reloads with a 1-second debounce window.
+
+Input: none (empty object `{}`).
+
+On success, the per-interface counter is reset so future `add_interface` calls start from `_i0` again.
+
+---
+
+#### rollback
+
+Topic: `{'cap', 'radio', <id>, 'rpc', 'rollback'}`
+
+Discards all staged changes. The staged config is reset to the same state as after `clear_radio_config` was last called. No backend call is made.
+
+Input: none (empty object `{}`).
+
+---
+
+## Stats Loop
+
+The stats loop runs in a separate fiber within the driver's scope. It calls backend methods to monitor client connect/disconnect events and to collect per-interface counters on each report period tick. All results are emitted via `emit_ch` as `Emit` values — HAL reads them and publishes them on the bus under `cap/radio/<id>/state/<name>` and `cap/radio/<id>/event/<name>`. The wifi service subscribes to these topics to perform session management, MAC hashing, and observability publishing. The driver is not aware of any of that logic.
+
+### Client events
+
+The backend monitors the wireless interface for `AP-STA-CONNECTED` and `AP-STA-DISCONNECTED` events (using `iw event` on OpenWrt). For each event the driver emits a raw `client_event` with the MAC address and connection state. The wifi service handles session ID generation, MAC address hashing, and deduplication.
+
+### Emitted stats
+
+Stats are refreshed on each `report_period` tick. All values are emitted via `emit_ch` for HAL to publish.
+
+| Emit key             | Content                                            | Source                                      |
+|----------------------|----------------------------------------------------|---------------------------------------------|
+| `client_event`       | `{ mac, connected, interface, timestamp }`         | backend event monitor (e.g. `iw event`)     |
+| `num_sta`            | Total connected station count (number)             | Derived from connect/disconnect tracking    |
+| `iface_num_sta`      | `{ interface, band, index, count }`                | Per-interface station count                 |
+| `iface_txpower`      | `{ interface, value }`                             | backend query (e.g. `iw dev <iface> info`)  |
+| `iface_channel`      | `{ interface, channel, freq, width }`              | backend query (e.g. `iw dev <iface> info`)  |
+| `iface_noise`        | `{ interface, value }`                             | backend query (e.g. `iw <iface> survey dump`) |
+| `iface_rx_bytes`     | `{ interface, value }`                             | `/sys/class/net/<iface>/statistics/`        |
+| `iface_tx_bytes`     | `{ interface, value }`                             | `/sys/class/net/<iface>/statistics/`        |
+| `iface_rx_packets`   | `{ interface, value }`                             | `/sys/class/net/<iface>/statistics/`        |
+| `iface_tx_packets`   | `{ interface, value }`                             | `/sys/class/net/<iface>/statistics/`        |
+| `iface_rx_dropped`   | `{ interface, value }`                             | `/sys/class/net/<iface>/statistics/`        |
+| `iface_tx_dropped`   | `{ interface, value }`                             | `/sys/class/net/<iface>/statistics/`        |
+| `iface_rx_errors`    | `{ interface, value }`                             | `/sys/class/net/<iface>/statistics/`        |
+| `iface_tx_errors`    | `{ interface, value }`                             | `/sys/class/net/<iface>/statistics/`        |
+| `client_signal`      | `{ mac, interface, signal }`                       | backend query (e.g. `iw dev <iface> station get <mac>`) |
+| `client_tx_bytes`    | `{ mac, interface, value }`                        | backend query (e.g. `iw dev <iface> station get <mac>`) |
+| `client_rx_bytes`    | `{ mac, interface, value }`                        | backend query (e.g. `iw dev <iface> station get <mac>`) |
+
+### Interface assignment
+
+Each radio has a **fixed interface name** assigned from config (no hotplug binding). Interface names are derived from the `add_interface` sequence (e.g. `radio0_i0`, `radio0_i1`). The mapping from SSID name to interface index is built when `add_interface` is called and held in-memory by the stats loop fiber.
+
+## Types
+
+All capability arg and reply types follow the conventions in `src/services/hal/types/`.
+
+### `RadioSetChannelsOpts`
+
+```lua
+---@class RadioSetChannelsOpts
+---@field band string         -- "2g" or "5g"
+---@field channel number|string  -- channel number or "auto"
+---@field htmode string
+---@field channels table|nil  -- required when channel=="auto"
+```
+
+### `RadioSetTxpowerOpts`
+
+```lua
+---@class RadioSetTxpowerOpts
+---@field txpower number|string
+```
+
+### `RadioSetCountryOpts`
+
+```lua
+---@class RadioSetCountryOpts
+---@field country string  -- 2-letter ISO code
+```
+
+### `RadioSetEnabledOpts`
+
+```lua
+---@class RadioSetEnabledOpts
+---@field enabled boolean
+```
+
+### `RadioAddInterfaceOpts`
+
+```lua
+---@class RadioAddInterfaceOpts
+---@field ssid string
+---@field encryption string
+---@field password string
+---@field network string
+---@field mode string
+---@field enable_steering boolean
+```
+
+### `RadioDeleteInterfaceOpts`
+
+```lua
+---@class RadioDeleteInterfaceOpts
+---@field interface string
+```
+
+### `RadioSetReportPeriodOpts`
+
+```lua
+---@class RadioSetReportPeriodOpts
+---@field period number  -- seconds, > 0
+```
+
+### `RadioCapabilityReply`
+
+```lua
+---@class RadioCapabilityReply
+---@field ok boolean
+---@field reason string|nil  -- present on failure; on add_interface success, holds the generated interface name
+```
+
+## Backend Contract
+
+The OpenWrt radio backend (`backends/radio/providers/openwrt/impl.lua`) must implement:
+
+| Function           | Description                                                                                                        |
+|--------------------|--------------------------------------------------------------------------------------------------------------------|
+| `is_supported()`   | Returns `true` if running on OpenWrt (checks `/etc/openwrt_release`)                                              |
+| `get_meta(name)`   | Returns `{ path, type }` for the radio. No config system cursor exposed to the driver.                             |
+| `apply(staged)`    | Writes the staged config table to the OS config system (UCI on OpenWrt) and triggers a reload. The 1-second debounce is an internal backend concern. |
+| `watch_events(interfaces, cb)` | Opens an event monitor (e.g. `iw event`) and calls `cb(event)` for each client connect/disconnect event. The driver calls this to feed the stats loop. |
+| `get_iface_info(iface)` | Returns txpower, channel, frequency, and channel width for a given interface (e.g. via `iw dev info`). |
+| `get_iface_survey(iface)` | Returns noise floor for a given interface (e.g. via `iw survey dump`). |
+| `get_station_info(iface, mac)` | Returns per-client signal, tx_bytes, rx_bytes (e.g. via `iw station get`). |
+
+The sysfs counters (`/sys/class/net/<iface>/statistics/`) are read directly by the driver, not the backend, as they are a standard Linux interface not specific to any wireless stack.
+
+The driver passes the staged config table opaquely to `apply`. The backend is the only component that knows how to interpret and write it.
+
+## Service Flow
+
+### RPC handler fiber
+
+1. Resolve backend; publish meta.
+2. Enter `named_choice` loop on `control_ch` and scope cancellation.
+3. On each RPC: validate inputs; update staged config table; reply `{ ok = true }` or `{ ok = false, reason = ... }`.
+4. On `apply`: pass staged config table to `backend:apply(staged)`; reset interface counter.
+5. On `rollback`: discard staged config table.
+6. On scope cancelled: exit loop.
+
+### Stats loop fiber
+
+1. Call `backend:watch_events(interfaces, cb)` to start monitoring client connect/disconnect events.
+2. Enter `named_choice` loop over: client event callback, report-period tick, new report period, scope cancelled.
+3. On client event: emit `client_event` with raw MAC and state; update in-memory station count; emit `num_sta` and `iface_num_sta`.
+4. On report-period tick: call `backend:get_iface_info`, `backend:get_iface_survey`, `backend:get_station_info` for each known interface; read sysfs statistics; emit all `iface_*` and `client_*` stats.
+5. On new report period: update sleep timer.
+6. On scope cancelled: exit; signal backend to stop event monitoring.
+
+## Architecture
+
+- The driver runs two concurrent fibers: the RPC handler and the stats loop. Both are children of the driver's scope.
+- Staged config is a plain Lua table local to the driver; it is only ever accessed by the RPC handler fiber (no concurrent access).
+- `apply` passes the staged config table to `backend:apply(staged)`. The driver has no knowledge of how the backend writes the config.
+- Stats are emitted via `emit_ch` as `Emit` objects. HAL reads `emit_ch` and publishes them to the bus under `cap/radio/<id>/state/<name>` or `cap/radio/<id>/event/<name>`. The driver never publishes to the bus directly.
+- All OS-specific tool calls (`iw event`, `iw dev info`, `iw survey dump`, `iw station get`) are encapsulated in the backend. The driver calls backend methods; the backend handles subprocess management, output parsing, and error recovery.
+- If the event monitor subprocess exits unexpectedly, the backend is responsible for restarting it. The driver is notified via the callback mechanism and may log a warning.
+- A `finally` block on the driver scope logs the reason for shutdown.

--- a/docs/specs/hal/wlan_manager.md
+++ b/docs/specs/hal/wlan_manager.md
@@ -1,0 +1,75 @@
+# WLAN Manager (HAL)
+
+## Description
+
+The WLAN Manager is a HAL manager that owns the lifecycle of all wireless drivers: one `RadioDriver` instance per configured radio and one `BandDriver` instance.
+
+The WLAN Manager owns no capabilities directly — all capabilities are owned by the drivers it creates.
+
+## Dependencies
+
+- HAL device config must contain a `radios` table with one entry per physical radio. If `radios` is absent or empty, no radio drivers are started and a warning is logged. The band driver is always started regardless of radio count.
+
+## Initialisation
+
+On startup:
+
+1. Read the HAL device config passed by the HAL service at startup.
+2. For each entry in `config.radios`: create a `RadioDriver` instance and emit a HAL device-added event.
+3. Create one `BandDriver` instance and emit a HAL device-added event.
+
+Each device-added event triggers the HAL service to register the corresponding capability, bind RPC endpoints, and start the emit-forwarding fiber.
+
+If `config.radios` is absent or not a table, log a warning and start only the band driver.
+
+## Managed Drivers
+
+| Driver        | Class   | Id                           | Quantity                  |
+|---------------|---------|------------------------------|---------------------------|
+| `RadioDriver` | `radio` | UCI radio name (e.g. `'radio0'`, `'radio1'`) | 1 per entry in `config.radios` |
+| `BandDriver`  | `band`  | `'1'`                        | 1                         |
+
+Radio capability IDs are derived from the UCI radio section name as configured in the device config (e.g. `radio0` → `'radio0'`).
+
+## Apply Config
+
+When `apply_config(config)` is called by the HAL service after startup:
+
+1. **Stop removed drivers** — stop any `RadioDriver` instances whose name no longer appears in `config.radios`. Emit a HAL device-removed event for each.
+2. **Stop changed drivers** — stop any `RadioDriver` instances whose name is present in `config.radios` but whose `path` or `type` has changed. Emit a HAL device-removed event for each. These will be recreated in the next step.
+3. **Start new and changed drivers** — for each entry in `config.radios` that does not have an existing running driver: create a new `RadioDriver` and emit a HAL device-added event.
+4. The `BandDriver` instance is not restarted on config update — it is persistent for the lifetime of the manager.
+
+## Manager Interface
+
+The WLAN Manager implements the standard `Manager` interface:
+
+- `start(scope)` — reads device config, instantiates drivers, emits device events.
+- `stop(reason)` — cancels the manager scope; all child driver fibers are stopped via structured concurrency.
+- `apply_config(config)` — reconciles the running driver set against the new config.
+
+## Service Flow
+
+```mermaid
+flowchart TD
+  St[Start] --> B{config.radios present?}
+  B -->|no| C(Log warning: no radios in device config)
+  B -->|yes| D(For each radio: create RadioDriver, emit device added event)
+  C --> E(Create BandDriver, emit device added event)
+  D --> E
+  E --> F{Wait for apply_config or scope cancelled}
+  F -->|apply_config| G1(Stop drivers not in new config; emit device removed)
+  G1 --> G2(Stop drivers whose path/type changed; emit device removed)
+  G2 --> G3(Create new/replacement drivers; emit device added)
+  G3 --> F
+  F -->|scope cancelled| H(Stop all driver scopes via structured concurrency)
+  H --> En[Stop]
+```
+
+## Architecture
+
+- All drivers are started within child scopes of the manager scope. If the manager scope is cancelled, all drivers stop automatically via structured concurrency — no explicit teardown loop is needed.
+- The manager holds a map of radio name → `{ driver, path, type }` to support reconciliation on `apply_config`. The `path` and `type` fields are compared on each `apply_config` call to detect hardware changes.
+- The `BandDriver` is created unconditionally. If the DAWN config is not present on the device, the driver’s `clear` step will fail at the backend level and the capability will not be registered. This is treated as a non-fatal warning.
+- UCI access is a concern of the backends only. The `backends/common/uci.lua` module exposes `uci.ensure_started()` — on first call it starts the UCI reactor fiber attached to the **root scope** (not the calling fiber’s scope), so it outlives any individual backend call. Subsequent calls to `ensure_started()` are no-ops. The manager has no dependency on `backends/common/uci.lua`.
+- A `finally` block logs the reason for manager shutdown.

--- a/docs/specs/wifi.md
+++ b/docs/specs/wifi.md
@@ -1,0 +1,235 @@
+# Wifi Service
+
+## Description
+
+The Wifi Service is an application-layer service responsible for:
+
+1. **Radio configuration** — forwarding per-radio settings (channel, txpower, country, enabled state) to HAL radio capabilities.
+2. **SSID management** — configuring wireless interfaces (SSIDs) on each radio, sourcing SSID credentials from `mainflux.json` via the `configs` filesystem capability when a `mainflux_path` is present in the config.
+3. **Band steering configuration** — forwarding band steering parameters to the HAL `band` capability (DAWN daemon).
+4. **Stats forwarding** — subscribing to `cap/radio/<id>/state|event` topics emitted by radio capabilities and forwarding them to the observability bus.
+5. **Session management** — tracking client association/disassociation events, hashing MAC addresses, and emitting session start/end records.
+6. **Capability lifecycle tracking** — starting and stopping radio configuration when radio capabilities come and go.
+
+The service interacts with hardware exclusively through HAL capabilities on the bus. No direct file reads or command execution are performed by the service itself.
+
+## Dependencies
+
+HAL capabilities consumed:
+
+| Capability class | Id                           | Usage                                                    |
+|------------------|------------------------------|----------------------------------------------------------|
+| `radio`          | per radio (e.g. `'radio0'`)  | Configure channels, txpower, country, SSIDs; `apply`     |
+| `band`           | `'1'`                        | Configure band steering (DAWN); `apply`                  |
+| `filesystem`     | `'configs'`                  | Read `mainflux.json` for SSID credential sourcing        |
+
+Service topics consumed:
+
+| Topic              | Usage                                                                       |
+|--------------------|-----------------------------------------------------------------------------|
+| `{'cfg', 'wifi'}`  | Retained config — the main fiber subscribes to this for all wifi settings   |
+
+Cap topics subscribed for radio stats:
+
+| Topic                                    | Usage                                                              |
+|------------------------------------------|--------------------------------------------------------------------|
+| `{'cap', 'radio', id, 'state', name}`    | Named stat emitted by the radio driver; forwarded to obs bus       |
+| `{'cap', 'radio', id, 'event', name}`    | Named client event emitted by the radio driver; used for sessions  |
+
+## Configuration
+
+Received via retained bus message on `{'cfg', 'wifi'}`. The message uses the standard versioned config envelope:
+
+```lua
+{
+  rev  = <number>,   -- config revision; service skips messages with rev <= last applied rev
+  data = {
+    schema        = "devicecode.config/wifi/1",
+    report_period = <number>,       -- required: stats publish interval in seconds
+    radios = {                      -- required: array of per-radio configs
+      {
+        name     = <string>,          -- required: radio section name, e.g. "radio0"
+        band     = <string>,          -- required: "2g" or "5g"
+        channel  = <number|string>,   -- required: channel number or "auto"
+        htmode   = <string>,          -- required: e.g. "HE80", "VHT80", "HT40+"
+        channels = <table|nil>,       -- required when channel == "auto": list of allowed channels
+        txpower  = <number|string|nil>, -- optional: transmit power
+        country  = <string|nil>,      -- optional: 2-letter ISO country code
+        disabled = <boolean|nil>,     -- optional: if true, radio is administratively disabled
+      },
+      ...
+    },
+    ssids = {                       -- required: array of SSID configs
+      {
+        name           = <string>,      -- required: SSID string
+        mode           = <string>,      -- required: "access_point"|"client"|"adhoc"|"mesh"|"monitor"
+        radios         = <table>,       -- required: list of radio names this SSID applies to
+        network        = <string|nil>,  -- required if mainflux_path absent: network interface name
+        mainflux_path  = <string|nil>,  -- optional: path within the configs filesystem cap to the mainflux credential file (e.g. "mainflux.json")
+        encryption     = <string|nil>,  -- optional: default "none"
+        password       = <string|nil>,  -- optional
+      },
+      ...
+    },
+    band_steering = {               -- required: band steering settings
+      globals = {
+        kicking = {
+          kick_mode           = <string>,   -- required: "none"|"compare"|"absolute"|"both"
+          bandwidth_threshold = <number>,   -- required
+          kicking_threshold   = <number>,   -- required
+          evals_before_kick   = <number>,   -- required
+        },
+        stations = {                -- optional
+          use_station_count = <boolean>,
+          max_station_diff  = <number>,
+        },
+        rrm_mode         = <string|nil>,    -- optional
+        neighbor_reports = {               -- optional
+          dyn_report_num      = <number>,
+          disassoc_report_len = <number>,
+        },
+        legacy = <table|nil>,       -- optional: key-value legacy options
+      },
+      timings = {
+        updates = {                 -- required: update frequencies in seconds
+          client     = <number>,
+          chan_util   = <number>,
+          hostapd    = <number>,
+        },
+        inactive_client_kickoff = <number>,  -- required
+        cleanup = {                 -- required
+          client = <number>,
+          probe  = <number>,
+          ap     = <number>,
+        },
+      },
+      bands = {                     -- required: per-band scoring config
+        ["2G"] = {
+          initial_score    = <number>,
+          rssi_scoring     = { ... },   -- optional
+          chan_util_scoring = { ... },  -- optional
+          support_bonuses  = { ... },   -- optional
+        },
+        ["5G"] = { ... },           -- same structure
+      },
+    },
+  },
+}
+```
+
+> **Underflow note:** JSON decoding may silently convert negative numbers to large positive integers due to integer underflow. The service must check decoded numeric fields that are expected to be non-negative and, if the value exceeds a sanity threshold (e.g. > 2^31), treat it as if the original value were negative by subtracting 2^32.
+
+## SSID Sourcing Policy
+
+When an SSID entry contains `mainflux_path`, the service reads that file from the `configs` filesystem capability:
+
+```lua
+cap_ref:call_control('read', FilesystemReadOpts(mainflux_path))
+```
+
+The file is expected to contain a JSON object with a `networks.networks` array holding credential payloads. Each network entry in the array is used to derive the SSID `name`, `password`, and `encryption` for one wireless interface.
+
+**If the file read fails or the content cannot be decoded, no SSIDs are configured for that entry at all.** No hardcoded fallback SSIDs are produced. This is an intentional strict policy — partial SSID configuration is considered worse than no configuration.
+
+When `mainflux_path` is absent, the SSID entry is applied directly using its `name`, `network`, and other fields.
+
+## Radio Capability Lifecycle
+
+The service discovers radio capabilities using `cap_sdk.new_cap_listener(conn, 'radio')`. When a radio capability is added:
+
+- The service applies the matching radio config (by name) from the stored `data.radios` config.
+- It configures SSIDs that reference that radio, sourcing credentials from the `configs` filesystem cap via `mainflux_path` when present.
+- It starts the stats forwarding and session tracking loop, subscribed to `{'cap', 'radio', id, 'state', '+'}` and `{'cap', 'radio', id, 'event', '+'}`.
+
+When a radio capability is removed, the service cancels its associated child scope, stopping all loops and releasing subscriptions.
+
+The band capability (`class = 'band'`, `id = '1'`) is discovered independently. Band steering configuration is applied whenever both the band capability is available and a valid config has been received.
+
+## Radio Configuration Sequence
+
+For each radio capability added, the service invokes RPCs via `cap_ref:call_control(method, args)` in the following order:
+
+1. `clear_radio_config` — resets the driver's staged radio config to base state.
+2. `set_report_period` — sets the stats emit interval.
+3. `set_channels` — sets band, channel, htmode, and optional auto-channels list.
+4. `set_txpower` — if present in config.
+5. `set_country` — if present in config.
+6. `set_enabled` — if `disabled` is present in config.
+7. `add_interface` (repeated per SSID) — stages each SSID as a wireless interface. For SSIDs with `mainflux_path`, credentials are fetched from the `configs` filesystem cap before this call.
+8. `apply` — tells the driver to commit staged config and reload wireless.
+
+Rollback is not called by the service on error; the radio driver's staged state is simply abandoned.
+
+## Session Management
+
+Client association and disassociation events arrive on `{'cap', 'radio', id, 'event'}`. The wifi service is responsible for:
+
+1. **MAC hashing** — raw MAC addresses are never forwarded to the observability bus. Each MAC is hashed using `gen.userid(mac)` to produce a stable, anonymous user identifier.
+2. **Session tracking** — on association, a new session ID is generated via `gen.gen_session_id()` and a `session_start` record is emitted. On disassociation, a `session_end` record is emitted with the same session ID.
+3. **Published session events** — emitted to the specific metric topic for the event type: `{'obs', 'v1', 'wifi', 'metric', 'session_start'}` and `{'obs', 'v1', 'wifi', 'metric', 'session_end'}`. Each record includes fields `user_id`, `session_id`, `radio`, and `timestamp`.
+
+The radio driver itself has no knowledge of sessions or MAC hashing — it emits raw events and the wifi service applies the anonymisation and session logic.
+
+## Published Topics
+
+All stats and events are forwarded to `obs/v1/wifi/metric/<name>` topics, matching the metrics collection keys used in device configs.
+
+| Topic                                               | Content                                                         |
+|-----------------------------------------------------|-----------------------------------------------------------------|
+| `{'svc', 'wifi', 'status'}`                         | Service status (via `service_base`)                             |
+| `{'obs', 'v1', 'wifi', 'metric', <name>}`           | Named stat or event from a radio (e.g. `num_sta`, `iface_rx_bytes`, `client_signal`) |
+| `{'obs', 'v1', 'wifi', 'metric', 'session_start'}`  | Anonymised session start record (MAC hashed to `user_id`)       |
+| `{'obs', 'v1', 'wifi', 'metric', 'session_end'}`    | Anonymised session end record (MAC hashed to `user_id`)         |
+
+## Service Flow
+
+```mermaid
+flowchart TD
+  St[Start] --> A(service_base.new: publish status)
+  A --> B(Subscribe to cfg/wifi)
+  B --> C(Start cap_listener for radio + band)
+  C --> D{named_choice: cfg msg, radio added, radio removed, band added, scope cancelled}
+  D -->|cfg msg| E(Validate config rev+schema; store configs)
+  E --> F(Re-apply config to all known radios)
+  F --> G(If band cap known: apply band steering)
+  G --> D
+  D -->|radio added| H(Spawn child scope for radio)
+  H --> I(Apply radio config sequence)
+  I --> J(Fetch mainflux_path from configs fs cap if present; add_interface per SSID)
+  J --> K(apply)
+  K --> L(Start stats + session forwarding loops)
+  L --> D
+  D -->|radio removed| M(Cancel child scope; stop loops)
+  M --> D
+  D -->|band added| N(Apply band steering if config received)
+  N --> D
+  D -->|scope cancelled| En[Stop]
+```
+
+### Stats forwarding loop (per radio)
+
+Runs in child scope, subscribes to `{'cap', 'radio', id, 'state', '+'}` and `{'cap', 'radio', id, 'event', '+'}`:
+
+1. On `state/<name>` message: forward payload to `{'obs', 'v1', 'wifi', 'metric', name}`.
+2. On `event/client_event` message (association):
+   - Hash MAC via `gen.userid(mac)` → `user_id`.
+   - Generate session ID via `gen.gen_session_id()` → `session_id`.
+   - Store `(mac → session_id)` in per-radio session table.
+   - Publish `session_start` record to `{'obs', 'v1', 'wifi', 'metric', 'session_start'}`.
+3. On `event/client_event` message (disassociation):
+   - Look up `session_id` from per-radio session table.
+   - Publish `session_end` record to `{'obs', 'v1', 'wifi', 'metric', 'session_end'}`.
+   - Remove entry from session table.
+4. On other `event/<name>` messages: forward payload to `{'obs', 'v1', 'wifi', 'metric', name}`.
+5. On scope cancellation: exit loop.
+
+## Architecture
+
+- The service uses `service_base.new(conn, opts)` for `svc:status`, `svc:obs_log`, and `svc:obs_event`.
+- Radio caps and the band cap are tracked independently. A config update always attempts to re-apply to all currently known capabilities.
+- Each radio capability runs its lifecycle in a child scope of the main service scope. Cancelling the child scope stops the stats/session forwarding loops and releases all subscriptions for that radio.
+- SSID configuration is always idempotent: each full config update clears and rebuilds all interfaces from scratch.
+- Mainflux credentials are read from the `configs` filesystem capability via `cap_ref:call_control('read', FilesystemReadOpts(mainflux_path))`. No bus topic subscription is used for mainflux data. On read failure, the SSID entry is skipped entirely.
+- `band_steering.data.globals.kicking.kick_mode` determines whether `has_band_steering = true` is set on each SSID. When `kick_mode == "none"`, band steering flags are not added to the wifi-iface entries.
+- Config version gating: the service checks `msg.rev` on each `cfg/wifi` update and skips messages with `rev <= last_rev` to avoid re-applying stale retained messages.
+- A `finally` block on the service scope logs the shutdown reason.

--- a/src/configs/bigbox-v1-cm.json
+++ b/src/configs/bigbox-v1-cm.json
@@ -493,143 +493,139 @@
     ]
   },
   "wifi": {
-    "report_period": 10,
-    "radios": [
-      {
-        "name": "radio0",
-        "band": "2g",
-        "channel": "auto",
-        "channels": [
-          "1",
-          "6",
-          "11"
-        ],
-        "country": "GB",
-        "htmode": "HE20",
-        "txpower": "20",
-        "disabled": false
-      },
-      {
-        "name": "radio1",
-        "band": "5g",
-        "channel": "36",
-        "country": "GB",
-        "htmode": "HE80",
-        "txpower": "23",
-        "disabled": false
-      }
-    ],
-    "ssids": [
-      {
-        "mainflux_path": "config/mainflux",
-        "encryption": "psk2",
-        "mode": "access_point",
-        "radios": [
-          "radio0",
-          "radio1"
-        ]
-      },
-      {
-        "name": "Jangala",
-        "mode": "access_point",
-        "encryption": "none",
-        "network": "jan",
-        "radios": [
-          "radio0",
-          "radio1"
-        ]
-      }
-    ],
-    "band_steering": {
-      "log_level": 2,
-      "globals": {
-        "rrm_mode": "PAT",
-        "kicking": {
-          "kick_mode": "both",
-          "bandwidth_threshold": 0,
-          "kicking_threshold": 15,
-          "evals_before_kick": 3
+    "rev": 1,
+    "data": {
+      "schema": "devicecode.config/wifi/1",
+      "report_period": 10,
+      "radios": [
+        {
+          "name": "radio0",
+          "band": "2g",
+          "channel": "auto",
+          "channels": [
+            "1",
+            "6",
+            "11"
+          ],
+          "country": "GB",
+          "htmode": "HE20",
+          "txpower": "20",
+          "disabled": false
         },
-        "stations": {
-          "use_station_count": false,
-          "max_station_diff": 1
-        },
-        "neighbor_reports": {
-          "dyn_report_num": 2,
-          "disassoc_report_len": 6
-        },
-        "legacy": {
-          "eval_probe_req": true,
-          "eval_assoc_req": false,
-          "eval_auth_req": false,
-          "min_probe_count": 2,
-          "deny_auth_reason": 1,
-          "deny_assoc_reason": 17
+        {
+          "name": "radio1",
+          "band": "5g",
+          "channel": "36",
+          "country": "GB",
+          "htmode": "HE80",
+          "txpower": "23",
+          "disabled": false
         }
-      },
-      "timings": {
-        "updates": {
-          "client": 10,
-          "chan_util": 5,
-          "beacon_reports": 5,
-          "hostapd": 10,
-          "tcp_con": 10
+      ],
+      "ssids": [
+        {
+          "mainflux_path": "mainflux.cfg",
+          "encryption": "psk2",
+          "mode": "access_point",
+          "radios": [
+            "radio0",
+            "radio1"
+          ]
         },
-        "cleanup": {
-          "client": 15,
-          "probe": 40,
-          "ap": 460
-        },
-        "inactive_client_kickoff": 60
-      },
-      "networking": {
-        "method": "tcp+umdns",
-        "ip": "0.0.0.0",
-        "port": 1026,
-        "broadcast_port": 1025,
-        "enable_encryption": false
-      },
-      "bands": {
-        "2g": {
-          "initial_score": 90,
-          "rssi_scoring": {
-            "center": "-69",
-            "weight": 2,
-            "good_threshold": "-66",
-            "good_reward": 12,
-            "bad_threshold": "-75",
-            "bad_penalty": "-15"
+        {
+          "name": "Jangala",
+          "mode": "access_point",
+          "encryption": "none",
+          "network": "jan",
+          "radios": [
+            "radio0",
+            "radio1"
+          ]
+        }
+      ],
+      "band_steering": {
+        "globals": {
+          "rrm_mode": "PAT",
+          "kicking": {
+            "kick_mode": "both",
+            "bandwidth_threshold": 0,
+            "kicking_threshold": 15,
+            "evals_before_kick": 3
           },
-          "chan_util_scoring": {
-            "good_threshold": 140,
-            "good_reward": 5,
-            "bad_threshold": 170,
-            "bad_penalty": "-20"
+          "stations": {
+            "use_station_count": false,
+            "max_station_diff": 1
           },
-          "support_bonuses": {
-            "vht": 5,
-            "ht": 5
+          "neighbor_reports": {
+            "dyn_report_num": 2,
+            "disassoc_report_len": 6
+          },
+          "legacy": {
+            "eval_probe_req": true,
+            "eval_assoc_req": false,
+            "eval_auth_req": false,
+            "min_probe_count": 2,
+            "deny_auth_reason": 1,
+            "deny_assoc_reason": 17
           }
         },
-        "5g": {
-          "initial_score": 95,
-          "rssi_scoring": {
-            "center": "-64",
-            "weight": 4,
-            "good_threshold": "-62",
-            "good_reward": 10,
-            "bad_threshold": "-70",
-            "bad_penalty": "-28"
+        "timings": {
+          "updates": {
+            "client": 10,
+            "chan_util": 5,
+            "beacon_reports": 5,
+            "hostapd": 10,
+            "tcp_con": 10
           },
-          "chan_util_scoring": {
-            "good_threshold": 140,
-            "good_reward": 5,
-            "bad_threshold": 170,
-            "bad_penalty": "-20"
+          "cleanup": {
+            "client": 15,
+            "probe": 40,
+            "ap": 460
           },
-          "support_bonuses": {
-            "vht": 2,
-            "ht": 2
+          "inactive_client_kickoff": 60
+        },
+        "bands": {
+          "2g": {
+            "initial_score": 90,
+            "rssi_scoring": {
+              "center": "-69",
+              "weight": 2,
+              "good_threshold": "-66",
+              "good_reward": 12,
+              "bad_threshold": "-75",
+              "bad_penalty": "-15"
+            },
+            "chan_util_scoring": {
+              "good_threshold": 140,
+              "good_reward": 5,
+              "bad_threshold": 170,
+              "bad_penalty": "-20"
+            },
+            "support_bonuses": {
+              "vht": 5,
+              "ht": 5
+            }
+          },
+          "5g": {
+            "initial_score": 95,
+            "rssi_scoring": {
+              "center": "-64",
+              "weight": 4,
+              "good_threshold": "-62",
+              "good_reward": 10,
+              "bad_threshold": "-70",
+              "bad_penalty": "-28"
+            },
+            "chan_util_scoring": {
+              "good_threshold": 140,
+              "good_reward": 5,
+              "bad_threshold": 170,
+              "bad_penalty": "-20"
+            },
+            "support_bonuses": {
+              "vht": 2,
+              "ht": 2
+            }
           }
         }
       }

--- a/src/configs/config.json
+++ b/src/configs/config.json
@@ -17,7 +17,21 @@
             "sysmon": {},
             "platform": {},
             "power": {},
-            "usb": {}
+            "usb": {},
+            "wlan": {
+                "radios": [
+                    {
+                        "name": "radio0",
+                        "type": "mac80211",
+                        "path": "axi/1000110000.pcie/pci0000:00/0000:00:00.0/0000:01:00.0"
+                    },
+                    {
+                        "name": "radio1",
+                        "type": "mac80211",
+                        "path": "axi/1000110000.pcie/pci0000:00/0000:00:00.0/0000:01:00.0+1"
+                    }
+                ]
+            }
         }
     },
     "gsm": {
@@ -43,6 +57,135 @@
                         "autoconnect": true
                     }
                 ]
+            }
+        }
+    },
+    "wifi": {
+        "rev": 1,
+        "data": {
+            "schema": "devicecode.config/wifi/1",
+            "report_period": 10,
+            "radios": [
+                {
+                    "name": "radio0",
+                    "band": "2g",
+                    "channel": "auto",
+                    "channels": ["1", "6", "11"],
+                    "country": "GB",
+                    "htmode": "HE20",
+                    "txpower": "20",
+                    "disabled": false
+                },
+                {
+                    "name": "radio1",
+                    "band": "5g",
+                    "channel": "36",
+                    "country": "GB",
+                    "htmode": "HE80",
+                    "txpower": "23",
+                    "disabled": false
+                }
+            ],
+            "ssids": [
+                {
+                    "mainflux_path": "mainflux.json",
+                    "encryption": "psk2",
+                    "mode": "access_point",
+                    "radios": ["radio0", "radio1"]
+                },
+                {
+                    "name": "Jangala",
+                    "mode": "access_point",
+                    "encryption": "none",
+                    "network": "jan",
+                    "radios": ["radio0", "radio1"]
+                }
+            ],
+            "band_steering": {
+                "globals": {
+                    "rrm_mode": "PAT",
+                    "kicking": {
+                        "kick_mode": "both",
+                        "bandwidth_threshold": 0,
+                        "kicking_threshold": 15,
+                        "evals_before_kick": 3
+                    },
+                    "stations": {
+                        "use_station_count": false,
+                        "max_station_diff": 1
+                    },
+                    "neighbor_reports": {
+                        "dyn_report_num": 2,
+                        "disassoc_report_len": 6
+                    },
+                    "legacy": {
+                        "eval_probe_req": true,
+                        "eval_assoc_req": false,
+                        "eval_auth_req": false,
+                        "min_probe_count": 2,
+                        "deny_auth_reason": 1,
+                        "deny_assoc_reason": 17
+                    }
+                },
+                "timings": {
+                    "updates": {
+                        "client": 10,
+                        "chan_util": 5,
+                        "beacon_reports": 5,
+                        "hostapd": 10,
+                        "tcp_con": 10
+                    },
+                    "cleanup": {
+                        "client": 15,
+                        "probe": 40,
+                        "ap": 460
+                    },
+                    "inactive_client_kickoff": 60
+                },
+                "bands": {
+                    "2g": {
+                        "initial_score": 90,
+                        "rssi_scoring": {
+                            "center": "-69",
+                            "weight": 2,
+                            "good_threshold": "-66",
+                            "good_reward": 12,
+                            "bad_threshold": "-75",
+                            "bad_penalty": "-15"
+                        },
+                        "chan_util_scoring": {
+                            "good_threshold": 140,
+                            "good_reward": 5,
+                            "bad_threshold": 170,
+                            "bad_penalty": "-20"
+                        },
+                        "support_bonuses": {
+                            "vht": 5,
+                            "ht": 5
+                        }
+                    },
+                    "5g": {
+                        "initial_score": 95,
+                        "rssi_scoring": {
+                            "center": "-64",
+                            "weight": 4,
+                            "good_threshold": "-62",
+                            "good_reward": 10,
+                            "bad_threshold": "-70",
+                            "bad_penalty": "-28"
+                        },
+                        "chan_util_scoring": {
+                            "good_threshold": 140,
+                            "good_reward": 5,
+                            "bad_threshold": 170,
+                            "bad_penalty": "-20"
+                        },
+                        "support_bonuses": {
+                            "vht": 2,
+                            "ht": 2
+                        }
+                    }
+                }
             }
         }
     },

--- a/src/configs/config.json
+++ b/src/configs/config.json
@@ -88,7 +88,7 @@
             ],
             "ssids": [
                 {
-                    "mainflux_path": "mainflux.json",
+                    "mainflux_path": "mainflux.cfg",
                     "encryption": "psk2",
                     "mode": "access_point",
                     "radios": ["radio0", "radio1"]

--- a/src/configs/config.json
+++ b/src/configs/config.json
@@ -101,7 +101,7 @@
             ],
             "ssids": [
                 {
-                    "mainflux_path": "mainflux.json",
+                    "mainflux_path": "mainflux.cfg",
                     "encryption": "psk2",
                     "mode": "access_point",
                     "radios": ["radio0", "radio1"]

--- a/src/configs/config.json
+++ b/src/configs/config.json
@@ -18,7 +18,21 @@
             "platform": {},
             "power": {},
             "usb": {},
-            "time": {}
+            "time": {},
+            "wlan": {
+                "radios": [
+                    {
+                        "name": "radio0",
+                        "type": "mac80211",
+                        "path": "axi/1000110000.pcie/pci0000:00/0000:00:00.0/0000:01:00.0"
+                    },
+                    {
+                        "name": "radio1",
+                        "type": "mac80211",
+                        "path": "axi/1000110000.pcie/pci0000:00/0000:00:00.0/0000:01:00.0+1"
+                    }
+                ]
+            }
         }
     },
     "gsm": {
@@ -56,6 +70,135 @@
                         "autoconnect": true
                     }
                 ]
+            }
+        }
+    },
+    "wifi": {
+        "rev": 1,
+        "data": {
+            "schema": "devicecode.config/wifi/1",
+            "report_period": 10,
+            "radios": [
+                {
+                    "name": "radio0",
+                    "band": "2g",
+                    "channel": "auto",
+                    "channels": ["1", "6", "11"],
+                    "country": "GB",
+                    "htmode": "HE20",
+                    "txpower": "20",
+                    "disabled": false
+                },
+                {
+                    "name": "radio1",
+                    "band": "5g",
+                    "channel": "36",
+                    "country": "GB",
+                    "htmode": "HE80",
+                    "txpower": "23",
+                    "disabled": false
+                }
+            ],
+            "ssids": [
+                {
+                    "mainflux_path": "mainflux.json",
+                    "encryption": "psk2",
+                    "mode": "access_point",
+                    "radios": ["radio0", "radio1"]
+                },
+                {
+                    "name": "Jangala",
+                    "mode": "access_point",
+                    "encryption": "none",
+                    "network": "jan",
+                    "radios": ["radio0", "radio1"]
+                }
+            ],
+            "band_steering": {
+                "globals": {
+                    "rrm_mode": "PAT",
+                    "kicking": {
+                        "kick_mode": "both",
+                        "bandwidth_threshold": 0,
+                        "kicking_threshold": 15,
+                        "evals_before_kick": 3
+                    },
+                    "stations": {
+                        "use_station_count": false,
+                        "max_station_diff": 1
+                    },
+                    "neighbor_reports": {
+                        "dyn_report_num": 2,
+                        "disassoc_report_len": 6
+                    },
+                    "legacy": {
+                        "eval_probe_req": true,
+                        "eval_assoc_req": false,
+                        "eval_auth_req": false,
+                        "min_probe_count": 2,
+                        "deny_auth_reason": 1,
+                        "deny_assoc_reason": 17
+                    }
+                },
+                "timings": {
+                    "updates": {
+                        "client": 10,
+                        "chan_util": 5,
+                        "beacon_reports": 5,
+                        "hostapd": 10,
+                        "tcp_con": 10
+                    },
+                    "cleanup": {
+                        "client": 15,
+                        "probe": 40,
+                        "ap": 460
+                    },
+                    "inactive_client_kickoff": 60
+                },
+                "bands": {
+                    "2g": {
+                        "initial_score": 90,
+                        "rssi_scoring": {
+                            "center": "-69",
+                            "weight": 2,
+                            "good_threshold": "-66",
+                            "good_reward": 12,
+                            "bad_threshold": "-75",
+                            "bad_penalty": "-15"
+                        },
+                        "chan_util_scoring": {
+                            "good_threshold": 140,
+                            "good_reward": 5,
+                            "bad_threshold": 170,
+                            "bad_penalty": "-20"
+                        },
+                        "support_bonuses": {
+                            "vht": 5,
+                            "ht": 5
+                        }
+                    },
+                    "5g": {
+                        "initial_score": 95,
+                        "rssi_scoring": {
+                            "center": "-64",
+                            "weight": 4,
+                            "good_threshold": "-62",
+                            "good_reward": 10,
+                            "bad_threshold": "-70",
+                            "bad_penalty": "-28"
+                        },
+                        "chan_util_scoring": {
+                            "good_threshold": 140,
+                            "good_reward": 5,
+                            "bad_threshold": 170,
+                            "bad_penalty": "-20"
+                        },
+                        "support_bonuses": {
+                            "vht": 2,
+                            "ht": 2
+                        }
+                    }
+                }
             }
         }
     },

--- a/src/main.lua
+++ b/src/main.lua
@@ -21,6 +21,7 @@ else
 	add_path('../vendor/lua-bus/src/')
 	add_path('../vendor/lua-trie/src/')
 	add_path('./')
+	add_path('/usr/lib/lua/')
 end
 
 local fibers = require 'fibers'

--- a/src/main.lua
+++ b/src/main.lua
@@ -22,6 +22,7 @@ else
 	add_path('../vendor/lua-bus/src/')
 	add_path('../vendor/lua-trie/src/')
 	add_path('./')
+	add_path('/usr/lib/lua/')
 end
 
 local fibers = require 'fibers'

--- a/src/services/hal/backends/band/contract.lua
+++ b/src/services/hal/backends/band/contract.lua
@@ -1,0 +1,28 @@
+---Band backend contract definition.
+---All band backends must implement the functions listed in BAND_BACKEND_FUNCTIONS.
+
+local BAND_BACKEND_FUNCTIONS = {
+    'clear',
+    'apply',
+}
+
+---Validate that a backend table implements all required functions.
+---@param backend table
+---@return boolean ok
+---@return string  err   Empty string on success.
+local function validate(backend)
+    if type(backend) ~= 'table' then
+        return false, "backend must be a table"
+    end
+    for _, fn_name in ipairs(BAND_BACKEND_FUNCTIONS) do
+        if type(backend[fn_name]) ~= 'function' then
+            return false, "backend missing required function: " .. fn_name
+        end
+    end
+    return true, ""
+end
+
+return {
+    BAND_BACKEND_FUNCTIONS = BAND_BACKEND_FUNCTIONS,
+    validate               = validate,
+}

--- a/src/services/hal/backends/band/provider.lua
+++ b/src/services/hal/backends/band/provider.lua
@@ -1,0 +1,31 @@
+---Band backend provider.
+---Iterates registered backends and returns the first supported one.
+
+local contract = require "services.hal.backends.band.contract"
+
+local BACKENDS = {
+    "services.hal.backends.band.providers.openwrt-dawn",
+}
+
+---Get the first supported band backend.
+---@return table|nil  backend
+---@return string     err  "" on success
+local function get_backend()
+    for _, path in ipairs(BACKENDS) do
+        local ok, provider = pcall(require, path)
+        if ok and provider.is_supported and provider.is_supported() then
+            local backend = provider.backend
+            local valid, verr = contract.validate(backend)
+            if valid then
+                return backend, ""
+            else
+                return nil, "backend " .. path .. " failed contract check: " .. verr
+            end
+        end
+    end
+    return nil, "no supported band backend found on this device"
+end
+
+return {
+    get_backend = get_backend,
+}

--- a/src/services/hal/backends/band/provider.lua
+++ b/src/services/hal/backends/band/provider.lua
@@ -7,14 +7,14 @@ local BACKENDS = {
     "services.hal.backends.band.providers.openwrt-dawn",
 }
 
----Get the first supported band backend.
----@return table|nil  backend
+---Instantiate a new backend from the first supported provider.
+---@return table|nil  backend instance
 ---@return string     err  "" on success
-local function get_backend()
+local function new()
     for _, path in ipairs(BACKENDS) do
         local ok, provider = pcall(require, path)
         if ok and provider.is_supported and provider.is_supported() then
-            local backend = provider.backend
+            local backend = provider.backend.new()
             local valid, verr = contract.validate(backend)
             if valid then
                 return backend, ""
@@ -27,5 +27,5 @@ local function get_backend()
 end
 
 return {
-    get_backend = get_backend,
+    new = new,
 }

--- a/src/services/hal/backends/band/providers/openwrt-dawn/impl.lua
+++ b/src/services/hal/backends/band/providers/openwrt-dawn/impl.lua
@@ -46,15 +46,23 @@ local REQUIRED_SECTIONS = {
 }
 
 ------------------------------------------------------------------------
--- Backend functions
+-- BandBackend class
 ------------------------------------------------------------------------
+
+---@class BandBackend
+local BandBackend = {}
+BandBackend.__index = BandBackend
+
+---@return BandBackend
+function BandBackend.new()
+    return setmetatable({}, BandBackend)
+end
 
 ---Reset DAWN's UCI config to a clean base state.
 ---Deletes all non-hostapd sections, re-creates required sections with empty defaults.
----Uses a synchronous commit so callers get immediate success/failure.
 ---@return boolean ok
 ---@return string  err
-local function clear()
+function BandBackend:clear()
     uci.ensure_started()
     local session = uci.new_session()
 
@@ -80,7 +88,7 @@ end
 
 ---Apply the staged band config table to DAWN UCI and restart the daemon.
 ---@param staged table  Band staged config as accumulated by the driver
-local function apply(staged)
+function BandBackend:apply(staged)
     uci.ensure_started()
     local session = uci.new_session()
 
@@ -220,6 +228,5 @@ local function apply(staged)
 end
 
 return {
-    clear        = clear,
-    apply        = apply,
+    new = BandBackend.new,
 }

--- a/src/services/hal/backends/band/providers/openwrt-dawn/impl.lua
+++ b/src/services/hal/backends/band/providers/openwrt-dawn/impl.lua
@@ -55,35 +55,24 @@ local REQUIRED_SECTIONS = {
 ---@return boolean ok
 ---@return string  err
 local function clear()
+    uci.ensure_started()
     local session = uci.new_session()
 
-    -- Delete each known managed section (if it exists)
+    -- Delete each known managed section only if it already exists
     for _, sec in ipairs(REQUIRED_SECTIONS) do
-        session:delete('dawn', sec.name)
+        if uci.section_exists('dawn', sec.name) then
+            session:delete('dawn', sec.name)
+        end
     end
 
-    -- Re-create required sections with their type
+    -- Re-create required sections with their type using named-section creation
     for _, sec in ipairs(REQUIRED_SECTIONS) do
-        session:add('dawn', sec.type)
-        -- UCI anonymous sections need to be renamed; the router adds them
-        -- sequentially, so we rely on the backend knowing the section names.
-        -- Named sections in OpenWrt UCI are addressed by name directly.
+        session:set('dawn', sec.name, sec.type)
     end
 
-    local ok, err = session:commit_sync('dawn')
+    local ok, err = session:commit('dawn')
     if not ok then
         return false, "failed to clear DAWN config: " .. tostring(err)
-    end
-
-    -- Rename the anonymous sections back to their canonical names by
-    -- doing explicit set operations on each section name.
-    local rename_session = uci.new_session()
-    for _, sec in ipairs(REQUIRED_SECTIONS) do
-        rename_session:set('dawn', sec.name, sec.type)
-    end
-    local rok, rerr = rename_session:commit_sync('dawn')
-    if not rok then
-        return false, "failed to re-create DAWN sections: " .. tostring(rerr)
     end
 
     return true, ""
@@ -224,7 +213,10 @@ local function apply(staged)
         end
     end
 
-    session:commit('dawn', { { 'service', 'dawn', 'restart' } })
+    local ok, err = session:commit('dawn', { { 'service', 'dawn', 'restart' } })
+    if not ok then
+        error('apply commit failed: ' .. tostring(err))
+    end
 end
 
 return {

--- a/src/services/hal/backends/band/providers/openwrt-dawn/impl.lua
+++ b/src/services/hal/backends/band/providers/openwrt-dawn/impl.lua
@@ -1,0 +1,233 @@
+---OpenWrt DAWN band steering backend implementation.
+---Translates staged driver config to dawn UCI sections via the shared UCI reactor.
+
+local uci = require "services.hal.backends.common.uci"
+
+local BAND_SECTION = {
+    ['2G'] = '802_11g',
+    ['5G'] = '802_11a',
+}
+
+local KICK_MODE_ID = {
+    none     = 0,
+    compare  = 1,
+    absolute = 2,
+    both     = 3,
+}
+
+local NETWORKING_METHOD_ID = {
+    broadcast   = 0,
+    ['tcp+umdns'] = 2,
+    multicast   = 2,
+    tcp         = 3,
+}
+
+local BAND_KICKING_KEYS = {
+    rssi_center                    = 'rssi_center',
+    rssi_reward_threshold          = 'rssi_val',
+    rssi_reward                    = 'rssi',
+    rssi_penalty_threshold         = 'low_rssi_val',
+    rssi_penalty                   = 'low_rssi',
+    rssi_weight                    = 'rssi_weight',
+    channel_util_reward_threshold  = 'chan_util_val',
+    channel_util_reward            = 'chan_util',
+    channel_util_penalty_threshold = 'max_chan_util_val',
+    channel_util_penalty           = 'max_chan_util',
+}
+
+-- Fixed sections required in a clean DAWN config
+local REQUIRED_SECTIONS = {
+    { name = 'global',   type = 'metric'  },
+    { name = '802_11g',  type = 'metric'  },
+    { name = '802_11a',  type = 'metric'  },
+    { name = 'gbltime',  type = 'times'   },
+    { name = 'gblnet',   type = 'network' },
+    { name = 'localcfg', type = 'local'   },
+}
+
+------------------------------------------------------------------------
+-- Backend functions
+------------------------------------------------------------------------
+
+---Reset DAWN's UCI config to a clean base state.
+---Deletes all non-hostapd sections, re-creates required sections with empty defaults.
+---Uses a synchronous commit so callers get immediate success/failure.
+---@return boolean ok
+---@return string  err
+local function clear()
+    local session = uci.new_session()
+
+    -- Delete each known managed section (if it exists)
+    for _, sec in ipairs(REQUIRED_SECTIONS) do
+        session:delete('dawn', sec.name)
+    end
+
+    -- Re-create required sections with their type
+    for _, sec in ipairs(REQUIRED_SECTIONS) do
+        session:add('dawn', sec.type)
+        -- UCI anonymous sections need to be renamed; the router adds them
+        -- sequentially, so we rely on the backend knowing the section names.
+        -- Named sections in OpenWrt UCI are addressed by name directly.
+    end
+
+    local ok, err = session:commit_sync('dawn')
+    if not ok then
+        return false, "failed to clear DAWN config: " .. tostring(err)
+    end
+
+    -- Rename the anonymous sections back to their canonical names by
+    -- doing explicit set operations on each section name.
+    local rename_session = uci.new_session()
+    for _, sec in ipairs(REQUIRED_SECTIONS) do
+        rename_session:set('dawn', sec.name, sec.type)
+    end
+    local rok, rerr = rename_session:commit_sync('dawn')
+    if not rok then
+        return false, "failed to re-create DAWN sections: " .. tostring(rerr)
+    end
+
+    return true, ""
+end
+
+---Apply the staged band config table to DAWN UCI and restart the daemon.
+---@param staged table  Band staged config as accumulated by the driver
+local function apply(staged)
+    uci.ensure_started()
+    local session = uci.new_session()
+
+    -- log_level
+    if staged.log_level ~= nil then
+        session:set('dawn', 'localcfg', 'log_level', staged.log_level)
+    end
+
+    -- kicking
+    if staged.kicking then
+        local k  = staged.kicking
+        if k.mode ~= nil then
+            session:set('dawn', 'global', 'kicking',
+                tostring(KICK_MODE_ID[k.mode] or 0))
+        end
+        if k.bandwidth_threshold ~= nil then
+            session:set('dawn', 'global', 'bandwidth_threshold', k.bandwidth_threshold)
+        end
+        if k.kicking_threshold ~= nil then
+            session:set('dawn', 'global', 'kicking_threshold', k.kicking_threshold)
+        end
+        if k.evals_before_kick ~= nil then
+            session:set('dawn', 'global', 'min_number_to_kick', k.evals_before_kick)
+        end
+    end
+
+    -- station counting
+    if staged.station_counting then
+        local sc = staged.station_counting
+        if sc.use_station_count ~= nil then
+            session:set('dawn', 'global', 'use_station_count',
+                sc.use_station_count and '1' or '0')
+        end
+        if sc.max_station_diff ~= nil then
+            session:set('dawn', 'global', 'max_station_diff', sc.max_station_diff)
+        end
+    end
+
+    -- rrm_mode
+    if staged.rrm_mode ~= nil then
+        session:set('dawn', 'global', 'rrm_mode', staged.rrm_mode)
+    end
+
+    -- neighbour reports
+    if staged.neighbour_reports then
+        local nr = staged.neighbour_reports
+        if nr.dyn_report_num ~= nil then
+            session:set('dawn', 'global', 'set_hostapd_nr', nr.dyn_report_num)
+        end
+        if nr.disassoc_report_len ~= nil then
+            session:set('dawn', 'global', 'disassoc_nr_length', nr.disassoc_report_len)
+        end
+    end
+
+    -- legacy options (flat key-value under global)
+    if staged.legacy then
+        for key, value in pairs(staged.legacy) do
+            session:set('dawn', 'global', key, value)
+        end
+    end
+
+    -- band priorities and kicking params
+    for band_key, section_name in pairs(BAND_SECTION) do
+        local bp = staged.band_priorities and staged.band_priorities[band_key]
+        if bp then
+            if bp.initial_score ~= nil then
+                session:set('dawn', section_name, 'initial_score', bp.initial_score)
+            end
+        end
+
+        local bk = staged.band_kicking and staged.band_kicking[band_key]
+        if bk then
+            for driver_key, uci_key in pairs(BAND_KICKING_KEYS) do
+                if bk[driver_key] ~= nil then
+                    session:set('dawn', section_name, uci_key, bk[driver_key])
+                end
+            end
+        end
+
+        local sb = staged.support_bonus and staged.support_bonus[band_key]
+        if sb then
+            for _, support in ipairs({'ht', 'vht'}) do
+                if sb[support] ~= nil then
+                    session:set('dawn', section_name, support .. '_support', sb[support])
+                end
+            end
+        end
+    end
+
+    -- update frequencies
+    if staged.update_freq then
+        for key, freq in pairs(staged.update_freq) do
+            session:set('dawn', 'gbltime', 'update_' .. key, freq)
+        end
+    end
+
+    -- client inactive kickoff (con_timeout)
+    if staged.con_timeout ~= nil then
+        session:set('dawn', 'gbltime', 'con_timeout', staged.con_timeout)
+    end
+
+    -- cleanup timeouts
+    if staged.cleanup then
+        for key, timeout in pairs(staged.cleanup) do
+            session:set('dawn', 'gbltime', 'remove_' .. key, timeout)
+        end
+    end
+
+    -- networking
+    if staged.networking then
+        local net = staged.networking
+        if net.method ~= nil then
+            local method_id = NETWORKING_METHOD_ID[net.method]
+            if method_id ~= nil then
+                session:set('dawn', 'gblnet', 'method', tostring(method_id))
+            end
+        end
+        if net.ip ~= nil then
+            session:set('dawn', 'gblnet', 'tcp_ip', net.ip)
+        end
+        if net.port ~= nil then
+            session:set('dawn', 'gblnet', 'tcp_port', net.port)
+        end
+        if net.broadcast_port ~= nil then
+            session:set('dawn', 'gblnet', 'broadcast_port', net.broadcast_port)
+        end
+        if net.enable_encryption ~= nil then
+            session:set('dawn', 'gblnet', 'use_symm_enc',
+                net.enable_encryption and '1' or '0')
+        end
+    end
+
+    session:commit('dawn', { { 'service', 'dawn', 'restart' } })
+end
+
+return {
+    clear        = clear,
+    apply        = apply,
+}

--- a/src/services/hal/backends/band/providers/openwrt-dawn/init.lua
+++ b/src/services/hal/backends/band/providers/openwrt-dawn/init.lua
@@ -1,9 +1,10 @@
 local impl = require "services.hal.backends.band.providers.openwrt-dawn.impl"
+local file = require "fibers.io.file"
 
 ---Check whether DAWN is installed and its UCI config is accessible.
 ---@return boolean
 local function is_supported()
-    local f = io.open('/etc/config/dawn', 'r')
+    local f, _ = file.open('/etc/config/dawn', 'r')
     if f then f:close() return true end
     return false
 end

--- a/src/services/hal/backends/band/providers/openwrt-dawn/init.lua
+++ b/src/services/hal/backends/band/providers/openwrt-dawn/init.lua
@@ -1,0 +1,14 @@
+local impl = require "services.hal.backends.band.providers.openwrt-dawn.impl"
+
+---Check whether DAWN is installed and its UCI config is accessible.
+---@return boolean
+local function is_supported()
+    local f = io.open('/etc/config/dawn', 'r')
+    if f then f:close() return true end
+    return false
+end
+
+return {
+    is_supported = is_supported,
+    backend      = impl,
+}

--- a/src/services/hal/backends/common/uci.lua
+++ b/src/services/hal/backends/common/uci.lua
@@ -6,12 +6,11 @@ local Scope     = require "fibers.scope"
 local exec      = require "fibers.io.exec"
 
 ---@class UciChange
----@field op 'set'|'add'|'delete'
+---@field op 'set'|'delete'
 ---@field config string
 ---@field section? string
----@field stype? string
----@field option? string
----@field value? any
+---@field option? string   section type when value is nil (named-section creation)
+---@field value? any       absent/nil means create a named section of type `option`
 
 ---@class UciCommitRecord
 ---@field changes UciChange[]
@@ -32,17 +31,21 @@ local started   = false
 local function apply_changes(cursor, record)
     for _, change in ipairs(record.changes) do
         if change.op == 'set' then
-            local ok = cursor:set(change.config, change.section, change.option, change.value)
-            if not ok then
-                error(("uci set failed: %s.%s.%s = %s"):format(
-                    change.config, change.section or '?',
-                    change.option or '?', tostring(change.value)))
-            end
-        elseif change.op == 'add' then
-            local name = cursor:add(change.config, change.stype)
-            if not name then
-                error(("uci add failed: %s type=%s"):format(
-                    change.config, change.stype or '?'))
+            local ok
+            if change.value == nil then
+                -- 3-arg form: create a named section of type change.option
+                ok = cursor:set(change.config, change.section, change.option)
+                if not ok then
+                    error(("uci set (named section) failed: %s.%s type=%s"):format(
+                        change.config, change.section or '?', change.option or '?'))
+                end
+            else
+                ok = cursor:set(change.config, change.section, change.option, change.value)
+                if not ok then
+                    error(("uci set failed: %s.%s.%s = %s"):format(
+                        change.config, change.section or '?',
+                        change.option or '?', tostring(change.value)))
+                end
             end
         elseif change.op == 'delete' then
             local ok
@@ -193,10 +196,13 @@ local function new_session()
     return setmetatable({ _changes = {} }, Session)
 end
 
+---Set an option value, or create a named section when called with 3 arguments.
+---3-arg form: `set(config, section, stype)` creates a named section of the given type.
+---4-arg form: `set(config, section, option, value)` sets an option value.
 ---@param config string
 ---@param section string
----@param option string
----@param value any
+---@param option string  option name, or section type when value is absent
+---@param value? any
 function Session:set(config, section, option, value)
     table.insert(self._changes, {
         op = 'set',
@@ -204,14 +210,6 @@ function Session:set(config, section, option, value)
         section = section,
         option = option,
         value = value,
-    })
-end
-
----@param config string
----@param stype string  UCI section type
-function Session:add(config, stype)
-    table.insert(self._changes, {
-        op = 'add', config = config, stype = stype,
     })
 end
 
@@ -240,29 +238,6 @@ function Session:commit(config, restart_cmds)
     })
     self._changes = {}
     return reply_ch
-end
-
----Apply staged changes immediately using a temporary cursor (synchronous).
----Use only during driver initialisation where blocking is acceptable.
----Returns ok (boolean) and err (string).
----@param config string
----@param restart_cmds string[][]|nil  List of argv lists to exec immediately (not debounced)
----@return boolean ok
----@return string  err
-function Session:commit_sync(config, restart_cmds)
-    local ok, err = pcall(function()
-        local c = uci_mod.cursor()
-        apply_changes(c, { changes = self._changes, config = config })
-        if restart_cmds then
-            local rok, rerr = run_restart_cmds(restart_cmds)
-            if not rok then error(rerr) end
-        end
-    end)
-    self._changes = {}
-    if not ok then
-        return false, tostring(err)
-    end
-    return true, ""
 end
 
 ---Read a single UCI value without going through the reactor queue.

--- a/src/services/hal/backends/common/uci.lua
+++ b/src/services/hal/backends/common/uci.lua
@@ -24,6 +24,15 @@ local commit_ch = channel.new(10)
 -- Reactor start guard
 local started   = false
 
+---Convert a value to a UCI-safe string.
+---Booleans become "1"/"0"; everything else uses tostring().
+---@param v any
+---@return string
+local function to_uci_string(v)
+    if type(v) == 'boolean' then return v and '1' or '0' end
+    return tostring(v)
+end
+
 ---Apply a single commit record to an open UCI cursor.
 ---Errors on any cursor failure so the caller can revert and propagate.
 ---@param cursor table  uci cursor object
@@ -31,39 +40,39 @@ local started   = false
 local function apply_changes(cursor, record)
     for _, change in ipairs(record.changes) do
         if change.op == 'set' then
-            local ok
+            local ok, err
             if change.value == nil then
                 -- 3-arg form: create a named section of type change.option
-                ok = cursor:set(change.config, change.section, change.option)
+                ok, err = cursor:set(change.config, change.section, change.option)
                 if not ok then
-                    error(("uci set (named section) failed: %s.%s type=%s"):format(
-                        change.config, change.section or '?', change.option or '?'))
+                    error(("uci set (named section) failed: %s.%s type=%s: %s"):format(
+                        change.config, change.section or '?', change.option or '?', tostring(err)))
                 end
             else
-                ok = cursor:set(change.config, change.section, change.option, change.value)
+                ok, err = cursor:set(change.config, change.section, change.option, to_uci_string(change.value))
                 if not ok then
-                    error(("uci set failed: %s.%s.%s = %s"):format(
+                    error(("uci set failed: %s.%s.%s = %s: %s"):format(
                         change.config, change.section or '?',
-                        change.option or '?', tostring(change.value)))
+                        change.option or '?', tostring(change.value), tostring(err)))
                 end
             end
         elseif change.op == 'delete' then
-            local ok
+            local ok, err
             if change.option then
-                ok = cursor:delete(change.config, change.section, change.option)
+                ok, err = cursor:delete(change.config, change.section, change.option)
             else
-                ok = cursor:delete(change.config, change.section)
+                ok, err = cursor:delete(change.config, change.section)
             end
             if not ok then
-                error(("uci delete failed: %s.%s%s"):format(
+                error(("uci delete failed: %s.%s%s: %s"):format(
                     change.config, change.section or '?',
-                    change.option and ('.' .. change.option) or ''))
+                    change.option and ('.' .. change.option) or '', tostring(err)))
             end
         end
     end
-    local ok = cursor:commit(record.config)
+    local ok, err = cursor:commit(record.config)
     if not ok then
-        error(("uci commit failed: %s"):format(record.config))
+        error(("uci commit failed: %s: %s"):format(record.config, tostring(err)))
     end
 end
 
@@ -133,7 +142,7 @@ local function reactor()
         while true do
             local name, result = fibers.perform(fibers.named_choice({
                 more    = commit_ch:get_op(),
-                timeout = sleep.sleep_op(1.0),
+                timeout = sleep.sleep_op(0.1),
             }))
             if name == 'timeout' then break end
             batch[#batch + 1] = result
@@ -222,12 +231,12 @@ function Session:delete(config, section, option)
     })
 end
 
----Queue staged changes to be applied by the reactor.
----Returns a reply channel that will receive {ok=boolean, err=string} once
----the commit (and any restart commands) have completed.
+---Queue staged changes to be applied by the reactor and wait for the result.
+---Blocks until the commit (and any restart commands) have completed.
 ---@param config string        UCI config file name
 ---@param restart_cmds string[][]|nil  List of argv lists to exec after apply (debounced, 1s)
----@return table reply_ch      channel — receive to wait for completion
+---@return boolean ok
+---@return string? err
 function Session:commit(config, restart_cmds)
     local reply_ch = channel.new(1)
     commit_ch:put({
@@ -237,7 +246,8 @@ function Session:commit(config, restart_cmds)
         reply_ch     = reply_ch,
     })
     self._changes = {}
-    return reply_ch
+    local result = reply_ch:get()
+    return result.ok, result.err
 end
 
 ---Read a single UCI value without going through the reactor queue.
@@ -251,8 +261,35 @@ local function get_value(config, section, option)
     return c:get(config, section, option)
 end
 
+---Return true if a UCI section exists in the given config file.
+---@param config string
+---@param section string
+---@return boolean
+local function section_exists(config, section)
+    local c = uci_mod.cursor()
+    return c:get(config, section) ~= nil
+end
+
+---Return all section names in a config file matching an optional type filter.
+---Calls cursor:foreach which iterates committed+staged values.
+---@param config string
+---@param stype? string  UCI section type to filter by (e.g. 'wifi-iface'); nil = all sections
+---@return string[]  section names
+local function get_sections(config, stype)
+    local c = uci_mod.cursor()
+    local names = {}
+    c:foreach(config, stype, function(s)
+        if s['.name'] then
+            names[#names + 1] = s['.name']
+        end
+    end)
+    return names
+end
+
 return {
-    ensure_started = ensure_started,
-    new_session    = new_session,
-    get_value      = get_value,
+    ensure_started  = ensure_started,
+    new_session     = new_session,
+    get_value       = get_value,
+    section_exists  = section_exists,
+    get_sections    = get_sections,
 }

--- a/src/services/hal/backends/common/uci.lua
+++ b/src/services/hal/backends/common/uci.lua
@@ -1,0 +1,283 @@
+local uci_mod   = require "uci"
+local fibers    = require "fibers"
+local channel   = require "fibers.channel"
+local sleep     = require "fibers.sleep"
+local Scope     = require "fibers.scope"
+local exec      = require "fibers.io.exec"
+
+---@class UciChange
+---@field op 'set'|'add'|'delete'
+---@field config string
+---@field section? string
+---@field stype? string
+---@field option? string
+---@field value? any
+
+---@class UciCommitRecord
+---@field changes UciChange[]
+---@field config string
+---@field restart_cmds? string[][]   list of argv lists to exec after commit
+---@field reply_ch? table            channel to receive {ok, err} when applied
+
+-- Module-level buffered commit queue shared by all sessions
+local commit_ch = channel.new(10)
+
+-- Reactor start guard
+local started   = false
+
+---Apply a single commit record to an open UCI cursor.
+---Errors on any cursor failure so the caller can revert and propagate.
+---@param cursor table  uci cursor object
+---@param record UciCommitRecord
+local function apply_changes(cursor, record)
+    for _, change in ipairs(record.changes) do
+        if change.op == 'set' then
+            local ok = cursor:set(change.config, change.section, change.option, change.value)
+            if not ok then
+                error(("uci set failed: %s.%s.%s = %s"):format(
+                    change.config, change.section or '?',
+                    change.option or '?', tostring(change.value)))
+            end
+        elseif change.op == 'add' then
+            local name = cursor:add(change.config, change.stype)
+            if not name then
+                error(("uci add failed: %s type=%s"):format(
+                    change.config, change.stype or '?'))
+            end
+        elseif change.op == 'delete' then
+            local ok
+            if change.option then
+                ok = cursor:delete(change.config, change.section, change.option)
+            else
+                ok = cursor:delete(change.config, change.section)
+            end
+            if not ok then
+                error(("uci delete failed: %s.%s%s"):format(
+                    change.config, change.section or '?',
+                    change.option and ('.' .. change.option) or ''))
+            end
+        end
+    end
+    local ok = cursor:commit(record.config)
+    if not ok then
+        error(("uci commit failed: %s"):format(record.config))
+    end
+end
+
+---Run a list of restart command specs sequentially using the exec module.
+---Each entry is an argv list, e.g. { '/etc/init.d/network', 'restart' }.
+---@param cmds string[][]
+---@return boolean ok
+---@return string  err
+local function run_restart_cmds(cmds)
+    for _, argv in ipairs(cmds) do
+        local cmd = exec.command(argv)
+        local status, code = fibers.perform(cmd:run_op())
+        if status ~= 'exited' or code ~= 0 then
+            return false, table.concat(argv, ' ') .. ' exited with status=' ..
+                tostring(status) .. ' code=' .. tostring(code)
+        end
+    end
+    return true, ""
+end
+
+---Deduplicate restart commands across a batch of record results.
+---Only includes entries from records whose changes applied successfully.
+---Returns a list of entries; each entry holds one unique argv and the set of
+---per-record result objects that depend on it so errors can be fed back.
+---@class RestartEntry
+---@field argv string[]
+---@field sessions table[]  elements are the result objects {record, ok, err}
+
+---@param record_results table[]  array of {record=UciCommitRecord, ok=boolean, err=string}
+---@return RestartEntry[]
+local function trim_restarts(record_results)
+    local seen    = {}  -- key → index into entries
+    local entries = {}
+    for _, res in ipairs(record_results) do
+        if res.ok and res.record.restart_cmds then
+            for _, argv in ipairs(res.record.restart_cmds) do
+                local key = table.concat(argv, '\0')
+                if not seen[key] then
+                    seen[key]          = #entries + 1
+                    entries[#entries + 1] = { argv = argv, sessions = {} }
+                end
+                local entry = entries[seen[key]]
+                -- Deduplicate sessions too (same record can list same cmd twice)
+                local already = false
+                for _, s in ipairs(entry.sessions) do
+                    if s == res then already = true; break end
+                end
+                if not already then
+                    entry.sessions[#entry.sessions + 1] = res
+                end
+            end
+        end
+    end
+    return entries
+end
+
+---Reactor fiber: drains the commit queue and debounces restarts (1s window).
+---Each record is applied independently; failures revert that record's staged
+---changes and are reported only to its own reply channel.
+local function reactor()
+    local cursor = uci_mod.cursor()
+
+    while true do
+        -- Collect the first record then debounce within a 1s window
+        local batch = { commit_ch:get() }
+
+        while true do
+            local name, result = fibers.perform(fibers.named_choice({
+                more    = commit_ch:get_op(),
+                timeout = sleep.sleep_op(1.0),
+            }))
+            if name == 'timeout' then break end
+            batch[#batch + 1] = result
+        end
+
+        -- Phase 1: apply each record's changes independently
+        local record_results = {}
+        for _, r in ipairs(batch) do
+            local ok, err = pcall(apply_changes, cursor, r)
+            if not ok then
+                -- Revert any uncommitted staged changes for this config
+                pcall(cursor.revert, cursor, r.config)
+                record_results[#record_results + 1] = { record = r, ok = false, err = tostring(err) }
+            else
+                record_results[#record_results + 1] = { record = r, ok = true, err = "" }
+            end
+        end
+
+        -- Phase 2: build deduplicated restart list from successful records
+        local restart_entries = trim_restarts(record_results)
+
+        -- Phase 3: run each unique restart; propagate failures to dependent sessions
+        for _, entry in ipairs(restart_entries) do
+            local rok, rerr = run_restart_cmds({ entry.argv })
+            if not rok then
+                for _, res in ipairs(entry.sessions) do
+                    res.ok  = false
+                    res.err = res.err ~= "" and (res.err .. "; " .. rerr) or rerr
+                end
+            end
+        end
+
+        -- Phase 4: reply to every session that supplied a reply channel
+        for _, res in ipairs(record_results) do
+            if res.record.reply_ch then
+                res.record.reply_ch:put({ ok = res.ok, err = res.err })
+            end
+        end
+    end
+end
+
+---Start the UCI reactor once, attached to the root scope.
+---Subsequent calls are no-ops.
+---@return nil
+local function ensure_started()
+    if started then return end
+    started = true
+    Scope.root():spawn(reactor)
+end
+
+---Create a new staged UCI session.
+---Changes are queued on commit(); the reactor applies them asynchronously.
+---@class UciSession
+---@field _changes UciChange[]
+local Session = {}
+Session.__index = Session
+
+---@return UciSession
+local function new_session()
+    return setmetatable({ _changes = {} }, Session)
+end
+
+---@param config string
+---@param section string
+---@param option string
+---@param value any
+function Session:set(config, section, option, value)
+    table.insert(self._changes, {
+        op = 'set',
+        config = config,
+        section = section,
+        option = option,
+        value = value,
+    })
+end
+
+---@param config string
+---@param stype string  UCI section type
+function Session:add(config, stype)
+    table.insert(self._changes, {
+        op = 'add', config = config, stype = stype,
+    })
+end
+
+---@param config string
+---@param section string
+---@param option? string  if omitted the whole section is deleted
+function Session:delete(config, section, option)
+    table.insert(self._changes, {
+        op = 'delete', config = config, section = section, option = option,
+    })
+end
+
+---Queue staged changes to be applied by the reactor.
+---Returns a reply channel that will receive {ok=boolean, err=string} once
+---the commit (and any restart commands) have completed.
+---@param config string        UCI config file name
+---@param restart_cmds string[][]|nil  List of argv lists to exec after apply (debounced, 1s)
+---@return table reply_ch      channel — receive to wait for completion
+function Session:commit(config, restart_cmds)
+    local reply_ch = channel.new(1)
+    commit_ch:put({
+        changes      = self._changes,
+        config       = config,
+        restart_cmds = restart_cmds,
+        reply_ch     = reply_ch,
+    })
+    self._changes = {}
+    return reply_ch
+end
+
+---Apply staged changes immediately using a temporary cursor (synchronous).
+---Use only during driver initialisation where blocking is acceptable.
+---Returns ok (boolean) and err (string).
+---@param config string
+---@param restart_cmds string[][]|nil  List of argv lists to exec immediately (not debounced)
+---@return boolean ok
+---@return string  err
+function Session:commit_sync(config, restart_cmds)
+    local ok, err = pcall(function()
+        local c = uci_mod.cursor()
+        apply_changes(c, { changes = self._changes, config = config })
+        if restart_cmds then
+            local rok, rerr = run_restart_cmds(restart_cmds)
+            if not rok then error(rerr) end
+        end
+    end)
+    self._changes = {}
+    if not ok then
+        return false, tostring(err)
+    end
+    return true, ""
+end
+
+---Read a single UCI value without going through the reactor queue.
+---Safe for read-only use from any fiber (no staged state involved).
+---@param config string
+---@param section string
+---@param option string
+---@return any value   nil if not found
+local function get_value(config, section, option)
+    local c = uci_mod.cursor()
+    return c:get(config, section, option)
+end
+
+return {
+    ensure_started = ensure_started,
+    new_session    = new_session,
+    get_value      = get_value,
+}

--- a/src/services/hal/backends/radio/contract.lua
+++ b/src/services/hal/backends/radio/contract.lua
@@ -1,0 +1,32 @@
+---Radio backend contract definition.
+---All radio backends must implement the functions listed in RADIO_BACKEND_FUNCTIONS.
+
+local RADIO_BACKEND_FUNCTIONS = {
+    'get_meta',
+    'apply',
+    'watch_events',
+    'get_iface_info',
+    'get_iface_survey',
+    'get_station_info',
+}
+
+---Validate that a backend table implements all required functions.
+---@param backend table
+---@return boolean ok
+---@return string  err   Empty string on success.
+local function validate(backend)
+    if type(backend) ~= 'table' then
+        return false, "backend must be a table"
+    end
+    for _, fn_name in ipairs(RADIO_BACKEND_FUNCTIONS) do
+        if type(backend[fn_name]) ~= 'function' then
+            return false, "backend missing required function: " .. fn_name
+        end
+    end
+    return true, ""
+end
+
+return {
+    RADIO_BACKEND_FUNCTIONS = RADIO_BACKEND_FUNCTIONS,
+    validate                = validate,
+}

--- a/src/services/hal/backends/radio/contract.lua
+++ b/src/services/hal/backends/radio/contract.lua
@@ -4,7 +4,10 @@
 local RADIO_BACKEND_FUNCTIONS = {
     'get_meta',
     'apply',
-    'watch_events',
+    'clear',
+    'start_client_monitor',
+    'watch_clients_op',
+    'get_connected_macs',
     'get_iface_info',
     'get_iface_survey',
     'get_station_info',

--- a/src/services/hal/backends/radio/provider.lua
+++ b/src/services/hal/backends/radio/provider.lua
@@ -13,6 +13,7 @@ local BACKENDS = {
 local function get_backend()
     for _, path in ipairs(BACKENDS) do
         local ok, provider = pcall(require, path)
+        print("radio", path, ok, (ok == false) and provider or nil)
         if ok and provider.is_supported and provider.is_supported() then
             local backend = provider.backend
             local valid, verr = contract.validate(backend)

--- a/src/services/hal/backends/radio/provider.lua
+++ b/src/services/hal/backends/radio/provider.lua
@@ -1,0 +1,31 @@
+---Radio backend provider.
+---Iterates registered backends and returns the first supported one.
+
+local contract = require "services.hal.backends.radio.contract"
+
+local BACKENDS = {
+    "services.hal.backends.radio.providers.openwrt",
+}
+
+---Get the first supported radio backend.
+---@return table|nil  backend
+---@return string     err  "" on success
+local function get_backend()
+    for _, path in ipairs(BACKENDS) do
+        local ok, provider = pcall(require, path)
+        if ok and provider.is_supported and provider.is_supported() then
+            local backend = provider.backend
+            local valid, verr = contract.validate(backend)
+            if valid then
+                return backend, ""
+            else
+                return nil, "backend " .. path .. " failed contract check: " .. verr
+            end
+        end
+    end
+    return nil, "no supported radio backend found on this device"
+end
+
+return {
+    get_backend = get_backend,
+}

--- a/src/services/hal/backends/radio/provider.lua
+++ b/src/services/hal/backends/radio/provider.lua
@@ -7,15 +7,16 @@ local BACKENDS = {
     "services.hal.backends.radio.providers.openwrt",
 }
 
----Get the first supported radio backend.
----@return table|nil  backend
+---Instantiate a new backend for the named radio from the first supported provider.
+---@param name string  UCI radio section name (e.g. "radio0")
+---@return table|nil  backend instance
 ---@return string     err  "" on success
-local function get_backend()
+local function new(name)
     for _, path in ipairs(BACKENDS) do
         local ok, provider = pcall(require, path)
         print("radio", path, ok, (ok == false) and provider or nil)
         if ok and provider.is_supported and provider.is_supported() then
-            local backend = provider.backend
+            local backend = provider.backend.new(name)
             local valid, verr = contract.validate(backend)
             if valid then
                 return backend, ""
@@ -28,5 +29,5 @@ local function get_backend()
 end
 
 return {
-    get_backend = get_backend,
+    new = new,
 }

--- a/src/services/hal/backends/radio/providers/openwrt/impl.lua
+++ b/src/services/hal/backends/radio/providers/openwrt/impl.lua
@@ -4,8 +4,8 @@
 
 local uci    = require "services.hal.backends.common.uci"
 local fibers = require "fibers"
-local exec   = require "fibers.exec"
-local file   = require "fibers.stream.file"
+local exec   = require "fibers.io.exec"
+local file   = require "fibers.io.file"
 
 local SYSFS_STATS = {
     'rx_bytes', 'tx_bytes',
@@ -22,10 +22,10 @@ local SYSFS_STATS = {
 local function read_sysfs_stat(iface, stat)
     local path = '/sys/class/net/' .. iface .. '/statistics/' .. stat
     local f, ferr = file.open(path, 'r')
-    if ferr then return nil, tostring(ferr) end
-    local content, rerr = f:read_all_chars()
+    if not f then return nil, tostring(ferr) end
+    local content, rerr = f:read_all()
     f:close()
-    if rerr then return nil, tostring(rerr) end
+    if not content then return nil, tostring(rerr) end
     local num = tonumber((content or ''):match('(%d+)'))
     if num == nil then return nil, stat .. ' invalid number' end
     return num, nil
@@ -108,7 +108,24 @@ local function apply(staged)
     local session = uci.new_session()
     local name = staged.name
 
-    -- Radio section (wifi-device)
+    -- Delete any existing wifi-iface sections that belong to this radio but
+    -- are not in the staged interfaces set, so stale sections don't linger.
+    local staged_iface_names = {}
+    for _, iface in ipairs(staged.interfaces or {}) do
+        staged_iface_names[iface.name] = true
+    end
+    for _, sec in ipairs(uci.get_sections('wireless', 'wifi-iface')) do
+        if uci.get_value('wireless', sec, 'device') == name
+                and not staged_iface_names[sec] then
+            session:delete('wireless', sec)
+        end
+    end
+
+    -- Radio section (wifi-device) — ensure it exists before setting options
+    session:set('wireless', name, 'wifi-device')
+    if staged.path and staged.path ~= '' then
+        session:set('wireless', name, 'path', staged.path)
+    end
     if staged.type and staged.type ~= '' then
         session:set('wireless', name, 'type', staged.type)
     end
@@ -141,6 +158,8 @@ local function apply(staged)
 
     -- Write interface sections (wifi-iface)
     for _, iface in ipairs(staged.interfaces or {}) do
+        -- Ensure the named section exists with the correct type before setting options
+        session:set('wireless', iface.name, 'wifi-iface')
         session:set('wireless', iface.name, 'ifname',  iface.name)
         session:set('wireless', iface.name, 'device',  name)
         session:set('wireless', iface.name, 'mode',    iface.mode or 'ap')
@@ -161,18 +180,52 @@ local function apply(staged)
         end
     end
 
-    session:commit('wireless', { { 'wifi', 'reload' } })
+    local ok, err = session:commit('wireless', { { 'wifi', 'reload' } })
+    if not ok then
+        error('apply commit failed: ' .. tostring(err))
+    end
+end
+
+---Delete all UCI config owned by this radio and reload wireless.
+---Removes all wifi-iface sections whose device == name, then
+---deletes the configurable options from the wifi-device section.
+---@param name string  UCI radio section name
+local function clear(name)
+    uci.ensure_started()
+    local session = uci.new_session()
+
+    -- Delete all wifi-iface sections that belong to this radio
+    for _, sec in ipairs(uci.get_sections('wireless', 'wifi-iface')) do
+        if uci.get_value('wireless', sec, 'device') == name then
+            session:delete('wireless', sec)
+        end
+    end
+
+    -- Delete the configurable options on the wifi-device section
+    -- (leave 'path' and 'type' intact since they are hardware facts)
+    local OPT_KEYS = { 'band', 'channel', 'channels', 'htmode', 'txpower',
+                       'country', 'disabled' }
+    for _, opt in ipairs(OPT_KEYS) do
+        if uci.get_value('wireless', name, opt) ~= nil then
+            session:delete('wireless', name, opt)
+        end
+    end
+
+    local ok, err = session:commit('wireless', { { 'wifi', 'reload' } })
+    if not ok then
+        error('clear failed: ' .. tostring(err))
+    end
 end
 
 ---Start monitoring client connect/disconnect events for the given interfaces.
 ---Calls cb(event) for each event where event = { mac, connected, interface }.
 ---Runs until the calling fiber's scope is cancelled.
----@param interfaces table  List of interface names to monitor
----@param cb function        Called with each event table
-local function watch_events(interfaces, cb)
+---@param interfaces_set table  Live set of interface names to monitor (name → true)
+---@param cb function            Called with each event table
+local function watch_events(interfaces_set, cb)
     -- `iw event` reports events across all interfaces on stdout
-    local proc = exec.command('iw', 'event')
-    local stdout, serr = proc:stdout_pipe()
+    local proc = exec.command{ 'iw', 'event', stdout = 'pipe' }
+    local stdout, serr = proc:stdout_stream()
     if serr then return end
 
     fibers.current_scope():finally(function()
@@ -195,18 +248,9 @@ local function watch_events(interfaces, cb)
             match_iface, is_connected, match_mac = iface3, false, mac3
         end
 
-        if match_iface and match_mac then
-            -- Only emit events for interfaces we're tracking
-            local tracked = false
-            for _, tracked_iface in ipairs(interfaces) do
-                if tracked_iface == match_iface then
-                    tracked = true
-                    break
-                end
-            end
-            if tracked then
-                cb({ mac = match_mac, connected = is_connected, interface = match_iface })
-            end
+        -- Only forward events for interfaces currently in the live set
+        if match_iface and match_mac and interfaces_set[match_iface] then
+            cb({ mac = match_mac, connected = is_connected, interface = match_iface })
         end
     end
 end
@@ -216,9 +260,9 @@ end
 ---@return table|nil  { txpower, channel, freq, width }
 ---@return string     err
 local function get_iface_info(iface)
-    local proc = exec.command('iw', 'dev', iface, 'info')
-    local out, err = proc:output()
-    if err then return nil, tostring(err) end
+    local proc = exec.command{ 'iw', 'dev', iface, 'info', stdout = 'pipe' }
+    local out, status, _, _, err = fibers.perform(proc:output_op())
+    if status ~= 'exited' or err then return nil, tostring(err or 'iw dev info failed') end
     local result = parse_iw_dev_info(out)
     if not result then return nil, "could not parse iw dev info output" end
     return result, ""
@@ -229,9 +273,9 @@ end
 ---@return number|nil  noise value
 ---@return string      err
 local function get_iface_survey(iface)
-    local proc = exec.command('iw', iface, 'survey', 'dump')
-    local out, err = proc:output()
-    if err then return nil, tostring(err) end
+    local proc = exec.command{ 'iw', iface, 'survey', 'dump', stdout = 'pipe' }
+    local out, status, _, _, err = fibers.perform(proc:output_op())
+    if status ~= 'exited' or err then return nil, tostring(err or 'iw survey failed') end
     local noise = parse_survey_noise(out)
     if noise == nil then return nil, "noise value not found" end
     return noise, ""
@@ -243,9 +287,9 @@ end
 ---@return table|nil  { signal, tx_bytes, rx_bytes }
 ---@return string     err
 local function get_station_info(iface, mac)
-    local proc = exec.command('iw', 'dev', iface, 'station', 'get', mac)
-    local out, err = proc:output()
-    if err then return nil, tostring(err) end
+    local proc = exec.command{ 'iw', 'dev', iface, 'station', 'get', mac, stdout = 'pipe' }
+    local out, status, _, _, err = fibers.perform(proc:output_op())
+    if status ~= 'exited' or err then return nil, tostring(err or 'iw station get failed') end
     local result = parse_station_info(out)
     if not result then return nil, "could not parse station info" end
     return result, ""
@@ -253,6 +297,7 @@ end
 
 return {
     get_meta        = get_meta,
+    clear           = clear,
     apply           = apply,
     watch_events    = watch_events,
     get_iface_info  = get_iface_info,

--- a/src/services/hal/backends/radio/providers/openwrt/impl.lua
+++ b/src/services/hal/backends/radio/providers/openwrt/impl.lua
@@ -2,10 +2,12 @@
 ---All UCI writes use the shared uci singleton (reactor). Reads use get_value.
 ---Subprocess management (iw event, iw dev info, iw survey) is handled here.
 
-local uci    = require "services.hal.backends.common.uci"
-local fibers = require "fibers"
-local exec   = require "fibers.io.exec"
-local file   = require "fibers.io.file"
+local uci         = require "services.hal.backends.common.uci"
+local fibers      = require "fibers"
+local op          = require "fibers.op"
+local scope       = require "fibers.scope"
+local exec        = require "fibers.io.exec"
+local file        = require "fibers.io.file"
 
 local SYSFS_STATS = {
     'rx_bytes', 'tx_bytes',
@@ -83,19 +85,49 @@ local function parse_station_info(raw)
     return result
 end
 
+---Parse `iw dev <iface> station dump` output into a list of MAC addresses.
+---Each station block starts with "Station <mac> (on <iface>)".
+---@param raw string
+---@return string[]  list of MAC addresses
+local function parse_station_dump_macs(raw)
+    if not raw or raw == '' then return {} end
+    local macs = {}
+    for mac in raw:gmatch('Station%s+([%x:]+)%s+%(on%s+%S+%)') do
+        macs[#macs + 1] = mac
+    end
+    return macs
+end
+
 ------------------------------------------------------------------------
--- Backend functions
+-- RadioBackend class
 ------------------------------------------------------------------------
 
+---@class ClientEvent
+---@field mac string
+---@field added boolean  true = new station, false = del station
+---@field interface string
+
+---@class RadioBackend
+---@field name string    UCI wifi-device section name (e.g. "radio0")
+---@field _monitor table|nil  active ClientMonitor, set by start_client_monitor
+local RadioBackend = {}
+RadioBackend.__index = RadioBackend
+RadioBackend.SYSFS_STATS = SYSFS_STATS
+
+---@param name string  UCI radio section name (e.g. "radio0")
+---@return RadioBackend
+function RadioBackend.new(name)
+    return setmetatable({ name = name, _monitor = nil }, RadioBackend)
+end
+
 ---Get radio metadata from UCI wireless config.
----@param name string   UCI wifi-device section name (e.g. "radio0")
 ---@return table|nil  { path, type }
 ---@return string     err  "" on success
-local function get_meta(name)
-    local path = uci.get_value('wireless', name, 'path')
-    local rtype = uci.get_value('wireless', name, 'type')
+function RadioBackend:get_meta()
+    local path  = uci.get_value('wireless', self.name, 'path')
+    local rtype = uci.get_value('wireless', self.name, 'type')
     if not path then
-        return nil, "could not read wireless." .. name .. ".path from UCI"
+        return nil, "could not read wireless." .. self.name .. ".path from UCI"
     end
     return { path = path, type = rtype or '' }, ""
 end
@@ -103,10 +135,10 @@ end
 ---Apply the staged radio config table to UCI and reload wireless.
 ---Uses the shared UCI reactor for debounced writes.
 ---@param staged table  Full staged config as accumulated by the driver
-local function apply(staged)
+function RadioBackend:apply(staged)
     uci.ensure_started()
     local session = uci.new_session()
-    local name = staged.name
+    local name = self.name
 
     -- Delete any existing wifi-iface sections that belong to this radio but
     -- are not in the staged interfaces set, so stale sections don't linger.
@@ -116,7 +148,7 @@ local function apply(staged)
     end
     for _, sec in ipairs(uci.get_sections('wireless', 'wifi-iface')) do
         if uci.get_value('wireless', sec, 'device') == name
-                and not staged_iface_names[sec] then
+            and not staged_iface_names[sec] then
             session:delete('wireless', sec)
         end
     end
@@ -160,21 +192,21 @@ local function apply(staged)
     for _, iface in ipairs(staged.interfaces or {}) do
         -- Ensure the named section exists with the correct type before setting options
         session:set('wireless', iface.name, 'wifi-iface')
-        session:set('wireless', iface.name, 'ifname',  iface.name)
-        session:set('wireless', iface.name, 'device',  name)
-        session:set('wireless', iface.name, 'mode',    iface.mode or 'ap')
-        session:set('wireless', iface.name, 'ssid',    iface.ssid)
+        session:set('wireless', iface.name, 'ifname', iface.name)
+        session:set('wireless', iface.name, 'device', name)
+        session:set('wireless', iface.name, 'mode', iface.mode or 'ap')
+        session:set('wireless', iface.name, 'ssid', iface.ssid)
         session:set('wireless', iface.name, 'encryption', iface.encryption)
-        session:set('wireless', iface.name, 'key',     iface.password or '')
+        session:set('wireless', iface.name, 'key', iface.password or '')
         session:set('wireless', iface.name, 'network', iface.network)
         if iface.enable_steering then
-            session:set('wireless', iface.name, 'bss_transition',    '1')
-            session:set('wireless', iface.name, 'ieee80211k',        '1')
+            session:set('wireless', iface.name, 'bss_transition', '1')
+            session:set('wireless', iface.name, 'ieee80211k', '1')
             session:set('wireless', iface.name, 'rrm_neighbor_report', '1')
             session:set('wireless', iface.name, 'rrm_beacon_report', '1')
         else
-            session:set('wireless', iface.name, 'bss_transition',    '0')
-            session:set('wireless', iface.name, 'ieee80211k',        '0')
+            session:set('wireless', iface.name, 'bss_transition', '0')
+            session:set('wireless', iface.name, 'ieee80211k', '0')
             session:set('wireless', iface.name, 'rrm_neighbor_report', '0')
             session:set('wireless', iface.name, 'rrm_beacon_report', '0')
         end
@@ -187,12 +219,12 @@ local function apply(staged)
 end
 
 ---Delete all UCI config owned by this radio and reload wireless.
----Removes all wifi-iface sections whose device == name, then
+---Removes all wifi-iface sections whose device == self.name, then
 ---deletes the configurable options from the wifi-device section.
----@param name string  UCI radio section name
-local function clear(name)
+function RadioBackend:clear()
     uci.ensure_started()
     local session = uci.new_session()
+    local name = self.name
 
     -- Delete all wifi-iface sections that belong to this radio
     for _, sec in ipairs(uci.get_sections('wireless', 'wifi-iface')) do
@@ -204,7 +236,7 @@ local function clear(name)
     -- Delete the configurable options on the wifi-device section
     -- (leave 'path' and 'type' intact since they are hardware facts)
     local OPT_KEYS = { 'band', 'channel', 'channels', 'htmode', 'txpower',
-                       'country', 'disabled' }
+        'country', 'disabled' }
     for _, opt in ipairs(OPT_KEYS) do
         if uci.get_value('wireless', name, opt) ~= nil then
             session:delete('wireless', name, opt)
@@ -217,50 +249,73 @@ local function clear(name)
     end
 end
 
----Start monitoring client connect/disconnect events for the given interfaces.
----Calls cb(event) for each event where event = { mac, connected, interface }.
----Runs until the calling fiber's scope is cancelled.
----@param interfaces_set table  Live set of interface names to monitor (name → true)
----@param cb function            Called with each event table
-local function watch_events(interfaces_set, cb)
-    -- `iw event` reports events across all interfaces on stdout
-    local proc = exec.command{ 'iw', 'event', stdout = 'pipe' }
-    local stdout, serr = proc:stdout_stream()
-    if serr then return end
+---Parse a single `iw event` line into a ClientEvent, or nil if not a station event.
+---Matches: "<iface>: new station <mac>" / "<iface>: del station <mac>"
+---@param line string
+---@return ClientEvent|nil
+local function parse_client_event_line(line)
+    local iface, verb, mac = line:match('^(%S-):%s+(%a+)%s+station%s+([%x:]+)$')
+    if not iface then return nil end
+    if verb ~= 'new' and verb ~= 'del' then return nil end
+    return { mac = mac, added = verb == 'new', interface = iface }
+end
 
-    fibers.current_scope():finally(function()
-        proc:kill()
-    end)
-
-    while true do
-        local line, lerr = stdout:read_line()
-        if lerr or not line then break end
-
-        -- Parse: "wlan0: AP-STA-CONNECTED aa:bb:cc:dd:ee:ff"
-        --   or   "wlan0: AP-STA-DISCONNECTED aa:bb:cc:dd:ee:ff"
-        local iface2, mac2 = line:match('^(%S-):%s+AP%-STA%-CONNECTED%s+([%x:]+)$')
-        local iface3, mac3 = line:match('^(%S-):%s+AP%-STA%-DISCONNECTED%s+([%x:]+)$')
-
-        local match_iface, is_connected, match_mac
-        if iface2 and mac2 then
-            match_iface, is_connected, match_mac = iface2, true, mac2
-        elseif iface3 and mac3 then
-            match_iface, is_connected, match_mac = iface3, false, mac3
-        end
-
-        -- Only forward events for interfaces currently in the live set
-        if match_iface and match_mac and interfaces_set[match_iface] then
-            cb({ mac = match_mac, connected = is_connected, interface = match_iface })
-        end
+---Start the iw event subprocess for client monitoring.
+---Stores the process and stream in self._monitor; idempotent if already started.
+---@return boolean ok
+---@return string  err
+function RadioBackend:start_client_monitor()
+    if self._monitor then
+        return false, 'client monitor already started'
     end
+    local cmd = exec.command { 'iw', 'event', stdin = 'null', stdout = 'pipe', stderr = 'null' }
+    local stdout, err = cmd:stdout_stream()
+    if not stdout then
+        return false, 'failed to start iw event: ' .. tostring(err)
+    end
+    self._monitor = { cmd = cmd, stdout = stdout }
+    return true, ''
+end
+
+---Return an op that blocks until the next client connect/disconnect event
+---for an interface in the monitor's interfaces_set, then returns a ClientEvent.
+---Each perform of the op yields exactly one matching event.
+---@return Op
+function RadioBackend:watch_clients_op()
+    return op.guard(function()
+        if not self._monitor then
+            return op.always(nil, 'client monitor not started')
+        end
+        return scope.run_op(function(s)
+            while true do
+                ---@diagnostic disable-next-line: need-check-nil
+                local line = s:perform(self._monitor.stdout:read_line_op()) --[[@as string?]]
+                if not line then
+                    return nil, 'iw event stream closed'
+                end
+                local ev = parse_client_event_line(line)
+                if ev then
+                    return ev
+                end
+            end
+        end):wrap(function(st, _, ...)
+            if st == 'ok' then
+                return ...
+            elseif st == 'cancelled' then
+                return nil, 'cancelled'
+            else
+                return nil, (... or 'iw event monitor failed')
+            end
+        end)
+    end)
 end
 
 ---Get interface info: txpower, channel, freq, width.
 ---@param iface string
 ---@return table|nil  { txpower, channel, freq, width }
 ---@return string     err
-local function get_iface_info(iface)
-    local proc = exec.command{ 'iw', 'dev', iface, 'info', stdout = 'pipe' }
+function RadioBackend:get_iface_info(iface)
+    local proc = exec.command { 'iw', 'dev', iface, 'info', stdout = 'pipe' }
     local out, status, _, _, err = fibers.perform(proc:output_op())
     if status ~= 'exited' or err then return nil, tostring(err or 'iw dev info failed') end
     local result = parse_iw_dev_info(out)
@@ -272,8 +327,8 @@ end
 ---@param iface string
 ---@return number|nil  noise value
 ---@return string      err
-local function get_iface_survey(iface)
-    local proc = exec.command{ 'iw', iface, 'survey', 'dump', stdout = 'pipe' }
+function RadioBackend:get_iface_survey(iface)
+    local proc = exec.command { 'iw', iface, 'survey', 'dump', stdout = 'pipe' }
     local out, status, _, _, err = fibers.perform(proc:output_op())
     if status ~= 'exited' or err then return nil, tostring(err or 'iw survey failed') end
     local noise = parse_survey_noise(out)
@@ -286,8 +341,8 @@ end
 ---@param mac string
 ---@return table|nil  { signal, tx_bytes, rx_bytes }
 ---@return string     err
-local function get_station_info(iface, mac)
-    local proc = exec.command{ 'iw', 'dev', iface, 'station', 'get', mac, stdout = 'pipe' }
+function RadioBackend:get_station_info(iface, mac)
+    local proc = exec.command { 'iw', 'dev', iface, 'station', 'get', mac, stdout = 'pipe' }
     local out, status, _, _, err = fibers.perform(proc:output_op())
     if status ~= 'exited' or err then return nil, tostring(err or 'iw station get failed') end
     local result = parse_station_info(out)
@@ -295,15 +350,26 @@ local function get_station_info(iface, mac)
     return result, ""
 end
 
+---Get all currently associated MAC addresses for an interface.
+---@param iface string
+---@return string[]  list of MAC addresses (may be empty)
+---@return string    err
+function RadioBackend:get_connected_macs(iface)
+    local proc = exec.command { 'iw', 'dev', iface, 'station', 'dump', stdout = 'pipe' }
+    local out, status, _, _, err = fibers.perform(proc:output_op())
+    if status ~= 'exited' or err then return {}, tostring(err or 'iw station dump failed') end
+    return parse_station_dump_macs(out), ''
+end
+
+---Read a sysfs statistics value for an interface.
+---@param iface string
+---@param stat string
+---@return number|nil
+---@return string|nil err
+function RadioBackend:read_sysfs_stat(iface, stat)
+    return read_sysfs_stat(iface, stat)
+end
+
 return {
-    get_meta        = get_meta,
-    clear           = clear,
-    apply           = apply,
-    watch_events    = watch_events,
-    get_iface_info  = get_iface_info,
-    get_iface_survey = get_iface_survey,
-    get_station_info = get_station_info,
-    -- Re-export sysfs stat reader for use by the driver
-    read_sysfs_stat = read_sysfs_stat,
-    SYSFS_STATS     = SYSFS_STATS,
+    new = RadioBackend.new,
 }

--- a/src/services/hal/backends/radio/providers/openwrt/impl.lua
+++ b/src/services/hal/backends/radio/providers/openwrt/impl.lua
@@ -1,0 +1,264 @@
+---OpenWrt radio backend implementation.
+---All UCI writes use the shared uci singleton (reactor). Reads use get_value.
+---Subprocess management (iw event, iw dev info, iw survey) is handled here.
+
+local uci    = require "services.hal.backends.common.uci"
+local fibers = require "fibers"
+local exec   = require "fibers.exec"
+local file   = require "fibers.stream.file"
+
+local SYSFS_STATS = {
+    'rx_bytes', 'tx_bytes',
+    'rx_packets', 'tx_packets',
+    'rx_dropped', 'tx_dropped',
+    'rx_errors', 'tx_errors',
+}
+
+---Read a single value from /sys/class/net/<iface>/statistics/<stat>
+---@param iface string
+---@param stat string
+---@return number|nil
+---@return string|nil err
+local function read_sysfs_stat(iface, stat)
+    local path = '/sys/class/net/' .. iface .. '/statistics/' .. stat
+    local f, ferr = file.open(path, 'r')
+    if ferr then return nil, tostring(ferr) end
+    local content, rerr = f:read_all_chars()
+    f:close()
+    if rerr then return nil, tostring(rerr) end
+    local num = tonumber((content or ''):match('(%d+)'))
+    if num == nil then return nil, stat .. ' invalid number' end
+    return num, nil
+end
+
+---Parse `iw dev <iface> info` output into {txpower, channel, freq, width}
+local function parse_iw_dev_info(raw)
+    if not raw or raw == '' then return nil end
+    local result = {}
+    for line in raw:gmatch('[^\r\n]+') do
+        local txpower = line:match('%s*txpower%s+([%d.]+)%s+dBm')
+        if txpower then result.txpower = tonumber(txpower) end
+
+        local chan, freq, width = line:match(
+            '%s*channel%s+(%d+)%s+%(([%d]+)%s*MHz%),%s*width:%s*(%d+)%s*MHz'
+        )
+        if chan then
+            result.channel = tonumber(chan)
+            result.freq    = tonumber(freq)
+            result.width   = tonumber(width)
+        end
+    end
+    return result
+end
+
+---Parse `iw <iface> survey dump` for in-use noise value
+local function parse_survey_noise(raw)
+    if not raw or raw == '' then return nil end
+    local in_use = false
+    for line in raw:gmatch('[^\r\n]+') do
+        if not in_use then
+            if line:find('%[in use%]') then in_use = true end
+        else
+            local val = line:match('noise:%s*(%-?%d+%.?%d*)')
+            if val then return tonumber(val) end
+        end
+    end
+    return nil
+end
+
+---Parse `iw dev <iface> station get <mac>` output into {signal, tx_bytes, rx_bytes}
+local function parse_station_info(raw)
+    if not raw or raw == '' then return nil end
+    local result = {}
+    for line in raw:gmatch('[^\r\n]+') do
+        local sig = line:match('%s*signal:%s*(%-?%d+)%s*dBm')
+        if sig then result.signal = tonumber(sig) end
+
+        local tx = line:match('%s*tx%s+bytes:%s+(%d+)')
+        if tx then result.tx_bytes = tonumber(tx) end
+
+        local rx = line:match('%s*rx%s+bytes:%s+(%d+)')
+        if rx then result.rx_bytes = tonumber(rx) end
+    end
+    return result
+end
+
+------------------------------------------------------------------------
+-- Backend functions
+------------------------------------------------------------------------
+
+---Get radio metadata from UCI wireless config.
+---@param name string   UCI wifi-device section name (e.g. "radio0")
+---@return table|nil  { path, type }
+---@return string     err  "" on success
+local function get_meta(name)
+    local path = uci.get_value('wireless', name, 'path')
+    local rtype = uci.get_value('wireless', name, 'type')
+    if not path then
+        return nil, "could not read wireless." .. name .. ".path from UCI"
+    end
+    return { path = path, type = rtype or '' }, ""
+end
+
+---Apply the staged radio config table to UCI and reload wireless.
+---Uses the shared UCI reactor for debounced writes.
+---@param staged table  Full staged config as accumulated by the driver
+local function apply(staged)
+    uci.ensure_started()
+    local session = uci.new_session()
+    local name = staged.name
+
+    -- Radio section (wifi-device)
+    if staged.type and staged.type ~= '' then
+        session:set('wireless', name, 'type', staged.type)
+    end
+    if staged.band then
+        session:set('wireless', name, 'band', staged.band)
+    end
+    if staged.channel ~= nil then
+        session:set('wireless', name, 'channel', staged.channel)
+    end
+    if staged.htmode then
+        session:set('wireless', name, 'htmode', staged.htmode)
+    end
+    if staged.channels then
+        session:set('wireless', name, 'channels', table.concat(staged.channels, ' '))
+    end
+    if staged.txpower ~= nil then
+        session:set('wireless', name, 'txpower', staged.txpower)
+    end
+    if staged.country then
+        session:set('wireless', name, 'country', staged.country)
+    end
+    if staged.disabled ~= nil then
+        session:set('wireless', name, 'disabled', staged.disabled)
+    end
+
+    -- Delete removed interfaces
+    for _, iface_name in ipairs(staged.deleted_interfaces or {}) do
+        session:delete('wireless', iface_name)
+    end
+
+    -- Write interface sections (wifi-iface)
+    for _, iface in ipairs(staged.interfaces or {}) do
+        session:set('wireless', iface.name, 'ifname',  iface.name)
+        session:set('wireless', iface.name, 'device',  name)
+        session:set('wireless', iface.name, 'mode',    iface.mode or 'ap')
+        session:set('wireless', iface.name, 'ssid',    iface.ssid)
+        session:set('wireless', iface.name, 'encryption', iface.encryption)
+        session:set('wireless', iface.name, 'key',     iface.password or '')
+        session:set('wireless', iface.name, 'network', iface.network)
+        if iface.enable_steering then
+            session:set('wireless', iface.name, 'bss_transition',    '1')
+            session:set('wireless', iface.name, 'ieee80211k',        '1')
+            session:set('wireless', iface.name, 'rrm_neighbor_report', '1')
+            session:set('wireless', iface.name, 'rrm_beacon_report', '1')
+        else
+            session:set('wireless', iface.name, 'bss_transition',    '0')
+            session:set('wireless', iface.name, 'ieee80211k',        '0')
+            session:set('wireless', iface.name, 'rrm_neighbor_report', '0')
+            session:set('wireless', iface.name, 'rrm_beacon_report', '0')
+        end
+    end
+
+    session:commit('wireless', { { 'wifi', 'reload' } })
+end
+
+---Start monitoring client connect/disconnect events for the given interfaces.
+---Calls cb(event) for each event where event = { mac, connected, interface }.
+---Runs until the calling fiber's scope is cancelled.
+---@param interfaces table  List of interface names to monitor
+---@param cb function        Called with each event table
+local function watch_events(interfaces, cb)
+    -- `iw event` reports events across all interfaces on stdout
+    local proc = exec.command('iw', 'event')
+    local stdout, serr = proc:stdout_pipe()
+    if serr then return end
+
+    fibers.current_scope():finally(function()
+        proc:kill()
+    end)
+
+    while true do
+        local line, lerr = stdout:read_line()
+        if lerr or not line then break end
+
+        -- Parse: "wlan0: AP-STA-CONNECTED aa:bb:cc:dd:ee:ff"
+        --   or   "wlan0: AP-STA-DISCONNECTED aa:bb:cc:dd:ee:ff"
+        local iface2, mac2 = line:match('^(%S-):%s+AP%-STA%-CONNECTED%s+([%x:]+)$')
+        local iface3, mac3 = line:match('^(%S-):%s+AP%-STA%-DISCONNECTED%s+([%x:]+)$')
+
+        local match_iface, is_connected, match_mac
+        if iface2 and mac2 then
+            match_iface, is_connected, match_mac = iface2, true, mac2
+        elseif iface3 and mac3 then
+            match_iface, is_connected, match_mac = iface3, false, mac3
+        end
+
+        if match_iface and match_mac then
+            -- Only emit events for interfaces we're tracking
+            local tracked = false
+            for _, tracked_iface in ipairs(interfaces) do
+                if tracked_iface == match_iface then
+                    tracked = true
+                    break
+                end
+            end
+            if tracked then
+                cb({ mac = match_mac, connected = is_connected, interface = match_iface })
+            end
+        end
+    end
+end
+
+---Get interface info: txpower, channel, freq, width.
+---@param iface string
+---@return table|nil  { txpower, channel, freq, width }
+---@return string     err
+local function get_iface_info(iface)
+    local proc = exec.command('iw', 'dev', iface, 'info')
+    local out, err = proc:output()
+    if err then return nil, tostring(err) end
+    local result = parse_iw_dev_info(out)
+    if not result then return nil, "could not parse iw dev info output" end
+    return result, ""
+end
+
+---Get noise floor for an interface via survey dump.
+---@param iface string
+---@return number|nil  noise value
+---@return string      err
+local function get_iface_survey(iface)
+    local proc = exec.command('iw', iface, 'survey', 'dump')
+    local out, err = proc:output()
+    if err then return nil, tostring(err) end
+    local noise = parse_survey_noise(out)
+    if noise == nil then return nil, "noise value not found" end
+    return noise, ""
+end
+
+---Get per-client stats: signal, tx_bytes, rx_bytes.
+---@param iface string
+---@param mac string
+---@return table|nil  { signal, tx_bytes, rx_bytes }
+---@return string     err
+local function get_station_info(iface, mac)
+    local proc = exec.command('iw', 'dev', iface, 'station', 'get', mac)
+    local out, err = proc:output()
+    if err then return nil, tostring(err) end
+    local result = parse_station_info(out)
+    if not result then return nil, "could not parse station info" end
+    return result, ""
+end
+
+return {
+    get_meta        = get_meta,
+    apply           = apply,
+    watch_events    = watch_events,
+    get_iface_info  = get_iface_info,
+    get_iface_survey = get_iface_survey,
+    get_station_info = get_station_info,
+    -- Re-export sysfs stat reader for use by the driver
+    read_sysfs_stat = read_sysfs_stat,
+    SYSFS_STATS     = SYSFS_STATS,
+}

--- a/src/services/hal/backends/radio/providers/openwrt/init.lua
+++ b/src/services/hal/backends/radio/providers/openwrt/init.lua
@@ -1,0 +1,14 @@
+local impl = require "services.hal.backends.radio.providers.openwrt.impl"
+
+---Check whether OpenWrt UCI is available on this device.
+---@return boolean
+local function is_supported()
+    local f = io.open('/etc/openwrt_release', 'r')
+    if f then f:close() return true end
+    return false
+end
+
+return {
+    is_supported = is_supported,
+    backend      = impl,
+}

--- a/src/services/hal/backends/radio/providers/openwrt/init.lua
+++ b/src/services/hal/backends/radio/providers/openwrt/init.lua
@@ -1,9 +1,10 @@
 local impl = require "services.hal.backends.radio.providers.openwrt.impl"
+local file = require "fibers.io.file"
 
 ---Check whether OpenWrt UCI is available on this device.
 ---@return boolean
 local function is_supported()
-    local f = io.open('/etc/openwrt_release', 'r')
+    local f, _ = file.open('/etc/openwrt_release', 'r')
     if f then f:close() return true end
     return false
 end

--- a/src/services/hal/drivers/band.lua
+++ b/src/services/hal/drivers/band.lua
@@ -383,7 +383,7 @@ end
 ---@return boolean ok
 ---@return string? reason
 function BandDriver:apply()
-    local ok, err = pcall(self.backend.apply, self.staged)
+    local ok, err = pcall(function() self.backend:apply(self.staged) end)
     if not ok then
         return false, tostring(err)
     end
@@ -393,7 +393,7 @@ end
 ---@return boolean ok
 ---@return string? reason
 function BandDriver:clear()
-    local ok, err = self.backend.clear()
+    local ok, err = self.backend:clear()
     if not ok then
         return false, err
     end
@@ -450,7 +450,7 @@ end
 
 ---@return string err  empty string on success
 function BandDriver:init()
-    local ok, err = self.backend.clear()
+    local ok, err = self.backend:clear()
     if not ok then
         return "band backend clear failed: " .. tostring(err)
     end
@@ -519,7 +519,7 @@ end
 ---@return BandDriver? driver
 ---@return string      err
 local function new(logger)
-    local bknd, berr = provider.get_backend()
+    local bknd, berr = provider.new()
     if not bknd then
         return nil, "no band backend: " .. tostring(berr)
     end

--- a/src/services/hal/drivers/band.lua
+++ b/src/services/hal/drivers/band.lua
@@ -1,0 +1,550 @@
+local hal_types = require "services.hal.types.core"
+local cap_types = require "services.hal.types.capabilities"
+local provider  = require "services.hal.backends.band.provider"
+local cap_args  = require "services.hal.types.capability_args"
+
+local fibers  = require "fibers"
+local channel = require "fibers.channel"
+
+local CONTROL_Q_LEN = 16
+
+local VALID_KICK_MODES = { 'none', 'compare', 'absolute', 'both' }
+local VALID_RRM_MODES  = { 'PAT' }
+local VALID_LEGACY_KEYS = {
+    'eval_probe_req', 'eval_assoc_req', 'eval_auth_req',
+    'min_probe_count', 'deny_assoc_reason', 'deny_auth_reason',
+}
+local VALID_BAND_KICKING_OPTS = {
+    'rssi_center', 'rssi_reward_threshold', 'rssi_reward',
+    'rssi_penalty_threshold', 'rssi_penalty', 'rssi_weight',
+    'channel_util_reward_threshold', 'channel_util_reward',
+    'channel_util_penalty_threshold', 'channel_util_penalty',
+}
+local VALID_UPDATE_KEYS = { 'client', 'chan_util', 'hostapd', 'beacon_reports', 'tcp_con' }
+local VALID_CLEANUP_KEYS = { 'probe', 'client', 'ap' }
+local VALID_NETWORKING_METHODS = { 'broadcast', 'tcp+umdns', 'multicast', 'tcp' }
+local VALID_NETWORKING_OPTS = { 'ip', 'port', 'broadcast_port', 'enable_encryption' }
+local VALID_BANDS    = { '2G', '5G' }
+local VALID_SUPPORTS = { 'ht', 'vht' }
+
+local function is_in(value, list)
+    for _, v in ipairs(list) do
+        if v == value then return true end
+    end
+    return false
+end
+
+---@class BandDriver
+---@field id string       Always '1'
+---@field scope Scope
+---@field control_ch Channel
+---@field cap_emit_ch Channel?
+---@field staged table    In-memory staged band config
+---@field initialised boolean
+---@field caps_applied boolean
+---@field log table
+---@field backend table
+local BandDriver = {}
+BandDriver.__index = BandDriver
+
+------------------------------------------------------------------------
+-- RPC handler methods
+------------------------------------------------------------------------
+
+---@param opts BandSetLogLevelOpts
+---@return boolean ok
+---@return string? reason
+function BandDriver:set_log_level(opts)
+    if getmetatable(opts) ~= cap_args.BandSetLogLevelOpts then
+        opts = opts or {}
+        local casted, err = cap_args.new.BandSetLogLevelOpts(opts.level)
+        if not casted then return false, err end
+        opts = casted
+    end
+    local level = opts.level
+    if type(level) ~= 'number' or level < 0 then
+        return false, 'level must be a non-negative number'
+    end
+    self.staged.log_level = level
+    return true
+end
+
+---@param opts BandSetKickingOpts
+---@return boolean ok
+---@return string? reason
+function BandDriver:set_kicking(opts)
+    if getmetatable(opts) ~= cap_args.BandSetKickingOpts then
+        opts = opts or {}
+        local casted, err = cap_args.new.BandSetKickingOpts(
+            opts.mode, opts.bandwidth_threshold, opts.kicking_threshold, opts.evals_before_kick)
+        if not casted then return false, err end
+        opts = casted
+    end
+    if not is_in(opts.mode, VALID_KICK_MODES) then
+        return false, 'mode must be one of: ' .. table.concat(VALID_KICK_MODES, ', ')
+    end
+    if type(opts.bandwidth_threshold) ~= 'number' or opts.bandwidth_threshold < 0 then
+        return false, 'bandwidth_threshold must be a non-negative number'
+    end
+    if type(opts.kicking_threshold) ~= 'number' or opts.kicking_threshold < 0 then
+        return false, 'kicking_threshold must be a non-negative number'
+    end
+    if type(opts.evals_before_kick) ~= 'number' or opts.evals_before_kick < 0 then
+        return false, 'evals_before_kick must be a non-negative integer'
+    end
+    self.staged.kicking = {
+        mode                = opts.mode,
+        bandwidth_threshold = opts.bandwidth_threshold,
+        kicking_threshold   = opts.kicking_threshold,
+        evals_before_kick   = opts.evals_before_kick,
+    }
+    return true
+end
+
+---@param opts BandSetStationCountingOpts
+---@return boolean ok
+---@return string? reason
+function BandDriver:set_station_counting(opts)
+    if getmetatable(opts) ~= cap_args.BandSetStationCountingOpts then
+        opts = opts or {}
+        local casted, err = cap_args.new.BandSetStationCountingOpts(opts.use_station_count, opts.max_station_diff)
+        if not casted then return false, err end
+        opts = casted
+    end
+    if type(opts.use_station_count) ~= 'boolean' then
+        return false, 'use_station_count must be a boolean'
+    end
+    if type(opts.max_station_diff) ~= 'number' or opts.max_station_diff < 0 then
+        return false, 'max_station_diff must be a non-negative integer'
+    end
+    self.staged.station_counting = {
+        use_station_count = opts.use_station_count,
+        max_station_diff  = opts.max_station_diff,
+    }
+    return true
+end
+
+---@param opts BandSetRrmModeOpts
+---@return boolean ok
+---@return string? reason
+function BandDriver:set_rrm_mode(opts)
+    if getmetatable(opts) ~= cap_args.BandSetRrmModeOpts then
+        opts = opts or {}
+        local casted, err = cap_args.new.BandSetRrmModeOpts(opts.mode)
+        if not casted then return false, err end
+        opts = casted
+    end
+    if not is_in(opts.mode, VALID_RRM_MODES) then
+        return false, 'mode must be one of: ' .. table.concat(VALID_RRM_MODES, ', ')
+    end
+    self.staged.rrm_mode = opts.mode
+    return true
+end
+
+---@param opts BandSetNeighbourReportsOpts
+---@return boolean ok
+---@return string? reason
+function BandDriver:set_neighbour_reports(opts)
+    if getmetatable(opts) ~= cap_args.BandSetNeighbourReportsOpts then
+        opts = opts or {}
+        local casted, err = cap_args.new.BandSetNeighbourReportsOpts(opts.dyn_report_num, opts.disassoc_report_len)
+        if not casted then return false, err end
+        opts = casted
+    end
+    local dyn = tonumber(opts.dyn_report_num)
+    local dis  = tonumber(opts.disassoc_report_len)
+    if not dyn or dyn < 0 then
+        return false, 'dyn_report_num must be a non-negative integer'
+    end
+    if not dis or dis < 0 then
+        return false, 'disassoc_report_len must be a non-negative integer'
+    end
+    self.staged.neighbour_reports = {
+        dyn_report_num    = dyn,
+        disassoc_report_len = dis,
+    }
+    return true
+end
+
+---@param opts BandSetLegacyOptionsOpts
+---@return boolean ok
+---@return string? reason
+function BandDriver:set_legacy_options(opts)
+    if getmetatable(opts) ~= cap_args.BandSetLegacyOptionsOpts then
+        opts = opts or {}
+        local casted, err = cap_args.new.BandSetLegacyOptionsOpts(opts.opts)
+        if not casted then return false, err end
+        opts = casted
+    end
+    local legacy_opts = opts.opts
+    if type(legacy_opts) ~= 'table' then
+        return false, 'opts.opts must be a table'
+    end
+    if not self.staged.legacy then self.staged.legacy = {} end
+    for key, value in pairs(legacy_opts) do
+        if not is_in(key, VALID_LEGACY_KEYS) then
+            return false, 'unknown legacy option key: ' .. tostring(key)
+        end
+        if value == nil then
+            return false, 'nil value for legacy option: ' .. key
+        end
+        self.staged.legacy[key] = value
+    end
+    return true
+end
+
+---@param opts BandSetBandPriorityOpts
+---@return boolean ok
+---@return string? reason
+function BandDriver:set_band_priority(opts)
+    if getmetatable(opts) ~= cap_args.BandSetBandPriorityOpts then
+        opts = opts or {}
+        local casted, err = cap_args.new.BandSetBandPriorityOpts(opts.band, opts.priority)
+        if not casted then return false, err end
+        opts = casted
+    end
+    local band = type(opts.band) == 'string' and opts.band:upper() or ''
+    if not is_in(band, VALID_BANDS) then
+        return false, 'band must be "2G" or "5G"'
+    end
+    if type(opts.priority) ~= 'number' or opts.priority < 0 then
+        return false, 'priority must be a non-negative number'
+    end
+    if not self.staged.band_priorities then self.staged.band_priorities = {} end
+    self.staged.band_priorities[band] = { initial_score = opts.priority }
+    return true
+end
+
+---@param opts BandSetBandKickingOpts
+---@return boolean ok
+---@return string? reason
+function BandDriver:set_band_kicking(opts)
+    if getmetatable(opts) ~= cap_args.BandSetBandKickingOpts then
+        opts = opts or {}
+        local casted, err = cap_args.new.BandSetBandKickingOpts(opts.band, opts.options)
+        if not casted then return false, err end
+        opts = casted
+    end
+    local band = type(opts.band) == 'string' and opts.band:upper() or ''
+    if not is_in(band, VALID_BANDS) then
+        return false, 'band must be "2G" or "5G"'
+    end
+    if type(opts.options) ~= 'table' then
+        return false, 'options must be a table'
+    end
+    if not self.staged.band_kicking then self.staged.band_kicking = {} end
+    if not self.staged.band_kicking[band] then self.staged.band_kicking[band] = {} end
+    for key, value in pairs(opts.options) do
+        if not is_in(key, VALID_BAND_KICKING_OPTS) then
+            return false, 'unknown band kicking option: ' .. tostring(key)
+        end
+        local n = tonumber(value)
+        if n == nil then
+            return false, 'value for ' .. key .. ' must be a number'
+        end
+        self.staged.band_kicking[band][key] = n
+    end
+    return true
+end
+
+---@param opts BandSetSupportBonusOpts
+---@return boolean ok
+---@return string? reason
+function BandDriver:set_support_bonus(opts)
+    if getmetatable(opts) ~= cap_args.BandSetSupportBonusOpts then
+        opts = opts or {}
+        local casted, err = cap_args.new.BandSetSupportBonusOpts(opts.band, opts.support, opts.reward)
+        if not casted then return false, err end
+        opts = casted
+    end
+    local band = type(opts.band) == 'string' and opts.band:upper() or ''
+    if not is_in(band, VALID_BANDS) then
+        return false, 'band must be "2G" or "5G"'
+    end
+    if not is_in(opts.support, VALID_SUPPORTS) then
+        return false, 'support must be "ht" or "vht"'
+    end
+    if type(opts.reward) ~= 'number' then
+        return false, 'reward must be a number'
+    end
+    if not self.staged.support_bonus then self.staged.support_bonus = {} end
+    if not self.staged.support_bonus[band] then self.staged.support_bonus[band] = {} end
+    self.staged.support_bonus[band][opts.support] = opts.reward
+    return true
+end
+
+---@param opts BandSetUpdateFreqOpts
+---@return boolean ok
+---@return string? reason
+function BandDriver:set_update_freq(opts)
+    if getmetatable(opts) ~= cap_args.BandSetUpdateFreqOpts then
+        opts = opts or {}
+        local casted, err = cap_args.new.BandSetUpdateFreqOpts(opts.updates)
+        if not casted then return false, err end
+        opts = casted
+    end
+    if type(opts.updates) ~= 'table' then
+        return false, 'updates must be a table'
+    end
+    if not self.staged.update_freq then self.staged.update_freq = {} end
+    for key, value in pairs(opts.updates) do
+        if not is_in(key, VALID_UPDATE_KEYS) then
+            return false, 'unknown update key: ' .. tostring(key)
+        end
+        if type(value) ~= 'number' or value < 0 then
+            return false, 'value for ' .. key .. ' must be a non-negative number'
+        end
+        self.staged.update_freq[key] = value
+    end
+    return true
+end
+
+---@param opts BandSetClientInactiveKickoffOpts
+---@return boolean ok
+---@return string? reason
+function BandDriver:set_client_inactive_kickoff(opts)
+    if getmetatable(opts) ~= cap_args.BandSetClientInactiveKickoffOpts then
+        opts = opts or {}
+        local casted, err = cap_args.new.BandSetClientInactiveKickoffOpts(opts.timeout)
+        if not casted then return false, err end
+        opts = casted
+    end
+    local timeout = tonumber(opts.timeout)
+    if not timeout or timeout < 0 then
+        return false, 'timeout must be a non-negative integer'
+    end
+    self.staged.con_timeout = timeout
+    return true
+end
+
+---@param opts BandSetCleanupOpts
+---@return boolean ok
+---@return string? reason
+function BandDriver:set_cleanup(opts)
+    if getmetatable(opts) ~= cap_args.BandSetCleanupOpts then
+        opts = opts or {}
+        local casted, err = cap_args.new.BandSetCleanupOpts(opts.timeouts)
+        if not casted then return false, err end
+        opts = casted
+    end
+    if type(opts.timeouts) ~= 'table' then
+        return false, 'timeouts must be a table'
+    end
+    if not self.staged.cleanup then self.staged.cleanup = {} end
+    for key, value in pairs(opts.timeouts) do
+        if not is_in(key, VALID_CLEANUP_KEYS) then
+            return false, 'unknown cleanup key: ' .. tostring(key)
+        end
+        if type(value) ~= 'number' or value < 0 then
+            return false, 'value for cleanup.' .. key .. ' must be a non-negative number'
+        end
+        self.staged.cleanup[key] = value
+    end
+    return true
+end
+
+---@param opts BandSetNetworkingOpts
+---@return boolean ok
+---@return string? reason
+function BandDriver:set_networking(opts)
+    if getmetatable(opts) ~= cap_args.BandSetNetworkingOpts then
+        opts = opts or {}
+        local casted, err = cap_args.new.BandSetNetworkingOpts(opts.method, opts.options)
+        if not casted then return false, err end
+        opts = casted
+    end
+    if not is_in(opts.method, VALID_NETWORKING_METHODS) then
+        return false, 'method must be one of: ' .. table.concat(VALID_NETWORKING_METHODS, ', ')
+    end
+    if type(opts.options) ~= 'table' then
+        return false, 'options must be a table'
+    end
+
+    local net = { method = opts.method }
+    for key, value in pairs(opts.options) do
+        if not is_in(key, VALID_NETWORKING_OPTS) then
+            return false, 'unknown networking option: ' .. tostring(key)
+        end
+        if key == 'ip' and type(value) ~= 'string' then
+            return false, 'networking.ip must be a string'
+        end
+        if (key == 'port' or key == 'broadcast_port') and type(value) ~= 'number' then
+            return false, 'networking.' .. key .. ' must be a number'
+        end
+        if key == 'enable_encryption' and type(value) ~= 'boolean' then
+            return false, 'networking.enable_encryption must be a boolean'
+        end
+        net[key] = value
+    end
+    self.staged.networking = net
+    return true
+end
+
+---@return boolean ok
+---@return string? reason
+function BandDriver:apply()
+    local ok, err = pcall(self.backend.apply, self.staged)
+    if not ok then
+        return false, tostring(err)
+    end
+    return true
+end
+
+---@return boolean ok
+---@return string? reason
+function BandDriver:clear()
+    local ok, err = self.backend.clear()
+    if not ok then
+        return false, err
+    end
+    self.staged = {}
+    return true
+end
+
+---@return boolean ok
+function BandDriver:rollback()
+    self.staged = {}
+    return true
+end
+
+------------------------------------------------------------------------
+-- Control manager fiber
+------------------------------------------------------------------------
+
+function BandDriver:control_manager()
+    fibers.current_scope():finally(function()
+        self.log:debug({ what = 'band_driver_stopped', id = self.id })
+    end)
+
+    while true do
+        local name, request = fibers.perform(fibers.named_choice({
+            rpc    = self.control_ch:get_op(),
+            cancel = fibers.current_scope():cancel_op(),
+        }))
+
+        if name == 'cancel' then break end
+
+        local fn = self[request.verb]
+        local ok, reason
+        if type(fn) ~= 'function' then
+            ok, reason = false, 'unknown verb: ' .. tostring(request.verb)
+        else
+            local call_ok, r1, r2 = pcall(fn, self, request.opts)
+            if not call_ok then
+                ok, reason = false, tostring(r1)
+            else
+                ok, reason = r1, r2
+            end
+        end
+
+        local reply = hal_types.new.Reply(ok, reason)
+        if reply then
+            request.reply_ch:put(reply)
+        end
+    end
+end
+
+------------------------------------------------------------------------
+-- Public driver interface
+------------------------------------------------------------------------
+
+---@return string err  empty string on success
+function BandDriver:init()
+    local ok, err = self.backend.clear()
+    if not ok then
+        return "band backend clear failed: " .. tostring(err)
+    end
+    self.initialised = true
+    return ""
+end
+
+---@param emit_ch Channel
+---@return Capability[]? caps
+---@return string err
+function BandDriver:capabilities(emit_ch)
+    if not self.initialised then
+        return nil, "driver not initialised"
+    end
+    if self.caps_applied then
+        return nil, "capabilities already applied"
+    end
+    self.cap_emit_ch = emit_ch
+
+    local cap, cap_err = cap_types.new.Capability(
+        'band',
+        '1',
+        self.control_ch,
+        {
+            'set_log_level',
+            'set_kicking',
+            'set_station_counting',
+            'set_rrm_mode',
+            'set_neighbour_reports',
+            'set_legacy_options',
+            'set_band_priority',
+            'set_band_kicking',
+            'set_support_bonus',
+            'set_update_freq',
+            'set_client_inactive_kickoff',
+            'set_cleanup',
+            'set_networking',
+            'apply',
+            'clear',
+            'rollback',
+        }
+    )
+    if not cap then
+        return nil, cap_err
+    end
+
+    self.caps_applied = true
+    return { cap }, ""
+end
+
+---@return boolean ok
+---@return string err
+function BandDriver:start()
+    if not self.initialised then
+        return false, "driver not initialised"
+    end
+    if not self.caps_applied then
+        return false, "capabilities not applied"
+    end
+    self.scope:spawn(function() self:control_manager() end)
+    return true, ""
+end
+
+---Create a new BandDriver instance.
+---@param logger table
+---@return BandDriver? driver
+---@return string      err
+local function new(logger)
+    local bknd, berr = provider.get_backend()
+    if not bknd then
+        return nil, "no band backend: " .. tostring(berr)
+    end
+
+    local scope, serr = fibers.current_scope():child()
+    if not scope then
+        return nil, "failed to create child scope: " .. tostring(serr)
+    end
+
+    local driver = setmetatable({
+        id           = '1',
+        scope        = scope,
+        control_ch   = channel.new(CONTROL_Q_LEN),
+        cap_emit_ch  = nil,
+        staged       = {},
+        initialised  = false,
+        caps_applied = false,
+        log          = logger,
+        backend      = bknd,
+    }, BandDriver)
+
+    return driver, ""
+end
+
+return {
+    new    = new,
+    Driver = BandDriver,
+}

--- a/src/services/hal/drivers/radio.lua
+++ b/src/services/hal/drivers/radio.lua
@@ -1,0 +1,616 @@
+local hal_types  = require "services.hal.types.core"
+local cap_types  = require "services.hal.types.capabilities"
+local provider   = require "services.hal.backends.radio.provider"
+local cap_args   = require "services.hal.types.capability_args"
+
+local fibers  = require "fibers"
+local channel = require "fibers.channel"
+local sleep   = require "fibers.sleep"
+
+local CONTROL_Q_LEN        = 16
+local DEFAULT_REPORT_PERIOD = 60  -- seconds
+local INT32_MAX             = 2147483647
+
+local VALID_BANDS = { '2g', '5g' }
+local VALID_HTMODES = {
+    'HE20', 'HE40+', 'HE40-', 'HE80', 'HE160',
+    'HT20', 'HT40+', 'HT40-',
+    'VHT20', 'VHT40+', 'VHT40-', 'VHT80', 'VHT160',
+}
+local VALID_ENCRYPTIONS = {
+    'none', 'wep', 'psk', 'psk2', 'psk-mixed',
+    'sae', 'sae-mixed', 'owe', 'wpa', 'wpa2', 'wpa3',
+}
+local VALID_MODES = { 'ap', 'sta', 'adhoc', 'mesh', 'monitor' }
+
+local function is_in(value, list)
+    for _, v in ipairs(list) do
+        if v == value then return true end
+    end
+    return false
+end
+
+local function is_list(t)
+    if type(t) ~= 'table' then return false end
+    local i = 1
+    for k in pairs(t) do
+        if k ~= i then return false end
+        i = i + 1
+    end
+    return true
+end
+
+local function fix_underflow(n)
+    if type(n) == 'number' and n > INT32_MAX then
+        return n - 4294967296
+    end
+    return n
+end
+
+---@class RadioDriver
+---@field id string             UCI radio section name
+---@field scope Scope
+---@field control_ch Channel
+---@field cap_emit_ch Channel?
+---@field staged table          In-memory staged config
+---@field iface_counter number  Counter for auto-named interfaces
+---@field report_period_ch Channel
+---@field initialised boolean
+---@field caps_applied boolean
+---@field log table
+---@field backend table
+local RadioDriver = {}
+RadioDriver.__index = RadioDriver
+
+local function emit_event(emit_ch, id, key, data)
+    local payload = hal_types.new.Emit('radio', id, 'event', key, data)
+    if payload then emit_ch:put(payload) end
+end
+
+local function emit_state(emit_ch, id, key, data)
+    local payload = hal_types.new.Emit('radio', id, 'state', key, data)
+    if payload then emit_ch:put(payload) end
+end
+
+------------------------------------------------------------------------
+-- RPC handler methods (called by control_manager)
+------------------------------------------------------------------------
+
+---@param opts RadioSetChannelsOpts
+---@return boolean ok
+---@return string? reason
+function RadioDriver:set_channels(opts)
+    if getmetatable(opts) ~= cap_args.RadioSetChannelsOpts then
+        opts = opts or {}
+        local casted, err = cap_args.new.RadioSetChannelsOpts(opts.band, opts.channel, opts.htmode, opts.channels)
+        if not casted then return false, err end
+        opts = casted
+    end
+    if type(opts.band) ~= 'string' or not is_in(opts.band, VALID_BANDS) then
+        return false, 'band must be one of: ' .. table.concat(VALID_BANDS, ', ')
+    end
+    if type(opts.htmode) ~= 'string' or not is_in(opts.htmode, VALID_HTMODES) then
+        return false, 'htmode must be one of: ' .. table.concat(VALID_HTMODES, ', ')
+    end
+    if opts.channel == 'auto' then
+        if not is_list(opts.channels) or #opts.channels == 0 then
+            return false, 'channels must be a non-empty list when channel is "auto"'
+        end
+    elseif type(opts.channel) ~= 'number' and type(opts.channel) ~= 'string' then
+        return false, 'channel must be a number, string, or "auto"'
+    end
+
+    self.staged.band    = opts.band
+    self.staged.channel = opts.channel
+    self.staged.htmode  = opts.htmode
+    self.staged.channels = (opts.channel == 'auto') and opts.channels or nil
+    return true
+end
+
+---@param opts RadioSetTxpowerOpts
+---@return boolean ok
+---@return string? reason
+function RadioDriver:set_txpower(opts)
+    if getmetatable(opts) ~= cap_args.RadioSetTxpowerOpts then
+        opts = opts or {}
+        local casted, err = cap_args.new.RadioSetTxpowerOpts(opts.txpower)
+        if not casted then return false, err end
+        opts = casted
+    end
+    if type(opts.txpower) ~= 'number' and type(opts.txpower) ~= 'string' then
+        return false, 'txpower must be a number or string'
+    end
+    self.staged.txpower = opts.txpower
+    return true
+end
+
+---@param opts RadioSetCountryOpts
+---@return boolean ok
+---@return string? reason
+function RadioDriver:set_country(opts)
+    if getmetatable(opts) ~= cap_args.RadioSetCountryOpts then
+        opts = opts or {}
+        local casted, err = cap_args.new.RadioSetCountryOpts(opts.country)
+        if not casted then return false, err end
+        opts = casted
+    end
+    if type(opts.country) ~= 'string' or #opts.country ~= 2 then
+        return false, 'country must be a 2-character string'
+    end
+    self.staged.country = opts.country:upper()
+    return true
+end
+
+---@param opts RadioSetEnabledOpts
+---@return boolean ok
+---@return string? reason
+function RadioDriver:set_enabled(opts)
+    if getmetatable(opts) ~= cap_args.RadioSetEnabledOpts then
+        opts = opts or {}
+        local casted, err = cap_args.new.RadioSetEnabledOpts(opts.enabled)
+        if not casted then return false, err end
+        opts = casted
+    end
+    if type(opts.enabled) ~= 'boolean' then
+        return false, 'enabled must be a boolean'
+    end
+    -- UCI disabled flag is inverted
+    self.staged.disabled = opts.enabled and '0' or '1'
+    return true
+end
+
+---@param opts RadioAddInterfaceOpts
+---@return boolean ok
+---@return string? iface_name  generated interface name on success
+function RadioDriver:add_interface(opts)
+    if getmetatable(opts) ~= cap_args.RadioAddInterfaceOpts then
+        opts = opts or {}
+        local casted, err = cap_args.new.RadioAddInterfaceOpts(
+            opts.ssid, opts.encryption, opts.password, opts.network, opts.mode, opts.enable_steering)
+        if not casted then return false, err end
+        opts = casted
+    end
+    if type(opts.ssid) ~= 'string' or opts.ssid == '' then
+        return false, 'ssid must be a non-empty string'
+    end
+    if type(opts.encryption) ~= 'string' or not is_in(opts.encryption, VALID_ENCRYPTIONS) then
+        return false, 'encryption must be one of: ' .. table.concat(VALID_ENCRYPTIONS, ', ')
+    end
+    if type(opts.password) ~= 'string' then
+        return false, 'password must be a string'
+    end
+    if type(opts.network) ~= 'string' or opts.network == '' then
+        return false, 'network must be a non-empty string'
+    end
+    if type(opts.mode) ~= 'string' or not is_in(opts.mode, VALID_MODES) then
+        return false, 'mode must be one of: ' .. table.concat(VALID_MODES, ', ')
+    end
+    if type(opts.enable_steering) ~= 'boolean' then
+        return false, 'enable_steering must be a boolean'
+    end
+
+    local iface_name = self.id .. '_i' .. tostring(self.iface_counter)
+    self.iface_counter = self.iface_counter + 1
+
+    table.insert(self.staged.interfaces, {
+        name            = iface_name,
+        ssid            = opts.ssid,
+        encryption      = opts.encryption,
+        password        = opts.password,
+        network         = opts.network,
+        mode            = opts.mode,
+        enable_steering = opts.enable_steering,
+    })
+    -- Reply carries the generated interface name in reason
+    return true, iface_name
+end
+
+---@param opts RadioDeleteInterfaceOpts
+---@return boolean ok
+---@return string? reason
+function RadioDriver:delete_interface(opts)
+    if getmetatable(opts) ~= cap_args.RadioDeleteInterfaceOpts then
+        opts = opts or {}
+        local casted, err = cap_args.new.RadioDeleteInterfaceOpts(opts.interface)
+        if not casted then return false, err end
+        opts = casted
+    end
+    if type(opts.interface) ~= 'string' or opts.interface == '' then
+        return false, 'interface must be a non-empty string'
+    end
+    -- Remove from staged interfaces list
+    for i, iface in ipairs(self.staged.interfaces) do
+        if iface.name == opts.interface then
+            table.remove(self.staged.interfaces, i)
+            table.insert(self.staged.deleted_interfaces, opts.interface)
+            return true
+        end
+    end
+    return false, 'interface not found in staged config: ' .. opts.interface
+end
+
+---@return boolean ok
+function RadioDriver:clear_radio_config()
+    self.staged = {
+        name               = self.id,
+        path               = self.staged.path,
+        type               = self.staged.type,
+        interfaces         = {},
+        deleted_interfaces = {},
+    }
+    return true
+end
+
+---@param opts RadioSetReportPeriodOpts
+---@return boolean ok
+---@return string? reason
+function RadioDriver:set_report_period(opts)
+    if getmetatable(opts) ~= cap_args.RadioSetReportPeriodOpts then
+        opts = opts or {}
+        local casted, err = cap_args.new.RadioSetReportPeriodOpts(opts.period)
+        if not casted then return false, err end
+        opts = casted
+    end
+    local period = opts.period
+    if type(period) ~= 'number' or period <= 0 then
+        return false, 'period must be a positive number'
+    end
+    self.report_period_ch:put(period)
+    return true
+end
+
+---@return boolean ok
+---@return string? reason
+function RadioDriver:apply()
+    local ok, err = pcall(self.backend.apply, self.staged)
+    if not ok then
+        return false, tostring(err)
+    end
+    -- Reset interface counter on successful apply
+    self.iface_counter = 0
+    return true
+end
+
+---@return boolean ok
+function RadioDriver:rollback()
+    self.staged = {
+        name               = self.id,
+        path               = self.staged.path,
+        type               = self.staged.type,
+        interfaces         = {},
+        deleted_interfaces = {},
+    }
+    self.iface_counter = 0
+    return true
+end
+
+------------------------------------------------------------------------
+-- Control manager fiber
+------------------------------------------------------------------------
+
+function RadioDriver:control_manager()
+    fibers.current_scope():finally(function()
+        self.log:debug({ what = 'radio_driver_stopped', id = self.id })
+    end)
+
+    while true do
+        local request = fibers.perform(fibers.named_choice({
+            rpc    = self.control_ch:get_op(),
+            cancel = fibers.current_scope():cancel_op(),
+        }))
+
+        if not request then break end  -- scope cancelled, request is nil
+
+        local fn = self[request.verb]
+        local ok, reason
+        if type(fn) ~= 'function' then
+            ok, reason = false, 'unknown verb: ' .. tostring(request.verb)
+        else
+            local call_ok, r1, r2 = pcall(fn, self, request.opts)
+            if not call_ok then
+                ok, reason = false, tostring(r1)
+            else
+                ok, reason = r1, r2
+            end
+        end
+
+        local reply = hal_types.new.Reply(ok, reason)
+        if reply then
+            request.reply_ch:put(reply)
+        end
+    end
+end
+
+------------------------------------------------------------------------
+-- Stats loop fiber
+------------------------------------------------------------------------
+
+function RadioDriver:stats_loop()
+    local emit_ch      = self.cap_emit_ch
+    local id           = self.id
+    local report_period = DEFAULT_REPORT_PERIOD
+    local backend       = self.backend
+
+    -- Track connected stations: { [iface] = { [mac] = true } }
+    local connected = {}
+
+    -- Collect all interface names from staged config at start
+    -- (interfaces are populated by the time start() is called)
+    local function get_interfaces()
+        local result = {}
+        for _, iface in ipairs(self.staged.interfaces) do
+            table.insert(result, iface.name)
+        end
+        return result
+    end
+
+    -- Client event callback channel (watch_events calls cb in its fiber)
+    local event_ch = channel.new(32)
+
+    -- Spawn the event watcher as a child fiber
+    local interfaces = get_interfaces()
+    fibers.current_scope():spawn(function()
+        backend.watch_events(interfaces, function(ev)
+            event_ch:put(ev)
+        end)
+    end)
+
+    local tick_ch = channel.new(1)
+    fibers.current_scope():spawn(function()
+        while true do
+            fibers.perform(sleep.sleep_op(report_period))
+            tick_ch:put(true)
+        end
+    end)
+
+    fibers.current_scope():finally(function()
+        self.log:debug({ what = 'radio_stats_loop_stopped', id = id })
+    end)
+
+    while true do
+        local name, val = fibers.perform(fibers.named_choice({
+            client_event  = event_ch:get_op(),
+            tick          = tick_ch:get_op(),
+            new_period    = self.report_period_ch:get_op(),
+            cancel        = fibers.current_scope():cancel_op(),
+        }))
+
+        if name == 'cancel' then
+            break
+
+        elseif name == 'new_period' then
+            report_period = val
+
+        elseif name == 'client_event' then
+            local ev = val
+            local mac       = ev.mac
+            local iface     = ev.interface
+            local timestamp = os.time()
+
+            if not connected[iface] then connected[iface] = {} end
+
+            if ev.connected then
+                connected[iface][mac] = true
+            else
+                connected[iface][mac] = nil
+            end
+
+            emit_event(emit_ch, id, 'client_event', {
+                mac       = mac,
+                connected = ev.connected,
+                interface = iface,
+                timestamp = timestamp,
+            })
+
+            -- Emit updated station counts
+            local total = 0
+            for _, macs in pairs(connected) do
+                for _ in pairs(macs) do total = total + 1 end
+            end
+            emit_state(emit_ch, id, 'num_sta', total)
+
+            local iface_list = get_interfaces()
+            for idx, iface_name in ipairs(iface_list) do
+                local count = 0
+                if connected[iface_name] then
+                    for _ in pairs(connected[iface_name]) do count = count + 1 end
+                end
+                emit_state(emit_ch, id, 'iface_num_sta', {
+                    interface = iface_name,
+                    index     = idx - 1,
+                    count     = count,
+                })
+            end
+
+        elseif name == 'tick' then
+            local iface_list = get_interfaces()
+            for _, iface_name in ipairs(iface_list) do
+
+                -- Interface info (txpower, channel, freq, width)
+                local info, _ = backend.get_iface_info(iface_name)
+                if info then
+                    if info.txpower ~= nil then
+                        emit_state(emit_ch, id, 'iface_txpower', {
+                            interface = iface_name,
+                            value     = fix_underflow(info.txpower),
+                        })
+                    end
+                    if info.channel ~= nil then
+                        emit_state(emit_ch, id, 'iface_channel', {
+                            interface = iface_name,
+                            channel   = info.channel,
+                            freq      = info.freq,
+                            width     = info.width,
+                        })
+                    end
+                end
+
+                -- Survey noise
+                local noise, _ = backend.get_iface_survey(iface_name)
+                if noise ~= nil then
+                    emit_state(emit_ch, id, 'iface_noise', {
+                        interface = iface_name,
+                        value     = fix_underflow(noise),
+                    })
+                end
+
+                -- sysfs network counters
+                for _, stat in ipairs(backend.SYSFS_STATS or {}) do
+                    local sval, _ = backend.read_sysfs_stat(iface_name, stat)
+                    if sval ~= nil then
+                        emit_state(emit_ch, id, 'iface_' .. stat, {
+                            interface = iface_name,
+                            value     = fix_underflow(sval),
+                        })
+                    end
+                end
+
+                -- Per-client stats
+                if connected[iface_name] then
+                    for mac in pairs(connected[iface_name]) do
+                        local sta, _ = backend.get_station_info(iface_name, mac)
+                        if sta then
+                            if sta.signal ~= nil then
+                                emit_state(emit_ch, id, 'client_signal', {
+                                    mac       = mac,
+                                    interface = iface_name,
+                                    signal    = fix_underflow(sta.signal),
+                                })
+                            end
+                            if sta.tx_bytes ~= nil then
+                                emit_state(emit_ch, id, 'client_tx_bytes', {
+                                    mac       = mac,
+                                    interface = iface_name,
+                                    value     = fix_underflow(sta.tx_bytes),
+                                })
+                            end
+                            if sta.rx_bytes ~= nil then
+                                emit_state(emit_ch, id, 'client_rx_bytes', {
+                                    mac       = mac,
+                                    interface = iface_name,
+                                    value     = fix_underflow(sta.rx_bytes),
+                                })
+                            end
+                        end
+                    end
+                end
+            end
+        end
+    end
+end
+
+------------------------------------------------------------------------
+-- Public driver interface
+------------------------------------------------------------------------
+
+---@return string err  empty string on success
+function RadioDriver:init()
+    local meta, err = self.backend.get_meta(self.id)
+    if not meta then
+        return "get_meta failed: " .. tostring(err)
+    end
+    self.staged.path = meta.path
+    self.staged.type = meta.type
+    self.initialised = true
+    return ""
+end
+
+---@param emit_ch Channel
+---@return Capability[]? caps
+---@return string err
+function RadioDriver:capabilities(emit_ch)
+    if not self.initialised then
+        return nil, "driver not initialised"
+    end
+    if self.caps_applied then
+        return nil, "capabilities already applied"
+    end
+    self.cap_emit_ch = emit_ch
+
+    local cap, cap_err = cap_types.new.Capability(
+        'radio',
+        self.id,
+        self.control_ch,
+        {
+            'set_channels',
+            'set_txpower',
+            'set_country',
+            'set_enabled',
+            'add_interface',
+            'delete_interface',
+            'clear_radio_config',
+            'set_report_period',
+            'apply',
+            'rollback',
+        }
+    )
+    if not cap then
+        return nil, cap_err
+    end
+
+    self.caps_applied = true
+    return { cap }, ""
+end
+
+---@return boolean ok
+---@return string err
+function RadioDriver:start()
+    if not self.initialised then
+        return false, "driver not initialised"
+    end
+    if not self.caps_applied then
+        return false, "capabilities not applied"
+    end
+
+    self.scope:spawn(function() self:control_manager() end)
+    self.scope:spawn(function() self:stats_loop() end)
+    return true, ""
+end
+
+---Create a new RadioDriver instance.
+---@param name string    UCI radio section name (e.g. "radio0")
+---@param logger table
+---@return RadioDriver? driver
+---@return string       err
+local function new(name, logger)
+    if type(name) ~= 'string' or name == '' then
+        return nil, "invalid radio name"
+    end
+
+    local bknd, berr = provider.get_backend()
+    if not bknd then
+        return nil, "no radio backend: " .. tostring(berr)
+    end
+
+    local scope, serr = fibers.current_scope():child()
+    if not scope then
+        return nil, "failed to create child scope: " .. tostring(serr)
+    end
+
+    local driver = setmetatable({
+        id               = name,
+        scope            = scope,
+        control_ch       = channel.new(CONTROL_Q_LEN),
+        cap_emit_ch      = nil,
+        report_period_ch = channel.new(1),
+        staged           = {
+            name               = name,
+            path               = '',
+            type               = '',
+            interfaces         = {},
+            deleted_interfaces = {},
+        },
+        iface_counter    = 0,
+        initialised      = false,
+        caps_applied     = false,
+        log              = logger,
+        backend          = bknd,
+    }, RadioDriver)
+
+    return driver, ""
+end
+
+return {
+    new    = new,
+    Driver = RadioDriver,
+}

--- a/src/services/hal/drivers/radio.lua
+++ b/src/services/hal/drivers/radio.lua
@@ -53,6 +53,7 @@ end
 ---@field control_ch Channel
 ---@field cap_emit_ch Channel?
 ---@field staged table          In-memory staged config
+---@field interfaces_set table  Live set of active interface names (name → true)
 ---@field iface_counter number  Counter for auto-named interfaces
 ---@field report_period_ch Channel
 ---@field initialised boolean
@@ -201,6 +202,7 @@ function RadioDriver:add_interface(opts)
         mode            = opts.mode,
         enable_steering = opts.enable_steering,
     })
+    self.interfaces_set[iface_name] = true
     -- Reply carries the generated interface name in reason
     return true, iface_name
 end
@@ -223,6 +225,7 @@ function RadioDriver:delete_interface(opts)
         if iface.name == opts.interface then
             table.remove(self.staged.interfaces, i)
             table.insert(self.staged.deleted_interfaces, opts.interface)
+            self.interfaces_set[opts.interface] = nil
             return true
         end
     end
@@ -238,6 +241,7 @@ function RadioDriver:clear_radio_config()
         interfaces         = {},
         deleted_interfaces = {},
     }
+    self.interfaces_set = {}
     return true
 end
 
@@ -256,6 +260,27 @@ function RadioDriver:set_report_period(opts)
         return false, 'period must be a positive number'
     end
     self.report_period_ch:put(period)
+    return true
+end
+
+---Clear all UCI config owned by this radio, resetting it to a blank state.
+---Resets staged driver state and commits + reloads wireless via the backend.
+---@return boolean ok
+---@return string? reason
+function RadioDriver:clear()
+    local ok, err = pcall(self.backend.clear, self.id)
+    if not ok then
+        return false, tostring(err)
+    end
+    self.staged = {
+        name               = self.id,
+        path               = self.staged.path,
+        type               = self.staged.type,
+        interfaces         = {},
+        deleted_interfaces = {},
+    }
+    self.interfaces_set = {}
+    self.iface_counter = 0
     return true
 end
 
@@ -280,6 +305,7 @@ function RadioDriver:rollback()
         interfaces         = {},
         deleted_interfaces = {},
     }
+    self.interfaces_set = {}
     self.iface_counter = 0
     return true
 end
@@ -294,12 +320,12 @@ function RadioDriver:control_manager()
     end)
 
     while true do
-        local request = fibers.perform(fibers.named_choice({
+        local source, request = fibers.perform(fibers.named_choice({
             rpc    = self.control_ch:get_op(),
             cancel = fibers.current_scope():cancel_op(),
         }))
 
-        if not request then break end  -- scope cancelled, request is nil
+        if source == 'cancel' then break end
 
         local fn = self[request.verb]
         local ok, reason
@@ -334,23 +360,15 @@ function RadioDriver:stats_loop()
     -- Track connected stations: { [iface] = { [mac] = true } }
     local connected = {}
 
-    -- Collect all interface names from staged config at start
-    -- (interfaces are populated by the time start() is called)
-    local function get_interfaces()
-        local result = {}
-        for _, iface in ipairs(self.staged.interfaces) do
-            table.insert(result, iface.name)
-        end
-        return result
-    end
-
     -- Client event callback channel (watch_events calls cb in its fiber)
     local event_ch = channel.new(32)
 
-    -- Spawn the event watcher as a child fiber
-    local interfaces = get_interfaces()
+    -- interfaces_set is a live table reference shared with add/delete_interface;
+    -- watch_events checks it on each kernel event so new interfaces are picked up
+    -- immediately without restarting the subprocess.
+    local interfaces_set = self.interfaces_set
     fibers.current_scope():spawn(function()
-        backend.watch_events(interfaces, function(ev)
+        backend.watch_events(interfaces_set, function(ev)
             event_ch:put(ev)
         end)
     end)
@@ -402,29 +420,8 @@ function RadioDriver:stats_loop()
                 timestamp = timestamp,
             })
 
-            -- Emit updated station counts
-            local total = 0
-            for _, macs in pairs(connected) do
-                for _ in pairs(macs) do total = total + 1 end
-            end
-            emit_state(emit_ch, id, 'num_sta', total)
-
-            local iface_list = get_interfaces()
-            for idx, iface_name in ipairs(iface_list) do
-                local count = 0
-                if connected[iface_name] then
-                    for _ in pairs(connected[iface_name]) do count = count + 1 end
-                end
-                emit_state(emit_ch, id, 'iface_num_sta', {
-                    interface = iface_name,
-                    index     = idx - 1,
-                    count     = count,
-                })
-            end
-
         elseif name == 'tick' then
-            local iface_list = get_interfaces()
-            for _, iface_name in ipairs(iface_list) do
+            for iface_name in pairs(interfaces_set) do
 
                 -- Interface info (txpower, channel, freq, width)
                 local info, _ = backend.get_iface_info(iface_name)
@@ -503,14 +500,15 @@ end
 -- Public driver interface
 ------------------------------------------------------------------------
 
+---@param path string   hardware sysfs path for this radio
+---@param rtype string  driver type (e.g. "mac80211")
 ---@return string err  empty string on success
-function RadioDriver:init()
-    local meta, err = self.backend.get_meta(self.id)
-    if not meta then
-        return "get_meta failed: " .. tostring(err)
+function RadioDriver:init(path, rtype)
+    if not path or path == '' then
+        return "init failed: path is required"
     end
-    self.staged.path = meta.path
-    self.staged.type = meta.type
+    self.staged.path = path
+    self.staged.type = rtype or ''
     self.initialised = true
     return ""
 end
@@ -540,6 +538,7 @@ function RadioDriver:capabilities(emit_ch)
             'delete_interface',
             'clear_radio_config',
             'set_report_period',
+            'clear',
             'apply',
             'rollback',
         }
@@ -600,6 +599,7 @@ local function new(name, logger)
             interfaces         = {},
             deleted_interfaces = {},
         },
+        interfaces_set   = {},
         iface_counter    = 0,
         initialised      = false,
         caps_applied     = false,

--- a/src/services/hal/drivers/radio.lua
+++ b/src/services/hal/drivers/radio.lua
@@ -1,27 +1,27 @@
-local hal_types  = require "services.hal.types.core"
-local cap_types  = require "services.hal.types.capabilities"
-local provider   = require "services.hal.backends.radio.provider"
-local cap_args   = require "services.hal.types.capability_args"
+local hal_types             = require "services.hal.types.core"
+local cap_types             = require "services.hal.types.capabilities"
+local provider              = require "services.hal.backends.radio.provider"
+local cap_args              = require "services.hal.types.capability_args"
 
-local fibers  = require "fibers"
-local channel = require "fibers.channel"
-local sleep   = require "fibers.sleep"
+local fibers                = require "fibers"
+local channel               = require "fibers.channel"
+local sleep                 = require "fibers.sleep"
 
-local CONTROL_Q_LEN        = 16
-local DEFAULT_REPORT_PERIOD = 60  -- seconds
+local CONTROL_Q_LEN         = 16
+local DEFAULT_REPORT_PERIOD = 60 -- seconds
 local INT32_MAX             = 2147483647
 
-local VALID_BANDS = { '2g', '5g' }
-local VALID_HTMODES = {
+local VALID_BANDS           = { '2g', '5g' }
+local VALID_HTMODES         = {
     'HE20', 'HE40+', 'HE40-', 'HE80', 'HE160',
     'HT20', 'HT40+', 'HT40-',
     'VHT20', 'VHT40+', 'VHT40-', 'VHT80', 'VHT160',
 }
-local VALID_ENCRYPTIONS = {
+local VALID_ENCRYPTIONS     = {
     'none', 'wep', 'psk', 'psk2', 'psk-mixed',
     'sae', 'sae-mixed', 'owe', 'wpa', 'wpa2', 'wpa3',
 }
-local VALID_MODES = { 'ap', 'sta', 'adhoc', 'mesh', 'monitor' }
+local VALID_MODES           = { 'ap', 'sta', 'adhoc', 'mesh', 'monitor' }
 
 local function is_in(value, list)
     for _, v in ipairs(list) do
@@ -53,7 +53,7 @@ end
 ---@field control_ch Channel
 ---@field cap_emit_ch Channel?
 ---@field staged table          In-memory staged config
----@field interfaces_set table  Live set of active interface names (name → true)
+---@field iface_update_ch Channel  Interface add/remove/reset messages for stats_loop
 ---@field iface_counter number  Counter for auto-named interfaces
 ---@field report_period_ch Channel
 ---@field initialised boolean
@@ -101,9 +101,9 @@ function RadioDriver:set_channels(opts)
         return false, 'channel must be a number, string, or "auto"'
     end
 
-    self.staged.band    = opts.band
-    self.staged.channel = opts.channel
-    self.staged.htmode  = opts.htmode
+    self.staged.band     = opts.band
+    self.staged.channel  = opts.channel
+    self.staged.htmode   = opts.htmode
     self.staged.channels = (opts.channel == 'auto') and opts.channels or nil
     return true
 end
@@ -202,7 +202,7 @@ function RadioDriver:add_interface(opts)
         mode            = opts.mode,
         enable_steering = opts.enable_steering,
     })
-    self.interfaces_set[iface_name] = true
+    self.iface_update_ch:put({ op = 'add', name = iface_name })
     -- Reply carries the generated interface name in reason
     return true, iface_name
 end
@@ -225,7 +225,7 @@ function RadioDriver:delete_interface(opts)
         if iface.name == opts.interface then
             table.remove(self.staged.interfaces, i)
             table.insert(self.staged.deleted_interfaces, opts.interface)
-            self.interfaces_set[opts.interface] = nil
+            self.iface_update_ch:put({ op = 'remove', name = opts.interface })
             return true
         end
     end
@@ -241,7 +241,7 @@ function RadioDriver:clear_radio_config()
         interfaces         = {},
         deleted_interfaces = {},
     }
-    self.interfaces_set = {}
+    self.iface_update_ch:put({ op = 'reset' })
     return true
 end
 
@@ -268,7 +268,7 @@ end
 ---@return boolean ok
 ---@return string? reason
 function RadioDriver:clear()
-    local ok, err = pcall(self.backend.clear, self.id)
+    local ok, err = pcall(function() self.backend:clear() end)
     if not ok then
         return false, tostring(err)
     end
@@ -279,7 +279,7 @@ function RadioDriver:clear()
         interfaces         = {},
         deleted_interfaces = {},
     }
-    self.interfaces_set = {}
+    self.iface_update_ch:put({ op = 'reset' })
     self.iface_counter = 0
     return true
 end
@@ -287,7 +287,7 @@ end
 ---@return boolean ok
 ---@return string? reason
 function RadioDriver:apply()
-    local ok, err = pcall(self.backend.apply, self.staged)
+    local ok, err = pcall(function() self.backend:apply(self.staged) end)
     if not ok then
         return false, tostring(err)
     end
@@ -305,7 +305,7 @@ function RadioDriver:rollback()
         interfaces         = {},
         deleted_interfaces = {},
     }
-    self.interfaces_set = {}
+    self.iface_update_ch:put({ op = 'reset' })
     self.iface_counter = 0
     return true
 end
@@ -355,7 +355,7 @@ end
 
 ---Emit all interface-level stats for one interface name.
 local function tick_iface(emit_ch, id, backend, iface_name, connected)
-    local info, _ = backend.get_iface_info(iface_name)
+    local info, _ = backend:get_iface_info(iface_name)
     if info then
         if info.txpower ~= nil then
             emit_state(emit_ch, id, 'iface_power', {
@@ -371,7 +371,7 @@ local function tick_iface(emit_ch, id, backend, iface_name, connected)
         end
     end
 
-    local noise, _ = backend.get_iface_survey(iface_name)
+    local noise, _ = backend:get_iface_survey(iface_name)
     if noise ~= nil then
         emit_state(emit_ch, id, 'iface_noise', {
             interface = iface_name,
@@ -380,7 +380,7 @@ local function tick_iface(emit_ch, id, backend, iface_name, connected)
     end
 
     for _, stat in ipairs(backend.SYSFS_STATS or {}) do
-        local sval, _ = backend.read_sysfs_stat(iface_name, stat)
+        local sval, _ = backend:read_sysfs_stat(iface_name, stat)
         if sval ~= nil then
             emit_state(emit_ch, id, 'iface_' .. stat, {
                 interface = iface_name,
@@ -391,7 +391,7 @@ local function tick_iface(emit_ch, id, backend, iface_name, connected)
 
     if connected[iface_name] then
         for mac in pairs(connected[iface_name]) do
-            local sta, _ = backend.get_station_info(iface_name, mac)
+            local sta, _ = backend:get_station_info(iface_name, mac)
             if sta then
                 if sta.signal ~= nil then
                     emit_state(emit_ch, id, 'client_signal', {
@@ -428,20 +428,23 @@ end
 
 ---Update connected-station bookkeeping and emit a client_event.
 local function on_client_event(emit_ch, id, connected, ev)
+    if not ev then return end
     local mac   = ev.mac
     local iface = ev.interface
 
     if not connected[iface] then connected[iface] = {} end
 
-    if ev.connected then
+    if ev.added then
         connected[iface][mac] = true
     else
         connected[iface][mac] = nil
     end
 
+    print("emitted event")
+
     emit_event(emit_ch, id, 'client_event', {
         mac       = mac,
-        connected = ev.connected,
+        connected = ev.added,
         interface = iface,
         timestamp = os.time(),
     })
@@ -452,36 +455,55 @@ end
 ------------------------------------------------------------------------
 
 function RadioDriver:stats_loop()
-    local emit_ch       = self.cap_emit_ch
-    local id            = self.id
-    local report_period = DEFAULT_REPORT_PERIOD
-    local backend       = self.backend
-    local connected     = {}
+    local emit_ch        = self.cap_emit_ch
+    local id             = self.id
+    local report_period  = DEFAULT_REPORT_PERIOD
+    local backend        = self.backend
+    local connected      = {}
+    local interfaces_set = {}
 
-    -- Client event callback channel (watch_events runs in a sibling fiber)
-    local event_ch       = channel.new(32)
-    local interfaces_set = self.interfaces_set
-
-    fibers.current_scope():spawn(function()
-        backend.watch_events(interfaces_set, function(ev) event_ch:put(ev) end)
-    end)
+    backend:start_client_monitor()
 
     fibers.current_scope():finally(function()
         self.log:debug({ what = 'radio_stats_loop_stopped', id = id })
     end)
 
+    local function update_interfaces(op, name)
+        if op == 'add' then
+            interfaces_set[name] = true
+            -- Seed connected set with any clients already associated before startup
+            local macs, _ = backend:get_connected_macs(name)
+            for _, mac in ipairs(macs) do
+                on_client_event(emit_ch, id, connected, { mac = mac, interface = name, added = true })
+            end
+        elseif op == 'remove' then
+            interfaces_set[name] = nil
+        elseif op == 'reset' then
+            interfaces_set = {}
+        end
+    end
+
     while true do
         local name, val = fibers.perform(fibers.named_choice({
-            client_event = event_ch:get_op(),
+            client_event = backend:watch_clients_op(),
+            iface_update = self.iface_update_ch:get_op(),
             tick         = sleep.sleep_op(report_period),
             new_period   = self.report_period_ch:get_op(),
             cancel       = fibers.current_scope():cancel_op(),
         }))
 
-        if name == 'cancel'       then break
-        elseif name == 'new_period'   then report_period = val
-        elseif name == 'client_event' then on_client_event(emit_ch, id, connected, val)
-        elseif name == 'tick'         then on_tick(emit_ch, id, backend, interfaces_set, connected)
+        if name == 'cancel' then
+            break
+        elseif name == 'new_period' then
+            report_period = val
+        elseif name == 'iface_update' then
+            update_interfaces(val.op, val.name)
+        elseif name == 'client_event' then
+            if val and interfaces_set[val.interface] then
+                on_client_event(emit_ch, id, connected, val)
+            end
+        elseif name == 'tick' then
+            on_tick(emit_ch, id, backend, interfaces_set, connected)
         end
     end
 end
@@ -566,7 +588,7 @@ local function new(name, logger)
         return nil, "invalid radio name"
     end
 
-    local bknd, berr = provider.get_backend()
+    local bknd, berr = provider.new(name)
     if not bknd then
         return nil, "no radio backend: " .. tostring(berr)
     end
@@ -581,6 +603,7 @@ local function new(name, logger)
         scope            = scope,
         control_ch       = channel.new(CONTROL_Q_LEN),
         cap_emit_ch      = nil,
+        iface_update_ch  = channel.new(16),
         report_period_ch = channel.new(1),
         staged           = {
             name               = name,
@@ -589,7 +612,6 @@ local function new(name, logger)
             interfaces         = {},
             deleted_interfaces = {},
         },
-        interfaces_set   = {},
         iface_counter    = 0,
         initialised      = false,
         caps_applied     = false,

--- a/src/services/hal/drivers/radio.lua
+++ b/src/services/hal/drivers/radio.lua
@@ -311,8 +311,27 @@ function RadioDriver:rollback()
 end
 
 ------------------------------------------------------------------------
--- Control manager fiber
+-- Control manager: RPC dispatch
 ------------------------------------------------------------------------
+
+local function dispatch_rpc(driver, request)
+    local fn = driver[request.verb]
+    local ok, reason
+    if type(fn) ~= 'function' then
+        ok, reason = false, 'unknown verb: ' .. tostring(request.verb)
+    else
+        local call_ok, r1, r2 = pcall(fn, driver, request.opts)
+        if not call_ok then
+            ok, reason = false, tostring(r1)
+        else
+            ok, reason = r1, r2
+        end
+    end
+    local reply = hal_types.new.Reply(ok, reason)
+    if reply then
+        request.reply_ch:put(reply)
+    end
+end
 
 function RadioDriver:control_manager()
     fibers.current_scope():finally(function()
@@ -326,25 +345,106 @@ function RadioDriver:control_manager()
         }))
 
         if source == 'cancel' then break end
+        dispatch_rpc(self, request)
+    end
+end
 
-        local fn = self[request.verb]
-        local ok, reason
-        if type(fn) ~= 'function' then
-            ok, reason = false, 'unknown verb: ' .. tostring(request.verb)
-        else
-            local call_ok, r1, r2 = pcall(fn, self, request.opts)
-            if not call_ok then
-                ok, reason = false, tostring(r1)
-            else
-                ok, reason = r1, r2
-            end
+------------------------------------------------------------------------
+-- Stats loop: tick and event handlers
+------------------------------------------------------------------------
+
+---Emit all interface-level stats for one interface name.
+local function tick_iface(emit_ch, id, backend, iface_name, connected)
+    local info, _ = backend.get_iface_info(iface_name)
+    if info then
+        if info.txpower ~= nil then
+            emit_state(emit_ch, id, 'iface_power', {
+                interface = iface_name,
+                value     = fix_underflow(info.txpower),
+            })
         end
-
-        local reply = hal_types.new.Reply(ok, reason)
-        if reply then
-            request.reply_ch:put(reply)
+        if info.channel ~= nil then
+            emit_state(emit_ch, id, 'iface_channel', {
+                interface = iface_name,
+                value     = fix_underflow(info.channel),
+            })
         end
     end
+
+    local noise, _ = backend.get_iface_survey(iface_name)
+    if noise ~= nil then
+        emit_state(emit_ch, id, 'iface_noise', {
+            interface = iface_name,
+            value     = fix_underflow(noise),
+        })
+    end
+
+    for _, stat in ipairs(backend.SYSFS_STATS or {}) do
+        local sval, _ = backend.read_sysfs_stat(iface_name, stat)
+        if sval ~= nil then
+            emit_state(emit_ch, id, 'iface_' .. stat, {
+                interface = iface_name,
+                value     = fix_underflow(sval),
+            })
+        end
+    end
+
+    if connected[iface_name] then
+        for mac in pairs(connected[iface_name]) do
+            local sta, _ = backend.get_station_info(iface_name, mac)
+            if sta then
+                if sta.signal ~= nil then
+                    emit_state(emit_ch, id, 'client_signal', {
+                        mac       = mac,
+                        interface = iface_name,
+                        value     = fix_underflow(sta.signal),
+                    })
+                end
+                if sta.tx_bytes ~= nil then
+                    emit_state(emit_ch, id, 'client_tx_bytes', {
+                        mac       = mac,
+                        interface = iface_name,
+                        value     = fix_underflow(sta.tx_bytes),
+                    })
+                end
+                if sta.rx_bytes ~= nil then
+                    emit_state(emit_ch, id, 'client_rx_bytes', {
+                        mac       = mac,
+                        interface = iface_name,
+                        value     = fix_underflow(sta.rx_bytes),
+                    })
+                end
+            end
+        end
+    end
+end
+
+---Emit stats for every currently-tracked interface.
+local function on_tick(emit_ch, id, backend, interfaces_set, connected)
+    for iface_name in pairs(interfaces_set) do
+        tick_iface(emit_ch, id, backend, iface_name, connected)
+    end
+end
+
+---Update connected-station bookkeeping and emit a client_event.
+local function on_client_event(emit_ch, id, connected, ev)
+    local mac   = ev.mac
+    local iface = ev.interface
+
+    if not connected[iface] then connected[iface] = {} end
+
+    if ev.connected then
+        connected[iface][mac] = true
+    else
+        connected[iface][mac] = nil
+    end
+
+    emit_event(emit_ch, id, 'client_event', {
+        mac       = mac,
+        connected = ev.connected,
+        interface = iface,
+        timestamp = os.time(),
+    })
 end
 
 ------------------------------------------------------------------------
@@ -352,33 +452,18 @@ end
 ------------------------------------------------------------------------
 
 function RadioDriver:stats_loop()
-    local emit_ch      = self.cap_emit_ch
-    local id           = self.id
+    local emit_ch       = self.cap_emit_ch
+    local id            = self.id
     local report_period = DEFAULT_REPORT_PERIOD
     local backend       = self.backend
+    local connected     = {}
 
-    -- Track connected stations: { [iface] = { [mac] = true } }
-    local connected = {}
-
-    -- Client event callback channel (watch_events calls cb in its fiber)
-    local event_ch = channel.new(32)
-
-    -- interfaces_set is a live table reference shared with add/delete_interface;
-    -- watch_events checks it on each kernel event so new interfaces are picked up
-    -- immediately without restarting the subprocess.
+    -- Client event callback channel (watch_events runs in a sibling fiber)
+    local event_ch       = channel.new(32)
     local interfaces_set = self.interfaces_set
-    fibers.current_scope():spawn(function()
-        backend.watch_events(interfaces_set, function(ev)
-            event_ch:put(ev)
-        end)
-    end)
 
-    local tick_ch = channel.new(1)
     fibers.current_scope():spawn(function()
-        while true do
-            fibers.perform(sleep.sleep_op(report_period))
-            tick_ch:put(true)
-        end
+        backend.watch_events(interfaces_set, function(ev) event_ch:put(ev) end)
     end)
 
     fibers.current_scope():finally(function()
@@ -387,111 +472,16 @@ function RadioDriver:stats_loop()
 
     while true do
         local name, val = fibers.perform(fibers.named_choice({
-            client_event  = event_ch:get_op(),
-            tick          = tick_ch:get_op(),
-            new_period    = self.report_period_ch:get_op(),
-            cancel        = fibers.current_scope():cancel_op(),
+            client_event = event_ch:get_op(),
+            tick         = sleep.sleep_op(report_period),
+            new_period   = self.report_period_ch:get_op(),
+            cancel       = fibers.current_scope():cancel_op(),
         }))
 
-        if name == 'cancel' then
-            break
-
-        elseif name == 'new_period' then
-            report_period = val
-
-        elseif name == 'client_event' then
-            local ev = val
-            local mac       = ev.mac
-            local iface     = ev.interface
-            local timestamp = os.time()
-
-            if not connected[iface] then connected[iface] = {} end
-
-            if ev.connected then
-                connected[iface][mac] = true
-            else
-                connected[iface][mac] = nil
-            end
-
-            emit_event(emit_ch, id, 'client_event', {
-                mac       = mac,
-                connected = ev.connected,
-                interface = iface,
-                timestamp = timestamp,
-            })
-
-        elseif name == 'tick' then
-            for iface_name in pairs(interfaces_set) do
-
-                -- Interface info (txpower, channel, freq, width)
-                local info, _ = backend.get_iface_info(iface_name)
-                if info then
-                    if info.txpower ~= nil then
-                        emit_state(emit_ch, id, 'iface_txpower', {
-                            interface = iface_name,
-                            value     = fix_underflow(info.txpower),
-                        })
-                    end
-                    if info.channel ~= nil then
-                        emit_state(emit_ch, id, 'iface_channel', {
-                            interface = iface_name,
-                            channel   = info.channel,
-                            freq      = info.freq,
-                            width     = info.width,
-                        })
-                    end
-                end
-
-                -- Survey noise
-                local noise, _ = backend.get_iface_survey(iface_name)
-                if noise ~= nil then
-                    emit_state(emit_ch, id, 'iface_noise', {
-                        interface = iface_name,
-                        value     = fix_underflow(noise),
-                    })
-                end
-
-                -- sysfs network counters
-                for _, stat in ipairs(backend.SYSFS_STATS or {}) do
-                    local sval, _ = backend.read_sysfs_stat(iface_name, stat)
-                    if sval ~= nil then
-                        emit_state(emit_ch, id, 'iface_' .. stat, {
-                            interface = iface_name,
-                            value     = fix_underflow(sval),
-                        })
-                    end
-                end
-
-                -- Per-client stats
-                if connected[iface_name] then
-                    for mac in pairs(connected[iface_name]) do
-                        local sta, _ = backend.get_station_info(iface_name, mac)
-                        if sta then
-                            if sta.signal ~= nil then
-                                emit_state(emit_ch, id, 'client_signal', {
-                                    mac       = mac,
-                                    interface = iface_name,
-                                    signal    = fix_underflow(sta.signal),
-                                })
-                            end
-                            if sta.tx_bytes ~= nil then
-                                emit_state(emit_ch, id, 'client_tx_bytes', {
-                                    mac       = mac,
-                                    interface = iface_name,
-                                    value     = fix_underflow(sta.tx_bytes),
-                                })
-                            end
-                            if sta.rx_bytes ~= nil then
-                                emit_state(emit_ch, id, 'client_rx_bytes', {
-                                    mac       = mac,
-                                    interface = iface_name,
-                                    value     = fix_underflow(sta.rx_bytes),
-                                })
-                            end
-                        end
-                    end
-                end
-            end
+        if name == 'cancel'       then break
+        elseif name == 'new_period'   then report_period = val
+        elseif name == 'client_event' then on_client_event(emit_ch, id, connected, val)
+        elseif name == 'tick'         then on_tick(emit_ch, id, backend, interfaces_set, connected)
         end
     end
 end

--- a/src/services/hal/managers/wlan.lua
+++ b/src/services/hal/managers/wlan.lua
@@ -32,16 +32,17 @@ local WLANManager = {
 ---Start a single radio driver and emit device-added event.
 ---Must be called from within the manager scope's context.
 ---@param name string
+---@param radio_cfg table  { name, path, type } from device config
 ---@param dev_ev_ch Channel
 ---@param cap_emit_ch Channel
-local function start_radio(name, dev_ev_ch, cap_emit_ch)
+local function start_radio(name, radio_cfg, dev_ev_ch, cap_emit_ch)
     local driver, drv_err = radio_driver.new(name, log:child({ radio = name }))
     if not driver then
         log:error({ what = 'create_radio_driver_failed', name = name, err = drv_err })
         return
     end
 
-    local init_err = driver:init()
+    local init_err = driver:init(radio_cfg.path or '', radio_cfg.type or '')
     if init_err ~= '' then
         log:error({ what = 'init_radio_driver_failed', name = name, err = init_err })
         return
@@ -193,9 +194,9 @@ local function reconcile_radios(config, dev_ev_ch, cap_emit_ch)
     end
 
     -- Start new or replacement radios
-    for name in pairs(new_radios) do
+    for name, radio_cfg in pairs(new_radios) do
         if not WLANManager.radios[name] then
-            start_radio(name, dev_ev_ch, cap_emit_ch)
+            start_radio(name, radio_cfg, dev_ev_ch, cap_emit_ch)
         end
     end
 end
@@ -204,9 +205,7 @@ end
 -- Manager fiber
 ------------------------------------------------------------------------
 
-local function manager_fiber(dev_ev_ch, cap_emit_ch)
-    local scope = fibers.current_scope()
-
+local function manager_fiber(scope, dev_ev_ch, cap_emit_ch)
     scope:finally(function()
         local st, primary = scope:status()
         if st == 'failed' then
@@ -224,7 +223,7 @@ local function manager_fiber(dev_ev_ch, cap_emit_ch)
         -- Build fault ops for each running radio driver
         local fault_ops = {}
         for name, entry in pairs(WLANManager.radios) do
-            table.insert(fault_ops, entry.driver.scope:fault_op():wrap(function() return name end))
+            table.insert(fault_ops, entry.driver.scope:fault_op():wrap(function(_, err) return name, err end))
         end
 
         local fault_op = op.never()
@@ -232,7 +231,7 @@ local function manager_fiber(dev_ev_ch, cap_emit_ch)
             fault_op = op.choice(unpack(fault_ops))
         end
 
-        local source, val = fibers.perform(fibers.named_choice({
+        local source, val, fault_err = fibers.perform(fibers.named_choice({
             config       = WLANManager.config_ch:get_op(),
             driver_fault = fault_op,
             cancel       = scope:cancel_op(),
@@ -246,7 +245,7 @@ local function manager_fiber(dev_ev_ch, cap_emit_ch)
             reconcile_radios(val, dev_ev_ch, cap_emit_ch)
         elseif source == 'driver_fault' then
             local name = val
-            log:error({ what = 'radio_driver_fault', name = tostring(name) })
+            log:error({ what = 'radio_driver_fault', name = tostring(name), err = tostring(fault_err) })
             -- Remove from registry (scope already failed); emit device-removed
             if WLANManager.radios[name] then
                 WLANManager.radios[name] = nil

--- a/src/services/hal/managers/wlan.lua
+++ b/src/services/hal/managers/wlan.lua
@@ -1,0 +1,326 @@
+local hal_types   = require "services.hal.types.core"
+local radio_driver = require "services.hal.drivers.radio"
+local band_driver  = require "services.hal.drivers.band"
+
+local fibers  = require "fibers"
+local op      = require "fibers.op"
+local sleep   = require "fibers.sleep"
+local channel = require "fibers.channel"
+
+local STOP_TIMEOUT = 5.0
+
+local log  -- set in start()
+
+---@class WLANManager
+---@field scope Scope?
+---@field started boolean
+---@field radios table<string, { driver: RadioDriver, path: string, type: string }>
+---@field band BandDriver?
+---@field config_ch Channel
+local WLANManager = {
+    started   = false,
+    radios    = {},
+    band      = nil,
+    scope     = nil,
+    config_ch = channel.new(4),
+}
+
+------------------------------------------------------------------------
+-- Internal helpers
+------------------------------------------------------------------------
+
+---Start a single radio driver and emit device-added event.
+---Must be called from within the manager scope's context.
+---@param name string
+---@param dev_ev_ch Channel
+---@param cap_emit_ch Channel
+local function start_radio(name, dev_ev_ch, cap_emit_ch)
+    local driver, drv_err = radio_driver.new(name, log:child({ radio = name }))
+    if not driver then
+        log:error({ what = 'create_radio_driver_failed', name = name, err = drv_err })
+        return
+    end
+
+    local init_err = driver:init()
+    if init_err ~= '' then
+        log:error({ what = 'init_radio_driver_failed', name = name, err = init_err })
+        return
+    end
+
+    local capabilities, cap_err = driver:capabilities(cap_emit_ch)
+    if not capabilities then
+        log:error({ what = 'radio_capabilities_failed', name = name, err = cap_err })
+        return
+    end
+
+    local ok, start_err = driver:start()
+    if not ok then
+        log:error({ what = 'start_radio_driver_failed', name = name, err = start_err })
+        return
+    end
+
+    WLANManager.radios[name] = {
+        driver = driver,
+        path   = driver.staged.path,
+        type   = driver.staged.type,
+    }
+
+    local device_event, ev_err = hal_types.new.DeviceEvent(
+        'added',
+        'radio',
+        name,
+        {
+            provider = 'hal',
+            version  = 1,
+            name     = name,
+            path     = driver.staged.path,
+            type     = driver.staged.type,
+        },
+        capabilities
+    )
+    if not device_event then
+        log:error({ what = 'create_radio_device_event_failed', name = name, err = ev_err })
+        return
+    end
+
+    dev_ev_ch:put(device_event)
+    log:info({ what = 'radio_driver_started', name = name })
+end
+
+---Stop a single radio driver and emit device-removed event.
+---@param name string
+---@param dev_ev_ch Channel
+local function stop_radio(name, dev_ev_ch)
+    local entry = WLANManager.radios[name]
+    if not entry then
+        log:warn({ what = 'stop_radio_not_found', name = name })
+        return
+    end
+
+    -- Cancel the driver's scope (structured concurrency handles cleanup)
+    entry.driver.scope:cancel('removed by manager')
+    WLANManager.radios[name] = nil
+
+    -- HAL unregisters by class+id, so an empty capabilities list is fine here
+    local device_event, ev_err = hal_types.new.DeviceEvent(
+        'removed',
+        'radio',
+        name,
+        {},
+        {}
+    )
+    if not device_event then
+        log:error({ what = 'create_radio_remove_event_failed', name = name, err = ev_err })
+        return
+    end
+    dev_ev_ch:put(device_event)
+    log:info({ what = 'radio_driver_stopped', name = name })
+end
+
+---Start the band driver and emit device-added event.
+---@param dev_ev_ch Channel
+---@param cap_emit_ch Channel
+local function start_band(dev_ev_ch, cap_emit_ch)
+    local driver, drv_err = band_driver.new(log:child({ driver = 'band' }))
+    if not driver then
+        log:warn({ what = 'create_band_driver_failed', err = drv_err })
+        return
+    end
+
+    local init_err = driver:init()
+    if init_err ~= '' then
+        log:warn({ what = 'init_band_driver_failed', err = init_err })
+        return
+    end
+
+    local capabilities, cap_err = driver:capabilities(cap_emit_ch)
+    if not capabilities then
+        log:warn({ what = 'band_capabilities_failed', err = cap_err })
+        return
+    end
+
+    local ok, start_err = driver:start()
+    if not ok then
+        log:warn({ what = 'start_band_driver_failed', err = start_err })
+        return
+    end
+
+    WLANManager.band = driver
+
+    local device_event, ev_err = hal_types.new.DeviceEvent(
+        'added',
+        'band',
+        '1',
+        { provider = 'hal', version = 1 },
+        capabilities
+    )
+    if not device_event then
+        log:warn({ what = 'create_band_device_event_failed', err = ev_err })
+        return
+    end
+
+    dev_ev_ch:put(device_event)
+    log:info({ what = 'band_driver_started' })
+end
+
+---Reconcile running radio drivers against a new config.
+---@param config table
+---@param dev_ev_ch Channel
+---@param cap_emit_ch Channel
+local function reconcile_radios(config, dev_ev_ch, cap_emit_ch)
+    local new_radios = {}
+    if type(config.radios) == 'table' then
+        for _, r in ipairs(config.radios) do
+            if type(r.name) == 'string' and r.name ~= '' then
+                new_radios[r.name] = r
+            end
+        end
+    end
+
+    -- Stop drivers no longer in config or whose path/type changed
+    local to_stop = {}
+    for name, entry in pairs(WLANManager.radios) do
+        local new_r = new_radios[name]
+        if not new_r then
+            table.insert(to_stop, { name = name, reason = 'removed' })
+        elseif (new_r.path or '') ~= entry.path or (new_r.type or '') ~= entry.type then
+            table.insert(to_stop, { name = name, reason = 'changed' })
+        end
+    end
+    for _, s in ipairs(to_stop) do
+        log:info({ what = 'stopping_radio', name = s.name, reason = s.reason })
+        stop_radio(s.name, dev_ev_ch)
+    end
+
+    -- Start new or replacement radios
+    for name in pairs(new_radios) do
+        if not WLANManager.radios[name] then
+            start_radio(name, dev_ev_ch, cap_emit_ch)
+        end
+    end
+end
+
+------------------------------------------------------------------------
+-- Manager fiber
+------------------------------------------------------------------------
+
+local function manager_fiber(dev_ev_ch, cap_emit_ch)
+    local scope = fibers.current_scope()
+
+    scope:finally(function()
+        local st, primary = scope:status()
+        if st == 'failed' then
+            log:error({ what = 'wlan_manager_scope_error', err = tostring(primary) })
+        end
+        log:debug({ what = 'wlan_manager_stopped' })
+    end)
+
+    -- Start the band driver immediately (always, regardless of radio count).
+    -- The band driver is persistent; it is not restarted on config updates.
+    start_band(dev_ev_ch, cap_emit_ch)
+
+    -- Watch for config updates and driver faults
+    while true do
+        -- Build fault ops for each running radio driver
+        local fault_ops = {}
+        for name, entry in pairs(WLANManager.radios) do
+            table.insert(fault_ops, entry.driver.scope:fault_op():wrap(function() return name end))
+        end
+
+        local fault_op = op.never()
+        if #fault_ops > 0 then
+            fault_op = op.choice(unpack(fault_ops))
+        end
+
+        local source, val = fibers.perform(fibers.named_choice({
+            config       = WLANManager.config_ch:get_op(),
+            driver_fault = fault_op,
+            cancel       = scope:cancel_op(),
+        }))
+
+        if source == 'cancel' then
+            break
+        elseif source == 'config' then
+            log:info({ what = 'apply_config_received' })
+            -- reconcile_radios handles both initial setup and subsequent updates
+            reconcile_radios(val, dev_ev_ch, cap_emit_ch)
+        elseif source == 'driver_fault' then
+            local name = val
+            log:error({ what = 'radio_driver_fault', name = tostring(name) })
+            -- Remove from registry (scope already failed); emit device-removed
+            if WLANManager.radios[name] then
+                WLANManager.radios[name] = nil
+                local device_event = hal_types.new.DeviceEvent('removed', 'radio', name, {}, {})
+                if device_event then dev_ev_ch:put(device_event) end
+            end
+        end
+    end
+end
+
+------------------------------------------------------------------------
+-- Public manager interface
+------------------------------------------------------------------------
+
+---Start the WLAN Manager.
+---Creates a child scope and launches the manager and driver fibers.
+---@param logger table
+---@param dev_ev_ch Channel
+---@param cap_emit_ch Channel
+---@return string err  "" on success
+function WLANManager.start(logger, dev_ev_ch, cap_emit_ch)
+    log = logger
+
+    if WLANManager.started then
+        return "already started"
+    end
+
+    local scope, scope_err = fibers.current_scope():child()
+    if not scope then
+        return "failed to create child scope: " .. tostring(scope_err)
+    end
+    WLANManager.scope = scope
+
+    scope:spawn(manager_fiber, dev_ev_ch, cap_emit_ch)
+
+    WLANManager.started = true
+    log:debug({ what = 'wlan_manager_started' })
+    return ""
+end
+
+---Apply a new device config to the WLAN Manager.
+---The manager reconciles radio drivers against the new config.
+---@param config table
+---@return boolean ok
+---@return string  err
+function WLANManager.apply_config(config)
+    if not WLANManager.started then
+        return false, "not started"
+    end
+    WLANManager.config_ch:put(config)
+    return true, ""
+end
+
+---Stop the WLAN Manager and all its child drivers.
+---@param timeout number?
+---@return boolean ok
+---@return string  err
+function WLANManager.stop(timeout)
+    if not WLANManager.started then
+        return false, "not started"
+    end
+    timeout = timeout or STOP_TIMEOUT
+    WLANManager.scope:cancel()
+
+    local source = fibers.perform(op.named_choice({
+        join    = WLANManager.scope:join_op(),
+        timeout = sleep.sleep_op(timeout),
+    }))
+
+    if source == 'timeout' then
+        return false, "wlan manager stop timeout"
+    end
+    WLANManager.started = false
+    return true, ""
+end
+
+return WLANManager

--- a/src/services/hal/types/capabilities.lua
+++ b/src/services/hal/types/capabilities.lua
@@ -132,24 +132,25 @@ function new.NetworkCapability(class, id, control_ch)
     return new.Capability(class, id, control_ch, offerings)
 end
 
----@param class CapabilityClass
+
 ---@param id CapabilityId
 ---@param control_ch Channel
 ---@return Capability?
 ---@return string error
-function new.WirelessCapability(class, id, control_ch)
+function new.RadioCapability(id, control_ch)
     local offerings = {
         'set_channels',
-        'set_country',
         'set_txpower',
-        'set_type',
+        'set_country',
         'set_enabled',
         'add_interface',
         'delete_interface',
         'clear_radio_config',
-        'apply'
+        'set_report_period',
+        'apply',
+        'rollback',
     }
-    return new.Capability(class, id, control_ch, offerings)
+    return new.Capability('radio', id, control_ch, offerings)
 end
 
 ---@param class CapabilityClass
@@ -172,7 +173,9 @@ function new.BandCapability(class, id, control_ch)
         'set_client_inactive_kickoff',
         'set_cleanup',
         'set_networking',
-        'apply'
+        'apply',
+        'clear',
+        'rollback',
     }
     return new.Capability(class, id, control_ch, offerings)
 end

--- a/src/services/hal/types/capabilities.lua
+++ b/src/services/hal/types/capabilities.lua
@@ -128,23 +128,25 @@ function new.NetworkCapability(id, control_ch)
     return new.Capability('network', id, control_ch, offerings)
 end
 
+
 ---@param id CapabilityId
 ---@param control_ch Channel
 ---@return Capability?
 ---@return string error
-function new.WirelessCapability(id, control_ch)
+function new.RadioCapability(id, control_ch)
     local offerings = {
         'set_channels',
-        'set_country',
         'set_txpower',
-        'set_type',
+        'set_country',
         'set_enabled',
         'add_interface',
         'delete_interface',
         'clear_radio_config',
-        'apply'
+        'set_report_period',
+        'apply',
+        'rollback',
     }
-    return new.Capability('wireless', id, control_ch, offerings)
+    return new.Capability('radio', id, control_ch, offerings)
 end
 
 ---@param id CapabilityId
@@ -166,7 +168,9 @@ function new.BandCapability(id, control_ch)
         'set_client_inactive_kickoff',
         'set_cleanup',
         'set_networking',
-        'apply'
+        'apply',
+        'clear',
+        'rollback',
     }
     return new.Capability('band', id, control_ch, offerings)
 end

--- a/src/services/hal/types/capability_args.lua
+++ b/src/services/hal/types/capability_args.lua
@@ -264,6 +264,565 @@ function new.PowerActionOpts(delay)
     return setmetatable({ delay = delay }, PowerActionOpts), ""
 end
 
+------------------------------------------------------------------------
+-- Radio capability arg types
+------------------------------------------------------------------------
+
+local RADIO_VALID_BANDS = { '2g', '5g' }
+local RADIO_VALID_HTMODES = {
+    'HE20', 'HE40+', 'HE40-', 'HE80', 'HE160',
+    'HT20', 'HT40+', 'HT40-',
+    'VHT20', 'VHT40+', 'VHT40-', 'VHT80', 'VHT160',
+}
+local RADIO_VALID_ENCRYPTIONS = {
+    'none', 'wep', 'psk', 'psk2', 'psk-mixed',
+    'sae', 'sae-mixed', 'owe', 'wpa', 'wpa2', 'wpa3',
+}
+local RADIO_VALID_IFACE_MODES = { 'ap', 'sta', 'adhoc', 'mesh', 'monitor' }
+
+local function is_in(value, list)
+    for _, v in ipairs(list) do
+        if v == value then return true end
+    end
+    return false
+end
+
+---@alias RadioBand '2g'|'5g'
+---@alias RadioHtmode 'HE20'|'HE40+'|'HE40-'|'HE80'|'HE160'|'HT20'|'HT40+'|'HT40-'|'VHT20'|'VHT40+'|'VHT40-'|'VHT80'|'VHT160'
+---@alias RadioEncryption 'none'|'wep'|'psk'|'psk2'|'psk-mixed'|'sae'|'sae-mixed'|'owe'|'wpa'|'wpa2'|'wpa3'
+---@alias RadioIfaceMode 'ap'|'sta'|'adhoc'|'mesh'|'monitor'
+
+---@class RadioSetChannelsOpts
+---@field band RadioBand
+---@field channel number|string        -- channel number, string, or "auto"
+---@field htmode RadioHtmode
+---@field channels? (number|string)[]  -- required when channel == "auto"
+local RadioSetChannelsOpts = {}
+RadioSetChannelsOpts.__index = RadioSetChannelsOpts
+
+---@param band RadioBand
+---@param channel number|string
+---@param htmode RadioHtmode
+---@param channels? (number|string)[]
+---@return RadioSetChannelsOpts?
+---@return string error
+function new.RadioSetChannelsOpts(band, channel, htmode, channels)
+    if not is_in(band, RADIO_VALID_BANDS) then
+        return nil, 'band must be one of: ' .. table.concat(RADIO_VALID_BANDS, ', ')
+    end
+    if not is_in(htmode, RADIO_VALID_HTMODES) then
+        return nil, 'htmode must be one of: ' .. table.concat(RADIO_VALID_HTMODES, ', ')
+    end
+    if channel == 'auto' then
+        if type(channels) ~= 'table' or #channels == 0 then
+            return nil, 'channels must be a non-empty list when channel is "auto"'
+        end
+    elseif type(channel) ~= 'number' and type(channel) ~= 'string' then
+        return nil, 'channel must be a number, string, or "auto"'
+    end
+    return setmetatable({
+        band = band, channel = channel, htmode = htmode, channels = channels,
+    }, RadioSetChannelsOpts), ""
+end
+
+---@class RadioSetTxpowerOpts
+---@field txpower number|string
+local RadioSetTxpowerOpts = {}
+RadioSetTxpowerOpts.__index = RadioSetTxpowerOpts
+
+---@param txpower number|string
+---@return RadioSetTxpowerOpts?
+---@return string error
+function new.RadioSetTxpowerOpts(txpower)
+    if type(txpower) ~= 'number' and type(txpower) ~= 'string' then
+        return nil, 'txpower must be a number or string'
+    end
+    return setmetatable({ txpower = txpower }, RadioSetTxpowerOpts), ""
+end
+
+---@class RadioSetCountryOpts
+---@field country string  -- 2-letter ISO code, normalised to uppercase
+local RadioSetCountryOpts = {}
+RadioSetCountryOpts.__index = RadioSetCountryOpts
+
+---@param country string  ISO-3166-1 alpha-2 code
+---@return RadioSetCountryOpts?
+---@return string error
+function new.RadioSetCountryOpts(country)
+    if type(country) ~= 'string' or #country ~= 2 then
+        return nil, 'country must be a 2-character string'
+    end
+    return setmetatable({ country = country:upper() }, RadioSetCountryOpts), ""
+end
+
+---@class RadioSetEnabledOpts
+---@field enabled boolean
+local RadioSetEnabledOpts = {}
+RadioSetEnabledOpts.__index = RadioSetEnabledOpts
+
+---@param enabled boolean
+---@return RadioSetEnabledOpts?
+---@return string error
+function new.RadioSetEnabledOpts(enabled)
+    if type(enabled) ~= 'boolean' then
+        return nil, 'enabled must be a boolean'
+    end
+    return setmetatable({ enabled = enabled }, RadioSetEnabledOpts), ""
+end
+
+---@class RadioAddInterfaceOpts
+---@field ssid string
+---@field encryption RadioEncryption
+---@field password string
+---@field network string
+---@field mode RadioIfaceMode
+---@field enable_steering boolean
+local RadioAddInterfaceOpts = {}
+RadioAddInterfaceOpts.__index = RadioAddInterfaceOpts
+
+---@param ssid string
+---@param encryption RadioEncryption
+---@param password string
+---@param network string
+---@param mode RadioIfaceMode
+---@param enable_steering boolean
+---@return RadioAddInterfaceOpts?
+---@return string error
+function new.RadioAddInterfaceOpts(ssid, encryption, password, network, mode, enable_steering)
+    if type(ssid) ~= 'string' or ssid == '' then
+        return nil, 'ssid must be a non-empty string'
+    end
+    if not is_in(encryption, RADIO_VALID_ENCRYPTIONS) then
+        return nil, 'encryption must be one of: ' .. table.concat(RADIO_VALID_ENCRYPTIONS, ', ')
+    end
+    if type(password) ~= 'string' then
+        return nil, 'password must be a string'
+    end
+    if type(network) ~= 'string' or network == '' then
+        return nil, 'network must be a non-empty string'
+    end
+    if not is_in(mode, RADIO_VALID_IFACE_MODES) then
+        return nil, 'mode must be one of: ' .. table.concat(RADIO_VALID_IFACE_MODES, ', ')
+    end
+    if type(enable_steering) ~= 'boolean' then
+        return nil, 'enable_steering must be a boolean'
+    end
+    return setmetatable({
+        ssid = ssid, encryption = encryption, password = password,
+        network = network, mode = mode, enable_steering = enable_steering,
+    }, RadioAddInterfaceOpts), ""
+end
+
+---@class RadioDeleteInterfaceOpts
+---@field interface string
+local RadioDeleteInterfaceOpts = {}
+RadioDeleteInterfaceOpts.__index = RadioDeleteInterfaceOpts
+
+---@param interface string
+---@return RadioDeleteInterfaceOpts?
+---@return string error
+function new.RadioDeleteInterfaceOpts(interface)
+    if type(interface) ~= 'string' or interface == '' then
+        return nil, 'interface must be a non-empty string'
+    end
+    return setmetatable({ interface = interface }, RadioDeleteInterfaceOpts), ""
+end
+
+---@class RadioSetReportPeriodOpts
+---@field period number  -- seconds, must be > 0
+local RadioSetReportPeriodOpts = {}
+RadioSetReportPeriodOpts.__index = RadioSetReportPeriodOpts
+
+---@param period number  seconds, must be > 0
+---@return RadioSetReportPeriodOpts?
+---@return string error
+function new.RadioSetReportPeriodOpts(period)
+    if type(period) ~= 'number' or period <= 0 then
+        return nil, 'period must be a positive number'
+    end
+    return setmetatable({ period = period }, RadioSetReportPeriodOpts), ""
+end
+
+---@class RadioCapabilityReply
+---@field ok boolean
+---@field reason? string  -- error message on failure; generated interface name on add_interface success
+
+------------------------------------------------------------------------
+-- Band capability arg types
+------------------------------------------------------------------------
+
+local BAND_VALID_KICK_MODES   = { 'none', 'compare', 'absolute', 'both' }
+local BAND_VALID_RRM_MODES    = { 'PAT' }
+local BAND_VALID_LEGACY_KEYS  = {
+    'eval_probe_req', 'eval_assoc_req', 'eval_auth_req',
+    'min_probe_count', 'deny_assoc_reason', 'deny_auth_reason',
+}
+local BAND_VALID_KICKING_OPTS = {
+    'rssi_center', 'rssi_reward_threshold', 'rssi_reward',
+    'rssi_penalty_threshold', 'rssi_penalty', 'rssi_weight',
+    'channel_util_reward_threshold', 'channel_util_reward',
+    'channel_util_penalty_threshold', 'channel_util_penalty',
+}
+local BAND_VALID_UPDATE_KEYS  = { 'client', 'chan_util', 'hostapd', 'beacon_reports', 'tcp_con' }
+local BAND_VALID_CLEANUP_KEYS = { 'probe', 'client', 'ap' }
+local BAND_VALID_NET_METHODS  = { 'broadcast', 'tcp+umdns', 'multicast', 'tcp' }
+local BAND_VALID_NET_OPTS     = { 'ip', 'port', 'broadcast_port', 'enable_encryption' }
+local BAND_VALID_BANDS        = { '2G', '5G' }
+local BAND_VALID_SUPPORTS     = { 'ht', 'vht' }
+
+---@alias BandId '2G'|'5G'
+---@alias BandKickMode 'none'|'compare'|'absolute'|'both'
+---@alias BandRrmMode 'PAT'
+---@alias BandNetworkingMethod 'broadcast'|'tcp+umdns'|'multicast'|'tcp'
+---@alias BandSupportType 'ht'|'vht'
+
+---@class BandSetLogLevelOpts
+---@field level number  -- non-negative integer
+local BandSetLogLevelOpts = {}
+BandSetLogLevelOpts.__index = BandSetLogLevelOpts
+
+---@param level number  non-negative integer
+---@return BandSetLogLevelOpts?
+---@return string error
+function new.BandSetLogLevelOpts(level)
+    if type(level) ~= 'number' or level < 0 then
+        return nil, 'level must be a non-negative number'
+    end
+    return setmetatable({ level = level }, BandSetLogLevelOpts), ""
+end
+
+---@class BandSetKickingOpts
+---@field mode BandKickMode
+---@field bandwidth_threshold number
+---@field kicking_threshold number
+---@field evals_before_kick number
+local BandSetKickingOpts = {}
+BandSetKickingOpts.__index = BandSetKickingOpts
+
+---@param mode BandKickMode
+---@param bandwidth_threshold number
+---@param kicking_threshold number
+---@param evals_before_kick number
+---@return BandSetKickingOpts?
+---@return string error
+function new.BandSetKickingOpts(mode, bandwidth_threshold, kicking_threshold, evals_before_kick)
+    if not is_in(mode, BAND_VALID_KICK_MODES) then
+        return nil, 'mode must be one of: ' .. table.concat(BAND_VALID_KICK_MODES, ', ')
+    end
+    if type(bandwidth_threshold) ~= 'number' or bandwidth_threshold < 0 then
+        return nil, 'bandwidth_threshold must be a non-negative number'
+    end
+    if type(kicking_threshold) ~= 'number' or kicking_threshold < 0 then
+        return nil, 'kicking_threshold must be a non-negative number'
+    end
+    if type(evals_before_kick) ~= 'number' or evals_before_kick < 0 then
+        return nil, 'evals_before_kick must be a non-negative integer'
+    end
+    return setmetatable({
+        mode                = mode,
+        bandwidth_threshold = bandwidth_threshold,
+        kicking_threshold   = kicking_threshold,
+        evals_before_kick   = evals_before_kick,
+    }, BandSetKickingOpts), ""
+end
+
+---@class BandSetStationCountingOpts
+---@field use_station_count boolean
+---@field max_station_diff number
+local BandSetStationCountingOpts = {}
+BandSetStationCountingOpts.__index = BandSetStationCountingOpts
+
+---@param use_station_count boolean
+---@param max_station_diff number
+---@return BandSetStationCountingOpts?
+---@return string error
+function new.BandSetStationCountingOpts(use_station_count, max_station_diff)
+    if type(use_station_count) ~= 'boolean' then
+        return nil, 'use_station_count must be a boolean'
+    end
+    if type(max_station_diff) ~= 'number' or max_station_diff < 0 then
+        return nil, 'max_station_diff must be a non-negative integer'
+    end
+    return setmetatable({
+        use_station_count = use_station_count,
+        max_station_diff  = max_station_diff,
+    }, BandSetStationCountingOpts), ""
+end
+
+---@class BandSetRrmModeOpts
+---@field mode BandRrmMode
+local BandSetRrmModeOpts = {}
+BandSetRrmModeOpts.__index = BandSetRrmModeOpts
+
+---@param mode BandRrmMode
+---@return BandSetRrmModeOpts?
+---@return string error
+function new.BandSetRrmModeOpts(mode)
+    if not is_in(mode, BAND_VALID_RRM_MODES) then
+        return nil, 'mode must be one of: ' .. table.concat(BAND_VALID_RRM_MODES, ', ')
+    end
+    return setmetatable({ mode = mode }, BandSetRrmModeOpts), ""
+end
+
+---@class BandSetNeighbourReportsOpts
+---@field dyn_report_num number
+---@field disassoc_report_len number
+local BandSetNeighbourReportsOpts = {}
+BandSetNeighbourReportsOpts.__index = BandSetNeighbourReportsOpts
+
+---@param dyn_report_num number
+---@param disassoc_report_len number
+---@return BandSetNeighbourReportsOpts?
+---@return string error
+function new.BandSetNeighbourReportsOpts(dyn_report_num, disassoc_report_len)
+    local dyn = tonumber(dyn_report_num)
+    local dis = tonumber(disassoc_report_len)
+    if not dyn or dyn < 0 then
+        return nil, 'dyn_report_num must be a non-negative integer'
+    end
+    if not dis or dis < 0 then
+        return nil, 'disassoc_report_len must be a non-negative integer'
+    end
+    return setmetatable({
+        dyn_report_num      = dyn,
+        disassoc_report_len = dis,
+    }, BandSetNeighbourReportsOpts), ""
+end
+
+---@class BandLegacyOpts
+---@field eval_probe_req? boolean
+---@field eval_assoc_req? boolean
+---@field eval_auth_req? boolean
+---@field min_probe_count? number
+---@field deny_auth_reason? number
+---@field deny_assoc_reason? number
+
+---@class BandSetLegacyOptionsOpts
+---@field opts BandLegacyOpts
+local BandSetLegacyOptionsOpts = {}
+BandSetLegacyOptionsOpts.__index = BandSetLegacyOptionsOpts
+
+---@param opts BandLegacyOpts
+---@return BandSetLegacyOptionsOpts?
+---@return string error
+function new.BandSetLegacyOptionsOpts(opts)
+    if type(opts) ~= 'table' then
+        return nil, 'opts must be a table'
+    end
+    for key in pairs(opts) do
+        if not is_in(key, BAND_VALID_LEGACY_KEYS) then
+            return nil, 'unknown legacy option key: ' .. tostring(key)
+        end
+    end
+    return setmetatable({ opts = opts }, BandSetLegacyOptionsOpts), ""
+end
+
+---@class BandSetBandPriorityOpts
+---@field band BandId
+---@field priority number
+local BandSetBandPriorityOpts = {}
+BandSetBandPriorityOpts.__index = BandSetBandPriorityOpts
+
+---@param band BandId
+---@param priority number
+---@return BandSetBandPriorityOpts?
+---@return string error
+function new.BandSetBandPriorityOpts(band, priority)
+    local b = type(band) == 'string' and band:upper() or ''
+    if not is_in(b, BAND_VALID_BANDS) then
+        return nil, 'band must be "2G" or "5G"'
+    end
+    if type(priority) ~= 'number' or priority < 0 then
+        return nil, 'priority must be a non-negative number'
+    end
+    return setmetatable({ band = b, priority = priority }, BandSetBandPriorityOpts), ""
+end
+
+---@class BandKickingOptions
+---@field rssi_center? number
+---@field rssi_reward_threshold? number
+---@field rssi_reward? number
+---@field rssi_penalty_threshold? number
+---@field rssi_penalty? number
+---@field rssi_weight? number
+---@field channel_util_reward_threshold? number
+---@field channel_util_reward? number
+---@field channel_util_penalty_threshold? number
+---@field channel_util_penalty? number
+
+---@class BandSetBandKickingOpts
+---@field band BandId
+---@field options BandKickingOptions
+local BandSetBandKickingOpts = {}
+BandSetBandKickingOpts.__index = BandSetBandKickingOpts
+
+---@param band BandId
+---@param options BandKickingOptions
+---@return BandSetBandKickingOpts?
+---@return string error
+function new.BandSetBandKickingOpts(band, options)
+    local b = type(band) == 'string' and band:upper() or ''
+    if not is_in(b, BAND_VALID_BANDS) then
+        return nil, 'band must be "2G" or "5G"'
+    end
+    if type(options) ~= 'table' then
+        return nil, 'options must be a table'
+    end
+    for key, value in pairs(options) do
+        if not is_in(key, BAND_VALID_KICKING_OPTS) then
+            return nil, 'unknown band kicking option: ' .. tostring(key)
+        end
+        if tonumber(value) == nil then
+            return nil, 'value for ' .. key .. ' must be a number'
+        end
+    end
+    return setmetatable({ band = b, options = options }, BandSetBandKickingOpts), ""
+end
+
+---@class BandSetSupportBonusOpts
+---@field band BandId
+---@field support BandSupportType
+---@field reward number
+local BandSetSupportBonusOpts = {}
+BandSetSupportBonusOpts.__index = BandSetSupportBonusOpts
+
+---@param band BandId
+---@param support BandSupportType
+---@param reward number
+---@return BandSetSupportBonusOpts?
+---@return string error
+function new.BandSetSupportBonusOpts(band, support, reward)
+    local b = type(band) == 'string' and band:upper() or ''
+    if not is_in(b, BAND_VALID_BANDS) then
+        return nil, 'band must be "2G" or "5G"'
+    end
+    if not is_in(support, BAND_VALID_SUPPORTS) then
+        return nil, 'support must be "ht" or "vht"'
+    end
+    if type(reward) ~= 'number' then
+        return nil, 'reward must be a number'
+    end
+    return setmetatable({ band = b, support = support, reward = reward }, BandSetSupportBonusOpts), ""
+end
+
+---@class BandUpdateFreqOptions
+---@field client? number
+---@field chan_util? number
+---@field hostapd? number
+---@field beacon_reports? number
+---@field tcp_con? number
+
+---@class BandSetUpdateFreqOpts
+---@field updates BandUpdateFreqOptions
+local BandSetUpdateFreqOpts = {}
+BandSetUpdateFreqOpts.__index = BandSetUpdateFreqOpts
+
+---@param updates BandUpdateFreqOptions
+---@return BandSetUpdateFreqOpts?
+---@return string error
+function new.BandSetUpdateFreqOpts(updates)
+    if type(updates) ~= 'table' then
+        return nil, 'updates must be a table'
+    end
+    for key, value in pairs(updates) do
+        if not is_in(key, BAND_VALID_UPDATE_KEYS) then
+            return nil, 'unknown update key: ' .. tostring(key)
+        end
+        if type(value) ~= 'number' or value < 0 then
+            return nil, 'value for ' .. key .. ' must be a non-negative number'
+        end
+    end
+    return setmetatable({ updates = updates }, BandSetUpdateFreqOpts), ""
+end
+
+---@class BandSetClientInactiveKickoffOpts
+---@field timeout number
+local BandSetClientInactiveKickoffOpts = {}
+BandSetClientInactiveKickoffOpts.__index = BandSetClientInactiveKickoffOpts
+
+---@param timeout number  non-negative integer
+---@return BandSetClientInactiveKickoffOpts?
+---@return string error
+function new.BandSetClientInactiveKickoffOpts(timeout)
+    local t = tonumber(timeout)
+    if not t or t < 0 then
+        return nil, 'timeout must be a non-negative integer'
+    end
+    return setmetatable({ timeout = t }, BandSetClientInactiveKickoffOpts), ""
+end
+
+---@class BandCleanupTimeouts
+---@field probe? number
+---@field client? number
+---@field ap? number
+
+---@class BandSetCleanupOpts
+---@field timeouts BandCleanupTimeouts
+local BandSetCleanupOpts = {}
+BandSetCleanupOpts.__index = BandSetCleanupOpts
+
+---@param timeouts BandCleanupTimeouts
+---@return BandSetCleanupOpts?
+---@return string error
+function new.BandSetCleanupOpts(timeouts)
+    if type(timeouts) ~= 'table' then
+        return nil, 'timeouts must be a table'
+    end
+    for key, value in pairs(timeouts) do
+        if not is_in(key, BAND_VALID_CLEANUP_KEYS) then
+            return nil, 'unknown cleanup key: ' .. tostring(key)
+        end
+        if type(value) ~= 'number' or value < 0 then
+            return nil, 'value for cleanup.' .. key .. ' must be a non-negative number'
+        end
+    end
+    return setmetatable({ timeouts = timeouts }, BandSetCleanupOpts), ""
+end
+
+---@class BandNetworkingOptions
+---@field ip? string
+---@field port? number
+---@field broadcast_port? number
+---@field enable_encryption? boolean
+
+---@class BandSetNetworkingOpts
+---@field method BandNetworkingMethod
+---@field options BandNetworkingOptions
+local BandSetNetworkingOpts = {}
+BandSetNetworkingOpts.__index = BandSetNetworkingOpts
+
+---@param method BandNetworkingMethod
+---@param options BandNetworkingOptions
+---@return BandSetNetworkingOpts?
+---@return string error
+function new.BandSetNetworkingOpts(method, options)
+    if not is_in(method, BAND_VALID_NET_METHODS) then
+        return nil, 'method must be one of: ' .. table.concat(BAND_VALID_NET_METHODS, ', ')
+    end
+    if type(options) ~= 'table' then
+        return nil, 'options must be a table'
+    end
+    for key, value in pairs(options) do
+        if not is_in(key, BAND_VALID_NET_OPTS) then
+            return nil, 'unknown networking option: ' .. tostring(key)
+        end
+        if key == 'ip' and type(value) ~= 'string' then
+            return nil, 'networking.ip must be a string'
+        end
+        if (key == 'port' or key == 'broadcast_port') and type(value) ~= 'number' then
+            return nil, 'networking.' .. key .. ' must be a number'
+        end
+        if key == 'enable_encryption' and type(value) ~= 'boolean' then
+            return nil, 'networking.enable_encryption must be a boolean'
+        end
+    end
+    return setmetatable({ method = method, options = options }, BandSetNetworkingOpts), ""
+end
+
+---@class BandCapabilityReply
+---@field ok boolean
+---@field reason? string  -- error message on failure
+
 return {
     ModemGetOpts = ModemGetOpts,
     ModemConnectOpts = ModemConnectOpts,
@@ -276,5 +835,25 @@ return {
     ThermalGetOpts = ThermalGetOpts,
     PlatformGetOpts = PlatformGetOpts,
     PowerActionOpts = PowerActionOpts,
+    RadioSetChannelsOpts = RadioSetChannelsOpts,
+    RadioSetTxpowerOpts = RadioSetTxpowerOpts,
+    RadioSetCountryOpts = RadioSetCountryOpts,
+    RadioSetEnabledOpts = RadioSetEnabledOpts,
+    RadioAddInterfaceOpts = RadioAddInterfaceOpts,
+    RadioDeleteInterfaceOpts = RadioDeleteInterfaceOpts,
+    RadioSetReportPeriodOpts = RadioSetReportPeriodOpts,
+    BandSetLogLevelOpts = BandSetLogLevelOpts,
+    BandSetKickingOpts = BandSetKickingOpts,
+    BandSetStationCountingOpts = BandSetStationCountingOpts,
+    BandSetRrmModeOpts = BandSetRrmModeOpts,
+    BandSetNeighbourReportsOpts = BandSetNeighbourReportsOpts,
+    BandSetLegacyOptionsOpts = BandSetLegacyOptionsOpts,
+    BandSetBandPriorityOpts = BandSetBandPriorityOpts,
+    BandSetBandKickingOpts = BandSetBandKickingOpts,
+    BandSetSupportBonusOpts = BandSetSupportBonusOpts,
+    BandSetUpdateFreqOpts = BandSetUpdateFreqOpts,
+    BandSetClientInactiveKickoffOpts = BandSetClientInactiveKickoffOpts,
+    BandSetCleanupOpts = BandSetCleanupOpts,
+    BandSetNetworkingOpts = BandSetNetworkingOpts,
     new = new,
 }

--- a/src/services/hal/types/capability_args.lua
+++ b/src/services/hal/types/capability_args.lua
@@ -518,34 +518,564 @@ function new.ArtifactStoreStatusOpts()
 	return setmetatable({}, ArtifactStoreStatusOpts), ''
 end
 
-----------------------------------------------------------------------
--- UART
-----------------------------------------------------------------------
+------------------------------------------------------------------------
+-- Radio capability arg types
+------------------------------------------------------------------------
 
----@class UARTOpenOpts
-local UARTOpenOpts = {}
-UARTOpenOpts.__index = UARTOpenOpts
+local RADIO_VALID_BANDS = { '2g', '5g' }
+local RADIO_VALID_HTMODES = {
+    'HE20', 'HE40+', 'HE40-', 'HE80', 'HE160',
+    'HT20', 'HT40+', 'HT40-',
+    'VHT20', 'VHT40+', 'VHT40-', 'VHT80', 'VHT160',
+}
+local RADIO_VALID_ENCRYPTIONS = {
+    'none', 'wep', 'psk', 'psk2', 'psk-mixed',
+    'sae', 'sae-mixed', 'owe', 'wpa', 'wpa2', 'wpa3',
+}
+local RADIO_VALID_IFACE_MODES = { 'ap', 'sta', 'adhoc', 'mesh', 'monitor' }
 
----@param opts table|nil
----@return UARTOpenOpts?|nil
----@return string
-function new.UARTOpenOpts(opts)
-    if opts ~= nil and type(opts) ~= 'table' then
-        return nil, 'invalid uart open opts'
+local function is_in(value, list)
+    for _, v in ipairs(list) do
+        if v == value then return true end
     end
-
-    opts = opts or {}
-
-    -- Deliberately empty for now.
-    -- On current OpenWrt targets UART line settings are assumed to come from
-    -- platform/devicetree configuration. Runtime termios configuration can be
-    -- added later without changing the capability surface.
-    for k in pairs(opts) do
-        return nil, 'unsupported uart open option: ' .. tostring(k)
-    end
-
-    return setmetatable({}, UARTOpenOpts), ''
+    return false
 end
+
+---@alias RadioBand '2g'|'5g'
+---@alias RadioHtmode 'HE20'|'HE40+'|'HE40-'|'HE80'|'HE160'|'HT20'|'HT40+'|'HT40-'|'VHT20'|'VHT40+'|'VHT40-'|'VHT80'|'VHT160'
+---@alias RadioEncryption 'none'|'wep'|'psk'|'psk2'|'psk-mixed'|'sae'|'sae-mixed'|'owe'|'wpa'|'wpa2'|'wpa3'
+---@alias RadioIfaceMode 'ap'|'sta'|'adhoc'|'mesh'|'monitor'
+
+---@class RadioSetChannelsOpts
+---@field band RadioBand
+---@field channel number|string        -- channel number, string, or "auto"
+---@field htmode RadioHtmode
+---@field channels? (number|string)[]  -- required when channel == "auto"
+local RadioSetChannelsOpts = {}
+RadioSetChannelsOpts.__index = RadioSetChannelsOpts
+
+---@param band RadioBand
+---@param channel number|string
+---@param htmode RadioHtmode
+---@param channels? (number|string)[]
+---@return RadioSetChannelsOpts?
+---@return string error
+function new.RadioSetChannelsOpts(band, channel, htmode, channels)
+    if not is_in(band, RADIO_VALID_BANDS) then
+        return nil, 'band must be one of: ' .. table.concat(RADIO_VALID_BANDS, ', ')
+    end
+    if not is_in(htmode, RADIO_VALID_HTMODES) then
+        return nil, 'htmode must be one of: ' .. table.concat(RADIO_VALID_HTMODES, ', ')
+    end
+    if channel == 'auto' then
+        if type(channels) ~= 'table' or #channels == 0 then
+            return nil, 'channels must be a non-empty list when channel is "auto"'
+        end
+    elseif type(channel) ~= 'number' and type(channel) ~= 'string' then
+        return nil, 'channel must be a number, string, or "auto"'
+    end
+    return setmetatable({
+        band = band, channel = channel, htmode = htmode, channels = channels,
+    }, RadioSetChannelsOpts), ""
+end
+
+---@class RadioSetTxpowerOpts
+---@field txpower number|string
+local RadioSetTxpowerOpts = {}
+RadioSetTxpowerOpts.__index = RadioSetTxpowerOpts
+
+---@param txpower number|string
+---@return RadioSetTxpowerOpts?
+---@return string error
+function new.RadioSetTxpowerOpts(txpower)
+    if type(txpower) ~= 'number' and type(txpower) ~= 'string' then
+        return nil, 'txpower must be a number or string'
+    end
+    return setmetatable({ txpower = txpower }, RadioSetTxpowerOpts), ""
+end
+
+---@class RadioSetCountryOpts
+---@field country string  -- 2-letter ISO code, normalised to uppercase
+local RadioSetCountryOpts = {}
+RadioSetCountryOpts.__index = RadioSetCountryOpts
+
+---@param country string  ISO-3166-1 alpha-2 code
+---@return RadioSetCountryOpts?
+---@return string error
+function new.RadioSetCountryOpts(country)
+    if type(country) ~= 'string' or #country ~= 2 then
+        return nil, 'country must be a 2-character string'
+    end
+    return setmetatable({ country = country:upper() }, RadioSetCountryOpts), ""
+end
+
+---@class RadioSetEnabledOpts
+---@field enabled boolean
+local RadioSetEnabledOpts = {}
+RadioSetEnabledOpts.__index = RadioSetEnabledOpts
+
+---@param enabled boolean
+---@return RadioSetEnabledOpts?
+---@return string error
+function new.RadioSetEnabledOpts(enabled)
+    if type(enabled) ~= 'boolean' then
+        return nil, 'enabled must be a boolean'
+    end
+    return setmetatable({ enabled = enabled }, RadioSetEnabledOpts), ""
+end
+
+---@class RadioAddInterfaceOpts
+---@field ssid string
+---@field encryption RadioEncryption
+---@field password string
+---@field network string
+---@field mode RadioIfaceMode
+---@field enable_steering boolean
+local RadioAddInterfaceOpts = {}
+RadioAddInterfaceOpts.__index = RadioAddInterfaceOpts
+
+---@param ssid string
+---@param encryption RadioEncryption
+---@param password string
+---@param network string
+---@param mode RadioIfaceMode
+---@param enable_steering boolean
+---@return RadioAddInterfaceOpts?
+---@return string error
+function new.RadioAddInterfaceOpts(ssid, encryption, password, network, mode, enable_steering)
+    if type(ssid) ~= 'string' or ssid == '' then
+        return nil, 'ssid must be a non-empty string'
+    end
+    if not is_in(encryption, RADIO_VALID_ENCRYPTIONS) then
+        return nil, 'encryption must be one of: ' .. table.concat(RADIO_VALID_ENCRYPTIONS, ', ')
+    end
+    if type(password) ~= 'string' then
+        return nil, 'password must be a string'
+    end
+    if type(network) ~= 'string' or network == '' then
+        return nil, 'network must be a non-empty string'
+    end
+    if not is_in(mode, RADIO_VALID_IFACE_MODES) then
+        return nil, 'mode must be one of: ' .. table.concat(RADIO_VALID_IFACE_MODES, ', ')
+    end
+    if type(enable_steering) ~= 'boolean' then
+        return nil, 'enable_steering must be a boolean'
+    end
+    return setmetatable({
+        ssid = ssid, encryption = encryption, password = password,
+        network = network, mode = mode, enable_steering = enable_steering,
+    }, RadioAddInterfaceOpts), ""
+end
+
+---@class RadioDeleteInterfaceOpts
+---@field interface string
+local RadioDeleteInterfaceOpts = {}
+RadioDeleteInterfaceOpts.__index = RadioDeleteInterfaceOpts
+
+---@param interface string
+---@return RadioDeleteInterfaceOpts?
+---@return string error
+function new.RadioDeleteInterfaceOpts(interface)
+    if type(interface) ~= 'string' or interface == '' then
+        return nil, 'interface must be a non-empty string'
+    end
+    return setmetatable({ interface = interface }, RadioDeleteInterfaceOpts), ""
+end
+
+---@class RadioSetReportPeriodOpts
+---@field period number  -- seconds, must be > 0
+local RadioSetReportPeriodOpts = {}
+RadioSetReportPeriodOpts.__index = RadioSetReportPeriodOpts
+
+---@param period number  seconds, must be > 0
+---@return RadioSetReportPeriodOpts?
+---@return string error
+function new.RadioSetReportPeriodOpts(period)
+    if type(period) ~= 'number' or period <= 0 then
+        return nil, 'period must be a positive number'
+    end
+    return setmetatable({ period = period }, RadioSetReportPeriodOpts), ""
+end
+
+---@class RadioCapabilityReply
+---@field ok boolean
+---@field reason? string  -- error message on failure; generated interface name on add_interface success
+
+------------------------------------------------------------------------
+-- Band capability arg types
+------------------------------------------------------------------------
+
+local BAND_VALID_KICK_MODES   = { 'none', 'compare', 'absolute', 'both' }
+local BAND_VALID_RRM_MODES    = { 'PAT' }
+local BAND_VALID_LEGACY_KEYS  = {
+    'eval_probe_req', 'eval_assoc_req', 'eval_auth_req',
+    'min_probe_count', 'deny_assoc_reason', 'deny_auth_reason',
+}
+local BAND_VALID_KICKING_OPTS = {
+    'rssi_center', 'rssi_reward_threshold', 'rssi_reward',
+    'rssi_penalty_threshold', 'rssi_penalty', 'rssi_weight',
+    'channel_util_reward_threshold', 'channel_util_reward',
+    'channel_util_penalty_threshold', 'channel_util_penalty',
+}
+local BAND_VALID_UPDATE_KEYS  = { 'client', 'chan_util', 'hostapd', 'beacon_reports', 'tcp_con' }
+local BAND_VALID_CLEANUP_KEYS = { 'probe', 'client', 'ap' }
+local BAND_VALID_NET_METHODS  = { 'broadcast', 'tcp+umdns', 'multicast', 'tcp' }
+local BAND_VALID_NET_OPTS     = { 'ip', 'port', 'broadcast_port', 'enable_encryption' }
+local BAND_VALID_BANDS        = { '2G', '5G' }
+local BAND_VALID_SUPPORTS     = { 'ht', 'vht' }
+
+---@alias BandId '2G'|'5G'
+---@alias BandKickMode 'none'|'compare'|'absolute'|'both'
+---@alias BandRrmMode 'PAT'
+---@alias BandNetworkingMethod 'broadcast'|'tcp+umdns'|'multicast'|'tcp'
+---@alias BandSupportType 'ht'|'vht'
+
+---@class BandSetLogLevelOpts
+---@field level number  -- non-negative integer
+local BandSetLogLevelOpts = {}
+BandSetLogLevelOpts.__index = BandSetLogLevelOpts
+
+---@param level number  non-negative integer
+---@return BandSetLogLevelOpts?
+---@return string error
+function new.BandSetLogLevelOpts(level)
+    if type(level) ~= 'number' or level < 0 then
+        return nil, 'level must be a non-negative number'
+    end
+    return setmetatable({ level = level }, BandSetLogLevelOpts), ""
+end
+
+---@class BandSetKickingOpts
+---@field mode BandKickMode
+---@field bandwidth_threshold number
+---@field kicking_threshold number
+---@field evals_before_kick number
+local BandSetKickingOpts = {}
+BandSetKickingOpts.__index = BandSetKickingOpts
+
+---@param mode BandKickMode
+---@param bandwidth_threshold number
+---@param kicking_threshold number
+---@param evals_before_kick number
+---@return BandSetKickingOpts?
+---@return string error
+function new.BandSetKickingOpts(mode, bandwidth_threshold, kicking_threshold, evals_before_kick)
+    if not is_in(mode, BAND_VALID_KICK_MODES) then
+        return nil, 'mode must be one of: ' .. table.concat(BAND_VALID_KICK_MODES, ', ')
+    end
+    if type(bandwidth_threshold) ~= 'number' or bandwidth_threshold < 0 then
+        return nil, 'bandwidth_threshold must be a non-negative number'
+    end
+    if type(kicking_threshold) ~= 'number' or kicking_threshold < 0 then
+        return nil, 'kicking_threshold must be a non-negative number'
+    end
+    if type(evals_before_kick) ~= 'number' or evals_before_kick < 0 then
+        return nil, 'evals_before_kick must be a non-negative integer'
+    end
+    return setmetatable({
+        mode                = mode,
+        bandwidth_threshold = bandwidth_threshold,
+        kicking_threshold   = kicking_threshold,
+        evals_before_kick   = evals_before_kick,
+    }, BandSetKickingOpts), ""
+end
+
+---@class BandSetStationCountingOpts
+---@field use_station_count boolean
+---@field max_station_diff number
+local BandSetStationCountingOpts = {}
+BandSetStationCountingOpts.__index = BandSetStationCountingOpts
+
+---@param use_station_count boolean
+---@param max_station_diff number
+---@return BandSetStationCountingOpts?
+---@return string error
+function new.BandSetStationCountingOpts(use_station_count, max_station_diff)
+    if type(use_station_count) ~= 'boolean' then
+        return nil, 'use_station_count must be a boolean'
+    end
+    if type(max_station_diff) ~= 'number' or max_station_diff < 0 then
+        return nil, 'max_station_diff must be a non-negative integer'
+    end
+    return setmetatable({
+        use_station_count = use_station_count,
+        max_station_diff  = max_station_diff,
+    }, BandSetStationCountingOpts), ""
+end
+
+---@class BandSetRrmModeOpts
+---@field mode BandRrmMode
+local BandSetRrmModeOpts = {}
+BandSetRrmModeOpts.__index = BandSetRrmModeOpts
+
+---@param mode BandRrmMode
+---@return BandSetRrmModeOpts?
+---@return string error
+function new.BandSetRrmModeOpts(mode)
+    if not is_in(mode, BAND_VALID_RRM_MODES) then
+        return nil, 'mode must be one of: ' .. table.concat(BAND_VALID_RRM_MODES, ', ')
+    end
+    return setmetatable({ mode = mode }, BandSetRrmModeOpts), ""
+end
+
+---@class BandSetNeighbourReportsOpts
+---@field dyn_report_num number
+---@field disassoc_report_len number
+local BandSetNeighbourReportsOpts = {}
+BandSetNeighbourReportsOpts.__index = BandSetNeighbourReportsOpts
+
+---@param dyn_report_num number
+---@param disassoc_report_len number
+---@return BandSetNeighbourReportsOpts?
+---@return string error
+function new.BandSetNeighbourReportsOpts(dyn_report_num, disassoc_report_len)
+    local dyn = tonumber(dyn_report_num)
+    local dis = tonumber(disassoc_report_len)
+    if not dyn or dyn < 0 then
+        return nil, 'dyn_report_num must be a non-negative integer'
+    end
+    if not dis or dis < 0 then
+        return nil, 'disassoc_report_len must be a non-negative integer'
+    end
+    return setmetatable({
+        dyn_report_num      = dyn,
+        disassoc_report_len = dis,
+    }, BandSetNeighbourReportsOpts), ""
+end
+
+---@class BandLegacyOpts
+---@field eval_probe_req? boolean
+---@field eval_assoc_req? boolean
+---@field eval_auth_req? boolean
+---@field min_probe_count? number
+---@field deny_auth_reason? number
+---@field deny_assoc_reason? number
+
+---@class BandSetLegacyOptionsOpts
+---@field opts BandLegacyOpts
+local BandSetLegacyOptionsOpts = {}
+BandSetLegacyOptionsOpts.__index = BandSetLegacyOptionsOpts
+
+---@param opts BandLegacyOpts
+---@return BandSetLegacyOptionsOpts?
+---@return string error
+function new.BandSetLegacyOptionsOpts(opts)
+    if type(opts) ~= 'table' then
+        return nil, 'opts must be a table'
+    end
+    for key in pairs(opts) do
+        if not is_in(key, BAND_VALID_LEGACY_KEYS) then
+            return nil, 'unknown legacy option key: ' .. tostring(key)
+        end
+    end
+    return setmetatable({ opts = opts }, BandSetLegacyOptionsOpts), ""
+end
+
+---@class BandSetBandPriorityOpts
+---@field band BandId
+---@field priority number
+local BandSetBandPriorityOpts = {}
+BandSetBandPriorityOpts.__index = BandSetBandPriorityOpts
+
+---@param band BandId
+---@param priority number
+---@return BandSetBandPriorityOpts?
+---@return string error
+function new.BandSetBandPriorityOpts(band, priority)
+    local b = type(band) == 'string' and band:upper() or ''
+    if not is_in(b, BAND_VALID_BANDS) then
+        return nil, 'band must be "2G" or "5G"'
+    end
+    if type(priority) ~= 'number' or priority < 0 then
+        return nil, 'priority must be a non-negative number'
+    end
+    return setmetatable({ band = b, priority = priority }, BandSetBandPriorityOpts), ""
+end
+
+---@class BandKickingOptions
+---@field rssi_center? number
+---@field rssi_reward_threshold? number
+---@field rssi_reward? number
+---@field rssi_penalty_threshold? number
+---@field rssi_penalty? number
+---@field rssi_weight? number
+---@field channel_util_reward_threshold? number
+---@field channel_util_reward? number
+---@field channel_util_penalty_threshold? number
+---@field channel_util_penalty? number
+
+---@class BandSetBandKickingOpts
+---@field band BandId
+---@field options BandKickingOptions
+local BandSetBandKickingOpts = {}
+BandSetBandKickingOpts.__index = BandSetBandKickingOpts
+
+---@param band BandId
+---@param options BandKickingOptions
+---@return BandSetBandKickingOpts?
+---@return string error
+function new.BandSetBandKickingOpts(band, options)
+    local b = type(band) == 'string' and band:upper() or ''
+    if not is_in(b, BAND_VALID_BANDS) then
+        return nil, 'band must be "2G" or "5G"'
+    end
+    if type(options) ~= 'table' then
+        return nil, 'options must be a table'
+    end
+    for key, value in pairs(options) do
+        if not is_in(key, BAND_VALID_KICKING_OPTS) then
+            return nil, 'unknown band kicking option: ' .. tostring(key)
+        end
+        if tonumber(value) == nil then
+            return nil, 'value for ' .. key .. ' must be a number'
+        end
+    end
+    return setmetatable({ band = b, options = options }, BandSetBandKickingOpts), ""
+end
+
+---@class BandSetSupportBonusOpts
+---@field band BandId
+---@field support BandSupportType
+---@field reward number
+local BandSetSupportBonusOpts = {}
+BandSetSupportBonusOpts.__index = BandSetSupportBonusOpts
+
+---@param band BandId
+---@param support BandSupportType
+---@param reward number
+---@return BandSetSupportBonusOpts?
+---@return string error
+function new.BandSetSupportBonusOpts(band, support, reward)
+    local b = type(band) == 'string' and band:upper() or ''
+    if not is_in(b, BAND_VALID_BANDS) then
+        return nil, 'band must be "2G" or "5G"'
+    end
+    if not is_in(support, BAND_VALID_SUPPORTS) then
+        return nil, 'support must be "ht" or "vht"'
+    end
+    if type(reward) ~= 'number' then
+        return nil, 'reward must be a number'
+    end
+    return setmetatable({ band = b, support = support, reward = reward }, BandSetSupportBonusOpts), ""
+end
+
+---@class BandUpdateFreqOptions
+---@field client? number
+---@field chan_util? number
+---@field hostapd? number
+---@field beacon_reports? number
+---@field tcp_con? number
+
+---@class BandSetUpdateFreqOpts
+---@field updates BandUpdateFreqOptions
+local BandSetUpdateFreqOpts = {}
+BandSetUpdateFreqOpts.__index = BandSetUpdateFreqOpts
+
+---@param updates BandUpdateFreqOptions
+---@return BandSetUpdateFreqOpts?
+---@return string error
+function new.BandSetUpdateFreqOpts(updates)
+    if type(updates) ~= 'table' then
+        return nil, 'updates must be a table'
+    end
+    for key, value in pairs(updates) do
+        if not is_in(key, BAND_VALID_UPDATE_KEYS) then
+            return nil, 'unknown update key: ' .. tostring(key)
+        end
+        if type(value) ~= 'number' or value < 0 then
+            return nil, 'value for ' .. key .. ' must be a non-negative number'
+        end
+    end
+    return setmetatable({ updates = updates }, BandSetUpdateFreqOpts), ""
+end
+
+---@class BandSetClientInactiveKickoffOpts
+---@field timeout number
+local BandSetClientInactiveKickoffOpts = {}
+BandSetClientInactiveKickoffOpts.__index = BandSetClientInactiveKickoffOpts
+
+---@param timeout number  non-negative integer
+---@return BandSetClientInactiveKickoffOpts?
+---@return string error
+function new.BandSetClientInactiveKickoffOpts(timeout)
+    local t = tonumber(timeout)
+    if not t or t < 0 then
+        return nil, 'timeout must be a non-negative integer'
+    end
+    return setmetatable({ timeout = t }, BandSetClientInactiveKickoffOpts), ""
+end
+
+---@class BandCleanupTimeouts
+---@field probe? number
+---@field client? number
+---@field ap? number
+
+---@class BandSetCleanupOpts
+---@field timeouts BandCleanupTimeouts
+local BandSetCleanupOpts = {}
+BandSetCleanupOpts.__index = BandSetCleanupOpts
+
+---@param timeouts BandCleanupTimeouts
+---@return BandSetCleanupOpts?
+---@return string error
+function new.BandSetCleanupOpts(timeouts)
+    if type(timeouts) ~= 'table' then
+        return nil, 'timeouts must be a table'
+    end
+    for key, value in pairs(timeouts) do
+        if not is_in(key, BAND_VALID_CLEANUP_KEYS) then
+            return nil, 'unknown cleanup key: ' .. tostring(key)
+        end
+        if type(value) ~= 'number' or value < 0 then
+            return nil, 'value for cleanup.' .. key .. ' must be a non-negative number'
+        end
+    end
+    return setmetatable({ timeouts = timeouts }, BandSetCleanupOpts), ""
+end
+
+---@class BandNetworkingOptions
+---@field ip? string
+---@field port? number
+---@field broadcast_port? number
+---@field enable_encryption? boolean
+
+---@class BandSetNetworkingOpts
+---@field method BandNetworkingMethod
+---@field options BandNetworkingOptions
+local BandSetNetworkingOpts = {}
+BandSetNetworkingOpts.__index = BandSetNetworkingOpts
+
+---@param method BandNetworkingMethod
+---@param options BandNetworkingOptions
+---@return BandSetNetworkingOpts?
+---@return string error
+function new.BandSetNetworkingOpts(method, options)
+    if not is_in(method, BAND_VALID_NET_METHODS) then
+        return nil, 'method must be one of: ' .. table.concat(BAND_VALID_NET_METHODS, ', ')
+    end
+    if type(options) ~= 'table' then
+        return nil, 'options must be a table'
+    end
+    for key, value in pairs(options) do
+        if not is_in(key, BAND_VALID_NET_OPTS) then
+            return nil, 'unknown networking option: ' .. tostring(key)
+        end
+        if key == 'ip' and type(value) ~= 'string' then
+            return nil, 'networking.ip must be a string'
+        end
+        if (key == 'port' or key == 'broadcast_port') and type(value) ~= 'number' then
+            return nil, 'networking.' .. key .. ' must be a number'
+        end
+        if key == 'enable_encryption' and type(value) ~= 'boolean' then
+            return nil, 'networking.enable_encryption must be a boolean'
+        end
+    end
+    return setmetatable({ method = method, options = options }, BandSetNetworkingOpts), ""
+end
+
+---@class BandCapabilityReply
+---@field ok boolean
+---@field reason? string  -- error message on failure
 
 return {
     ModemGetOpts = ModemGetOpts,
@@ -571,5 +1101,25 @@ return {
     ArtifactStoreOpenOpts = ArtifactStoreOpenOpts,
     ArtifactStoreDeleteOpts = ArtifactStoreDeleteOpts,
     ArtifactStoreStatusOpts = ArtifactStoreStatusOpts,
+    RadioSetChannelsOpts = RadioSetChannelsOpts,
+    RadioSetTxpowerOpts = RadioSetTxpowerOpts,
+    RadioSetCountryOpts = RadioSetCountryOpts,
+    RadioSetEnabledOpts = RadioSetEnabledOpts,
+    RadioAddInterfaceOpts = RadioAddInterfaceOpts,
+    RadioDeleteInterfaceOpts = RadioDeleteInterfaceOpts,
+    RadioSetReportPeriodOpts = RadioSetReportPeriodOpts,
+    BandSetLogLevelOpts = BandSetLogLevelOpts,
+    BandSetKickingOpts = BandSetKickingOpts,
+    BandSetStationCountingOpts = BandSetStationCountingOpts,
+    BandSetRrmModeOpts = BandSetRrmModeOpts,
+    BandSetNeighbourReportsOpts = BandSetNeighbourReportsOpts,
+    BandSetLegacyOptionsOpts = BandSetLegacyOptionsOpts,
+    BandSetBandPriorityOpts = BandSetBandPriorityOpts,
+    BandSetBandKickingOpts = BandSetBandKickingOpts,
+    BandSetSupportBonusOpts = BandSetSupportBonusOpts,
+    BandSetUpdateFreqOpts = BandSetUpdateFreqOpts,
+    BandSetClientInactiveKickoffOpts = BandSetClientInactiveKickoffOpts,
+    BandSetCleanupOpts = BandSetCleanupOpts,
+    BandSetNetworkingOpts = BandSetNetworkingOpts,
     new = new,
 }

--- a/src/services/wifi.lua
+++ b/src/services/wifi.lua
@@ -2,15 +2,25 @@
 --
 -- Wifi service: forwards radio/band configs to HAL capabilities,
 -- manages SSIDs, subscribes to radio stats, handles MAC session tracking.
+--
+-- Structure:
+--   Constants / helpers
+--   band_rpc / apply_band_steering
+--   radio_rpc / apply_radio_config
+--   on_radio_state / on_radio_event / radio_stats_loop
+--   run_global_num_sta
+--   Service context helpers  (get_radio_cfg … reapply_all_radios)
+--   Main-loop handlers       (on_cfg … on_fs_cap)
+--   WifiService.start
 
-local fibers = require "fibers"
+local fibers   = require "fibers"
 
-local perform = fibers.perform
+local perform  = fibers.perform
 
-local base    = require 'devicecode.service_base'
-local cap_sdk = require 'services.hal.sdk.cap'
-local gen     = require 'services.wifi.gen'
-local utils   = require 'services.wifi.utils'
+local base     = require 'devicecode.service_base'
+local cap_sdk  = require 'services.hal.sdk.cap'
+local gen      = require 'services.wifi.gen'
+local utils    = require 'services.wifi.utils'
 
 ------------------------------------------------------------------------
 -- Config types (annotation-only)
@@ -92,46 +102,58 @@ local function remap_keys(src, mapping)
     return out
 end
 
+-- Parse interface index from generated name suffix (e.g. "radio0_i2" → "2")
+local function iface_idx(name)
+    return (name and name:match('_i(%d+)$')) or '0'
+end
+
+------------------------------------------------------------------------
+-- Band steering RPC helper
+------------------------------------------------------------------------
+
+local function band_rpc(band_cap, svc, method, args, opts)
+    local reply, err = perform(band_cap:call_control_op(method, args, opts))
+    if err and err ~= "" then
+        svc:obs_log('warn', { what = 'band_rpc_failed', method = method, err = tostring(err) })
+        return false
+    end
+    if not reply or reply.ok ~= true then
+        svc:obs_log('warn', {
+            what   = 'band_rpc_error',
+            method = method,
+            reason = reply and reply.reason or 'nil',
+        })
+        return false
+    end
+    return true
+end
+
 ---@param band_cap CapabilityReference
 ---@param band_cfg WifiBandSteeringConfig
 ---@param svc ServiceBase
 local function apply_band_steering(band_cap, band_cfg, svc)
     if not is_table(band_cfg) then return end
-    local globals  = band_cfg.globals  or {}
-    local timings  = band_cfg.timings  or {}
-    local bands    = band_cfg.bands    or {}
-
-    local function rpc(method, args, opts)
-        local reply, err = perform(band_cap:call_control_op(method, args, opts))
-        if err and err ~= "" then
-            svc:obs_log('warn', { what = 'band_rpc_failed', method = method, err = tostring(err) })
-            return false
-        end
-        if not reply or reply.ok ~= true then
-            svc:obs_log('warn', { what = 'band_rpc_error', method = method,
-                                   reason = reply and reply.reason or 'nil' })
-            return false
-        end
-        return true
-    end
+    local globals = band_cfg.globals or {}
+    local timings = band_cfg.timings or {}
+    local bands   = band_cfg.bands or {}
 
     local slow = { timeout = 10.0 }
 
     svc:obs_log('debug', { what = 'band_config_start' })
-    rpc('clear', {}, slow)
+    band_rpc(band_cap, svc, 'clear', {}, slow)
 
     -- kicking
     local kicking = globals.kicking
     if is_table(kicking) then
         local args, err = cap_sdk.args.new.BandSetKickingOpts(
-            kicking.kick_mode        or 'none',
+            kicking.kick_mode or 'none',
             kicking.bandwidth_threshold or 0,
-            kicking.kicking_threshold   or 0,
-            kicking.evals_before_kick   or 0)
+            kicking.kicking_threshold or 0,
+            kicking.evals_before_kick or 0)
         if not args then
             svc:obs_log('warn', { what = 'band_args_invalid', method = 'set_kicking', err = err })
         else
-            rpc('set_kicking', args)
+            band_rpc(band_cap, svc, 'set_kicking', args)
         end
     end
 
@@ -140,11 +162,11 @@ local function apply_band_steering(band_cap, band_cfg, svc)
         local st = globals.stations
         local args, err = cap_sdk.args.new.BandSetStationCountingOpts(
             st.use_station_count or false,
-            st.max_station_diff  or 0)
+            st.max_station_diff or 0)
         if not args then
             svc:obs_log('warn', { what = 'band_args_invalid', method = 'set_station_counting', err = err })
         else
-            rpc('set_station_counting', args)
+            band_rpc(band_cap, svc, 'set_station_counting', args)
         end
     end
 
@@ -154,7 +176,7 @@ local function apply_band_steering(band_cap, band_cfg, svc)
         if not args then
             svc:obs_log('warn', { what = 'band_args_invalid', method = 'set_rrm_mode', err = err })
         else
-            rpc('set_rrm_mode', args)
+            band_rpc(band_cap, svc, 'set_rrm_mode', args)
         end
     end
 
@@ -162,12 +184,12 @@ local function apply_band_steering(band_cap, band_cfg, svc)
     if is_table(globals.neighbor_reports) then
         local nr = globals.neighbor_reports
         local args, err = cap_sdk.args.new.BandSetNeighbourReportsOpts(
-            nr.dyn_report_num      or 0,
+            nr.dyn_report_num or 0,
             nr.disassoc_report_len or 0)
         if not args then
             svc:obs_log('warn', { what = 'band_args_invalid', method = 'set_neighbour_reports', err = err })
         else
-            rpc('set_neighbour_reports', args)
+            band_rpc(band_cap, svc, 'set_neighbour_reports', args)
         end
     end
 
@@ -177,7 +199,7 @@ local function apply_band_steering(band_cap, band_cfg, svc)
         if not args then
             svc:obs_log('warn', { what = 'band_args_invalid', method = 'set_legacy_options', err = err })
         else
-            rpc('set_legacy_options', args)
+            band_rpc(band_cap, svc, 'set_legacy_options', args)
         end
     end
 
@@ -187,7 +209,7 @@ local function apply_band_steering(band_cap, band_cfg, svc)
         if not args then
             svc:obs_log('warn', { what = 'band_args_invalid', method = 'set_update_freq', err = err })
         else
-            rpc('set_update_freq', args)
+            band_rpc(band_cap, svc, 'set_update_freq', args)
         end
     end
 
@@ -197,7 +219,7 @@ local function apply_band_steering(band_cap, band_cfg, svc)
         if not args then
             svc:obs_log('warn', { what = 'band_args_invalid', method = 'set_client_inactive_kickoff', err = err })
         else
-            rpc('set_client_inactive_kickoff', args)
+            band_rpc(band_cap, svc, 'set_client_inactive_kickoff', args)
         end
     end
 
@@ -207,7 +229,7 @@ local function apply_band_steering(band_cap, band_cfg, svc)
         if not args then
             svc:obs_log('warn', { what = 'band_args_invalid', method = 'set_cleanup', err = err })
         else
-            rpc('set_cleanup', args)
+            band_rpc(band_cap, svc, 'set_cleanup', args)
         end
     end
 
@@ -219,7 +241,7 @@ local function apply_band_steering(band_cap, band_cfg, svc)
                 if not args then
                     svc:obs_log('warn', { what = 'band_args_invalid', method = 'set_band_priority', err = err })
                 else
-                    rpc('set_band_priority', args)
+                    band_rpc(band_cap, svc, 'set_band_priority', args)
                 end
             end
             if is_table(band_data.rssi_scoring) then
@@ -228,7 +250,7 @@ local function apply_band_steering(band_cap, band_cfg, svc)
                 if not args then
                     svc:obs_log('warn', { what = 'band_args_invalid', method = 'set_band_kicking', err = err })
                 else
-                    rpc('set_band_kicking', args)
+                    band_rpc(band_cap, svc, 'set_band_kicking', args)
                 end
             end
             if is_table(band_data.chan_util_scoring) then
@@ -237,7 +259,7 @@ local function apply_band_steering(band_cap, band_cfg, svc)
                 if not args then
                     svc:obs_log('warn', { what = 'band_args_invalid', method = 'set_band_kicking', err = err })
                 else
-                    rpc('set_band_kicking', args)
+                    band_rpc(band_cap, svc, 'set_band_kicking', args)
                 end
             end
             if is_table(band_data.support_bonuses) then
@@ -246,15 +268,42 @@ local function apply_band_steering(band_cap, band_cfg, svc)
                     if not args then
                         svc:obs_log('warn', { what = 'band_args_invalid', method = 'set_support_bonus', err = err })
                     else
-                        rpc('set_support_bonus', args)
+                        band_rpc(band_cap, svc, 'set_support_bonus', args)
                     end
                 end
             end
         end
     end
 
-    rpc('apply', {}, slow)
+    band_rpc(band_cap, svc, 'apply', {}, slow)
     svc:obs_log('info', { what = 'band_config_applied' })
+end
+
+------------------------------------------------------------------------
+-- Radio configuration RPC helper
+------------------------------------------------------------------------
+
+local function radio_rpc(radio_cap, radio_id, svc, method, args)
+    local reply, err = radio_cap:call_control(method, args)
+    if err and err ~= "" then
+        svc:obs_log('warn', {
+            what   = 'radio_rpc_failed',
+            radio  = radio_id,
+            method = method,
+            err    = tostring(err),
+        })
+        return false
+    end
+    if not reply or reply.ok ~= true then
+        svc:obs_log('warn', {
+            what   = 'radio_rpc_error',
+            radio  = radio_id,
+            method = method,
+            reason = reply and reply.reason or 'nil',
+        })
+        return false
+    end
+    return true, reply
 end
 
 ------------------------------------------------------------------------
@@ -270,25 +319,10 @@ end
 local function apply_radio_config(radio_cap, radio_cfg, ssid_cfgs, fs_configs_cap, band_steering_cfg, svc)
     local radio_id = radio_cap.id
 
-    local function rpc(method, args)
-        local reply, err = radio_cap:call_control(method, args)
-        if err and err ~= "" then
-            svc:obs_log('warn', { what = 'radio_rpc_failed', radio = radio_id,
-                                   method = method, err = tostring(err) })
-            return false
-        end
-        if not reply or reply.ok ~= true then
-            svc:obs_log('warn', { what = 'radio_rpc_error', radio = radio_id,
-                                   method = method, reason = reply and reply.reason or 'nil' })
-            return false
-        end
-        return true, reply
-    end
-
     svc:obs_log('debug', { what = 'radio_config_start', radio = radio_id })
 
     -- 1. Clear staged config
-    if not rpc('clear_radio_config', {}) then return end
+    if not radio_rpc(radio_cap, radio_id, svc, 'clear_radio_config', {}) then return end
 
     -- 2. Set report period
     do
@@ -297,7 +331,7 @@ local function apply_radio_config(radio_cap, radio_cfg, ssid_cfgs, fs_configs_ca
             svc:obs_log('warn', { what = 'radio_args_invalid', method = 'set_report_period', err = err })
             return
         end
-        if not rpc('set_report_period', args) then return end
+        if not radio_rpc(radio_cap, radio_id, svc, 'set_report_period', args) then return end
     end
 
     -- 3. Set channels
@@ -308,9 +342,14 @@ local function apply_radio_config(radio_cap, radio_cfg, ssid_cfgs, fs_configs_ca
             svc:obs_log('warn', { what = 'radio_args_invalid', method = 'set_channels', err = err })
             return
         end
-        if not rpc('set_channels', args) then return end
-        svc:obs_log('debug', { what = 'radio_channels_set', radio = radio_id,
-            band = radio_cfg.band, channel = radio_cfg.channel, htmode = radio_cfg.htmode })
+        if not radio_rpc(radio_cap, radio_id, svc, 'set_channels', args) then return end
+        svc:obs_log('debug', {
+            what    = 'radio_channels_set',
+            radio   = radio_id,
+            band    = radio_cfg.band,
+            channel = radio_cfg.channel,
+            htmode  = radio_cfg.htmode,
+        })
     end
 
     -- 4. txpower (optional)
@@ -319,7 +358,7 @@ local function apply_radio_config(radio_cap, radio_cfg, ssid_cfgs, fs_configs_ca
         if not args then
             svc:obs_log('warn', { what = 'radio_args_invalid', method = 'set_txpower', err = err })
         else
-            rpc('set_txpower', args)
+            radio_rpc(radio_cap, radio_id, svc, 'set_txpower', args)
         end
     end
 
@@ -329,7 +368,7 @@ local function apply_radio_config(radio_cap, radio_cfg, ssid_cfgs, fs_configs_ca
         if not args then
             svc:obs_log('warn', { what = 'radio_args_invalid', method = 'set_country', err = err })
         else
-            rpc('set_country', args)
+            radio_rpc(radio_cap, radio_id, svc, 'set_country', args)
         end
     end
 
@@ -339,7 +378,7 @@ local function apply_radio_config(radio_cap, radio_cfg, ssid_cfgs, fs_configs_ca
         if not args then
             svc:obs_log('warn', { what = 'radio_args_invalid', method = 'set_enabled', err = err })
         else
-            rpc('set_enabled', args)
+            radio_rpc(radio_cap, radio_id, svc, 'set_enabled', args)
         end
     end
 
@@ -357,7 +396,9 @@ local function apply_radio_config(radio_cap, radio_cfg, ssid_cfgs, fs_configs_ca
             local applies = false
             if is_table(ssid_cfg.radios) then
                 for _, r in ipairs(ssid_cfg.radios) do
-                    if r == radio_cap.id then applies = true; break end
+                    if r == radio_cap.id then
+                        applies = true; break
+                    end
                 end
             end
             if not applies then break end
@@ -371,7 +412,7 @@ local function apply_radio_config(radio_cap, radio_cfg, ssid_cfgs, fs_configs_ca
                 local base_cfg = {
                     network    = ssid_cfg.network,
                     encryption = ssid_cfg.encryption or 'none',
-                    password   = ssid_cfg.password   or '',
+                    password   = ssid_cfg.password or '',
                     mode       = map_mode(ssid_cfg.mode or 'access_point'),
                 }
                 local ssids, serr = utils.parse_mainflux_ssids(fs_configs_cap, ssid_cfg.mainflux_path, base_cfg)
@@ -390,11 +431,15 @@ local function apply_radio_config(radio_cap, radio_cfg, ssid_cfgs, fs_configs_ca
                     if not args then
                         svc:obs_log('warn', { what = 'radio_args_invalid', method = 'add_interface', err = err })
                     else
-                        local ok, reply = rpc('add_interface', args)
+                        local ok, reply = radio_rpc(radio_cap, radio_id, svc, 'add_interface', args)
                         if ok then
-                            svc:obs_log('debug', { what = 'radio_iface_added', radio = radio_id,
-                                ssid = mssd.name or mssd.ssid, network = mssd.network,
-                                iface = reply and reply.reason or nil })
+                            svc:obs_log('debug', {
+                                what    = 'radio_iface_added',
+                                radio   = radio_id,
+                                ssid    = mssd.name or mssd.ssid,
+                                network = mssd.network,
+                                iface   = reply and reply.reason or nil,
+                            })
                         end
                     end
                 end
@@ -410,11 +455,15 @@ local function apply_radio_config(radio_cap, radio_cfg, ssid_cfgs, fs_configs_ca
                 if not args then
                     svc:obs_log('warn', { what = 'radio_args_invalid', method = 'add_interface', err = err })
                 else
-                    local ok, reply = rpc('add_interface', args)
+                    local ok, reply = radio_rpc(radio_cap, radio_id, svc, 'add_interface', args)
                     if ok then
-                        svc:obs_log('debug', { what = 'radio_iface_added', radio = radio_id,
-                            ssid = ssid_cfg.name, network = ssid_cfg.network,
-                            iface = reply and reply.reason or nil })
+                        svc:obs_log('debug', {
+                            what    = 'radio_iface_added',
+                            radio   = radio_id,
+                            ssid    = ssid_cfg.name,
+                            network = ssid_cfg.network,
+                            iface   = reply and reply.reason or nil,
+                        })
                     end
                 end
             end
@@ -422,8 +471,72 @@ local function apply_radio_config(radio_cap, radio_cfg, ssid_cfgs, fs_configs_ca
     end
 
     -- 8. Apply
-    if not rpc('apply', {}) then return end
+    if not radio_rpc(radio_cap, radio_id, svc, 'apply', {}) then return end
     svc:obs_log('info', { what = 'radio_config_applied', radio = radio_id })
+end
+
+------------------------------------------------------------------------
+-- Per-radio stats loop: message handlers
+------------------------------------------------------------------------
+
+---@param ctx table  stats loop context (conn, band, hw_platform, sessions)
+---@param msg table
+local function on_radio_state(ctx, msg)
+    local key = msg.topic and msg.topic[5]
+    local p   = msg.payload
+    if not (key and is_table(p)) then return end
+
+    local prefix, stat = key:match('^(iface)_(.+)$')
+    if prefix then
+        local idx = iface_idx(p.interface)
+        ctx.conn:publish({ 'wifi', 'hp', ctx.hw_platform, 'rd' .. ctx.band, idx, stat }, p.value)
+        return
+    end
+
+    prefix, stat = key:match('^(client)_(.+)$')
+    if prefix then
+        local uid = gen.userid(p.mac)
+        local sid = ctx.sessions[p.mac]
+        if sid then
+            ctx.conn:publish({ 'wifi', 'clients', uid, 'sessions', sid, stat }, p.value)
+        end
+    end
+end
+
+---@param ctx table  stats loop context (conn, band, hw_platform, sessions, iface_sta, radio_sta)
+---@param msg table
+local function on_radio_event(ctx, msg)
+    local event_name = msg.topic and msg.topic[5]
+    if event_name ~= 'client_event' then return end
+
+    local p = msg.payload
+    if not (is_table(p) and p.mac) then return end
+
+    local mac       = p.mac
+    local iface     = p.interface
+    local connected = p.connected
+    local timestamp = p.timestamp or os.time()
+    local uid       = gen.userid(mac)
+    local change    = connected and 1 or -1
+
+    ctx.iface_sta[iface] = math.max(0, (ctx.iface_sta[iface] or 0) + change)
+    ctx.radio_sta        = math.max(0, ctx.radio_sta + change)
+
+    local idx = iface_idx(iface)
+    ctx.conn:publish({ 'wifi', 'hp', ctx.hw_platform, 'rd' .. ctx.band, idx, 'num_sta' }, ctx.iface_sta[iface])
+    ctx.conn:publish({ 'wifi', 'hp', ctx.hw_platform, 'num_sta' }, ctx.radio_sta)
+
+    if connected then
+        local sid = gen.gen_session_id()
+        ctx.sessions[mac] = sid
+        ctx.conn:publish({ 'wifi', 'clients', uid, 'sessions', sid, 'session_start' }, timestamp)
+    else
+        local sid = ctx.sessions[mac]
+        if sid then
+            ctx.conn:publish({ 'wifi', 'clients', uid, 'sessions', sid, 'session_end' }, timestamp)
+            ctx.sessions[mac] = nil
+        end
+    end
 end
 
 ------------------------------------------------------------------------
@@ -435,22 +548,14 @@ end
 ---@param radio_cfg WifiRadioConfig?
 ---@param svc ServiceBase
 local function radio_stats_loop(conn, id, radio_cfg, svc)
-    -- Sessions: mac → session_id (raw MAC as key)
-    local sessions = {}
-
-    -- Per-interface and per-radio station counts
-    local iface_sta = {}  -- iface_name → count
-    local radio_sta = 0
-
-    -- Band digit for metric topics: "2g" → "2", "5g" → "5"
-    local band        = ((radio_cfg and radio_cfg.band) or ''):sub(1, 1)
-    local hw_platform = '1'
-
-    -- Parse interface index from generated name suffix (e.g. "radio0_i2" → "2")
-    local function iface_idx(name)
-        local n = name and name:match('_i(%d+)$')
-        return n or '0'
-    end
+    local ctx = {
+        conn        = conn,
+        band        = ((radio_cfg and radio_cfg.band) or ''):sub(1, 1),
+        hw_platform = '1',
+        sessions    = {},
+        iface_sta   = {},
+        radio_sta   = 0,
+    }
 
     local state_sub = conn:subscribe({ 'cap', 'radio', id, 'state', '+' })
     local event_sub = conn:subscribe({ 'cap', 'radio', id, 'event', '+' })
@@ -475,76 +580,165 @@ local function radio_stats_loop(conn, id, radio_cfg, svc)
         end
 
         if which == 'state' then
-            local key = msg.topic and msg.topic[5]
-            local p   = msg.payload
-            if key and is_table(p) then
-                local rd  = 'rd' .. band
-                local idx = iface_idx(p.interface)
-                if key == 'iface_txpower' then
-                    conn:publish({'wifi','hp',hw_platform,rd,idx,'power'}, p.value)
-                elseif key == 'iface_channel' then
-                    conn:publish({'wifi','hp',hw_platform,rd,idx,'channel'}, p.channel)
-                elseif key == 'iface_noise' then
-                    conn:publish({'wifi','hp',hw_platform,rd,idx,'noise'}, p.value)
-                elseif key == 'iface_rx_bytes'    or key == 'iface_tx_bytes'
-                    or key == 'iface_rx_packets'  or key == 'iface_tx_packets'
-                    or key == 'iface_rx_dropped'  or key == 'iface_tx_dropped'
-                    or key == 'iface_rx_errors'   or key == 'iface_tx_errors' then
-                    -- Strip "iface_" prefix (6 chars) to get the metric name
-                    conn:publish({'wifi','hp',hw_platform,rd,idx, key:sub(7)}, p.value)
-                elseif key == 'client_signal' then
-                    local uid = gen.userid(p.mac)
-                    local sid = sessions[p.mac]
-                    if sid then
-                        conn:publish({'wifi','clients',uid,'sessions',sid,'signal'}, p.signal)
-                    end
-                elseif key == 'client_tx_bytes' or key == 'client_rx_bytes' then
-                    -- Strip "client_" prefix (7 chars) to get tx_bytes / rx_bytes
-                    local uid = gen.userid(p.mac)
-                    local sid = sessions[p.mac]
-                    if sid then
-                        conn:publish({'wifi','clients',uid,'sessions',sid, key:sub(8)}, p.value)
-                    end
-                end
-            end
-
+            on_radio_state(ctx, msg)
         elseif which == 'event' then
-            local event_name = msg.topic and msg.topic[5]
-
-            if event_name == 'client_event' then
-                local p = msg.payload
-                if is_table(p) and p.mac then
-                    local mac       = p.mac
-                    local iface     = p.interface
-                    local connected = p.connected
-                    local timestamp = p.timestamp or os.time()
-                    local uid       = gen.userid(mac)
-                    local change    = connected and 1 or -1
-
-                    -- Update per-interface and per-radio station counts
-                    iface_sta[iface] = math.max(0, (iface_sta[iface] or 0) + change)
-                    radio_sta        = math.max(0, radio_sta + change)
-
-                    local rd  = 'rd' .. band
-                    local idx = iface_idx(iface)
-                    conn:publish({'wifi','hp',hw_platform,rd,idx,'num_sta'}, iface_sta[iface])
-                    conn:publish({'wifi','hp',hw_platform,'num_sta'}, radio_sta)
-
-                    -- Session tracking + session event publish
-                    if connected then
-                        local sid = gen.gen_session_id()
-                        sessions[mac] = sid
-                        conn:publish({'wifi','clients',uid,'sessions',sid,'session_start'}, timestamp)
-                    else
-                        local sid = sessions[mac]
-                        if sid then
-                            conn:publish({'wifi','clients',uid,'sessions',sid,'session_end'}, timestamp)
-                            sessions[mac] = nil
-                        end
-                    end
-                end
-            end
+            on_radio_event(ctx, msg)
         end
+    end
+end
+
+------------------------------------------------------------------------
+-- Global num_sta aggregator fiber
+------------------------------------------------------------------------
+
+---Subscribes to all radio client_event emissions and maintains a single
+---wifi/num_sta count across all radios.
+---@param conn Connection
+---@param parent_scope Scope
+local function run_global_num_sta(conn, parent_scope)
+    local global_sta       = 0
+    local global_event_sub = conn:subscribe({ 'cap', 'radio', '+', 'event', 'client_event' })
+
+    fibers.current_scope():finally(function()
+        global_event_sub:unsubscribe()
+    end)
+
+    while true do
+        local which, msg = perform(fibers.named_choice({
+            event  = global_event_sub:recv_op(),
+            cancel = parent_scope:cancel_op(),
+        }))
+
+        if which == 'cancel' then break end
+
+        if msg and is_table(msg.payload) and msg.payload.mac then
+            local change = msg.payload.connected and 1 or -1
+            global_sta = math.max(0, global_sta + change)
+            conn:publish({ 'wifi', 'num_sta' }, global_sta)
+        end
+    end
+end
+
+------------------------------------------------------------------------
+-- Service context helpers
+------------------------------------------------------------------------
+
+local function get_radio_cfg(ctx, radio_id)
+    if not is_table(ctx.data) or not is_table(ctx.data.radios) then return nil end
+    for _, r in ipairs(ctx.data.radios) do
+        if r.name == radio_id then return r end
+    end
+    return nil
+end
+
+local function configure_radio(ctx, id)
+    local radio_cfg = get_radio_cfg(ctx, id)
+    if not radio_cfg then
+        ctx.svc:obs_log('debug', { what = 'no_config_for_radio', radio = id })
+        return
+    end
+    local cap   = cap_sdk.new_cap_ref(ctx.conn, 'radio', id)
+    local ssids = is_table(ctx.data.ssids) and ctx.data.ssids or {}
+    apply_radio_config(cap, radio_cfg, ssids, ctx.fs_configs_cap,
+        is_table(ctx.data) and ctx.data.band_steering or nil, ctx.svc)
+end
+
+local function radio_fiber_body(ctx, id)
+    configure_radio(ctx, id)
+    radio_stats_loop(ctx.conn, id, get_radio_cfg(ctx, id), ctx.svc)
+end
+
+local function spawn_radio_scope(ctx, id)
+    if ctx.radio_scopes[id] then
+        ctx.radio_scopes[id]:cancel('reconfigure')
+        ctx.radio_scopes[id] = nil
+    end
+    local scope, serr = ctx.parent_scope:child()
+    if not scope then
+        ctx.svc:obs_log('error', { what = 'radio_scope_failed', radio = id, err = serr })
+        return
+    end
+    ctx.radio_scopes[id] = scope
+    scope:spawn(function() radio_fiber_body(ctx, id) end)
+end
+
+local function remove_radio(ctx, id)
+    if ctx.radio_scopes[id] then
+        ctx.radio_scopes[id]:cancel('radio removed')
+        ctx.radio_scopes[id] = nil
+    end
+end
+
+local function apply_band_config(ctx)
+    if ctx.band_cap and is_table(ctx.data) and is_table(ctx.data.band_steering) then
+        apply_band_steering(ctx.band_cap, ctx.data.band_steering, ctx.svc)
+    end
+end
+
+local function reapply_all_radios(ctx)
+    for id in pairs(ctx.radio_scopes) do
+        spawn_radio_scope(ctx, id)
+    end
+end
+
+------------------------------------------------------------------------
+-- Main service loop: message handlers
+------------------------------------------------------------------------
+
+local function on_cfg(ctx, msg)
+    local payload = msg.payload
+    if not is_table(payload) then
+        ctx.svc:obs_log('warn', { what = 'invalid_config_payload' })
+        return
+    end
+    local rev  = payload.rev
+    local data = payload.data
+    if type(rev) == 'number' and rev <= ctx.last_rev then
+        ctx.svc:obs_log('debug', { what = 'stale_config', rev = rev, last_rev = ctx.last_rev })
+    elseif not is_table(data) then
+        ctx.svc:obs_log('warn', { what = 'config_data_not_table' })
+    else
+        ctx.last_rev = rev or ctx.last_rev
+        ctx.data     = data
+        ctx.svc:obs_event('config_applied', { rev = rev })
+        reapply_all_radios(ctx)
+        apply_band_config(ctx)
+    end
+end
+
+local function on_radio_cap(ctx, msg)
+    local id    = msg.topic and msg.topic[3]
+    local state = msg.payload
+    if state == 'added' then
+        ctx.svc:obs_log('info', { what = 'radio_cap_added', radio = id })
+        spawn_radio_scope(ctx, id)
+    elseif state == 'removed' then
+        ctx.svc:obs_log('info', { what = 'radio_cap_removed', radio = id })
+        remove_radio(ctx, id)
+    end
+end
+
+local function on_band_cap(ctx, msg)
+    local state = msg.payload
+    if state == 'added' then
+        ctx.svc:obs_log('info', { what = 'band_cap_added' })
+        ctx.band_cap = cap_sdk.new_cap_ref(ctx.conn, 'band', '1')
+        apply_band_config(ctx)
+    elseif state == 'removed' then
+        ctx.svc:obs_log('info', { what = 'band_cap_removed' })
+        ctx.band_cap = nil
+    end
+end
+
+local function on_fs_cap(ctx, msg)
+    local state = msg.payload
+    if state == 'added' then
+        ctx.svc:obs_log('info', { what = 'fs_configs_cap_added' })
+        ctx.fs_configs_cap = cap_sdk.new_cap_ref(ctx.conn, 'fs', 'configs')
+        reapply_all_radios(ctx)
+    elseif state == 'removed' then
+        ctx.svc:obs_log('info', { what = 'fs_configs_cap_removed' })
+        ctx.fs_configs_cap = nil
     end
 end
 
@@ -576,190 +770,54 @@ function WifiService.start(conn, opts)
         svc:obs_log('info', 'service stopped')
     end)
 
-    -- Current service state
-    ---@type any
-    local current_data   = nil   -- data field of last valid config
-    local last_rev       = -1
-    local fs_configs_cap = nil   -- configs filesystem cap reference
-    local band_cap       = nil   -- band capability reference
-    local radio_scopes   = {}    -- radio_id → child scope
+    local ctx = {
+        conn           = conn,
+        svc            = svc,
+        parent_scope   = parent_scope,
+        data           = nil,   -- data field of last valid config
+        last_rev       = -1,
+        fs_configs_cap = nil,   -- configs filesystem cap reference
+        band_cap       = nil,   -- band capability reference
+        radio_scopes   = {},    -- radio_id → child scope
+    }
 
     -- Subscribe to config topic
-    local cfg_sub = conn:subscribe({ 'cfg', 'wifi' })
+    local cfg_sub            = conn:subscribe({ 'cfg', 'wifi' })
 
     -- Subscribe to cap state notifications (radio, band, fs/configs)
     local radio_cap_listener = cap_sdk.new_cap_listener(conn, 'radio', '+')
-    local band_cap_listener  = cap_sdk.new_cap_listener(conn, 'band',  '1')
-    local fs_cap_listener    = cap_sdk.new_cap_listener(conn, 'fs',    'configs')
-
-    local function get_radio_cfg(radio_id)
-        if not is_table(current_data) or not is_table(current_data.radios) then
-            return nil
-        end
-        for _, r in ipairs(current_data.radios) do
-            if r.name == radio_id then return r end
-        end
-        return nil
-    end
-
-    local function configure_radio(id)
-        local radio_cfg = get_radio_cfg(id)
-        if not radio_cfg then
-            svc:obs_log('debug', { what = 'no_config_for_radio', radio = id })
-            return
-        end
-        local cap = cap_sdk.new_cap_ref(conn, 'radio', id)
-        local ssids = is_table(current_data.ssids) and current_data.ssids or {}
-        apply_radio_config(cap, radio_cfg, ssids, fs_configs_cap,
-            is_table(current_data) and current_data.band_steering or nil, svc)
-    end
-
-    local function spawn_radio_scope(id)
-        -- Cancel existing scope if any
-        if radio_scopes[id] then
-            radio_scopes[id]:cancel('reconfigure')
-            radio_scopes[id] = nil
-        end
-
-        local scope, serr = parent_scope:child()
-        if not scope then
-            svc:obs_log('error', { what = 'radio_scope_failed', radio = id, err = serr })
-            return
-        end
-        radio_scopes[id] = scope
-
-        scope:spawn(function()
-            -- Apply configuration for this radio
-            configure_radio(id)
-            -- Capture radio_cfg after configure so band is available for metric topics
-            local radio_cfg = get_radio_cfg(id)
-            -- Run stats forwarding loop
-            radio_stats_loop(conn, id, radio_cfg, svc)
-        end)
-    end
-
-    local function remove_radio(id)
-        if radio_scopes[id] then
-            radio_scopes[id]:cancel('radio removed')
-            radio_scopes[id] = nil
-        end
-    end
-
-    local function apply_band_config()
-        if band_cap and is_table(current_data) and is_table(current_data.band_steering) then
-            apply_band_steering(band_cap, current_data.band_steering, svc)
-        end
-    end
-
-    local function reapply_all_radios()
-        for id in pairs(radio_scopes) do
-            spawn_radio_scope(id)
-        end
-    end
+    local band_cap_listener  = cap_sdk.new_cap_listener(conn, 'band', '1')
+    local fs_cap_listener    = cap_sdk.new_cap_listener(conn, 'fs', 'configs')
 
     svc:status('running')
     svc:obs_log('info', 'service running')
 
-    -- Aggregate global wifi/num_sta across all radios.
-    -- Each radio also publishes wifi/hp/<platform>/num_sta for its own total.
-    parent_scope:spawn(function()
-        local global_sta = 0
-        local global_event_sub = conn:subscribe({ 'cap', 'radio', '+', 'event', 'client_event' })
-        fibers.current_scope():finally(function()
-            global_event_sub:unsubscribe()
-        end)
-        while true do
-            local which, msg = perform(fibers.named_choice({
-                event  = global_event_sub:recv_op(),
-                cancel = parent_scope:cancel_op(),
-            }))
-            if which == 'cancel' then break end
-            if msg and is_table(msg.payload) and msg.payload.mac then
-                local change = msg.payload.connected and 1 or -1
-                global_sta = math.max(0, global_sta + change)
-                conn:publish({ 'wifi', 'num_sta' }, global_sta)
-            end
-        end
-    end)
+    parent_scope:spawn(function() run_global_num_sta(conn, parent_scope) end)
 
     while true do
-        local choices = {
+        local which, msg = perform(fibers.named_choice({
             cfg    = cfg_sub:recv_op(),
             radio  = radio_cap_listener.sub:recv_op(),
             band   = band_cap_listener.sub:recv_op(),
             fs     = fs_cap_listener.sub:recv_op(),
             cancel = parent_scope:cancel_op(),
-        }
-
-        local which, msg = perform(fibers.named_choice(choices))
+        }))
 
         if which == 'cancel' then break end
 
         if not msg then
             svc:obs_log('debug', { what = 'subscription_closed', source = which })
-            -- A closed subscription is non-fatal; continue
-        elseif which == 'cfg' then
-            local payload = msg.payload
-            if not is_table(payload) then
-                svc:obs_log('warn', { what = 'invalid_config_payload' })
-            else
-                local rev  = payload.rev
-                local data = payload.data
-                if type(rev) == 'number' and rev <= last_rev then
-                    svc:obs_log('debug', { what = 'stale_config', rev = rev, last_rev = last_rev })
-                elseif not is_table(data) then
-                    svc:obs_log('warn', { what = 'config_data_not_table' })
-                else
-                    last_rev     = rev or last_rev
-                    current_data = data
-                    svc:obs_event('config_applied', { rev = rev })
-
-                    -- Re-apply config to all existing radios and band
-                    reapply_all_radios()
-                    apply_band_config()
-                end
-            end
-
-        elseif which == 'radio' then
-            local id    = msg.topic and msg.topic[3]
-            local state = msg.payload
-            if state == 'added' then
-                svc:obs_log('info', { what = 'radio_cap_added', radio = id })
-                spawn_radio_scope(id)
-            elseif state == 'removed' then
-                svc:obs_log('info', { what = 'radio_cap_removed', radio = id })
-                remove_radio(id)
-            end
-
-        elseif which == 'band' then
-            local state = msg.payload
-            if state == 'added' then
-                svc:obs_log('info', { what = 'band_cap_added' })
-                band_cap = cap_sdk.new_cap_ref(conn, 'band', '1')
-                apply_band_config()
-            elseif state == 'removed' then
-                svc:obs_log('info', { what = 'band_cap_removed' })
-                band_cap = nil
-            end
-
-        elseif which == 'fs' then
-            local state = msg.payload
-            if state == 'added' then
-                svc:obs_log('info', { what = 'fs_configs_cap_added' })
-                fs_configs_cap = cap_sdk.new_cap_ref(conn, 'fs', 'configs')
-                -- Re-apply radios since SSIDs may need the fs cap
-                reapply_all_radios()
-            elseif state == 'removed' then
-                svc:obs_log('info', { what = 'fs_configs_cap_removed' })
-                fs_configs_cap = nil
-            end
+        elseif which == 'cfg'   then on_cfg(ctx, msg)
+        elseif which == 'radio' then on_radio_cap(ctx, msg)
+        elseif which == 'band'  then on_band_cap(ctx, msg)
+        elseif which == 'fs'    then on_fs_cap(ctx, msg)
         end
     end
 
     -- Cleanup all radio scopes on exit
-    for id, scope in pairs(radio_scopes) do
+    for id, scope in pairs(ctx.radio_scopes) do
         scope:cancel('service stopping')
-        radio_scopes[id] = nil
+        ctx.radio_scopes[id] = nil
     end
 
     cfg_sub:unsubscribe()

--- a/src/services/wifi.lua
+++ b/src/services/wifi.lua
@@ -145,7 +145,7 @@ local function apply_band_steering(band_cap, band_cfg, svc)
     local timings = band_cfg.timings or {}
     local bands   = band_cfg.bands or {}
 
-    local slow = { timeout = 10.0 }
+    local slow    = { timeout = 10.0 }
 
     svc:obs_log('debug', { what = 'band_config_start' })
     band_rpc(band_cap, svc, 'clear', {}, slow)
@@ -508,7 +508,7 @@ local function radio_stats_loop(conn, id, radio_cfg, svc)
             local idx = iface_idx(p.interface)
             conn:retain(t_obs_metric(stat), {
                 value     = p.value,
-                namespace = { 'wifi', 'hp', hw_platform, 'rd' .. band, idx },
+                namespace = { 'wifi', 'hp', hw_platform, 'rd' .. band, idx, stat },
             })
             return
         end
@@ -520,7 +520,7 @@ local function radio_stats_loop(conn, id, radio_cfg, svc)
             if sid then
                 conn:retain(t_obs_metric(stat), {
                     value     = p.value,
-                    namespace = { 'wifi', 'clients', uid, 'sessions', sid },
+                    namespace = { 'wifi', 'clients', uid, 'sessions', sid, stat },
                 })
             end
         end
@@ -533,24 +533,24 @@ local function radio_stats_loop(conn, id, radio_cfg, svc)
         local p = msg.payload
         if not (is_table(p) and p.mac) then return end
 
-        local mac       = p.mac
-        local iface     = p.interface
-        local connected = p.connected
-        local timestamp = p.timestamp or os.time()
-        local uid       = gen.userid(mac)
-        local change    = connected and 1 or -1
+        local mac        = p.mac
+        local iface      = p.interface
+        local connected  = p.connected
+        local timestamp  = p.timestamp or os.time()
+        local uid        = gen.userid(mac)
+        local change     = connected and 1 or -1
 
         iface_sta[iface] = math.max(0, (iface_sta[iface] or 0) + change)
         radio_sta        = math.max(0, radio_sta + change)
 
-        local idx = iface_idx(iface)
+        local idx        = iface_idx(iface)
         conn:retain(t_obs_metric('num_sta'), {
             value     = iface_sta[iface],
-            namespace = { 'wifi', 'hp', hw_platform, 'rd' .. band, idx },
+            namespace = { 'wifi', 'hp', hw_platform, 'rd' .. band, idx, 'num_sta' },
         })
         conn:retain(t_obs_metric('num_sta'), {
             value     = radio_sta,
-            namespace = { 'wifi', 'hp', hw_platform },
+            namespace = { 'wifi', 'hp', hw_platform, 'rd' .. band, 'num_sta' },
         })
 
         if connected then
@@ -558,14 +558,14 @@ local function radio_stats_loop(conn, id, radio_cfg, svc)
             sessions[mac] = sid
             conn:publish(t_obs_event('session_start'), {
                 value     = timestamp,
-                namespace = { 'wifi', 'clients', uid, 'sessions', sid },
+                namespace = { 'wifi', 'clients', uid, 'sessions', sid, 'session_start' },
             })
         else
             local sid = sessions[mac]
             if sid then
                 conn:publish(t_obs_event('session_end'), {
                     value     = timestamp,
-                    namespace = { 'wifi', 'clients', uid, 'sessions', sid },
+                    namespace = { 'wifi', 'clients', uid, 'sessions', sid, 'session_end' },
                 })
                 sessions[mac] = nil
             end
@@ -785,15 +785,15 @@ function WifiService.start(conn, opts)
         svc:obs_log('info', 'service stopped')
     end)
 
-    local ctx = {
+    local ctx                = {
         conn           = conn,
         svc            = svc,
         parent_scope   = parent_scope,
-        data           = nil,   -- data field of last valid config
+        data           = nil, -- data field of last valid config
         last_rev       = -1,
-        fs_configs_cap = nil,   -- configs filesystem cap reference
-        band_cap       = nil,   -- band capability reference
-        radio_scopes   = {},    -- radio_id → child scope
+        fs_configs_cap = nil, -- configs filesystem cap reference
+        band_cap       = nil, -- band capability reference
+        radio_scopes   = {},  -- radio_id → child scope
     }
 
     -- Subscribe to config topic
@@ -822,10 +822,14 @@ function WifiService.start(conn, opts)
 
         if not msg then
             svc:obs_log('debug', { what = 'subscription_closed', source = which })
-        elseif which == 'cfg'   then on_cfg(ctx, msg)
-        elseif which == 'radio' then on_radio_cap(ctx, msg)
-        elseif which == 'band'  then on_band_cap(ctx, msg)
-        elseif which == 'fs'    then on_fs_cap(ctx, msg)
+        elseif which == 'cfg' then
+            on_cfg(ctx, msg)
+        elseif which == 'radio' then
+            on_radio_cap(ctx, msg)
+        elseif which == 'band' then
+            on_band_cap(ctx, msg)
+        elseif which == 'fs' then
+            on_fs_cap(ctx, msg)
         end
     end
 

--- a/src/services/wifi.lua
+++ b/src/services/wifi.lua
@@ -1,0 +1,662 @@
+-- services/wifi.lua
+--
+-- Wifi service: forwards radio/band configs to HAL capabilities,
+-- manages SSIDs, subscribes to radio stats, handles MAC session tracking.
+
+local fibers = require "fibers"
+
+local perform = fibers.perform
+
+local base    = require 'devicecode.service_base'
+local cap_sdk = require 'services.hal.sdk.cap'
+local gen     = require 'services.wifi.gen'
+local utils   = require 'services.wifi.utils'
+
+------------------------------------------------------------------------
+-- Config types (annotation-only)
+------------------------------------------------------------------------
+
+---@class WifiRadioConfig
+---@field name string          UCI radio section name (e.g. "radio0")
+---@field band RadioBand
+---@field channel number|string
+---@field htmode RadioHtmode
+---@field channels? (number|string)[]  required when channel == 'auto'
+---@field txpower? number|string
+---@field country? string      ISO-3166-1 alpha-2 country code
+---@field disabled? boolean
+---@field report_period? number  seconds between stats reports
+
+---@class WifiSsidConfig
+---@field name? string         SSID / network name
+---@field mode string          access_point | client | adhoc | mesh | monitor
+---@field encryption? RadioEncryption
+---@field password? string
+---@field network? string      UCI network interface name
+---@field radios string[]      radio section names this SSID should be added to
+---@field mainflux_path? string  path in the configs filesystem cap
+
+---@class WifiBandSteeringConfig
+---@field globals? table        global band-steering tunables
+---@field timings? table        timing / threshold tunables
+---@field bands? table          per-band scoring configuration
+
+---@class WifiServiceData
+---@field schema string
+---@field report_period? number
+---@field radios WifiRadioConfig[]
+---@field ssids WifiSsidConfig[]
+---@field band_steering? WifiBandSteeringConfig
+
+---@class WifiServiceOpts
+---@field name? string
+---@field env? table
+
+-- Mode names the config uses vs what the radio driver expects
+local MODE_MAP = {
+    access_point = 'ap',
+    client       = 'sta',
+}
+
+local function map_mode(mode)
+    return MODE_MAP[mode] or mode
+end
+
+local function is_table(v) return type(v) == 'table' end
+
+------------------------------------------------------------------------
+-- Band steering application
+------------------------------------------------------------------------
+
+---@param band_cap CapabilityReference
+---@param band_cfg WifiBandSteeringConfig
+---@param svc ServiceBase
+local function apply_band_steering(band_cap, band_cfg, svc)
+    if not is_table(band_cfg) then return end
+    local globals  = band_cfg.globals  or {}
+    local timings  = band_cfg.timings  or {}
+    local bands    = band_cfg.bands    or {}
+
+    local function rpc(method, args)
+        local reply, err = band_cap:call_control(method, args)
+        if err and err ~= "" then
+            svc:obs_log('warn', { what = 'band_rpc_failed', method = method, err = tostring(err) })
+            return false
+        end
+        if not reply or reply.ok ~= true then
+            svc:obs_log('warn', { what = 'band_rpc_error', method = method,
+                                   reason = reply and reply.reason or 'nil' })
+            return false
+        end
+        return true
+    end
+
+    rpc('clear', {})
+
+    -- kicking
+    local kicking = globals.kicking
+    if is_table(kicking) then
+        local args, err = cap_sdk.args.new.BandSetKickingOpts(
+            kicking.kick_mode        or 'none',
+            kicking.bandwidth_threshold or 0,
+            kicking.kicking_threshold   or 0,
+            kicking.evals_before_kick   or 0)
+        if not args then
+            svc:obs_log('warn', { what = 'band_args_invalid', method = 'set_kicking', err = err })
+        else
+            rpc('set_kicking', args)
+        end
+    end
+
+    -- station counting
+    if is_table(globals.stations) then
+        local st = globals.stations
+        local args, err = cap_sdk.args.new.BandSetStationCountingOpts(
+            st.use_station_count or false,
+            st.max_station_diff  or 0)
+        if not args then
+            svc:obs_log('warn', { what = 'band_args_invalid', method = 'set_station_counting', err = err })
+        else
+            rpc('set_station_counting', args)
+        end
+    end
+
+    -- rrm_mode
+    if globals.rrm_mode then
+        local args, err = cap_sdk.args.new.BandSetRrmModeOpts(globals.rrm_mode)
+        if not args then
+            svc:obs_log('warn', { what = 'band_args_invalid', method = 'set_rrm_mode', err = err })
+        else
+            rpc('set_rrm_mode', args)
+        end
+    end
+
+    -- neighbour reports
+    if is_table(globals.neighbor_reports) then
+        local nr = globals.neighbor_reports
+        local args, err = cap_sdk.args.new.BandSetNeighbourReportsOpts(
+            nr.dyn_report_num      or 0,
+            nr.disassoc_report_len or 0)
+        if not args then
+            svc:obs_log('warn', { what = 'band_args_invalid', method = 'set_neighbour_reports', err = err })
+        else
+            rpc('set_neighbour_reports', args)
+        end
+    end
+
+    -- legacy options
+    if is_table(globals.legacy) then
+        local args, err = cap_sdk.args.new.BandSetLegacyOptionsOpts(globals.legacy)
+        if not args then
+            svc:obs_log('warn', { what = 'band_args_invalid', method = 'set_legacy_options', err = err })
+        else
+            rpc('set_legacy_options', args)
+        end
+    end
+
+    -- update frequencies
+    if is_table(timings.updates) then
+        local args, err = cap_sdk.args.new.BandSetUpdateFreqOpts(timings.updates)
+        if not args then
+            svc:obs_log('warn', { what = 'band_args_invalid', method = 'set_update_freq', err = err })
+        else
+            rpc('set_update_freq', args)
+        end
+    end
+
+    -- inactive client kickoff
+    if timings.inactive_client_kickoff ~= nil then
+        local args, err = cap_sdk.args.new.BandSetClientInactiveKickoffOpts(timings.inactive_client_kickoff)
+        if not args then
+            svc:obs_log('warn', { what = 'band_args_invalid', method = 'set_client_inactive_kickoff', err = err })
+        else
+            rpc('set_client_inactive_kickoff', args)
+        end
+    end
+
+    -- cleanup timeouts
+    if is_table(timings.cleanup) then
+        local args, err = cap_sdk.args.new.BandSetCleanupOpts(timings.cleanup)
+        if not args then
+            svc:obs_log('warn', { what = 'band_args_invalid', method = 'set_cleanup', err = err })
+        else
+            rpc('set_cleanup', args)
+        end
+    end
+
+    -- per-band settings
+    for band_key, band_data in pairs(bands) do
+        if is_table(band_data) then
+            if band_data.initial_score ~= nil then
+                local args, err = cap_sdk.args.new.BandSetBandPriorityOpts(band_key, band_data.initial_score)
+                if not args then
+                    svc:obs_log('warn', { what = 'band_args_invalid', method = 'set_band_priority', err = err })
+                else
+                    rpc('set_band_priority', args)
+                end
+            end
+            if is_table(band_data.rssi_scoring) then
+                local args, err = cap_sdk.args.new.BandSetBandKickingOpts(band_key, band_data.rssi_scoring)
+                if not args then
+                    svc:obs_log('warn', { what = 'band_args_invalid', method = 'set_band_kicking', err = err })
+                else
+                    rpc('set_band_kicking', args)
+                end
+            end
+            if is_table(band_data.chan_util_scoring) then
+                local args, err = cap_sdk.args.new.BandSetBandKickingOpts(band_key, band_data.chan_util_scoring)
+                if not args then
+                    svc:obs_log('warn', { what = 'band_args_invalid', method = 'set_band_kicking', err = err })
+                else
+                    rpc('set_band_kicking', args)
+                end
+            end
+            if is_table(band_data.support_bonuses) then
+                for support_key, reward in pairs(band_data.support_bonuses) do
+                    local args, err = cap_sdk.args.new.BandSetSupportBonusOpts(band_key, support_key, reward)
+                    if not args then
+                        svc:obs_log('warn', { what = 'band_args_invalid', method = 'set_support_bonus', err = err })
+                    else
+                        rpc('set_support_bonus', args)
+                    end
+                end
+            end
+        end
+    end
+
+    rpc('apply', {})
+end
+
+------------------------------------------------------------------------
+-- Radio configuration sequence
+------------------------------------------------------------------------
+
+---@param radio_cap CapabilityReference
+---@param radio_cfg WifiRadioConfig
+---@param ssid_cfgs WifiSsidConfig[]
+---@param fs_configs_cap CapabilityReference?
+---@param band_steering_cfg WifiBandSteeringConfig?
+---@param svc ServiceBase
+local function apply_radio_config(radio_cap, radio_cfg, ssid_cfgs, fs_configs_cap, band_steering_cfg, svc)
+    local function rpc(method, args)
+        local reply, err = radio_cap:call_control(method, args)
+        if err and err ~= "" then
+            svc:obs_log('warn', { what = 'radio_rpc_failed', radio = radio_cap.id,
+                                   method = method, err = tostring(err) })
+            return false
+        end
+        if not reply or reply.ok ~= true then
+            svc:obs_log('warn', { what = 'radio_rpc_error', radio = radio_cap.id,
+                                   method = method, reason = reply and reply.reason or 'nil' })
+            return false
+        end
+        return true, reply
+    end
+
+    -- 1. Clear staged config
+    if not rpc('clear_radio_config', {}) then return end
+
+    -- 2. Set report period
+    do
+        local args, err = cap_sdk.args.new.RadioSetReportPeriodOpts(radio_cfg.report_period or 60)
+        if not args then
+            svc:obs_log('warn', { what = 'radio_args_invalid', method = 'set_report_period', err = err })
+            return
+        end
+        if not rpc('set_report_period', args) then return end
+    end
+
+    -- 3. Set channels
+    do
+        local args, err = cap_sdk.args.new.RadioSetChannelsOpts(
+            radio_cfg.band, radio_cfg.channel, radio_cfg.htmode, radio_cfg.channels)
+        if not args then
+            svc:obs_log('warn', { what = 'radio_args_invalid', method = 'set_channels', err = err })
+            return
+        end
+        if not rpc('set_channels', args) then return end
+    end
+
+    -- 4. txpower (optional)
+    if radio_cfg.txpower ~= nil then
+        local args, err = cap_sdk.args.new.RadioSetTxpowerOpts(radio_cfg.txpower)
+        if not args then
+            svc:obs_log('warn', { what = 'radio_args_invalid', method = 'set_txpower', err = err })
+        else
+            rpc('set_txpower', args)
+        end
+    end
+
+    -- 5. country (optional)
+    if radio_cfg.country then
+        local args, err = cap_sdk.args.new.RadioSetCountryOpts(radio_cfg.country)
+        if not args then
+            svc:obs_log('warn', { what = 'radio_args_invalid', method = 'set_country', err = err })
+        else
+            rpc('set_country', args)
+        end
+    end
+
+    -- 6. enabled / disabled (optional)
+    if radio_cfg.disabled ~= nil then
+        local args, err = cap_sdk.args.new.RadioSetEnabledOpts(not radio_cfg.disabled)
+        if not args then
+            svc:obs_log('warn', { what = 'radio_args_invalid', method = 'set_enabled', err = err })
+        else
+            rpc('set_enabled', args)
+        end
+    end
+
+    -- Determine enable_steering from band steering kick_mode
+    local kick_mode = band_steering_cfg
+        and is_table(band_steering_cfg.globals)
+        and is_table(band_steering_cfg.globals.kicking)
+        and band_steering_cfg.globals.kicking.kick_mode
+    local enable_steering = kick_mode and kick_mode ~= 'none' or false
+
+    -- 7. Add interfaces per SSID
+    for _, ssid_cfg in ipairs(ssid_cfgs) do
+        repeat
+            -- Check if this SSID applies to this radio
+            local applies = false
+            if is_table(ssid_cfg.radios) then
+                for _, r in ipairs(ssid_cfg.radios) do
+                    if r == radio_cap.id then applies = true; break end
+                end
+            end
+            if not applies then break end
+
+            if ssid_cfg.mainflux_path then
+                -- Source credentials from filesystem cap; strict: skip on failure
+                if not fs_configs_cap then
+                    svc:obs_log('warn', { what = 'no_fs_configs_cap', ssid = ssid_cfg.name })
+                    break
+                end
+                local base_cfg = {
+                    network    = ssid_cfg.network,
+                    encryption = ssid_cfg.encryption or 'none',
+                    password   = ssid_cfg.password   or '',
+                    mode       = map_mode(ssid_cfg.mode or 'access_point'),
+                }
+                local ssids, serr = utils.parse_mainflux_ssids(fs_configs_cap, ssid_cfg.mainflux_path, base_cfg)
+                if not ssids then
+                    svc:obs_log('warn', { what = 'mainflux_ssid_failed', ssid = ssid_cfg.name, err = serr })
+                    break
+                end
+                for _, mssd in ipairs(ssids) do
+                    local args, err = cap_sdk.args.new.RadioAddInterfaceOpts(
+                        mssd.name or mssd.ssid or '',
+                        mssd.encryption or 'none',
+                        mssd.password or '',
+                        mssd.network or '',
+                        map_mode(mssd.mode or 'ap'),
+                        enable_steering)
+                    if not args then
+                        svc:obs_log('warn', { what = 'radio_args_invalid', method = 'add_interface', err = err })
+                    else
+                        rpc('add_interface', args)
+                    end
+                end
+            else
+                -- Direct SSID from config
+                local args, err = cap_sdk.args.new.RadioAddInterfaceOpts(
+                    ssid_cfg.name or '',
+                    ssid_cfg.encryption or 'none',
+                    ssid_cfg.password or '',
+                    ssid_cfg.network or '',
+                    map_mode(ssid_cfg.mode or 'access_point'),
+                    enable_steering)
+                if not args then
+                    svc:obs_log('warn', { what = 'radio_args_invalid', method = 'add_interface', err = err })
+                else
+                    rpc('add_interface', args)
+                end
+            end
+        until true
+    end
+
+    -- 8. Apply
+    rpc('apply', {})
+end
+
+------------------------------------------------------------------------
+-- Per-radio stats and session forwarding loop
+------------------------------------------------------------------------
+
+---@param conn Connection
+---@param id string
+---@param svc ServiceBase
+local function radio_stats_loop(conn, id, svc)
+    -- Sessions: mac → session_id
+    local sessions = {}
+
+    local state_sub = conn:subscribe({ 'cap', 'radio', id, 'state', '+' })
+    local event_sub = conn:subscribe({ 'cap', 'radio', id, 'event', '+' })
+
+    fibers.current_scope():finally(function()
+        state_sub:unsubscribe()
+        event_sub:unsubscribe()
+    end)
+
+    while true do
+        local which, msg = perform(fibers.named_choice({
+            state  = state_sub:recv_op(),
+            event  = event_sub:recv_op(),
+            cancel = fibers.current_scope():cancel_op(),
+        }))
+
+        if which == 'cancel' then break end
+
+        if not msg then
+            svc:obs_log('debug', { what = 'radio_sub_closed', radio = id })
+            break
+        end
+
+        if which == 'state' then
+            -- Forward stat to obs bus
+            local stat_name = msg.topic and msg.topic[5]
+            if stat_name then
+                conn:publish({ 'obs', 'v1', 'wifi', 'metric', stat_name }, msg.payload)
+            end
+
+        elseif which == 'event' then
+            local event_name = msg.topic and msg.topic[5]
+
+            if event_name == 'client_event' then
+                local payload = msg.payload
+                if is_table(payload) then
+                    local mac       = payload.mac
+                    local connected = payload.connected
+                    local timestamp = payload.timestamp or os.time()
+
+                    if connected and mac then
+                        local user_id    = gen.userid(mac)
+                        local session_id = gen.gen_session_id()
+                        sessions[mac]    = session_id
+                        conn:publish({ 'obs', 'v1', 'wifi', 'metric', 'session_start' }, {
+                            user_id    = user_id,
+                            session_id = session_id,
+                            radio      = id,
+                            timestamp  = timestamp,
+                        })
+                    elseif not connected and mac then
+                        local session_id = sessions[mac]
+                        if session_id then
+                            local user_id = gen.userid(mac)
+                            conn:publish({ 'obs', 'v1', 'wifi', 'metric', 'session_end' }, {
+                                user_id    = user_id,
+                                session_id = session_id,
+                                radio      = id,
+                                timestamp  = timestamp,
+                            })
+                            sessions[mac] = nil
+                        end
+                    end
+                end
+            else
+                -- Forward other events
+                if event_name then
+                    conn:publish({ 'obs', 'v1', 'wifi', 'metric', event_name }, msg.payload)
+                end
+            end
+        end
+    end
+end
+
+------------------------------------------------------------------------
+-- Service entry point
+------------------------------------------------------------------------
+
+local WifiService = {}
+
+---@param conn Connection
+---@param opts? WifiServiceOpts
+function WifiService.start(conn, opts)
+    local svc = base.new(conn, { name = opts and opts.name or 'wifi', env = opts and opts.env })
+
+    svc:obs_state('boot', { at = svc:wall(), ts = svc:now(), state = 'entered' })
+    svc:obs_log('info', 'service start() entered')
+    svc:status('starting')
+    svc:spawn_heartbeat(10, 'tick')
+
+    local parent_scope = fibers.current_scope()
+
+    parent_scope:finally(function()
+        local scope = fibers.current_scope()
+        local st, primary = scope:status()
+        if st == 'failed' then
+            svc:obs_log('error', { what = 'scope_failed', err = tostring(primary) })
+        end
+        svc:status('stopped', primary and { reason = tostring(primary) } or nil)
+        svc:obs_log('info', 'service stopped')
+    end)
+
+    -- Current service state
+    ---@type any
+    local current_data   = nil   -- data field of last valid config
+    local last_rev       = -1
+    local fs_configs_cap = nil   -- configs filesystem cap reference
+    local band_cap       = nil   -- band capability reference
+    local radio_scopes   = {}    -- radio_id → child scope
+
+    -- Subscribe to config topic
+    local cfg_sub = conn:subscribe({ 'cfg', 'wifi' })
+
+    -- Subscribe to cap state notifications (radio, band, fs/configs)
+    local radio_cap_listener = cap_sdk.new_cap_listener(conn, 'radio', '+')
+    local band_cap_listener  = cap_sdk.new_cap_listener(conn, 'band',  '1')
+    local fs_cap_listener    = cap_sdk.new_cap_listener(conn, 'fs',    'configs')
+
+    local function get_radio_cfg(radio_id)
+        if not is_table(current_data) or not is_table(current_data.radios) then
+            return nil
+        end
+        for _, r in ipairs(current_data.radios) do
+            if r.name == radio_id then return r end
+        end
+        return nil
+    end
+
+    local function configure_radio(id)
+        local radio_cfg = get_radio_cfg(id)
+        if not radio_cfg then
+            svc:obs_log('debug', { what = 'no_config_for_radio', radio = id })
+            return
+        end
+        local cap = cap_sdk.new_cap_ref(conn, 'radio', id)
+        local ssids = is_table(current_data.ssids) and current_data.ssids or {}
+        apply_radio_config(cap, radio_cfg, ssids, fs_configs_cap,
+            is_table(current_data) and current_data.band_steering or nil, svc)
+    end
+
+    local function spawn_radio_scope(id)
+        -- Cancel existing scope if any
+        if radio_scopes[id] then
+            radio_scopes[id]:cancel('reconfigure')
+            radio_scopes[id] = nil
+        end
+
+        local scope, serr = parent_scope:child()
+        if not scope then
+            svc:obs_log('error', { what = 'radio_scope_failed', radio = id, err = serr })
+            return
+        end
+        radio_scopes[id] = scope
+
+        scope:spawn(function()
+            -- Apply configuration for this radio
+            configure_radio(id)
+            -- Run stats forwarding loop
+            radio_stats_loop(conn, id, svc)
+        end)
+    end
+
+    local function remove_radio(id)
+        if radio_scopes[id] then
+            radio_scopes[id]:cancel('radio removed')
+            radio_scopes[id] = nil
+        end
+    end
+
+    local function apply_band_config()
+        if band_cap and is_table(current_data) and is_table(current_data.band_steering) then
+            apply_band_steering(band_cap, current_data.band_steering, svc)
+        end
+    end
+
+    local function reapply_all_radios()
+        for id in pairs(radio_scopes) do
+            spawn_radio_scope(id)
+        end
+    end
+
+    svc:status('running')
+    svc:obs_log('info', 'service running')
+
+    while true do
+        local choices = {
+            cfg    = cfg_sub:recv_op(),
+            radio  = radio_cap_listener.sub:recv_op(),
+            band   = band_cap_listener.sub:recv_op(),
+            fs     = fs_cap_listener.sub:recv_op(),
+            cancel = parent_scope:cancel_op(),
+        }
+
+        local which, msg = perform(fibers.named_choice(choices))
+
+        if which == 'cancel' then break end
+
+        if not msg then
+            svc:obs_log('debug', { what = 'subscription_closed', source = which })
+            -- A closed subscription is non-fatal; continue
+        elseif which == 'cfg' then
+            local payload = msg.payload
+            if not is_table(payload) then
+                svc:obs_log('warn', { what = 'invalid_config_payload' })
+            else
+                local rev  = payload.rev
+                local data = payload.data
+                if type(rev) == 'number' and rev <= last_rev then
+                    svc:obs_log('debug', { what = 'stale_config', rev = rev, last_rev = last_rev })
+                elseif not is_table(data) then
+                    svc:obs_log('warn', { what = 'config_data_not_table' })
+                else
+                    last_rev     = rev or last_rev
+                    current_data = data
+                    svc:obs_event('config_applied', { rev = rev })
+
+                    -- Re-apply config to all existing radios and band
+                    reapply_all_radios()
+                    apply_band_config()
+                end
+            end
+
+        elseif which == 'radio' then
+            local id    = msg.topic and msg.topic[3]
+            local state = msg.payload
+            if state == 'added' then
+                svc:obs_log('info', { what = 'radio_cap_added', radio = id })
+                spawn_radio_scope(id)
+            elseif state == 'removed' then
+                svc:obs_log('info', { what = 'radio_cap_removed', radio = id })
+                remove_radio(id)
+            end
+
+        elseif which == 'band' then
+            local state = msg.payload
+            if state == 'added' then
+                svc:obs_log('info', { what = 'band_cap_added' })
+                band_cap = cap_sdk.new_cap_ref(conn, 'band', '1')
+                apply_band_config()
+            elseif state == 'removed' then
+                svc:obs_log('info', { what = 'band_cap_removed' })
+                band_cap = nil
+            end
+
+        elseif which == 'fs' then
+            local state = msg.payload
+            if state == 'added' then
+                svc:obs_log('info', { what = 'fs_configs_cap_added' })
+                fs_configs_cap = cap_sdk.new_cap_ref(conn, 'fs', 'configs')
+                -- Re-apply radios since SSIDs may need the fs cap
+                reapply_all_radios()
+            elseif state == 'removed' then
+                svc:obs_log('info', { what = 'fs_configs_cap_removed' })
+                fs_configs_cap = nil
+            end
+        end
+    end
+
+    -- Cleanup all radio scopes on exit
+    for id, scope in pairs(radio_scopes) do
+        scope:cancel('service stopping')
+        radio_scopes[id] = nil
+    end
+
+    cfg_sub:unsubscribe()
+    radio_cap_listener:close()
+    band_cap_listener:close()
+    fs_cap_listener:close()
+end
+
+return WifiService

--- a/src/services/wifi.lua
+++ b/src/services/wifi.lua
@@ -107,6 +107,14 @@ local function iface_idx(name)
     return (name and name:match('_i(%d+)$')) or '0'
 end
 
+---@param key string
+---@return Topic
+local function t_obs_metric(key) return { 'obs', 'v1', 'wifi', 'metric', key } end
+
+---@param key string
+---@return Topic
+local function t_obs_event(key) return { 'obs', 'v1', 'wifi', 'event', key } end
+
 ------------------------------------------------------------------------
 -- Band steering RPC helper
 ------------------------------------------------------------------------
@@ -476,70 +484,6 @@ local function apply_radio_config(radio_cap, radio_cfg, ssid_cfgs, fs_configs_ca
 end
 
 ------------------------------------------------------------------------
--- Per-radio stats loop: message handlers
-------------------------------------------------------------------------
-
----@param ctx table  stats loop context (conn, band, hw_platform, sessions)
----@param msg table
-local function on_radio_state(ctx, msg)
-    local key = msg.topic and msg.topic[5]
-    local p   = msg.payload
-    if not (key and is_table(p)) then return end
-
-    local prefix, stat = key:match('^(iface)_(.+)$')
-    if prefix then
-        local idx = iface_idx(p.interface)
-        ctx.conn:publish({ 'wifi', 'hp', ctx.hw_platform, 'rd' .. ctx.band, idx, stat }, p.value)
-        return
-    end
-
-    prefix, stat = key:match('^(client)_(.+)$')
-    if prefix then
-        local uid = gen.userid(p.mac)
-        local sid = ctx.sessions[p.mac]
-        if sid then
-            ctx.conn:publish({ 'wifi', 'clients', uid, 'sessions', sid, stat }, p.value)
-        end
-    end
-end
-
----@param ctx table  stats loop context (conn, band, hw_platform, sessions, iface_sta, radio_sta)
----@param msg table
-local function on_radio_event(ctx, msg)
-    local event_name = msg.topic and msg.topic[5]
-    if event_name ~= 'client_event' then return end
-
-    local p = msg.payload
-    if not (is_table(p) and p.mac) then return end
-
-    local mac       = p.mac
-    local iface     = p.interface
-    local connected = p.connected
-    local timestamp = p.timestamp or os.time()
-    local uid       = gen.userid(mac)
-    local change    = connected and 1 or -1
-
-    ctx.iface_sta[iface] = math.max(0, (ctx.iface_sta[iface] or 0) + change)
-    ctx.radio_sta        = math.max(0, ctx.radio_sta + change)
-
-    local idx = iface_idx(iface)
-    ctx.conn:publish({ 'wifi', 'hp', ctx.hw_platform, 'rd' .. ctx.band, idx, 'num_sta' }, ctx.iface_sta[iface])
-    ctx.conn:publish({ 'wifi', 'hp', ctx.hw_platform, 'num_sta' }, ctx.radio_sta)
-
-    if connected then
-        local sid = gen.gen_session_id()
-        ctx.sessions[mac] = sid
-        ctx.conn:publish({ 'wifi', 'clients', uid, 'sessions', sid, 'session_start' }, timestamp)
-    else
-        local sid = ctx.sessions[mac]
-        if sid then
-            ctx.conn:publish({ 'wifi', 'clients', uid, 'sessions', sid, 'session_end' }, timestamp)
-            ctx.sessions[mac] = nil
-        end
-    end
-end
-
-------------------------------------------------------------------------
 -- Per-radio stats and session forwarding loop
 ------------------------------------------------------------------------
 
@@ -548,14 +492,85 @@ end
 ---@param radio_cfg WifiRadioConfig?
 ---@param svc ServiceBase
 local function radio_stats_loop(conn, id, radio_cfg, svc)
-    local ctx = {
-        conn        = conn,
-        band        = ((radio_cfg and radio_cfg.band) or ''):sub(1, 1),
-        hw_platform = '1',
-        sessions    = {},
-        iface_sta   = {},
-        radio_sta   = 0,
-    }
+    local band        = ((radio_cfg and radio_cfg.band) or ''):sub(1, 1)
+    local hw_platform = '1'
+    local sessions    = {}
+    local iface_sta   = {}
+    local radio_sta   = 0
+
+    local function on_radio_state(msg)
+        local key = msg.topic and msg.topic[5]
+        local p   = msg.payload
+        if not (key and is_table(p)) then return end
+
+        local prefix, stat = key:match('^(iface)_(.+)$')
+        if prefix then
+            local idx = iface_idx(p.interface)
+            conn:retain(t_obs_metric(stat), {
+                value     = p.value,
+                namespace = { 'wifi', 'hp', hw_platform, 'rd' .. band, idx },
+            })
+            return
+        end
+
+        prefix, stat = key:match('^(client)_(.+)$')
+        if prefix then
+            local uid = gen.userid(p.mac)
+            local sid = sessions[p.mac]
+            if sid then
+                conn:retain(t_obs_metric(stat), {
+                    value     = p.value,
+                    namespace = { 'wifi', 'clients', uid, 'sessions', sid },
+                })
+            end
+        end
+    end
+
+    local function on_radio_event(msg)
+        local event_name = msg.topic and msg.topic[5]
+        if event_name ~= 'client_event' then return end
+
+        local p = msg.payload
+        if not (is_table(p) and p.mac) then return end
+
+        local mac       = p.mac
+        local iface     = p.interface
+        local connected = p.connected
+        local timestamp = p.timestamp or os.time()
+        local uid       = gen.userid(mac)
+        local change    = connected and 1 or -1
+
+        iface_sta[iface] = math.max(0, (iface_sta[iface] or 0) + change)
+        radio_sta        = math.max(0, radio_sta + change)
+
+        local idx = iface_idx(iface)
+        conn:retain(t_obs_metric('num_sta'), {
+            value     = iface_sta[iface],
+            namespace = { 'wifi', 'hp', hw_platform, 'rd' .. band, idx },
+        })
+        conn:retain(t_obs_metric('num_sta'), {
+            value     = radio_sta,
+            namespace = { 'wifi', 'hp', hw_platform },
+        })
+
+        if connected then
+            local sid = gen.gen_session_id()
+            sessions[mac] = sid
+            conn:publish(t_obs_event('session_start'), {
+                value     = timestamp,
+                namespace = { 'wifi', 'clients', uid, 'sessions', sid },
+            })
+        else
+            local sid = sessions[mac]
+            if sid then
+                conn:publish(t_obs_event('session_end'), {
+                    value     = timestamp,
+                    namespace = { 'wifi', 'clients', uid, 'sessions', sid },
+                })
+                sessions[mac] = nil
+            end
+        end
+    end
 
     local state_sub = conn:subscribe({ 'cap', 'radio', id, 'state', '+' })
     local event_sub = conn:subscribe({ 'cap', 'radio', id, 'event', '+' })
@@ -580,9 +595,9 @@ local function radio_stats_loop(conn, id, radio_cfg, svc)
         end
 
         if which == 'state' then
-            on_radio_state(ctx, msg)
+            on_radio_state(msg)
         elseif which == 'event' then
-            on_radio_event(ctx, msg)
+            on_radio_event(msg)
         end
     end
 end
@@ -614,7 +629,7 @@ local function run_global_num_sta(conn, parent_scope)
         if msg and is_table(msg.payload) and msg.payload.mac then
             local change = msg.payload.connected and 1 or -1
             global_sta = math.max(0, global_sta + change)
-            conn:publish({ 'wifi', 'num_sta' }, global_sta)
+            conn:retain(t_obs_metric('num_sta'), { value = global_sta, namespace = { 'wifi', 'num_sta' } })
         end
     end
 end

--- a/src/services/wifi.lua
+++ b/src/services/wifi.lua
@@ -68,6 +68,30 @@ local function is_table(v) return type(v) == 'table' end
 -- Band steering application
 ------------------------------------------------------------------------
 
+-- Remap tables for config-level scoring keys → band driver option keys
+local RSSI_SCORING_REMAP = {
+    center         = 'rssi_center',
+    weight         = 'rssi_weight',
+    good_threshold = 'rssi_reward_threshold',
+    good_reward    = 'rssi_reward',
+    bad_threshold  = 'rssi_penalty_threshold',
+    bad_penalty    = 'rssi_penalty',
+}
+local CHAN_UTIL_SCORING_REMAP = {
+    good_threshold = 'channel_util_reward_threshold',
+    good_reward    = 'channel_util_reward',
+    bad_threshold  = 'channel_util_penalty_threshold',
+    bad_penalty    = 'channel_util_penalty',
+}
+
+local function remap_keys(src, mapping)
+    local out = {}
+    for src_key, dst_key in pairs(mapping) do
+        if src[src_key] ~= nil then out[dst_key] = src[src_key] end
+    end
+    return out
+end
+
 ---@param band_cap CapabilityReference
 ---@param band_cfg WifiBandSteeringConfig
 ---@param svc ServiceBase
@@ -77,8 +101,8 @@ local function apply_band_steering(band_cap, band_cfg, svc)
     local timings  = band_cfg.timings  or {}
     local bands    = band_cfg.bands    or {}
 
-    local function rpc(method, args)
-        local reply, err = band_cap:call_control(method, args)
+    local function rpc(method, args, opts)
+        local reply, err = perform(band_cap:call_control_op(method, args, opts))
         if err and err ~= "" then
             svc:obs_log('warn', { what = 'band_rpc_failed', method = method, err = tostring(err) })
             return false
@@ -91,7 +115,10 @@ local function apply_band_steering(band_cap, band_cfg, svc)
         return true
     end
 
-    rpc('clear', {})
+    local slow = { timeout = 10.0 }
+
+    svc:obs_log('debug', { what = 'band_config_start' })
+    rpc('clear', {}, slow)
 
     -- kicking
     local kicking = globals.kicking
@@ -196,7 +223,8 @@ local function apply_band_steering(band_cap, band_cfg, svc)
                 end
             end
             if is_table(band_data.rssi_scoring) then
-                local args, err = cap_sdk.args.new.BandSetBandKickingOpts(band_key, band_data.rssi_scoring)
+                local args, err = cap_sdk.args.new.BandSetBandKickingOpts(
+                    band_key, remap_keys(band_data.rssi_scoring, RSSI_SCORING_REMAP))
                 if not args then
                     svc:obs_log('warn', { what = 'band_args_invalid', method = 'set_band_kicking', err = err })
                 else
@@ -204,7 +232,8 @@ local function apply_band_steering(band_cap, band_cfg, svc)
                 end
             end
             if is_table(band_data.chan_util_scoring) then
-                local args, err = cap_sdk.args.new.BandSetBandKickingOpts(band_key, band_data.chan_util_scoring)
+                local args, err = cap_sdk.args.new.BandSetBandKickingOpts(
+                    band_key, remap_keys(band_data.chan_util_scoring, CHAN_UTIL_SCORING_REMAP))
                 if not args then
                     svc:obs_log('warn', { what = 'band_args_invalid', method = 'set_band_kicking', err = err })
                 else
@@ -224,7 +253,8 @@ local function apply_band_steering(band_cap, band_cfg, svc)
         end
     end
 
-    rpc('apply', {})
+    rpc('apply', {}, slow)
+    svc:obs_log('info', { what = 'band_config_applied' })
 end
 
 ------------------------------------------------------------------------
@@ -238,20 +268,24 @@ end
 ---@param band_steering_cfg WifiBandSteeringConfig?
 ---@param svc ServiceBase
 local function apply_radio_config(radio_cap, radio_cfg, ssid_cfgs, fs_configs_cap, band_steering_cfg, svc)
+    local radio_id = radio_cap.id
+
     local function rpc(method, args)
         local reply, err = radio_cap:call_control(method, args)
         if err and err ~= "" then
-            svc:obs_log('warn', { what = 'radio_rpc_failed', radio = radio_cap.id,
+            svc:obs_log('warn', { what = 'radio_rpc_failed', radio = radio_id,
                                    method = method, err = tostring(err) })
             return false
         end
         if not reply or reply.ok ~= true then
-            svc:obs_log('warn', { what = 'radio_rpc_error', radio = radio_cap.id,
+            svc:obs_log('warn', { what = 'radio_rpc_error', radio = radio_id,
                                    method = method, reason = reply and reply.reason or 'nil' })
             return false
         end
         return true, reply
     end
+
+    svc:obs_log('debug', { what = 'radio_config_start', radio = radio_id })
 
     -- 1. Clear staged config
     if not rpc('clear_radio_config', {}) then return end
@@ -275,6 +309,8 @@ local function apply_radio_config(radio_cap, radio_cfg, ssid_cfgs, fs_configs_ca
             return
         end
         if not rpc('set_channels', args) then return end
+        svc:obs_log('debug', { what = 'radio_channels_set', radio = radio_id,
+            band = radio_cfg.band, channel = radio_cfg.channel, htmode = radio_cfg.htmode })
     end
 
     -- 4. txpower (optional)
@@ -354,7 +390,12 @@ local function apply_radio_config(radio_cap, radio_cfg, ssid_cfgs, fs_configs_ca
                     if not args then
                         svc:obs_log('warn', { what = 'radio_args_invalid', method = 'add_interface', err = err })
                     else
-                        rpc('add_interface', args)
+                        local ok, reply = rpc('add_interface', args)
+                        if ok then
+                            svc:obs_log('debug', { what = 'radio_iface_added', radio = radio_id,
+                                ssid = mssd.name or mssd.ssid, network = mssd.network,
+                                iface = reply and reply.reason or nil })
+                        end
                     end
                 end
             else
@@ -369,14 +410,20 @@ local function apply_radio_config(radio_cap, radio_cfg, ssid_cfgs, fs_configs_ca
                 if not args then
                     svc:obs_log('warn', { what = 'radio_args_invalid', method = 'add_interface', err = err })
                 else
-                    rpc('add_interface', args)
+                    local ok, reply = rpc('add_interface', args)
+                    if ok then
+                        svc:obs_log('debug', { what = 'radio_iface_added', radio = radio_id,
+                            ssid = ssid_cfg.name, network = ssid_cfg.network,
+                            iface = reply and reply.reason or nil })
+                    end
                 end
             end
         until true
     end
 
     -- 8. Apply
-    rpc('apply', {})
+    if not rpc('apply', {}) then return end
+    svc:obs_log('info', { what = 'radio_config_applied', radio = radio_id })
 end
 
 ------------------------------------------------------------------------
@@ -385,10 +432,25 @@ end
 
 ---@param conn Connection
 ---@param id string
+---@param radio_cfg WifiRadioConfig?
 ---@param svc ServiceBase
-local function radio_stats_loop(conn, id, svc)
-    -- Sessions: mac → session_id
+local function radio_stats_loop(conn, id, radio_cfg, svc)
+    -- Sessions: mac → session_id (raw MAC as key)
     local sessions = {}
+
+    -- Per-interface and per-radio station counts
+    local iface_sta = {}  -- iface_name → count
+    local radio_sta = 0
+
+    -- Band digit for metric topics: "2g" → "2", "5g" → "5"
+    local band        = ((radio_cfg and radio_cfg.band) or ''):sub(1, 1)
+    local hw_platform = '1'
+
+    -- Parse interface index from generated name suffix (e.g. "radio0_i2" → "2")
+    local function iface_idx(name)
+        local n = name and name:match('_i(%d+)$')
+        return n or '0'
+    end
 
     local state_sub = conn:subscribe({ 'cap', 'radio', id, 'state', '+' })
     local event_sub = conn:subscribe({ 'cap', 'radio', id, 'event', '+' })
@@ -413,50 +475,73 @@ local function radio_stats_loop(conn, id, svc)
         end
 
         if which == 'state' then
-            -- Forward stat to obs bus
-            local stat_name = msg.topic and msg.topic[5]
-            if stat_name then
-                conn:publish({ 'obs', 'v1', 'wifi', 'metric', stat_name }, msg.payload)
+            local key = msg.topic and msg.topic[5]
+            local p   = msg.payload
+            if key and is_table(p) then
+                local rd  = 'rd' .. band
+                local idx = iface_idx(p.interface)
+                if key == 'iface_txpower' then
+                    conn:publish({'wifi','hp',hw_platform,rd,idx,'power'}, p.value)
+                elseif key == 'iface_channel' then
+                    conn:publish({'wifi','hp',hw_platform,rd,idx,'channel'}, p.channel)
+                elseif key == 'iface_noise' then
+                    conn:publish({'wifi','hp',hw_platform,rd,idx,'noise'}, p.value)
+                elseif key == 'iface_rx_bytes'    or key == 'iface_tx_bytes'
+                    or key == 'iface_rx_packets'  or key == 'iface_tx_packets'
+                    or key == 'iface_rx_dropped'  or key == 'iface_tx_dropped'
+                    or key == 'iface_rx_errors'   or key == 'iface_tx_errors' then
+                    -- Strip "iface_" prefix (6 chars) to get the metric name
+                    conn:publish({'wifi','hp',hw_platform,rd,idx, key:sub(7)}, p.value)
+                elseif key == 'client_signal' then
+                    local uid = gen.userid(p.mac)
+                    local sid = sessions[p.mac]
+                    if sid then
+                        conn:publish({'wifi','clients',uid,'sessions',sid,'signal'}, p.signal)
+                    end
+                elseif key == 'client_tx_bytes' or key == 'client_rx_bytes' then
+                    -- Strip "client_" prefix (7 chars) to get tx_bytes / rx_bytes
+                    local uid = gen.userid(p.mac)
+                    local sid = sessions[p.mac]
+                    if sid then
+                        conn:publish({'wifi','clients',uid,'sessions',sid, key:sub(8)}, p.value)
+                    end
+                end
             end
 
         elseif which == 'event' then
             local event_name = msg.topic and msg.topic[5]
 
             if event_name == 'client_event' then
-                local payload = msg.payload
-                if is_table(payload) then
-                    local mac       = payload.mac
-                    local connected = payload.connected
-                    local timestamp = payload.timestamp or os.time()
+                local p = msg.payload
+                if is_table(p) and p.mac then
+                    local mac       = p.mac
+                    local iface     = p.interface
+                    local connected = p.connected
+                    local timestamp = p.timestamp or os.time()
+                    local uid       = gen.userid(mac)
+                    local change    = connected and 1 or -1
 
-                    if connected and mac then
-                        local user_id    = gen.userid(mac)
-                        local session_id = gen.gen_session_id()
-                        sessions[mac]    = session_id
-                        conn:publish({ 'obs', 'v1', 'wifi', 'metric', 'session_start' }, {
-                            user_id    = user_id,
-                            session_id = session_id,
-                            radio      = id,
-                            timestamp  = timestamp,
-                        })
-                    elseif not connected and mac then
-                        local session_id = sessions[mac]
-                        if session_id then
-                            local user_id = gen.userid(mac)
-                            conn:publish({ 'obs', 'v1', 'wifi', 'metric', 'session_end' }, {
-                                user_id    = user_id,
-                                session_id = session_id,
-                                radio      = id,
-                                timestamp  = timestamp,
-                            })
+                    -- Update per-interface and per-radio station counts
+                    iface_sta[iface] = math.max(0, (iface_sta[iface] or 0) + change)
+                    radio_sta        = math.max(0, radio_sta + change)
+
+                    local rd  = 'rd' .. band
+                    local idx = iface_idx(iface)
+                    conn:publish({'wifi','hp',hw_platform,rd,idx,'num_sta'}, iface_sta[iface])
+                    conn:publish({'wifi','hp',hw_platform,'num_sta'}, radio_sta)
+
+                    -- Session tracking + session event publish
+                    if connected then
+                        local sid = gen.gen_session_id()
+                        sessions[mac] = sid
+                        conn:publish({'wifi','clients',uid,'sessions',sid,'session_start'}, timestamp)
+                    else
+                        local sid = sessions[mac]
+                        if sid then
+                            conn:publish({'wifi','clients',uid,'sessions',sid,'session_end'}, timestamp)
                             sessions[mac] = nil
                         end
                     end
-                end
-            else
-                -- Forward other events
-                if event_name then
-                    conn:publish({ 'obs', 'v1', 'wifi', 'metric', event_name }, msg.payload)
                 end
             end
         end
@@ -546,8 +631,10 @@ function WifiService.start(conn, opts)
         scope:spawn(function()
             -- Apply configuration for this radio
             configure_radio(id)
+            -- Capture radio_cfg after configure so band is available for metric topics
+            local radio_cfg = get_radio_cfg(id)
             -- Run stats forwarding loop
-            radio_stats_loop(conn, id, svc)
+            radio_stats_loop(conn, id, radio_cfg, svc)
         end)
     end
 
@@ -572,6 +659,28 @@ function WifiService.start(conn, opts)
 
     svc:status('running')
     svc:obs_log('info', 'service running')
+
+    -- Aggregate global wifi/num_sta across all radios.
+    -- Each radio also publishes wifi/hp/<platform>/num_sta for its own total.
+    parent_scope:spawn(function()
+        local global_sta = 0
+        local global_event_sub = conn:subscribe({ 'cap', 'radio', '+', 'event', 'client_event' })
+        fibers.current_scope():finally(function()
+            global_event_sub:unsubscribe()
+        end)
+        while true do
+            local which, msg = perform(fibers.named_choice({
+                event  = global_event_sub:recv_op(),
+                cancel = parent_scope:cancel_op(),
+            }))
+            if which == 'cancel' then break end
+            if msg and is_table(msg.payload) and msg.payload.mac then
+                local change = msg.payload.connected and 1 or -1
+                global_sta = math.max(0, global_sta + change)
+                conn:publish({ 'wifi', 'num_sta' }, global_sta)
+            end
+        end
+    end)
 
     while true do
         local choices = {

--- a/src/services/wifi/gen.lua
+++ b/src/services/wifi/gen.lua
@@ -1,0 +1,36 @@
+local digest = require "openssl.digest"
+local string = require "string"
+
+function string.tohex(str)
+    return (str:gsub('.', function (c)
+        return string.format('%02X', string.byte(c))
+    end))
+end
+
+if digest.digest == nil then
+    function digest.digest(algo, str)
+        return digest.new(algo):final(str):tohex():lower()
+    end
+end
+
+local USER_SALT = "$USER_SALT"
+local USER_ID_LEN = 6
+
+local function userid(mac)
+    local hash = digest.digest("sha256", USER_SALT..mac)
+    return string.sub(hash, 1, USER_ID_LEN)
+end
+
+local function gen_session_id()
+    local random = math.random
+    local template = 'xxxxxxxx_xxxx_4xxx_yxxx_xxxxxxxxxxxx'
+    return string.gsub(template, '[xy]', function (char)
+        local value = (char == 'x') and random(0, 0xf) or random(8, 0xb)
+        return string.format('%x', value)
+    end)
+end
+
+return {
+    userid = userid,
+    gen_session_id = gen_session_id,
+}

--- a/src/services/wifi/utils.lua
+++ b/src/services/wifi/utils.lua
@@ -27,9 +27,21 @@ local function parse_mainflux_ssids(fs_cap, mainflux_path, base_ssid_cfg)
         return nil, tostring(reply.reason or "filesystem read failed")
     end
 
-    local content_parsed, derr = json.decode(reply.reason or '')
-    if not content_parsed then
+    local outer, derr = json.decode(reply.reason or '')
+    if not outer then
         return nil, tostring(derr)
+    end
+
+    -- The mainflux file wraps the actual config as a JSON-encoded string in `content`
+    local content_parsed
+    if type(outer.content) == 'string' then
+        local inner_err
+        content_parsed, inner_err = json.decode(outer.content)
+        if not content_parsed then
+            return nil, "failed to decode mainflux content field: " .. tostring(inner_err)
+        end
+    else
+        content_parsed = outer
     end
 
     local ssid_cfgs = content_parsed.networks

--- a/src/services/wifi/utils.lua
+++ b/src/services/wifi/utils.lua
@@ -1,0 +1,63 @@
+local json = require "cjson.safe"
+local cap_args = require "services.hal.types.capability_args"
+
+local mainflux_to_ssid_keys = {
+    name    = "network",
+    ssid    = "name",
+}
+
+---Read mainflux SSID credentials from the configs filesystem capability
+---and merge them with the base SSID config.
+---@param fs_cap any        CapabilityReference for the configs filesystem cap
+---@param mainflux_path string  Filename within the filesystem cap (e.g. "mainflux.json")
+---@param base_ssid_cfg table   Base SSID fields to merge into each resulting SSID
+---@return table?  ssids  Array of SSID config tables, or nil on any error
+---@return string  err    Error message, or "" on success
+local function parse_mainflux_ssids(fs_cap, mainflux_path, base_ssid_cfg)
+    local opts, opts_err = cap_args.new.FilesystemReadOpts(mainflux_path)
+    if not opts then
+        return nil, tostring(opts_err)
+    end
+
+    local reply, call_err = fs_cap:call_control('read', opts)
+    if not reply then
+        return nil, tostring(call_err)
+    end
+    if reply.ok ~= true then
+        return nil, tostring(reply.reason or "filesystem read failed")
+    end
+
+    local content_parsed, derr = json.decode(reply.reason or '')
+    if not content_parsed then
+        return nil, tostring(derr)
+    end
+
+    local ssid_cfgs = content_parsed.networks
+        and content_parsed.networks.networks
+        or nil
+    if not ssid_cfgs then
+        return nil, "no ssid configs found in mainflux file"
+    end
+
+    local ssids = {}
+    for _, ssid_cfg in ipairs(ssid_cfgs) do
+        local ssid = {}
+        for k, v in pairs(base_ssid_cfg) do
+            ssid[k] = v
+        end
+        for k, v in pairs(ssid_cfg) do
+            local key = mainflux_to_ssid_keys[k] or k
+            -- Temporary workaround: mainflux uses "jng" for what we call "adm"
+            if key == "network" and v == "jng" then
+                v = "adm"
+            end
+            ssid[key] = v
+        end
+        table.insert(ssids, ssid)
+    end
+    return ssids, ""
+end
+
+return {
+    parse_mainflux_ssids = parse_mainflux_ssids,
+}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [x] 📝 Documentation Update
- [ ] 🎨 Style
- [x] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description
Migrated the Wifi service to use new scoped fibers and runtime proposal. 

- New radio and band backend - dependent on openwrt and easily extendable to use specific openwrt versions if needed
- Re-implementation of radio and band driver to use backend system
- wlan manager has been simplified to no longer coordinate relationship between UCI radio name and iw phy iface name
- wifi service is a 1-1 parity of previous wifi service, following same config paradigms as before

## Manual test
<!-- Have you manually tested this code and confirmed it is working? -->
- [x] 👍 yes
- [ ] 🙅 no

## Manual test description
Move the src and vendor folders over to the target bigbox-v1 making sure the vendor repos are on versions:
`lua-fibers`: v0.8.1
`lua-trie`: v0.3
`lua-bus`: v0.4

Make sure to stop previous devicecode instances by doing `killall luajit`

*For more riguous testing*: vi into both /etc/config/wireless and /etc/config/dawn and remove the contents from each file

Then in the src directory run:
`DEVICECODE_CONFIG_DIR=./configs/ CONFIG_TARGET=config DEVICECODE_SERVICES=config,hal,monitor,wifi luajit main.lua`

Check that the wifi service reported successfully configuring the band and radio drivers. Look out for:

```
LOG  wifi       info   { what="band_config_applied" }
LOG  wifi       info   { radio="radio0" what="radio_config_applied" }
LOG  wifi       info   { radio="radio1" what="radio_config_applied" }
```

With a phone or another device (be careful using your host device as this could cause you to disconnect from your ssh session) connected to the box' SSID, you should see session start metrics, the specific radio may be different

```
2026-04-20 08:10:55 (mono=269.855)  OBS  v1         obs/v1/wifi/metric/num_sta  { namespace=[ "wifi" "num_sta" ] value=1 }
2026-04-20 08:10:55 (mono=269.855)  OBS  v1         obs/v1/wifi/metric/num_sta  { namespace=[ "wifi" "hp" "1" "rd5" "0" ] value=1 }
2026-04-20 08:10:55 (mono=269.855)  OBS  v1         obs/v1/wifi/metric/num_sta  { namespace=[ "wifi" "hp" "1" ] value=1 }
2026-04-20 08:10:55 (mono=269.855)  OBS  v1         obs/v1/wifi/event/session_start  { namespace=[ "wifi" "clients" "cccf26" "sessions" "8adafec5_9fc3_4f45_bc38_464ff358a856" ] value=1776672655 }
```

Wait 2 minutes

Disconnect your device from the box and you should session end metrics

Then look for the remaining metrics output from the wifi service 

rd2 and rd5, interface 0 and 1:
- power
- channel
- noise
- rx_bytes
- tx_bytes
- rx_packets
- tx_packets
- rx_dropped
- tx_dropped
- rx_errors
- tx_errors

clients metrics
- signal
- tx_bytes
- rx_bytes
- session_start
- session_end

num sta metrics:
- total num sta (wifi/num_sta)
- per hp num sta (wifi/hp/1/num_sta)
- per interface num sta (wifi/hp/1/rdX/<interface_idx>/num_sta)

Check the /etc/config/wireless file and make sure there is radio0, radio1, radio0_i0, radio0_i1, radio1_i0, radio1_i1 sections

## Added tests?
- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [x] no, because of time left

## Added to documentation?
- [x] 📜 spec folder
- [ ] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?

