### PR TITLE
Refactors the devhost test diagnostics

### DIFF
--- a/tests/integration/devhost/config_recovery_spec.lua
+++ b/tests/integration/devhost/config_recovery_spec.lua
@@ -1,22 +1,25 @@
--- integration/devhost/config_recovery_spec.lua
-
 local cjson          = require 'cjson.safe'
-
 local busmod         = require 'bus'
+local safe           = require 'coxpcall'
 
 local runfibers      = require 'tests.support.run_fibers'
 local probe          = require 'tests.support.bus_probe'
 local fake_hal_mod   = require 'tests.support.fake_hal'
-local diag           = require 'tests.support.stack_diag'
+local test_diag      = require 'tests.support.test_diag'
 
 local config_service = require 'services.config'
 
 local T = {}
 
+local function decode_json(s)
+	local v, err = cjson.decode(s)
+	assert(v ~= nil, tostring(err))
+	return v
+end
+
 local function config_timings()
 	return {
 		hal_wait_timeout_s       = 0.25,
-		hal_wait_tick_s          = 0.01,
 		heartbeat_s              = 60.0,
 		persist_debounce_s       = 0.02,
 		persist_max_delay_s      = 0.05,
@@ -25,99 +28,61 @@ local function config_timings()
 	}
 end
 
