### PR TITLE
Test harness fix

### DIFF
--- a/tests/run.lua
+++ b/tests/run.lua
@@ -1,6 +1,5 @@
 -- tests/run.lua
 
--- look one level up
 package.path = "../src/?.lua;" .. package.path
 package.path = '../?.lua;../?/init.lua;./?.lua;./?/init.lua;' .. package.path
 
@@ -32,25 +31,77 @@ local files = {
 	'integration.devhost.config_recovery_spec'
 }
 
-local total, failed = 0, 0
+local function monotonic_now()
+	if type(os.clock) == 'function' then return os.clock() end
+	return 0
+end
+
+local function sorted_keys(t)
+	local keys = {}
+	for k in pairs(t) do keys[#keys + 1] = k end
+	table.sort(keys, function(a, b) return tostring(a) < tostring(b) end)
+	return keys
+end
+
+local function should_run(modname, testname, filter_text)
+	if not filter_text or filter_text == '' then return true end
+	local needle = string.lower(filter_text)
+	local hay = string.lower(('%s :: %s'):format(tostring(modname), tostring(testname)))
+	return string.find(hay, needle, 1, true) ~= nil
+end
+
+local function format_duration_s(dt)
+	return ('%.3fs'):format(tonumber(dt) or 0)
+end
+
+local TEST_FILTER = os.getenv('TEST_FILTER') or ''
+
+local total, failed, skipped = 0, 0, 0
+local failure_rows = {}
 
 for i = 1, #files do
 	local modname = files[i]
 	local mod = require(modname)
+	local keys = sorted_keys(mod)
 
-	for name, fn in pairs(mod) do
-		total = total + 1
-		io.write(('[TEST] %s :: %s ... '):format(modname, name))
-		local ok, err = safe.pcall(fn)
-		if ok then
-			io.write('ok\n')
-		else
-			failed = failed + 1
-			io.write('FAIL\n')
-			io.write(tostring(err) .. '\n')
+	for j = 1, #keys do
+		local name = keys[j]
+		local fn = mod[name]
+		if type(fn) == 'function' then
+			if should_run(modname, name, TEST_FILTER) then
+				total = total + 1
+				io.write(('[TEST] %s :: %s ... '):format(modname, name))
+				local t0 = monotonic_now()
+				local ok, err = safe.xpcall(fn, function(e)
+					return debug.traceback(tostring(e), 2)
+				end)
+				local dt = monotonic_now() - t0
+				if ok then
+					io.write('ok ' .. format_duration_s(dt) .. '\n')
+				else
+					failed = failed + 1
+					failure_rows[#failure_rows + 1] = {
+						name = ('%s :: %s'):format(modname, name),
+						err = tostring(err),
+						dt = dt,
+					}
+					io.write('FAIL ' .. format_duration_s(dt) .. '\n')
+					io.write(tostring(err) .. '\n')
+				end
+			else
+				skipped = skipped + 1
+			end
 		end
 	end
 end
 
-io.write(('\n%d tests, %d failed\n'):format(total, failed))
+io.write(('\n%d tests, %d failed, %d skipped\n'):format(total, failed, skipped))
+if #failure_rows > 0 then
+	io.write('\nFailure summary:\n')
+	for i = 1, #failure_rows do
+		local row = failure_rows[i]
+		local first = tostring(row.err):match('([^\n]+)') or tostring(row.err)
+		io.write(('  - %s [%s]\n    %s\n'):format(row.name, format_duration_s(row.dt), first))
+	end
+end
 os.exit(failed == 0 and 0 or 1)

--- a/tests/support/fake_hal.lua
+++ b/tests/support/fake_hal.lua
@@ -4,10 +4,6 @@ local fibers = require 'fibers'
 
 local M = {}
 
-local function topic(method)
-	return { 'rpc', 'hal', method }
-end
-
 local function cap_state_topic(class, id)
 	return { 'cap', class, id, 'state' }
 end
@@ -21,9 +17,7 @@ local function cap_rpc_topic(class, id, method)
 end
 
 local function strip_json_suffix(filename)
-	if type(filename) ~= 'string' then
-		return nil
-	end
+	if type(filename) ~= 'string' then return nil end
 	return (filename:gsub('%.json$', ''))
 end
 
@@ -39,66 +33,41 @@ local function map_cap_call(class, id, method, req)
 	if class == 'fs' and id == 'config' and method == 'read' then
 		return 'read_state', legacy_state_req_from_filename(req and req.filename)
 	end
-
 	if class == 'fs' and id == 'state' and method == 'write' then
 		return 'write_state', legacy_state_req_from_filename(req and req.filename, req and req.data)
 	end
-
 	return method, req
 end
 
 local function map_cap_reply(method, reply)
-	if type(reply) ~= 'table' then
-		return reply
-	end
-
+	if type(reply) ~= 'table' then return reply end
 	if method == 'read_state' then
 		local found = rawget(reply, 'found')
 		local data = rawget(reply, 'data')
 		local err_text = rawget(reply, 'err')
 		if reply.ok == true and found == true then
-			return {
-				ok = true,
-				reason = data,
-			}
+			return { ok = true, reason = data }
 		end
-
 		if reply.ok == true and found == false then
-			return {
-				ok = false,
-				reason = err_text or 'not found',
-				code = reply.code,
-			}
+			return { ok = false, reason = err_text or 'not found', code = reply.code }
 		end
 	end
-
 	local err_text = rawget(reply, 'err')
 	if reply.ok ~= nil and reply.reason == nil and err_text ~= nil then
-		return {
-			ok = reply.ok,
-			reason = err_text,
-			code = reply.code,
-		}
+		return { ok = reply.ok, reason = err_text, code = reply.code }
 	end
-
 	return reply
 end
 
 local function method_offerings(method)
-	if method == 'read_state' then
-		return 'fs', 'config', { read = true }
-	end
-
-	if method == 'write_state' then
-		return 'fs', 'state', { write = true }
-	end
-
+	if method == 'read_state' then return 'fs', 'config', { read = true } end
+	if method == 'write_state' then return 'fs', 'state', { write = true } end
 	return nil, nil, nil
 end
 
 ---@class FakeHal
 ---@field calls table[]
----@field scripted table<string, fun(req:any,msg:any):table>|table[]
+---@field scripted table<string, fun(req:any,request:any):table>|table[]
 ---@field backend string
 ---@field caps table
 local FakeHal = {}
@@ -107,61 +76,30 @@ FakeHal.__index = FakeHal
 function FakeHal:new(opts)
 	opts = opts or {}
 	return setmetatable({
-		calls    = {},
+		calls = {},
 		scripted = opts.scripted or {},
-		backend  = opts.backend or 'fakehal',
-		caps     = opts.caps or {},
+		backend = opts.backend or 'fakehal',
+		caps = opts.caps or {},
 	}, FakeHal)
 end
 
-function FakeHal:_next_reply(method, req, msg)
+function FakeHal:_next_reply(method, req, request)
 	local entry = self.scripted[method]
-	if type(entry) == 'function' then
-		return entry(req, msg)
-	end
+	if type(entry) == 'function' then return entry(req, request) end
 	if type(entry) == 'table' and #entry > 0 then
 		local v = table.remove(entry, 1)
-		if type(v) == 'function' then
-			return v(req, msg)
-		end
+		if type(v) == 'function' then return v(req, request) end
 		return v
 	end
 	return { ok = false, err = 'no scripted reply for ' .. tostring(method) }
 end
 
-function FakeHal:_record_call(method, req, msg)
+function FakeHal:_record_call(method, req, request)
 	self.calls[#self.calls + 1] = {
 		method = method,
-		req    = req,
-		msg    = msg,
+		req = req,
+		request = request,
 	}
-end
-
-function FakeHal:_start_legacy_rpc(conn)
-	local methods = {}
-	for method in pairs(self.scripted) do
-		methods[#methods + 1] = method
-	end
-
-	for i = 1, #methods do
-		local method = methods[i]
-		local ep = conn:bind(topic(method), { queue_len = 16 })
-
-		fibers.spawn(function()
-			while true do
-				local req, err = ep:recv()
-				if not req then
-					return
-				end
-
-				local payload = req.payload or {}
-				self:_record_call(method, payload, req)
-
-				local reply = self:_next_reply(method, payload, req)
-				req:reply(reply)
-			end
-		end)
-	end
 end
 
 function FakeHal:_start_capability_rpc(conn, class, id, offering, legacy_method)
@@ -172,37 +110,36 @@ function FakeHal:_start_capability_rpc(conn, class, id, offering, legacy_method)
 
 	fibers.spawn(function()
 		while true do
-			local msg, err = ep:recv()
-			if not msg then
-				return
-			end
+			local req, err = ep:recv()
+			if not req then return end
 
-			local raw_req = msg.payload or {}
-			local method, req = map_cap_call(class, id, offering, raw_req)
+			local raw_req = req.payload or {}
+			local method, mapped_req = map_cap_call(class, id, offering, raw_req)
 			method = legacy_method or method
 
-			self:_record_call(method, req, msg)
+			self:_record_call(method, mapped_req, req)
 
-			local reply = self:_next_reply(method, req, msg)
+			local reply = self:_next_reply(method, mapped_req, req)
 			reply = map_cap_reply(method, reply)
-
-			msg:reply(reply)
+			if type(reply) ~= 'table' then
+				req:fail(reply)
+			elseif reply.ok == true then
+				req:reply(reply)
+			else
+				req:reply(reply)
+			end
 		end
 	end)
 end
 
 function FakeHal:_start_capabilities(conn)
 	local started = {}
-
 	for method, enabled in pairs(self.caps) do
 		if enabled then
 			local class, id, offerings = method_offerings(method)
-			if class ~= nil and id ~= nil and offerings ~= nil then
+			if class and id and offerings then
 				local key = class .. '\0' .. tostring(id)
-				if not started[key] then
-					started[key] = true
-				end
-
+				if not started[key] then started[key] = true end
 				for offering in pairs(offerings) do
 					self:_start_capability_rpc(conn, class, id, offering, method)
 				end
@@ -214,15 +151,11 @@ end
 function FakeHal:start(conn, opts)
 	opts = opts or {}
 	local name = opts.name or 'hal'
-
 	conn:retain({ 'svc', name, 'announce' }, {
-		role     = 'hal',
-		rpc_root = { 'rpc', 'hal' },
-		backend  = self.backend,
-		caps     = self.caps,
+		role = 'hal',
+		backend = self.backend,
+		caps = self.caps,
 	})
-
-	self:_start_legacy_rpc(conn)
 	self:_start_capabilities(conn)
 end
 

--- a/tests/support/run_fibers.lua
+++ b/tests/support/run_fibers.lua
@@ -21,6 +21,7 @@ function M.run(fn, opts)
 			end
 
 			local done = pulse.new()
+			local done_ver = done:version()
 			local body_err = nil
 
 			local ok_spawn, spawn_err = test_scope:spawn(function(s)
@@ -42,7 +43,7 @@ function M.run(fn, opts)
 
 			local ok_timer, timer_err = root_scope:spawn(function()
 				local completed = fibers.perform(op.boolean_choice(
-					done:next_op():wrap(function() return true end),
+					done:changed_op(done_ver):wrap(function() return true end),
 					sleep.sleep_op(timeout):wrap(function() return false end)
 				))
 
@@ -56,7 +57,7 @@ function M.run(fn, opts)
 				error(timer_err, 0)
 			end
 
-			done:next()
+			done:changed(done_ver)
 
 			test_scope:cancel('test complete')
 			fibers.perform(test_scope:join_op())

--- a/tests/support/stack_diag.lua
+++ b/tests/support/stack_diag.lua
@@ -90,7 +90,7 @@ function M.start(scope, bus, specs, opts)
 					kind    = 'msg',
 					topic   = msg.topic,
 					payload = msg.payload,
-					origin  = msg.origin,
+					id      = msg.id,
 				})
 			end
 		end)
@@ -185,6 +185,13 @@ function M.explain(message, rec, fake_hal)
 		M.render_fake_hal(fake_hal),
 	}
 	return table.concat(parts, '\n')