-local function decode_json(s)
-	local obj, err = cjson.decode(s)
-	assert(obj ~= nil, tostring(err))
-	return obj
-end
-
-function T.devhost_config_degrades_on_persist_failure_then_recovers()
+function T.devhost_config_recovers_after_failed_persist_retry()
 	runfibers.run(function(scope)
-		local bus  = busmod.new()
-		local conn = bus:connect()
-
+		local bus = busmod.new()
 		local fake_hal = fake_hal_mod.new({
 			backend = 'fakehal',
-			caps = {
-				read_state  = true,
-				write_state = true,
-			},
+			caps = { read_state = true, write_state = true },
 			scripted = {
-				read_state = {
-					{ ok = true, found = false },
-				},
+				read_state = { { ok = true, found = false } },
 				write_state = {
 					{ ok = false, err = 'disk full' },
 					{ ok = true },
 				},
 			},
 		})
-
-		local rec = diag.start(scope, bus, {
-			{ label = 'obs',    topic = { 'obs', '#' } },
-			{ label = 'svc',    topic = { 'svc', '#' } },
-			{ label = 'cfg',    topic = { 'cfg', '#' } },
-		}, {
-			max_records = 300,
-		})
-
 		fake_hal:start(bus:connect(), { name = 'hal' })
 
 		local status_events = {}
+		local diag = test_diag.for_stack(scope, bus, { config = true, obs = true, max_records = 300, fake_hal = fake_hal })
+		test_diag.add_calls(diag, 'status_events', status_events)
+		test_diag.add_subsystem(diag, 'device', {
+			summary_fn = test_diag.retained_fn(bus:connect(), { 'state', 'device' }),
+		})
 
+		local conn = bus:connect()
+		local sub = conn:subscribe({ 'svc', 'config', 'status' }, { queue_len = 32 })
 		local ok_collector, cerr = scope:spawn(function()
-			local sub = conn:subscribe({ 'svc', 'config', 'status' }, {
-				queue_len = 64,
-				full      = 'drop_oldest',
-			})
-
 			while true do
 				local msg = sub:recv()
-				if not msg then
-					return
-				end
+				if not msg then return end
 				status_events[#status_events + 1] = msg.payload
 			end
 		end)
 		assert(ok_collector, tostring(cerr))
 
 		local ok_spawn, err = scope:spawn(function()
-			config_service.start(bus:connect(), {
-				name    = 'config',
-				env     = 'dev',
-				timings = config_timings(),
-			})
+			config_service.start(bus:connect(), { name = 'config', env = 'dev', timings = config_timings() })
 		end)
 		assert(ok_spawn, tostring(err))
 
-		local config_ready = probe.wait_until(function()
+		local ready = probe.wait_until(function()
 			for i = 1, #status_events do
 				local p = status_events[i]
-				if type(p) == 'table' and p.state == 'running' then
-					return true
-				end
+				if type(p) == 'table' and p.state == 'running' then return true end
 			end
 			return false
 		end, { timeout = 0.75, interval = 0.01 })
-
-		if not config_ready then
-			error(diag.explain(
-				'expected config service to reach running state before publishing config set',
-				rec,
-				fake_hal
-			), 0)
-		end
+		if not ready then diag:fail('expected config to reach running') end
 
 		local req_conn = bus:connect()
-		local reply, call_err = req_conn:call({ 'cmd', 'config', 'set' }, {
+		local reply, rerr = req_conn:call({ 'cmd', 'config', 'set' }, {
 			service = 'net',
-			data = {
-				schema = 'devicecode.net/1',
-				answer = 42,
-			},
+			data = { schema = 'devicecode.net/1', answer = 42 },
 		}, { timeout = 0.25 })
-		assert(call_err == nil, tostring(call_err))
-		assert(type(reply) == 'table' and reply.ok == true and reply.persisted == false)
+		assert(reply ~= nil, tostring(rerr))
+		assert(reply.ok == true)
 
 		local degraded_index = nil
 		local saw_degraded = probe.wait_until(function()
@@ -130,61 +95,29 @@ function T.devhost_config_degrades_on_persist_failure_then_recovers()
 			end
 			return false
 		end, { timeout = 0.75, interval = 0.01 })
+		if not saw_degraded then diag:fail('expected degraded after failed persist') end
 
-		if not saw_degraded then
-			error(diag.explain(
-				'expected config service to enter degraded state after failed write_state',
-				rec,
-				fake_hal
-			), 0)
-		end
-
-		local saw_recovered_running = probe.wait_until(function()
-			if degraded_index == nil then
-				return false
-			end
-
+		local saw_recovered = probe.wait_until(function()
+			if degraded_index == nil then return false end
 			for i = degraded_index + 1, #status_events do
 				local p = status_events[i]
-				if type(p) == 'table' and p.state == 'running' then
-					return true
-				end
+				if type(p) == 'table' and p.state == 'running' then return true end
 			end
 			return false
 		end, { timeout = 0.75, interval = 0.01 })
-
-		if not saw_recovered_running then
-			error(diag.explain(
-				'expected config service to recover to running state after retry succeeds',
-				rec,
-				fake_hal
-			), 0)
-		end
+		if not saw_recovered then diag:fail('expected recovery to running after retry') end
 
 		local writes = {}
 		for i = 1, #fake_hal.calls do
 			local c = fake_hal.calls[i]
-			if c.method == 'write_state' then
-				writes[#writes + 1] = c
-			end
+			if c.method == 'write_state' then writes[#writes + 1] = c end
 		end
-
 		assert(#writes >= 2, 'expected at least two write_state attempts')
-
-		assert(type(writes[1].req) == 'table')
-		assert(type(writes[2].req) == 'table')
-		assert(type(writes[1].req.data) == 'string')
-		assert(type(writes[2].req.data) == 'string')
 
 		local blob1 = decode_json(writes[1].req.data)
 		local blob2 = decode_json(writes[2].req.data)
-
-		assert(type(blob1.net) == 'table')
-		assert(type(blob2.net) == 'table')
 		assert(blob1.net.rev == 1)
 		assert(blob2.net.rev == 1)
-		assert(type(blob1.net.data) == 'table')
-		assert(type(blob2.net.data) == 'table')
 		assert(blob1.net.data.answer == 42)
 		assert(blob2.net.data.answer == 42)
 	end, { timeout = 1.5 })

--- a/tests/integration/devhost/main_failure_spec.lua
+++ b/tests/integration/devhost/main_failure_spec.lua
@@ -9,7 +9,7 @@ local safe = require 'coxpcall'
 local runfibers     = require 'tests.support.run_fibers'
 local probe         = require 'tests.support.bus_probe'
 local fake_hal_mod  = require 'tests.support.fake_hal'
-local diag          = require 'tests.support.stack_diag'
+local test_diag     = require 'tests.support.test_diag'
 
 local mainmod       = require 'devicecode.main'
 
@@ -122,12 +122,8 @@ function T.devhost_main_fails_fast_when_child_service_errors()
 			scripted = {},
 		})
 
-		local rec = diag.start(scope, bus, {
-			{ label = 'obs', topic = { 'obs', '#' } },
-			{ label = 'svc', topic = { 'svc', '#' } },
-		}, {
-			max_records = 300,
-		})
+		local diag = test_diag.for_stack(scope, bus, { obs = true, max_records = 300, fake_hal = fake_hal })
+		test_diag.add_table(diag, 'linger_box', function() return linger_box end)
 
 		local main_scope = spawn_main(scope, bus, fake_hal, linger_box, 'hal,linger,boom')
 
@@ -139,11 +135,7 @@ function T.devhost_main_fails_fast_when_child_service_errors()
 		end, { timeout = 0.75 })
 
 		if main_failed == nil then
-			error(diag.explain(
-				'expected main to fail because boom service errored',
-				rec,
-				fake_hal
-			), 0)
+			diag:fail('expected main to fail because boom service errored')
 		end
 
 		local boom_failed = wait_retained_payload_matching(conn, { 'obs', 'state', 'service', 'boom' }, function(payload)
@@ -154,11 +146,7 @@ function T.devhost_main_fails_fast_when_child_service_errors()
 		end, { timeout = 0.75 })
 
 		if boom_failed == nil then
-			error(diag.explain(
-				'expected failing boom service state to be retained',
-				rec,
-				fake_hal
-			), 0)
+			diag:fail('expected failing boom service state to be retained')
 		end
 
 		-- Cancellation is not join. Join the main child scope so that cancelled
@@ -173,19 +161,15 @@ function T.devhost_main_fails_fast_when_child_service_errors()
 		end, { timeout = 0.75, interval = 0.01 })
 
 		if not linger_final then
-			error(diag.explain(
-				('expected sibling linger service to be cancelled and finalised'
-					.. ' after joining main scope'
-					.. ' (join_status=%s finalised=%s aborted=%s status=%s primary=%s)'):format(
-						tostring(jst),
-						tostring(linger_box.finalised),
-						tostring(linger_box.aborted),
-						tostring(linger_box.status),
-						tostring(linger_box.primary)
-					),
-				rec,
-				fake_hal
-			), 0)
+			diag:fail(('expected sibling linger service to be cancelled and finalised'
+				.. ' after joining main scope'
+				.. ' (join_status=%s finalised=%s aborted=%s status=%s primary=%s)'):format(
+					tostring(jst),
+					tostring(linger_box.finalised),
+					tostring(linger_box.aborted),
+					tostring(linger_box.status),
+					tostring(linger_box.primary)
+				))
 		end
 	end, { timeout = 1.25 })
 end

--- a/tests/run.lua
+++ b/tests/run.lua
@@ -1,6 +1,5 @@
 -- tests/run.lua
 
--- look one level up
 package.path = "../src/?.lua;" .. package.path
 package.path = '../?.lua;../?/init.lua;./?.lua;./?/init.lua;' .. package.path
 
@@ -32,25 +31,77 @@ local files = {
 	'integration.devhost.config_recovery_spec'
 }
 
-local total, failed = 0, 0
+local function monotonic_now()
+	if type(os.clock) == 'function' then return os.clock() end
+	return 0
+end
+
+local function sorted_keys(t)
+	local keys = {}
+	for k in pairs(t) do keys[#keys + 1] = k end
+	table.sort(keys, function(a, b) return tostring(a) < tostring(b) end)
+	return keys
+end
+
+local function should_run(modname, testname, filter_text)
+	if not filter_text or filter_text == '' then return true end
+	local needle = string.lower(filter_text)
+	local hay = string.lower(('%s :: %s'):format(tostring(modname), tostring(testname)))
+	return string.find(hay, needle, 1, true) ~= nil
+end
+
+local function format_duration_s(dt)
+	return ('%.3fs'):format(tonumber(dt) or 0)
+end
+
+local TEST_FILTER = os.getenv('TEST_FILTER') or ''
+
+local total, failed, skipped = 0, 0, 0
+local failure_rows = {}
 
 for i = 1, #files do
 	local modname = files[i]
 	local mod = require(modname)
+	local keys = sorted_keys(mod)
 
-	for name, fn in pairs(mod) do
-		total = total + 1
-		io.write(('[TEST] %s :: %s ... '):format(modname, name))
-		local ok, err = safe.pcall(fn)
-		if ok then
-			io.write('ok\n')
-		else
-			failed = failed + 1
-			io.write('FAIL\n')
-			io.write(tostring(err) .. '\n')
+	for j = 1, #keys do
+		local name = keys[j]
+		local fn = mod[name]
+		if type(fn) == 'function' then
+			if should_run(modname, name, TEST_FILTER) then
+				total = total + 1
+				io.write(('[TEST] %s :: %s ... '):format(modname, name))
+				local t0 = monotonic_now()
+				local ok, err = safe.xpcall(fn, function(e)
+					return debug.traceback(tostring(e), 2)
+				end)
+				local dt = monotonic_now() - t0
+				if ok then
+					io.write('ok ' .. format_duration_s(dt) .. '\n')
+				else
+					failed = failed + 1
+					failure_rows[#failure_rows + 1] = {
+						name = ('%s :: %s'):format(modname, name),
+						err = tostring(err),
+						dt = dt,
+					}
+					io.write('FAIL ' .. format_duration_s(dt) .. '\n')
+					io.write(tostring(err) .. '\n')
+				end
+			else
+				skipped = skipped + 1
+			end
 		end
 	end
 end
 
-io.write(('\n%d tests, %d failed\n'):format(total, failed))
+io.write(('\n%d tests, %d failed, %d skipped\n'):format(total, failed, skipped))
+if #failure_rows > 0 then
+	io.write('\nFailure summary:\n')
+	for i = 1, #failure_rows do
+		local row = failure_rows[i]
+		local first = tostring(row.err):match('([^\n]+)') or tostring(row.err)
+		io.write(('  - %s [%s]\n    %s\n'):format(row.name, format_duration_s(row.dt), first))
+	end
+end
 os.exit(failed == 0 and 0 or 1)

--- a/tests/support/device_diag.lua
+++ b/tests/support/device_diag.lua
@@ -1,0 +1,34 @@
+local cjson = require 'cjson.safe'
+
+local M = {}
+
+local function enc(v)
+  local ok, s = pcall(cjson.encode, v)
+  if ok and s then return s end
+  return tostring(v)
+end
+
+local function add(out, label, fn)
+  if not fn then return end
+  local ok, v = pcall(fn)
+  if ok then
+    out[#out + 1] = label .. '=' .. enc(v)
+  else
+    out[#out + 1] = label .. '=<error:' .. tostring(v) .. '>'
+  end
+end
+
+function M.render(opts)
+  opts = opts or {}
+  local out = { '-- device diag --' }
+  add(out, 'service', opts.service_fn)
+  add(out, 'summary', opts.summary_fn)
+  add(out, 'components', opts.components_fn)
+  add(out, 'sources', opts.sources_fn)
+  add(out, 'component_cm5', opts.cm5_fn)
+  add(out, 'component_mcu', opts.mcu_fn)
+  add(out, 'extra', opts.extra_fn)
+  return table.concat(out, '\n')
+end
+
+return M

--- a/tests/support/diag_plugins/config.lua
+++ b/tests/support/diag_plugins/config.lua
@@ -1,0 +1,10 @@
+return {
+  name = 'config',
+  topic_groups = {
+    { label = 'cfg', topic = { 'cfg', '#' } },
+    { label = 'ccmd', topic = { 'cmd', 'config', '#' } },
+    { label = 'csvc', topic = { 'svc', 'config', '#' } },
+
+
+  },
+}

--- a/tests/support/diag_plugins/device.lua
+++ b/tests/support/diag_plugins/device.lua
@@ -1,0 +1,25 @@
+local device_diag = require 'tests.support.device_diag'
+
+return {
+  name = 'device',
+  topic_groups = {
+    { label = 'device', topic = { 'state', 'device', '#' } },
+    { label = 'dcmd', topic = { 'cmd', 'device', '#' } },
+  },
+  section = function(helper, opts)
+    opts = opts or {}
+    local conn = opts.conn
+
+    return {
+      render = function()
+        return device_diag.render(helper.shallow_merge({
+          service_fn = opts.service_fn or opts.device_service_fn or (conn and helper.retained_fn(conn, { 'svc', 'device', 'status' }) or nil),
+          summary_fn = opts.summary_fn or opts.device_summary_fn or (conn and helper.retained_fn(conn, { 'state', 'device' }) or nil),
+          cm5_fn = opts.cm5_fn or (conn and helper.retained_fn(conn, { 'state', 'device', 'component', opts.cm5_component or 'cm5' }) or nil),
+          mcu_fn = opts.mcu_fn or (conn and helper.retained_fn(conn, { 'state', 'device', 'component', opts.mcu_component or 'mcu' }) or nil),
+          extra_fn = opts.extra_fn or opts.device_extra_fn,
+        }, opts))
+      end,
+    }
+  end,
+}

--- a/tests/support/diag_plugins/obs.lua
+++ b/tests/support/diag_plugins/obs.lua
@@ -1,0 +1,9 @@
+return {
+  name = 'obs',
+  topic_groups = {
+
+    { label = 'obs', topic = { 'obs', '#' } },
+    { label = 'svc', topic = { 'svc', '#' } },
+
+  },
+}

--- a/tests/support/diag_plugins/rpc.lua
+++ b/tests/support/diag_plugins/rpc.lua
@@ -1,0 +1,8 @@
+return {
+  name = 'rpc',
+  topic_groups = {
+
+
+    { label = 'rpc', topic = { 'rpc', '#' } },
+  },
+}

--- a/tests/support/diag_registry.lua
+++ b/tests/support/diag_registry.lua
@@ -1,0 +1,10 @@
+return {
+  plugins = {
+    config = require 'tests.support.diag_plugins.config',
+    device = require 'tests.support.diag_plugins.device',
+    obs    = require 'tests.support.diag_plugins.obs',
+    rpc    = require 'tests.support.diag_plugins.rpc',
+  },
+  profiles = {
+  },
+}

--- a/tests/support/fake_hal.lua
+++ b/tests/support/fake_hal.lua
@@ -4,10 +4,6 @@ local fibers = require 'fibers'
 
 local M = {}
 
-local function topic(method)
-	return { 'rpc', 'hal', method }
-end
-
 local function cap_state_topic(class, id)
 	return { 'cap', class, id, 'state' }
 end
@@ -21,9 +17,7 @@ local function cap_rpc_topic(class, id, method)
 end
 
 local function strip_json_suffix(filename)
-	if type(filename) ~= 'string' then
-		return nil
-	end
+	if type(filename) ~= 'string' then return nil end
 	return (filename:gsub('%.json$', ''))
 end
 
@@ -39,66 +33,41 @@ local function map_cap_call(class, id, method, req)
 	if class == 'fs' and id == 'config' and method == 'read' then
 		return 'read_state', legacy_state_req_from_filename(req and req.filename)
 	end
-
 	if class == 'fs' and id == 'state' and method == 'write' then
 		return 'write_state', legacy_state_req_from_filename(req and req.filename, req and req.data)
 	end
-
 	return method, req
 end
 
 local function map_cap_reply(method, reply)
-	if type(reply) ~= 'table' then
-		return reply
-	end
-
+	if type(reply) ~= 'table' then return reply end
 	if method == 'read_state' then
 		local found = rawget(reply, 'found')
 		local data = rawget(reply, 'data')
 		local err_text = rawget(reply, 'err')
 		if reply.ok == true and found == true then
-			return {
-				ok = true,
-				reason = data,
-			}
+			return { ok = true, reason = data }
 		end
-
 		if reply.ok == true and found == false then
-			return {
-				ok = false,
-				reason = err_text or 'not found',
-				code = reply.code,
-			}
+			return { ok = false, reason = err_text or 'not found', code = reply.code }
 		end
 	end
-
 	local err_text = rawget(reply, 'err')
 	if reply.ok ~= nil and reply.reason == nil and err_text ~= nil then
-		return {
-			ok = reply.ok,
-			reason = err_text,
-			code = reply.code,
-		}
+		return { ok = reply.ok, reason = err_text, code = reply.code }
 	end
-
 	return reply
 end
 
 local function method_offerings(method)
-	if method == 'read_state' then
-		return 'fs', 'config', { read = true }
-	end
-
-	if method == 'write_state' then
-		return 'fs', 'state', { write = true }
-	end
-
+	if method == 'read_state' then return 'fs', 'config', { read = true } end
+	if method == 'write_state' then return 'fs', 'state', { write = true } end
 	return nil, nil, nil
 end
 
 ---@class FakeHal
 ---@field calls table[]
----@field scripted table<string, fun(req:any,msg:any):table>|table[]
+---@field scripted table<string, fun(req:any,request:any):table>|table[]
 ---@field backend string
 ---@field caps table
 local FakeHal = {}
@@ -107,61 +76,30 @@ FakeHal.__index = FakeHal
 function FakeHal:new(opts)
 	opts = opts or {}
 	return setmetatable({
-		calls    = {},
+		calls = {},
 		scripted = opts.scripted or {},
-		backend  = opts.backend or 'fakehal',
-		caps     = opts.caps or {},
+		backend = opts.backend or 'fakehal',
+		caps = opts.caps or {},
 	}, FakeHal)
 end
 
-function FakeHal:_next_reply(method, req, msg)
+function FakeHal:_next_reply(method, req, request)
 	local entry = self.scripted[method]
-	if type(entry) == 'function' then
-		return entry(req, msg)
-	end
+	if type(entry) == 'function' then return entry(req, request) end
 	if type(entry) == 'table' and #entry > 0 then
 		local v = table.remove(entry, 1)
-		if type(v) == 'function' then
-			return v(req, msg)
-		end
+		if type(v) == 'function' then return v(req, request) end
 		return v
 	end
 	return { ok = false, err = 'no scripted reply for ' .. tostring(method) }
 end
 
-function FakeHal:_record_call(method, req, msg)
+function FakeHal:_record_call(method, req, request)
 	self.calls[#self.calls + 1] = {
 		method = method,
-		req    = req,
-		msg    = msg,
+		req = req,
+		request = request,
 	}
-end
-
-function FakeHal:_start_legacy_rpc(conn)
-	local methods = {}
-	for method in pairs(self.scripted) do
-		methods[#methods + 1] = method
-	end
-
-	for i = 1, #methods do
-		local method = methods[i]
-		local ep = conn:bind(topic(method), { queue_len = 16 })
-
-		fibers.spawn(function()
-			while true do
-				local req, err = ep:recv()
-				if not req then
-					return
-				end
-
-				local payload = req.payload or {}
-				self:_record_call(method, payload, req)
-
-				local reply = self:_next_reply(method, payload, req)
-				req:reply(reply)
-			end
-		end)
-	end
 end
 
 function FakeHal:_start_capability_rpc(conn, class, id, offering, legacy_method)
@@ -172,37 +110,36 @@ function FakeHal:_start_capability_rpc(conn, class, id, offering, legacy_method)
 
 	fibers.spawn(function()
 		while true do
-			local msg, err = ep:recv()
-			if not msg then
-				return
-			end
+			local req, err = ep:recv()
+			if not req then return end
 
-			local raw_req = msg.payload or {}
-			local method, req = map_cap_call(class, id, offering, raw_req)
+			local raw_req = req.payload or {}
+			local method, mapped_req = map_cap_call(class, id, offering, raw_req)
 			method = legacy_method or method
 
-			self:_record_call(method, req, msg)
+			self:_record_call(method, mapped_req, req)
 
-			local reply = self:_next_reply(method, req, msg)
+			local reply = self:_next_reply(method, mapped_req, req)
 			reply = map_cap_reply(method, reply)
-
-			msg:reply(reply)
+			if type(reply) ~= 'table' then
+				req:fail(reply)
+			elseif reply.ok == true then
+				req:reply(reply)
+			else
+				req:reply(reply)
+			end
 		end
 	end)
 end
 
 function FakeHal:_start_capabilities(conn)
 	local started = {}
-
 	for method, enabled in pairs(self.caps) do
 		if enabled then
 			local class, id, offerings = method_offerings(method)
-			if class ~= nil and id ~= nil and offerings ~= nil then
+			if class and id and offerings then
 				local key = class .. '\0' .. tostring(id)
-				if not started[key] then
-					started[key] = true
-				end
-
+				if not started[key] then started[key] = true end
 				for offering in pairs(offerings) do
 					self:_start_capability_rpc(conn, class, id, offering, method)
 				end
@@ -214,15 +151,11 @@ end
 function FakeHal:start(conn, opts)
 	opts = opts or {}
 	local name = opts.name or 'hal'
-
 	conn:retain({ 'svc', name, 'announce' }, {
-		role     = 'hal',
-		rpc_root = { 'rpc', 'hal' },
-		backend  = self.backend,
-		caps     = self.caps,
+		role = 'hal',
+		backend = self.backend,
+		caps = self.caps,
 	})
-
-	self:_start_legacy_rpc(conn)
 	self:_start_capabilities(conn)
 end
 

--- a/tests/support/run_fibers.lua
+++ b/tests/support/run_fibers.lua
@@ -21,6 +21,7 @@ function M.run(fn, opts)
 			end
 
 			local done = pulse.new()
+			local done_ver = done:version()
 			local body_err = nil
 
 			local ok_spawn, spawn_err = test_scope:spawn(function(s)
@@ -42,7 +43,7 @@ function M.run(fn, opts)
 
 			local ok_timer, timer_err = root_scope:spawn(function()
 				local completed = fibers.perform(op.boolean_choice(
-					done:next_op():wrap(function() return true end),
+					done:changed_op(done_ver):wrap(function() return true end),
 					sleep.sleep_op(timeout):wrap(function() return false end)
 				))
 
@@ -56,7 +57,7 @@ function M.run(fn, opts)
 				error(timer_err, 0)
 			end
 
-			done:next()
+			done:changed(done_ver)
 
 			test_scope:cancel('test complete')
 			fibers.perform(test_scope:join_op())

--- a/tests/support/stack_diag.lua
+++ b/tests/support/stack_diag.lua
@@ -90,7 +90,7 @@ function M.start(scope, bus, specs, opts)
 					kind    = 'msg',
 					topic   = msg.topic,
 					payload = msg.payload,
-					origin  = msg.origin,
+					id      = msg.id,
 				})
 			end
 		end)
@@ -185,6 +185,13 @@ function M.explain(message, rec, fake_hal)
 		M.render_fake_hal(fake_hal),
 	}
 	return table.concat(parts, '\n')
+end
+
+---@param rec table
+---@param opts? { max_records?: integer }
+---@return string
+function M.render_records(rec, opts)
+	return M.render(rec, opts)
 end
 
 return M

--- a/tests/support/test_diag.lua
+++ b/tests/support/test_diag.lua
@@ -1,0 +1,311 @@
+local cjson = require 'cjson.safe'
+local probe = require 'tests.support.bus_probe'
+local stack_diag = require 'tests.support.stack_diag'
+local registry = require 'tests.support.diag_registry'
+
+local M = {}
+M.__index = M
+
+local function encode_one(v)
+  local ok, s = pcall(cjson.encode, v)
+  if ok and s then return s end
+  return tostring(v)
+end
+
+local function value_key(v)
+  return encode_one(v)
+end
+
+function M.shallow_merge(a, b)
+  local out = {}
+  if type(a) == 'table' then
+    for k, v in pairs(a) do out[k] = v end
+  end
+  if type(b) == 'table' then
+    for k, v in pairs(b) do out[k] = v end
+  end
+  return out
+end
+
+local function render_calls(label, calls, opts)
+  opts = opts or {}
+  local max_calls = opts.max_calls or 80
+  calls = calls or {}
+  local start_idx = math.max(1, #calls - max_calls + 1)
+  local out = {}
+  out[#out + 1] = ('%s=%d'):format(tostring(label), #calls)
+  out[#out + 1] = ('-- %s --'):format(tostring(label))
+  for i = start_idx, #calls do
+    local c = calls[i]
+    if type(c) == 'table' then
+      out[#out + 1] = ('[%d] %s'):format(i, encode_one(c))
+    else
+      out[#out + 1] = ('[%d] %s'):format(i, tostring(c))
+    end
+  end
+  return table.concat(out, '\n')
+end
+
+local function render_table(label, value)
+  return ('-- %s --\n%s'):format(tostring(label), encode_one(value))
+end
+
+local function plugin_named(name)
+  local plugin = registry.plugins[name]
+  assert(type(plugin) == 'table', 'unknown diag plugin: ' .. tostring(name))
+  return plugin
+end
+
+local function profile_named(name)
+  local profile = registry.profiles[name]
+  assert(type(profile) == 'function', 'unknown stack profile: ' .. tostring(name))
+  return profile
+end
+
+local function plugin_section(name, opts)
+  local plugin = plugin_named(name)
+  assert(type(plugin.section) == 'function', 'diag plugin has no section builder: ' .. tostring(name))
+  return plugin.section(M, opts or {})
+end
+
+local function append_plugin_topics(out, name)
+  local plugin = plugin_named(name)
+  local groups = plugin.topic_groups or {}
+  for i = 1, #groups do
+    out[#out + 1] = groups[i]
+  end
+end
+
+function M.add_section(diag, section)
+  diag.extra_sections[#diag.extra_sections + 1] = section
+  return diag
+end
+
+function M.add_calls(diag, label, calls, opts)
+  diag.extra_sections[#diag.extra_sections + 1] = { label = label, calls = calls, opts = opts }
+  return diag
+end
+
+function M.add_render(diag, label, fn)
+  diag.extra_sections[#diag.extra_sections + 1] = {
+    render = function()
+      return ('-- %s --\n%s'):format(tostring(label), tostring(fn()))
+    end,
+  }
+  return diag
+end
+
+function M.add_table(diag, label, value_fn)
+  diag.extra_sections[#diag.extra_sections + 1] = {
+    render = function()
+      local value = (type(value_fn) == 'function') and value_fn() or value_fn
+      return render_table(label, value)
+    end,
+  }
+  return diag
+end
+
+function M.add_subsystem(diag, kind, opts)
+  diag.extra_sections[#diag.extra_sections + 1] = plugin_section(kind, opts)
+  return diag
+end
+
+function M.retained_fn(conn, topic, opts)
+  opts = opts or {}
+  return function()
+    local ok, payload = pcall(function()
+      return probe.wait_payload(conn, topic, { timeout = opts.timeout or 0.01 })
+    end)
+    if ok then return payload end
+    return { __error = tostring(payload), topic = topic }
+  end
+end
+
+function M.assert_true(diag, cond, message)
+  if not cond then diag:fail(message or 'assert_true failed') end
+  return true
+end
+
+function M.assert_eq(diag, want, got, message)
+  if want ~= got then
+    diag:fail((message or 'assert_eq failed') .. ('\nwant=%s\ngot=%s'):format(encode_one(want), encode_one(got)))
+  end
+  return true
+end
+
+function M.assert_match(diag, got, partial, message)
+  if type(got) ~= 'table' or type(partial) ~= 'table' then
+    diag:fail((message or 'assert_match failed') .. ('\nwant_partial=%s\ngot=%s'):format(encode_one(partial), encode_one(got)))
+  end
+  for k, v in pairs(partial) do
+    if got[k] ~= v then
+      diag:fail((message or 'assert_match failed') .. ('\nkey=%s\nwant=%s\ngot=%s\nfull=%s'):format(tostring(k), encode_one(v), encode_one(got[k]), encode_one(got)))
+    end
+  end
+  return true
+end
+
+function M.assert_eventually_eq(diag, label, getter, want, opts)
+  local got
+  diag:assert_until((label or 'assert_eventually_eq failed') .. ('\nwant=%s\ngot=%s'):format(encode_one(want), encode_one(got)), function()
+    got = getter()
+    return got == want
+  end, opts)
+  return true
+end
+
+function M.assert_no_event(diag, pred, window_s, message)
+  local ok = probe.wait_until(function()
+    return pred() == true
+  end, { timeout = window_s or 0.1, interval = 0.01 })
+  if ok then
+    diag:fail(message or 'assert_no_event failed: observed forbidden event')
+  end
+  return true
+end
+
+function M.start_profile(scope, bus, name, opts)
+  opts = opts or {}
+  local spec = profile_named(name)(M, opts)
+  local diag = M.for_stack(scope, bus, spec.stack or {})
+  local plugins = spec.plugins or {}
+
+  for i = 1, #plugins do
+    local item = plugins[i]
+    local merged_opts = M.shallow_merge(opts, item.opts or {})
+    diag.extra_sections[#diag.extra_sections + 1] = plugin_section(item.name, merged_opts)
+  end
+
+  if type(spec.sections) == 'table' then
+    for i = 1, #spec.sections do
+      diag.extra_sections[#diag.extra_sections + 1] = spec.sections[i]
+    end
+  end
+  if type(spec.extra_sections) == 'table' then
+    for i = 1, #spec.extra_sections do
+      diag.extra_sections[#diag.extra_sections + 1] = spec.extra_sections[i]
+    end
+  end
+  return diag
+end
+
+M.for_stack_profile = M.start_profile
+
+function M.assert_transitions(diag, label, getter, expected, opts)
+  opts = opts or {}
+  local timeout = opts.timeout or 1.0
+  local interval = opts.interval or 0.005
+  local selector = opts.selector or function(v) return v end
+  local matches = opts.matches or function(got, want) return got == want end
+  local ignore_nil = (opts.ignore_nil ~= false)
+  local allow_other = (opts.allow_other ~= false)
+  local collapse = (opts.collapse ~= false)
+  local history = {}
+  local idx = 1
+  local last_key = nil
+
+  local function maybe_record(v)
+    local key = value_key(v)
+    if not collapse or key ~= last_key then
+      history[#history + 1] = v
+      last_key = key
+    end
+  end
+
+  local ok = probe.wait_until(function()
+    local got_ok, raw = pcall(getter)
+    if not got_ok then return false end
+    local got = selector(raw)
+    if got == nil and ignore_nil then return false end
+    maybe_record(got)
+    if matches(got, expected[idx]) then
+      idx = idx + 1
+      return idx > #expected
+    end
+    if not allow_other then
+      return false
+    end
+    return false
+  end, { timeout = timeout, interval = interval })
+
+  if not ok or idx <= #expected then
+    diag:fail((label or 'assert_transitions failed')
+      .. ('\nexpected=%s\nobserved=%s'):format(encode_one(expected), encode_one(history)))
+  end
+
+  return history
+end
+
+function M.assert_retained_transitions(diag, conn, topic, expected, opts)
+  opts = opts or {}
+  local getter = M.retained_fn(conn, topic, { timeout = opts.sample_timeout or 0.02 })
+  return M.assert_transitions(diag, opts.label or ('retained transitions for ' .. encode_one(topic)), getter, expected, opts)
+end
+
+function M.for_stack(scope, bus, opts)
+  opts = opts or {}
+  local topics = {}
+  for _, name in ipairs({ 'update', 'device', 'fabric', 'config', 'obs', 'rpc', 'ui' }) do
+    if opts[name] then append_plugin_topics(topics, name) end
+  end
+  if type(opts.topics) == 'table' then
+    for i = 1, #opts.topics do topics[#topics + 1] = opts.topics[i] end
+  end
+  return M.start(scope, bus, {
+    topics = topics,
+    max_records = opts.max_records,
+    fake_hal = opts.fake_hal,
+    extra_sections = opts.extra_sections,
+  })
+end
+
+function M.start(scope, bus, opts)
+  opts = opts or {}
+  local rec = stack_diag.start(scope, bus, opts.topics or {}, { max_records = opts.max_records })
+  return setmetatable({
+    rec = rec,
+    fake_hal = opts.fake_hal,
+    extra_sections = opts.extra_sections or {},
+  }, M)
+end
+
+function M:render(message)
+  local parts = {
+    tostring(message),
+    '',
+    stack_diag.render(self.rec),
+  }
+  if self.fake_hal then
+    parts[#parts + 1] = ''
+    parts[#parts + 1] = stack_diag.render_fake_hal(self.fake_hal)
+  end
+  for i = 1, #self.extra_sections do
+    local sec = self.extra_sections[i]
+    parts[#parts + 1] = ''
+    if type(sec) == 'function' then
+      parts[#parts + 1] = tostring(sec())
+    elseif type(sec) == 'table' and sec.render then
+      parts[#parts + 1] = tostring(sec.render())
+    elseif type(sec) == 'table' and sec.calls then
+      parts[#parts + 1] = render_calls(sec.label or ('calls' .. tostring(i)), sec.calls, sec.opts)
+    else
+      parts[#parts + 1] = tostring(sec)
+    end
+  end
+  return table.concat(parts, '\n')
+end
+
+function M:fail(message)
+  error(self:render(message), 0)
+end
+
+function M:assert_until(message, pred, opts)
+  if not probe.wait_until(pred, opts) then
+    self:fail(message)
+  end
+end
+
+M.render_calls = render_calls
+M.render_table = render_table
+
+return M


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] 🧑‍💻 Code Refactor
- [x] ✅ Test

## Description
Refactors the devhost test diagnostics and modernises a couple of support paths so the tests are easier to debug and better aligned with the current architecture.

Changes:
- introduces a new shared test diagnostic helper in `tests/support/test_diag.lua`
- adds a small plugin/registry structure for diagnostics:
  - `tests/support/diag_registry.lua`
  - `tests/support/diag_plugins/config.lua`
  - `tests/support/diag_plugins/device.lua`
  - `tests/support/diag_plugins/obs.lua`
  - `tests/support/diag_plugins/rpc.lua`
- adds `tests/support/device_diag.lua` for device-specific state rendering
- updates integration specs to use the new diagnostics helper instead of wiring stack diagnostics inline:
  - `tests/integration/devhost/config_recovery_spec.lua`
  - `tests/integration/devhost/main_failure_spec.lua`
- simplifies `config_recovery_spec` assertions and naming to better reflect the retry/recovery behaviour being tested
- removes an unused `coxpcall` import from `config_recovery_spec`
- improves failure reporting in those specs by using `diag:fail(...)` and richer contextual output rather than ad hoc `error(...)` blocks
- keeps the underlying stack/bus diagnostics, but makes subsystem-specific views easier to attach and reuse across tests

This PR is primarily a test-support cleanup. It does not change the production service architecture, but it should make future devhost failures much easier to understand and troubleshoot.

## Related Issues, Tickets & Documents
Part of the preparatory cleanup ahead of the larger service PR stack.

## Screenshots/Recordings
Not applicable.

## Manual test
- [x] 👍 yes

## Manual test description
Ran the full test suite locally with `lua run.lua` from `tests/` and confirmed it passed after the refactor.

## Added tests?
- [x] 👍 yes

## Added to documentation?
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?
None.