+end
+
+---@param rec table
+---@param opts? { max_records?: integer }
+---@return string
+function M.render_records(rec, opts)
+	return M.render(rec, opts)
 end
 
 return M


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] 🐛 Bug Fix
- [x] 🧑‍💻 Code Refactor
- [x] ✅ Test

## Description
Tightens the local test harness and support fakes so they match the current capability-based HAL and bus model, and makes test execution more deterministic and easier to diagnose.

Changes:
- updates `tests/run.lua` to:
  - run test functions in a stable sorted order
  - support `TEST_FILTER`
  - print per-test timings
  - collect and print a short failure summary
  - track skipped tests explicitly
- updates `tests/support/fake_hal.lua` to remove the old legacy HAL RPC surface and exercise the current capability-based HAL interface only
- simplifies and tidies the fake HAL request/reply mapping and call recording paths
- fixes `tests/support/run_fibers.lua` to wait on a captured pulse version rather than racing on `next()` after the pulse may already have advanced
- updates `tests/support/stack_diag.lua` to reflect current bus message shape and adds a small rendering helper
- bumps `vendor/lua-bus` to revision v0.6.2 expected by the revised tests and fakes

This is intended as a preparatory cleanup PR ahead of the larger service PRs, so the test harness and fake infrastructure reflect the current architecture rather than carrying older compatibility paths.

## Related Issues, Tickets & Documents
Part of the preparatory cleanup for the upcoming `fabric` / `device` / `update` / `ui` PR stack.

## Screenshots/Recordings
Not applicable.

## Manual test
- [x] 👍 yes

## Manual test description
Ran the full Lua test suite locally with `lua run.lua` from `tests/` and confirmed all tests passed.

## Added tests?
- [x] 👍 yes

## Added to documentation?
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?
None.