### PR TITLE
Extend service_base, `hal` and cap SDK with compatible migration helpers

### DIFF
--- a/docs/naming.md
+++ b/docs/naming.md
@@ -1,0 +1,1067 @@
+# Devicecode control-plane naming standard
+
+## Status
+
+Draft for team review.
+
+## 0. Why this scheme exists
+
+Devicecode has now grown beyond a simple in-process service runtime.
+
+It has become a local control plane for:
+
+* appliance composition
+* imported internal members
+* raw provider-native capabilities
+* stable public manager interfaces
+* retained workflow records
+* canonical retained domain truth
+* operator-facing local UI
+* compatibility publication during migration
+
+Earlier naming was developed while we were still conceiving the system. It's revealed not be be adequate once the system must clearly distinguish:
+
+* raw provenance-bearing truth from curated public truth
+* appliance composition from domain policy
+* stable public interfaces from provider-native interfaces
+* workflow managers from retained workflow instances
+* intended behaviour from observed state
+* canonical surfaces from temporary compatibility aliases
+
+This scheme exists to make those distinctions **structural**, not merely conventional.
+
+It is intended to ensure that public contracts remain stable even when:
+
+* implementation placement changes
+* transport changes
+* a domain is split across multiple services
+* a provider is replaced
+* a raw source moves behind a compatibility seam
+* or a service is renamed, decomposed or merged
+
+The central change in this scheme is away from “whatever topic tree the current service happens to publish” and towards a control plane with explicit abstraction planes, explicit ownership and explicit provenance. One day this might become graph view projections over canonical objects, but not today!
+
+## 1. Purpose
+
+This specification defines the canonical control-plane naming model for Devicecode.
+
+It gives stable answers to these questions:
+
+* how are service lifecycle and intended configuration named?
+* how is raw provenance-bearing truth separated from canonical public truth?
+* how is appliance composition separated from domain policy state?
+* how are stable public interfaces separated from raw provider-native interfaces?
+* how are workflow manager interfaces separated from retained workflow instance records?
+* how are durable desired state, retained workflow truth and immediate controls kept distinct?
+* how is canonical public ownership declared?
+* how are compatibility aliases handled during migration?
+* how do public contracts survive changes in implementation placement, transport, decomposition and provider choice?
+
+This specification governs control-plane naming, ownership and abstraction boundaries. It absolutely doesn't redefine fibers, bus semantics, scope semantics or service lifecycle rules.
+
+## 2. Architectural position
+
+This model preserves the non-negotiable Devicecode rules:
+
+* services are implementation boundaries
+* HAL is the only OS and hardware boundary
+* services depend on interfaces, not on each other’s internals
+* each service owns its own lifecycle and scoped connection
+
+The following architectural rules are explicit.
+
+> `device` is the authoritative appliance composition service.
+
+`device` composes appliance-local truth from raw local, internal, imported and software-defined parts.
+
+> Raw provenance-bearing surfaces (eg. hardware modem capability path) and curated public interfaces (eg. modem-1) MUST remain structurally segregated.
+
+Metadata alone is not sufficient to preserve this distinction.
+
+> Canonical retained domain truth MAY exist outside `device` where a domain service genuinely owns it.
+
+Not all public retained truth is appliance composition truth.
+
+> A service is an implementation boundary. A service is not, by itself, a public naming boundary.
+
+A service MAY own one or more public naming families, but those families are justified by semantic ownership, not by the service name alone.
+
+> `state/<domain>` names a semantic public domain, not the implementing service.
+
+A domain family MUST NOT be introduced merely by copying the name of the service that currently publishes it.
+
+> Durable intended behaviour SHOULD normally be expressed declaratively and reconciled by the owning service.
+
+Imperative controls are the exception, not the default. For example, a modem is disabled by changing config, not by flipping a switch.
+
+> Compatibility seams MAY exist at controlled branching points during migration.
+
+A compatibility seam MUST preserve canonical ownership and MUST NOT become a second public architecture.
+
+## 3. Normative language
+
+The key words **MUST**, **MUST NOT**, **SHOULD**, **SHOULD NOT** and **MAY** are to be interpreted as normative requirements.
+
+## 3.1 Canonical, summary and compatibility surfaces
+
+The following distinctions are normative.
+
+* A **canonical surface** is the one authoritative public surface for an abstraction role.
+* A **summary surface** is a deliberately reduced public projection of richer canonical truth.
+* A **compatibility alias** is a temporary additional surface retained only to preserve compatibility during migration.
+
+Compatibility aliases MUST:
+
+* declare which canonical surface they mirror
+* preserve the abstraction role of the canonical surface
+* be implemented as one-way projections from canonical truth
+* not become the dependency target of new work
+* be sunsetted as soon as practicable
+
+Summary surfaces MUST:
+
+* clearly differ in abstraction role from the canonical surface they summarise
+* not pretend to be the authoritative home of richer truth
+
+## 4. Canonical top-level roots
+
+The canonical top-level roots are:
+
+* `svc`
+* `cfg`
+* `raw`
+* `state`
+* `cap`
+* `obs`
+
+No new top-level root SHOULD be introduced without strong justification.
+
+`obs` is versioned below the root. The canonical initial observability plane is `obs/v1/...`.
+
+`state` is the root for canonical retained state families.
+
+The initial required canonical `state/...` families are:
+
+* `state/device/...`
+* `state/workflow/...`
+
+Common additional domain families include:
+
+* `state/update/...`
+* `state/fabric/...`
+* `state/gsm/...`
+* `state/net/...`
+* `state/wifi/...`
+* `state/time/...`
+* `state/site/...`
+
+A narrow `state/ui/...` family MAY exist where the UI service owns genuine canonical retained UI-domain truth such as operator-facing session or model summaries. It MUST remain narrow and MUST NOT become the naming boundary for workflows owned elsewhere.
+
+Any `state/<domain>/...` family MUST have one clearly identified owning service.
+
+## 5. Canonical token form
+
+Topics are represented in code as dense token arrays.
+
+Slash form MAY be used in documentation.
+
+Example:
+
+* documentation: `cap/update-manager/main/rpc/create-job`
+* code: `{ 'cap', 'update-manager', 'main', 'rpc', 'create-job' }`
+
+### 5.1 Token rules
+
+* tokens MUST be lowercase
+* multiword tokens MUST use kebab-case
+* method names MUST use verbs in kebab-case
+* curated public identifiers SHOULD be semantic and stable for the intended audience
+* raw identifiers MAY be concrete, topology-bearing, provider-facing or transport-bearing where provenance requires it
+
+## 6. Identifier scope and stability
+
+Every identifier used in control-plane naming MUST have an intended scope and stability class.
+
+At minimum, the following distinctions apply:
+
+* **service ids** are runtime-local implementation identifiers
+* **source ids** identify concrete provenance boundaries under `raw/...` and MAY be topology-bearing
+* **component ids** identify appliance-level parts and SHOULD remain stable across routine reprovisioning, transport changes and provider replacement
+* **domain ids** identify semantic domain-owned public instances, roles or summaries and SHOULD be stable for the intended domain audience
+* **curated interface ids** identify stable local public interfaces under `cap/...`
+* **raw ids** identify provider-native concrete interfaces and MAY be provider-facing or topology-bearing
+* **workflow instance ids** identify retained operation records and MUST be unique within their workflow family
+
+An identifier MUST NOT be reused casually across scopes with different meanings.
+
+### 6.1 Service ids and domain ids
+
+Service ids and domain ids are distinct.
+
+* A **service id** identifies a runtime-local implementation boundary.
+* A **domain id** identifies a stable semantic public audience or meaning.
+
+A service id MUST NOT be assumed to define the correct `state/<domain>` family name.
+
+A service MAY own canonical truth for a domain whose name differs from the service id.
+
+A domain family SHOULD remain meaningful even if:
+
+* the implementing service is renamed
+* implementation is split across multiple services
+* implementation is merged into another service
+* the backing provider changes
+
+### 6.2 Component ids and role ids
+
+Component ids and role ids are distinct.
+
+A component id identifies an appliance part, for example:
+
+* `modem-1`
+* `wifi-radio-2`
+* `ethernet-port-1`
+
+A role or semantic domain id identifies a domain-owned public meaning, for example:
+
+* `primary`
+* `secondary`
+* `wan`
+* `guest`
+* `mesh`
+
+A component id MUST NOT implicitly carry a domain role meaning.
+
+A domain role mapping SHOULD be published explicitly by the domain service that owns that role.
+
+## 7. Core address planes
+
+## 7.1 `svc`: service lifecycle
+
+Use `svc` for service lifecycle only.
+
+Topics:
+
+* `svc/<service>/status`
+* `svc/<service>/meta`
+
+This plane answers:
+
+* is the service running?
+* is it degraded?
+* why did it fail?
+* what build or version is it?
+
+No business state, workflow state or configuration intent belongs under `svc`.
+
+`svc/...` SHOULD remain intentionally boring.
+
+## 7.2 `cfg`: intended service configuration and declarative policy input
+
+Use `cfg` for the intended configuration and declarative policy input currently supplied to a service.
+
+Topics:
+
+* `cfg/<service>`
+
+This plane answers:
+
+* what configuration is this implementation boundary expected to reconcile against?
+* what durable intended behaviour is this service being asked to achieve?
+
+`cfg` is not persistence itself. Persistence MAY be provided by a capability, but `cfg/<service>` is the canonical intended-configuration plane.
+
+`cfg/<service>` is not the general plane for “effective configuration currently in force”. If a service needs to distinguish between:
+
+* intended configuration
+* currently effective configuration
+* last successfully applied or reconciled state
+
+that distinction MUST be represented explicitly in canonical retained state rather than left ambiguous in `cfg/<service>`.
+
+A configuration change MUST NOT be treated as a hidden imperative shortcut without the owning service’s reconciliation semantics.
+
+## 7.3 `raw`: provenance-bearing truth and raw source-scoped interfaces
+
+Use `raw` for concrete provenance-bearing truth and raw provider-native interfaces.
+
+Topics:
+
+* `raw/<kind>/<source>/meta`
+* `raw/<kind>/<source>/status`
+* `raw/<kind>/<source>/state/...`
+* `raw/<kind>/<source>/cap/<class>/<id>/meta`
+* `raw/<kind>/<source>/cap/<class>/<id>/status`
+* `raw/<kind>/<source>/cap/<class>/<id>/state/<field>`
+* `raw/<kind>/<source>/cap/<class>/<id>/event/<name>`
+* `raw/<kind>/<source>/cap/<class>/<id>/rpc/<method>`
+
+This plane answers:
+
+* what concrete source exists?
+* what did it actually publish or expose?
+* what provider-native interfaces does it expose?
+* what imported remote surfaces exist locally as provenance-bearing sources?
+
+At minimum, each source MUST publish:
+
+* `raw/<kind>/<source>/meta`
+* `raw/<kind>/<source>/status`
+
+### 7.3.1 Source kind semantics
+
+`<kind>` identifies what sort of source this is.
+
+Initial common values include:
+
+* `host`
+* `member`
+* `peer`
+* `software`
+
+This vocabulary SHOULD remain small and stable.
+
+Relation, placement and trust qualifiers such as `local`, `internal`, `federated`, `derived`, `managed` or `owner` SHOULD normally live in metadata, not in the path, unless there is strong justification for path-level distinction.
+
+### 7.3.2 Raw source-wide state
+
+`raw/<kind>/<source>/state/...` is for source-owned raw facts that are not naturally attached to a specific provider-native interface.
+
+It MUST remain narrow.
+
+It MUST NOT become a miscellaneous compatibility tree or a dumping ground for inconvenient facts.
+
+Where a fact belongs to a raw provider-native interface, it SHOULD live under:
+
+* `raw/<kind>/<source>/cap/<class>/<id>/state/<field>`
+
+not under the source-wide state tree.
+
+Legitimate source-wide raw state typically includes:
+
+* source incarnation or generation
+* session or link state
+* source-wide health
+* transport state
+* source trust or assurance state
+* source boot state
+* source-wide diagnostics not naturally attached to a particular interface
+
+### 7.3.3 Imported remote interfaces
+
+Imported remote interfaces, even if curated at their point of origin, are locally treated as provenance-bearing source-scoped surfaces under `raw/...` unless and until deliberately re-curated into a local public alias.
+
+### 7.3.4 Source ids
+
+A source id under `raw/<kind>/<source>/...` MUST identify a concrete provenance boundary as observed locally.
+
+A source id:
+
+* MAY be topology-bearing
+* MAY be transport-bearing where provenance requires it
+* SHOULD remain stable for the local runtime while that source identity remains meaningful
+* SHOULD NOT be re-used for a different concrete source merely because it occupies the same transport position later
+
+Imported remote sources SHOULD normally be assigned a stable local source id by the importing service rather than exposing remote naming or transport details directly as the canonical local source id.
+
+## 7.4 `state`: canonical retained state families
+
+Use `state/...` for canonical retained state families.
+
+This plane is for canonical public retained truth, not raw provider-native truth and not merely interface availability.
+
+The initial required families are:
+
+* `state/device/...`
+* `state/workflow/...`
+
+Additional domain families MAY be introduced where a service owns canonical public retained truth for its domain.
+
+## 7.4.1 `state/device`: composed appliance truth
+
+Use `state/device/...` for composed appliance-local truth.
+
+This is the canonical place to ask:
+
+* what appliance is this?
+* what components does it have?
+* what is their current state?
+* what appliance-level summaries are true?
+
+Only `device` publishes `state/device/...`.
+
+Typical topics include:
+
+* `state/device/identity`
+* `state/device/components`
+* `state/device/component/<component>`
+* `state/device/component/<component>/software`
+* `state/device/component/<component>/update`
+
+`state/device/...` is for appliance-facing composed truth. It is not a dumping ground for raw provider state, workflow state or unrelated domain policy.
+
+## 7.4.2 `state/workflow`: retained workflow truth
+
+Use `state/workflow/...` for retained workflow instance records.
+
+Examples:
+
+* `state/workflow/update-job/<id>`
+* `state/workflow/artifact-ingest/<id>`
+
+Workflow state is public truth about concrete operations, not manager interfaces.
+
+Not every action needs a workflow instance. This family SHOULD be used where the retained record is justified by the criteria in section 11.
+
+## 7.4.3 `state/<domain>`: canonical retained domain truth
+
+Use `state/<domain>/...` where a service owns canonical public retained truth for a semantic domain.
+
+`state/<domain>` is **not** a synonym for `state/<service>`.
+
+A domain family names the public domain audience and meaning of the truth, not the current implementation module or service boundary.
+
+Therefore:
+
+* `state/<domain>` MUST NOT be introduced merely because a service of the same name exists
+* renaming, splitting or merging services SHOULD NOT by itself require renaming a `state/<domain>` family
+* if the only justification for a family name is “this service publishes it”, that family name is not yet justified
+
+Examples may include:
+
+* `state/gsm/role/primary`
+* `state/gsm/modem/modem-1`
+* `state/net/interface/wan`
+* `state/net/dns`
+* `state/wifi/ap/main`
+* `state/site/member/<id>`
+* `state/update/summary`
+* `state/update/component/mcu`
+* `state/fabric/link/<id>`
+
+A `state/<domain>/...` family MUST:
+
+* have one clear owning service
+* represent canonical public retained truth for that domain
+* not merely restate raw provider-native truth
+* not merely duplicate appliance composition truth
+* not merely act as interface availability
+* not merely be a workflow instance record
+
+## 7.5 `cap`: stable public interfaces
+
+Use `cap/...` for stable local public callable and inspectable interfaces intended for ordinary consumers.
+
+Topics:
+
+* `cap/<class>/<id>/meta`
+* `cap/<class>/<id>/status`
+* `cap/<class>/<id>/rpc/<method>`
+* optionally `cap/<class>/<id>/event/<name>`
+* narrowly and by exception, optionally `cap/<class>/<id>/state/<field>`
+
+This plane answers:
+
+* what stable local public interfaces exist?
+* what methods can callers invoke?
+* what broad interface-level condition applies?
+* where justified, what small amount of interface-scoped retained state is part of the public contract?
+
+Every address under `cap/...` MUST be intended as a stable public contract.
+
+`cap/...` is the canonical local public interface plane. It includes both:
+
+* stable feature interfaces
+* stable manager interfaces
+
+Examples include:
+
+* `cap/modem/modem-1/rpc/connect`
+* `cap/update-manager/main/rpc/create-job`
+* `cap/artifact-ingest/main/rpc/commit`
+
+Provider-native or topology-bearing concrete interfaces MUST NOT appear directly under `cap/...`.
+
+`cap/...` is not a general retained state plane.
+
+### 7.5.1 Ownership of `cap`
+
+Any service MAY publish under `cap/...` where it owns a stable semantic public interface.
+
+`device` MAY publish curated aliases for appliance-defining features.
+
+Non-device services MAY publish stable public interfaces they own, including manager interfaces and domain feature interfaces.
+
+`device` is authoritative for appliance composition. It is not the mandatory owner of every public interface.
+
+### 7.5.2 Capability status
+
+`cap/<class>/<id>/status` is for interface availability and broad operational condition only.
+
+It MAY describe, for example:
+
+* available or unavailable
+* degraded
+* broad reason or mode
+* interface version or compatibility summary where useful
+
+It MUST NOT be used as a substitute for canonical retained state.
+
+In particular, `cap/.../status` MUST NOT quietly become a general state tree under another name.
+
+`cap/.../status` SHOULD usually be summary-level and low-cardinality.
+
+### 7.5.3 Capability events
+
+`cap/<class>/<id>/event/<name>` MAY be used where a curated interface has meaningful interface-level events.
+
+Events are optional.
+
+They MUST NOT be used as authoritative retained state.
+
+### 7.5.4 Narrow interface-scoped retained state
+
+Some stable public interfaces MAY, by exception, publish a small amount of retained interface-scoped state under:
+
+* `cap/<class>/<id>/state/<field>`
+
+This is appropriate only where all of the following are true:
+
+* the state is genuinely part of the interface contract rather than broad domain truth
+* the state is naturally scoped to that one interface
+* publishing it under `cap/...` materially improves inspectability or usability
+* the interface-scoped state is not being used as the hidden canonical home of a larger retained state family
+
+Examples that MAY be justified include:
+
+* current ingest progress for a narrow public ingest interface
+* current broad mode of a stable public manager interface
+* a small interface-scoped summary that is meaningful to ordinary callers
+
+If a richer retained state model exists, that richer canonical truth SHOULD usually live under:
+
+* `state/device/...`
+* `state/workflow/...`
+* `state/<domain>/...`
+
+and `cap/.../state/...` SHOULD remain summary-level.
+
+If `cap/.../state/...` grows beyond a small interface adjunct, the design SHOULD be reconsidered.
+
+### 7.5.5 Curated aliases and provenance
+
+Where a curated public interface is backed by raw sources or raw provider-native interfaces, its `meta` SHOULD include references to those backing sources and interfaces.
+
+Curated aliases MUST NOT erase provenance completely.
+
+### 7.5.6 Common public interface patterns
+
+The following patterns are recommended.
+
+* Manager interfaces SHOULD use semantic manager classes such as:
+
+  * `cap/update-manager/<id>/...`
+  * `cap/artifact-ingest/<id>/...`
+  * `cap/transfer-manager/<id>/...`
+
+* Curated appliance-defining feature aliases published by `device` SHOULD normally use:
+
+  * `cap/component/<component>/...`
+
+* Provider-native interfaces MUST NOT be exposed directly under these curated classes. Where a provider-native interface is intentionally re-curated as a stable public alias, the alias `meta` SHOULD reference the backing raw source and raw interface.
+
+* Stable utility interfaces MAY exist under `cap/...` only where they are intentionally public and are not merely convenient wrappers around raw provider-native utilities.
+
+## 8. Declarative state, workflows and immediate controls
+
+The normal Devicecode control-plane pattern is:
+
+* durable intended behaviour enters through configuration
+* services reconcile that intended behaviour into observed state
+* structured operations are managed through stable public manager interfaces
+* narrow immediate controls exist only where they are clearly justified
+
+### 8.1 Durable desired state
+
+Durable intended behaviour SHOULD normally be represented declaratively in service configuration or other canonical retained state owned by the appropriate service.
+
+Examples include:
+
+* modem preference and role policy
+* APN policy
+* network role assignment
+* Wi-Fi configuration
+* PoE policy
+* update policy
+* telemetry export policy
+
+Public systems MUST NOT accumulate ad hoc imperative command trees for things that are really durable policy changes.
+
+For update systems, durable desired behaviour such as bundled-image preference, approval policy or automatic reconcile policy SHOULD normally live in `cfg/update`.
+
+`state/update/...` is for canonical retained update-domain truth such as current summary state, component-level update summaries or reconcile outcomes. It is not the canonical home of desired intent.
+
+### 8.2 Workflow-managed operations
+
+Workflow-managed operations are represented through stable public manager interfaces under `cap/...` and retained workflow instance records under `state/workflow/...`.
+
+These are appropriate for operations that are at least one of:
+
+* asynchronous
+* multi-step
+* reboot-spanning
+* auditable
+* operator-visible
+* worth retaining after the initiating call completes
+
+Examples include:
+
+* uploaded artefact ingest
+* update job creation
+* update job approval
+* update job commit
+* support bundle generation
+* onboarding and bootstrap flows
+
+Workflow managers are not substitutes for durable policy. Durable policy belongs in configuration or canonical retained domain state, depending on ownership.
+
+### 8.3 Immediate controls
+
+Immediate controls are narrow, explicit actions that do not fit durable desired state and do not necessarily require a retained workflow instance.
+
+Examples include:
+
+* reboot the device
+* power-cycle a member
+* commit a prepared update job
+* force a rescan
+* acknowledge or clear a transient condition
+
+An immediate control MUST NOT silently create durable policy unless that is its explicit and documented purpose.
+
+### 8.4 Operational overrides
+
+A service MAY define retained operational overrides where temporary intended behaviour needs to be represented declaratively without becoming long-lived user configuration.
+
+Such overrides MUST be:
+
+* explicitly modelled
+* clearly owned by one service
+* distinguishable from durable configuration
+* distinguishable from immediate controls
+
+## 9. Curated and raw segregation rules
+
+The following rules are normative.
+
+1. All stable public callable interfaces MUST live under `cap/...`.
+2. All provider-native callable or inspectable interfaces MUST live under `raw/.../cap/...`.
+3. No provider-native interface MAY also appear directly under `cap/...` without deliberate curation into a distinct alias.
+4. Ordinary business services SHOULD depend on `cap/...`, not on `raw/...`.
+5. `device` and other composing or orchestrating services MAY depend on `raw/...` where required.
+6. Structural segregation MUST be preserved even where metadata could in principle distinguish the surfaces.
+
+## 10. Device composition rules
+
+The central composition rule is:
+
+> Raw sources publish raw truth.
+> Raw providers publish raw source-scoped interfaces.
+> `device` composes appliance truth.
+> Curated public interfaces are stable semantic contracts, not mirrors of raw topology.
+
+### 10.1 What `device` publishes
+
+`device` publishes:
+
+* composed appliance truth under `state/device/...`
+* explicit references to backing sources and interfaces where appropriate
+* a curated subset of appliance-defining aliases under `cap/...`
+
+### 10.2 What `device` MUST NOT do
+
+`device` MUST NOT:
+
+* mirror every raw source-scoped interface under a curated alias
+* erase provenance completely
+* absorb unrelated domain policy merely because it composes appliance state
+* turn component ids into domain role ids
+
+`device` is the authoritative appliance composition service. It is not the universal owner of all policy domains or all public interfaces.
+
+## 11. Workflow rules
+
+A workflow-managing public interface is a stable public manager interface under `cap/...`.
+
+Examples include:
+
+* `cap/update-manager/main/rpc/create-job`
+* `cap/update-manager/main/rpc/commit-job`
+* `cap/artifact-ingest/main/rpc/create`
+* `cap/artifact-ingest/main/rpc/append`
+* `cap/artifact-ingest/main/rpc/commit`
+* `cap/artifact-ingest/main/rpc/abort`
+
+A retained workflow record lives under:
+
+* `state/workflow/...`
+
+The manager is not the instance.
+
+Not every action needs a workflow instance. Workflow records SHOULD be used for operations that are at least one of:
+
+* asynchronous
+* multi-step
+* reboot-spanning
+* auditable
+* operator-visible
+* worth retaining after the initiating call completes
+
+Public workflows MUST NOT be exposed through ad hoc service-named command trees such as:
+
+* `cmd/update/...`
+* `cmd/ui/upload/...`
+
+## 12. Canonical ownership rule
+
+A fact MUST have one canonical public owner within its abstraction plane.
+
+In particular:
+
+* `raw/...` owns raw provenance-bearing truth
+* `state/device/...` owns composed appliance truth
+* `state/workflow/...` owns retained workflow instance truth
+* `state/<domain>/...` owns canonical retained domain truth
+* `cap/...` owns stable public interface contracts and broad interface status
+
+If related truth appears in more than one plane, each occurrence MUST be justified by a distinct abstraction role.
+
+For example:
+
+* raw provider truth under `raw/...`
+* composed appliance truth under `state/device/...`
+* retained workflow instance truth under `state/workflow/...`
+* retained domain truth under `state/<domain>/...`
+
+may all legitimately describe the same real-world situation at different levels.
+
+What is prohibited is casual mirroring of the same abstraction-role fact across multiple planes for convenience.
+
+If equivalent truth appears in more than one place within the same abstraction role, one surface MUST be explicitly canonical and the others MUST be summaries, projections or compatibility aliases.
+
+## 13. Minimal publication requirements
+
+The following rules are normative.
+
+1. Every service publishes:
+
+   * `svc/<service>/status`
+   * `svc/<service>/meta`
+   * observability under `obs/v1/<service>/...`
+
+2. Intended service configuration is published under:
+
+   * `cfg/<service>`
+
+3. Only `device` publishes:
+
+   * `state/device/...`
+
+4. Raw provenance-bearing truth is published under:
+
+   * `raw/...`
+
+5. Every source publishes:
+
+   * `raw/<kind>/<source>/meta`
+   * `raw/<kind>/<source>/status`
+
+6. All stable public callable interfaces use:
+
+   * `cap/<class>/<id>/rpc/<method>`
+
+7. Every stable public curated interface publishes:
+
+   * `cap/<class>/<id>/meta`
+   * `cap/<class>/<id>/status`
+
+8. All provider-native callable interfaces use:
+
+   * `raw/<kind>/<source>/cap/<class>/<id>/rpc/<method>`
+
+9. Retained workflow truth lives under:
+
+   * `state/workflow/...`
+
+10. Curated and raw capability surfaces MUST remain structurally segregated.
+
+## 14. Decision guide
+
+Use this quick test.
+
+* Is this service lifecycle or build state?
+  Use `svc/...`
+
+* Is this intended configuration or declarative policy input for one service?
+  Use `cfg/...`
+
+* Is this raw provenance-bearing truth from a concrete source?
+  Use `raw/...`
+
+* Is this a raw provider-native callable or inspectable interface?
+  Use `raw/.../cap/...`
+
+* Is this composed appliance truth?
+  Use `state/device/...`
+
+* Is this canonical retained truth for a semantic public domain?
+  Use `state/<domain>/...`
+
+* Is this a retained record of a specific long-running or operator-visible operation?
+  Use `state/workflow/...`
+
+* Is this a stable local public interface?
+  Use `cap/...`
+
+* Is this an immediate control that is neither durable desired state nor a retained workflow?
+  Use a narrow stable public interface under `cap/...`
+
+* Is this logs, audit or observability rather than operational truth?
+  Use `obs/v1/...`
+
+### 14.1 `state/<domain>` versus service name
+
+Before choosing `<domain>`, ask:
+
+* would this family still have the same public meaning if the implementing service were renamed?
+* would this family still have the same public meaning if implementation were split across multiple services?
+* is the audience for this truth a domain audience rather than an implementation audience?
+
+If the answer is no, this is probably not a `state/<domain>` family.
+
+### 14.2 Public interface versus canonical retained state
+
+When choosing between `cap/...` and `state/...`, apply this additional test.
+
+Use `cap/...` when the thing you are naming is primarily:
+
+* a callable method surface
+* an inspectable interface contract
+* a manager for creating or controlling operations
+* a stable local alias for a semantic feature
+
+Use `state/<domain>/...` or `state/device/...` when the thing you are naming is primarily:
+
+* canonical retained truth for a domain or appliance audience
+* a durable public summary of current reality
+* a role mapping, selection result or composed view
+* a state model that should remain meaningful even if the backing interface changes
+
+If both exist, be explicit about which is canonical for which purpose:
+
+* `cap/...` is canonical for invoking and inspecting the interface contract
+* `state/...` is canonical for retained public truth
+
+## 15. Compatibility publication
+
+Compatibility aliases MAY be published temporarily during migration.
+
+The following rules are normative.
+
+1. A compatibility alias MUST name its canonical source in metadata or in the owning service documentation.
+2. A compatibility alias MUST be implemented as a one-way projection from canonical truth.
+3. New consumers MUST depend on canonical surfaces, not on compatibility aliases.
+4. Compatibility aliases MUST NOT be used to bypass raw-versus-curated segregation.
+5. Compatibility aliases SHOULD be removed once dependent consumers have migrated.
+
+Compatibility publication is a migration tool, not a long-term architecture pattern.
+
+## 16. Migration rule
+
+Older public `cap/...` surfaces MAY remain as legacy-compatible public interface names where already shipped.
+
+New work SHOULD adopt this model.
+
+Compatibility aliases MAY exist temporarily, but canonical ownership MUST still be declared.
+
+Raw-versus-curated segregation SHOULD improve over time and MUST NOT be broken for convenience.
+
+## 17. Where we are now
+
+Devicecode is now in the middle of a concrete migration to this model.
+
+The current state after the `update-migration` PR stack establishes:
+
+-   `raw/...` as the home of provenance-bearing imported member and host/provider surfaces
+-   `state/device/...` as the canonical appliance composition plane
+-   `state/workflow/...` as the retained workflow plane
+-   `state/update/...` and `state/fabric/...` as domain-level retained summary planes
+-   stable public managers such as:
+    -   `cap/update-manager/...`
+    -   `cap/artifact-ingest/...`
+    -   `cap/transfer-manager/...`
+-   curated component interfaces under:
+    -   `cap/component/<component>/...`
+-   compatibility seams at controlled branch points to project older surfaces from canonical truth during migration
+
+This means the model is being landed through a stacked set of implementation PRs.
+
+The main remaining work is not conceptual discovery but:
+
+* tightening canonical ownership
+* reducing compatibility publication
+* and continuing migration of older surfaces and consumers
+
+## 18. Next steps
+
+The next steps are:
+
+1. make canonical ownership explicit for all major published families
+2. ensure new work depends only on canonical surfaces
+3. narrow compatibility seams so that they remain migration tools rather than parallel architectures
+4. retire legacy publication from raw/provider-facing areas before summary or observability aliases
+5. strengthen tests so that they assert primarily on canonical surfaces
+6. continue reviewing `cap/.../state/...` and `raw/.../state/...` for misuse
+7. continue reviewing candidate `state/<domain>` families to ensure they are truly domain families, not service-local trees under another name
+
+In practical terms, the near-term focus is:
+
+* remove dependence on old `cmd/...` trees
+* reduce legacy mirroring of provider-native capabilities
+* make summary versus canonical versus compatibility surfaces explicit
+* and keep `device` focused on appliance composition rather than raw mirroring or domain ownership creep
+
+## 19. Migration appendix: worked examples
+
+This appendix is non-normative, but strongly recommended.
+
+### 19.1 Current migrated update manager
+
+Manager interfaces:
+
+* `cap/update-manager/main/rpc/create-job`
+* `cap/update-manager/main/rpc/start-job`
+* `cap/update-manager/main/rpc/commit-job`
+* `cap/update-manager/main/rpc/cancel-job`
+* `cap/update-manager/main/rpc/retry-job`
+* `cap/update-manager/main/rpc/discard-job`
+
+Retained workflow truth:
+
+* `state/workflow/update-job/<id>`
+
+Retained domain summaries:
+
+* `state/update/summary`
+* `state/update/component/mcu`
+
+Durable desired bundled behaviour belongs in:
+
+* `cfg/update`
+
+not in retained workflow state.
+
+### 19.2 Current migrated artifact ingest
+
+A public ingest flow is modelled as:
+
+* `cap/artifact-ingest/main/rpc/create`
+* `cap/artifact-ingest/main/rpc/append`
+* `cap/artifact-ingest/main/rpc/commit`
+* `cap/artifact-ingest/main/rpc/abort`
+
+Retained ingest truth lives under:
+
+* `state/workflow/artifact-ingest/<id>`
+
+The UI service may transport operator input to this manager, but the UI service is not the public naming boundary of the ingest workflow.
+
+### 19.3 Current migrated fabric and device
+
+Raw imported member truth:
+
+* `raw/member/mcu/meta`
+* `raw/member/mcu/status`
+* `raw/member/mcu/state/...`
+* `raw/member/mcu/cap/updater/main/...`
+
+Fabric domain summaries:
+
+* `state/fabric/link/<id>`
+* `cap/transfer-manager/main/rpc/send-blob`
+
+Device-composed appliance truth:
+
+* `state/device/identity`
+* `state/device/component/mcu`
+* `state/device/component/mcu/software`
+* `state/device/component/mcu/update`
+
+Curated device-facing control:
+
+* `cap/component/mcu/rpc/prepare-update`
+* `cap/component/mcu/rpc/stage-update`
+* `cap/component/mcu/rpc/commit-update`
+
+### 19.4 HAL host/provider utilities
+
+Raw host/provider utility surfaces may include:
+
+* `raw/host/platform/cap/artifact-store/main/...`
+* `raw/host/platform/cap/updater/cm5/...`
+
+Curated public manager interfaces may include:
+
+* `cap/artifact-ingest/main/...`
+
+Canonical retained truth remains under:
+
+* `state/update/...`
+* `state/workflow/...`
+
+### 19.5 Ryan's GSM tree
+
+Provider-native host modem interfaces exposed directly as public capabilities SHOULD be reviewed and split into:
+
+* raw provider-native interfaces under `raw/host/<source>/cap/modem/<id>/...`
+* canonical GSM domain truth under `state/gsm/...`
+* stable public semantic interfaces under `cap/...` where deliberate curation is intended (for example, `device` owning the replublishing of the raw `hal` provided capability into `modem-1`/`modem-2`)
+
+Examples of canonical GSM retained state may include:
+
+* `state/gsm/role/primary`
+* `state/gsm/modem/modem-1`
+* `state/gsm/apn/selected`
+* `state/gsm/uplink/primary`
+
+This allows the GSM service to remain the canonical owner of GSM domain truth while preserving raw provider provenance under `raw/...`.
+
+## 20. Conclusion
+
+The canonical Devicecode naming model is:
+
+* `svc/...` for service lifecycle
+* `cfg/...` for intended service configuration and declarative policy input
+* `raw/...` for raw provenance-bearing truth and raw source-scoped interfaces
+* `state/device/...` for composed appliance truth
+* `state/workflow/...` for retained workflow records
+* `state/<domain>/...` for canonical retained domain truth
+* `cap/...` for stable public interfaces
+* `obs/v1/...` for observability
+
+Within this model:
+
+* services remain implementation boundaries
+* HAL remains the only OS and hardware boundary
+* `device` is the authoritative appliance composition service
+* raw sources preserve provenance
+* curated and raw interfaces remain structurally segregated
+* workflows are managed through stable public interfaces and recorded as workflow instances
+* canonical retained domain truth is allowed where a domain service genuinely owns it
+* `state/<domain>` names semantic public domains, not service ids
+* durable intended behaviour is expressed declaratively by default
+* immediate controls remain narrow and explicit
+* component ids remain distinct from role ids
+* identifier scope and stability are explicit rather than assumed
+* canonical, summary and compatibility surfaces remain distinct
+* and the distinction between interface contracts and canonical retained truth remains explicit

--- a/src/devicecode/service_base.lua
+++ b/src/devicecode/service_base.lua
@@ -2,19 +2,27 @@
 --
 -- Small service scaffold:
 --   * obs helpers (log/event/state)
---   * svc/<name>/status retained
---   * HAL discovery (via retained svc/hal/announce)
---   * fixed HAL RPC calls (rpc/hal/<method>)
+--   * legacy svc/<name>/status retained publishing
+--   * additive lifecycle helpers (announce/starting/running/set_ready/...)
+--   * retained wait helper for other services
+--
+-- Compatibility:
+--   * existing svc:status(...) semantics are preserved
+--   * new lifecycle helpers publish richer payloads, including run_id/ready
+--   * lifecycle retained topics are automatically unretained on scope exit
 --
 ---@module 'devicecode.service_base'
 
 local fibers  = require 'fibers'
 local runtime = require 'fibers.runtime'
 local sleep   = require 'fibers.sleep'
+local uuid    = require 'uuid'
 
 local M = {}
 
-local function t(...) return { ... } end
+local function t(...)
+	return { ... }
+end
 
 local function wall()
 	return os.date('%Y-%m-%d %H:%M:%S')
@@ -23,8 +31,36 @@ end
 local function topic_to_string(topic)
 	if type(topic) ~= 'table' then return tostring(topic) end
 	local parts = {}
-	for i = 1, #topic do parts[#parts + 1] = tostring(topic[i]) end
+	for i = 1, #topic do
+		parts[#parts + 1] = tostring(topic[i])
+	end
 	return table.concat(parts, '/')
+end
+
+local function copy_table(src)
+	local out = {}
+	if type(src) ~= 'table' then return out end
+	for k, v in pairs(src) do out[k] = v end
+	return out
+end
+
+local function merge_payload(base_payload, extra)
+	local payload = copy_table(base_payload)
+	if type(extra) == 'table' then
+		for k, v in pairs(extra) do
+			payload[k] = v
+		end
+	end
+	return payload
+end
+
+local function default_ready_predicate(payload, opts)
+	if type(payload) ~= 'table' then return false end
+	if payload.ready == true then return true end
+	if opts and opts.accept_running_without_ready and payload.state == 'running' and payload.ready == nil then
+		return true
+	end
+	return false
 end
 
 ---@param conn any
@@ -40,10 +76,40 @@ function M.new(conn, opts)
 	svc.name = opts.name or 'service'
 	svc.env  = opts.env or (os.getenv('DEVICECODE_ENV') or 'dev')
 
-	function svc:now() return runtime.now() end
-	function svc:wall() return wall() end
-	function svc:t(...) return t(...) end
-	function svc:topic_to_string(topic) return topic_to_string(topic) end
+	-- New lifecycle state is tracked separately so old status() callers keep
+	-- their current payload semantics.
+	svc.run_id = tostring(uuid.new())
+	svc._announce_published = false
+	svc._lifecycle_state = nil
+	svc._lifecycle_extra = nil
+
+	function svc:now()
+		return runtime.now()
+	end
+
+	function svc:wall()
+		return wall()
+	end
+
+	function svc:t(...)
+		return t(...)
+	end
+
+	function svc:topic_to_string(topic)
+		return topic_to_string(topic)
+	end
+
+	function svc:service_topic(kind)
+		return t('svc', self.name, kind)
+	end
+
+	function svc:status_topic()
+		return self:service_topic('status')
+	end
+
+	function svc:announce_topic()
+		return self:service_topic('announce')
+	end
 
 	function svc:obs_log(level, payload)
 		self.conn:publish(t('obs', 'log', self.name, level), payload)
@@ -57,19 +123,91 @@ function M.new(conn, opts)
 		self.conn:retain(t('obs', 'state', self.name, name), payload)
 	end
 
+	-- Compatibility path: keep the existing payload shape.
 	function svc:status(state, extra)
 		local payload = { state = state, ts = self:now(), at = self:wall() }
 		if type(extra) == 'table' then
 			for k, v in pairs(extra) do payload[k] = v end
 		end
-		self.conn:retain(t('svc', self.name, 'status'), payload)
+		self.conn:retain(self:status_topic(), payload)
 		self:obs_state('status', payload)
+		return payload
+	end
+
+	-- New lifecycle path: explicit ready/run_id semantics for dependants.
+	function svc:lifecycle(state, extra)
+		local payload = {
+			state = state,
+			ts = self:now(),
+			at = self:wall(),
+			run_id = self.run_id,
+		}
+		if type(extra) == 'table' then
+			for k, v in pairs(extra) do payload[k] = v end
+		end
+
+		self._lifecycle_state = state
+		self._lifecycle_extra = copy_table(extra)
+
+		self.conn:retain(self:status_topic(), payload)
+		self:obs_state('status', payload)
+		return payload
+	end
+
+	function svc:announce(meta)
+		local payload = {
+			name = self.name,
+			env = self.env,
+			run_id = self.run_id,
+			ts = self:now(),
+			at = self:wall(),
+		}
+		if type(meta) == 'table' then
+			for k, v in pairs(meta) do payload[k] = v end
+		end
+		self._announce_published = true
+		self.conn:retain(self:announce_topic(), payload)
+		return payload
+	end
+
+	function svc:starting(extra)
+		local payload = merge_payload({ ready = false }, extra)
+		return self:lifecycle('starting', payload)
+	end
+
+	-- Intentionally does not imply ready=true.
+	function svc:running(extra)
+		local payload = merge_payload({ ready = false }, extra)
+		return self:lifecycle('running', payload)
+	end
+
+	function svc:degraded(extra)
+		local ready = false
+		if type(extra) == 'table' and extra.ready ~= nil then
+			ready = not not extra.ready
+		elseif type(self._lifecycle_extra) == 'table' and self._lifecycle_extra.ready ~= nil then
+			ready = not not self._lifecycle_extra.ready
+		end
+		local payload = merge_payload({ ready = ready }, extra)
+		return self:lifecycle('degraded', payload)
+	end
+
+	function svc:failed(reason, extra)
+		local payload = merge_payload({ ready = false, reason = reason }, extra)
+		return self:lifecycle('failed', payload)
+	end
+
+	function svc:set_ready(ready, extra)
+		local state = self._lifecycle_state or 'running'
+		local payload = merge_payload(self._lifecycle_extra or {}, extra)
+		payload.ready = not not ready
+		return self:lifecycle(state, payload)
 	end
 
 	function svc:spawn_heartbeat(period_s, event_name)
 		period_s = period_s or 30.0
 		event_name = event_name or 'tick'
-		fibers.spawn(function ()
+		fibers.spawn(function()
 			local n = 0
 			while true do
 				n = n + 1
@@ -77,6 +215,74 @@ function M.new(conn, opts)
 				sleep.sleep(period_s)
 			end
 		end)
+	end
+
+	-- Consumer-side helper: wait on retained service status rather than probing.
+	function svc:wait_service_ready(name, opts_)
+		opts_ = opts_ or {}
+		local timeout = (type(opts_.timeout) == 'number') and opts_.timeout or 30.0
+		local queue_len = (type(opts_.queue_len) == 'number') and opts_.queue_len or 8
+		local full = opts_.full or 'drop_oldest'
+		local predicate = opts_.predicate or function(payload)
+			return default_ready_predicate(payload, opts_)
+		end
+
+		local watch = self.conn:watch_retained(
+			t('svc', name, 'status'),
+			{ replay = true, queue_len = queue_len, full = full }
+		)
+
+		local deadline = self:now() + timeout
+
+		local function cleanup()
+			pcall(function() watch:unwatch() end)
+		end
+
+		while true do
+			local remaining = deadline - self:now()
+			if remaining <= 0 then
+				cleanup()
+				return nil, 'timeout'
+			end
+
+			local which, a, b = fibers.perform(fibers.named_choice({
+				ev = watch:recv_op(),
+				timeout = sleep.sleep_op(remaining):wrap(function()
+					return true
+				end),
+			}))
+
+			if which == 'timeout' then
+				cleanup()
+				return nil, 'timeout'
+			end
+
+			local ev, err = a, b
+			if not ev then
+				cleanup()
+				return nil, err or 'watch_closed'
+			end
+
+			if ev.op == 'retain' and predicate(ev.payload) then
+				local payload = ev.payload
+				cleanup()
+				return payload, nil
+			end
+		end
+	end
+
+	-- Scope-exit cleanup for lifecycle topics. This is additive and safe even if
+	-- the service never used the richer helpers.
+	if runtime.current_fiber() then
+		local current_scope = fibers.current_scope and fibers.current_scope() or nil
+		if current_scope and current_scope.finally then
+			current_scope:finally(function()
+				pcall(function() svc.conn:unretain(svc:status_topic()) end)
+				if svc._announce_published then
+					pcall(function() svc.conn:unretain(svc:announce_topic()) end)
+				end
+			end)
+		end
 	end
 
 	return svc

--- a/src/devicecode/service_base.lua
+++ b/src/devicecode/service_base.lua
@@ -1,15 +1,17 @@
 -- devicecode/service_base.lua
 --
 -- Small service scaffold:
---   * obs helpers (log/event/state)
---   * legacy svc/<name>/status retained publishing
---   * additive lifecycle helpers (announce/starting/running/set_ready/...)
+--   * obs helpers (legacy + obs/v1 compatibility)
+--   * svc/<name>/status retained publishing
+--   * additive lifecycle helpers (meta/announce, starting/running/set_ready/...)
 --   * retained wait helper for other services
 --
--- Compatibility:
+-- Compatibility policy:
 --   * existing svc:status(...) semantics are preserved
---   * new lifecycle helpers publish richer payloads, including run_id/ready
---   * lifecycle retained topics are automatically unretained on scope exit
+--   * existing obs/log|event|state helpers are preserved
+--   * announce() now publishes BOTH svc/<name>/meta (canonical) and
+--     svc/<name>/announce (legacy-compatible)
+--   * obs helpers fan out to BOTH obs/v1/... and legacy obs/... topics
 --
 ---@module 'devicecode.service_base'
 
@@ -80,6 +82,7 @@ function M.new(conn, opts)
 	-- their current payload semantics.
 	svc.run_id = tostring(uuid.new())
 	svc._announce_published = false
+	svc._meta_published = false
 	svc._lifecycle_state = nil
 	svc._lifecycle_extra = nil
 
@@ -107,21 +110,93 @@ function M.new(conn, opts)
 		return self:service_topic('status')
 	end
 
+	-- New canonical metadata surface.
+	function svc:meta_topic()
+		return self:service_topic('meta')
+	end
+
+	-- Legacy compatibility surface.
 	function svc:announce_topic()
 		return self:service_topic('announce')
 	end
 
+	----------------------------------------------------------------------
+	-- Observability topics
+	----------------------------------------------------------------------
+
+	-- Legacy forms
+	function svc:obs_log_legacy_topic(level)
+		return t('obs', 'log', self.name, level)
+	end
+
+	function svc:obs_event_legacy_topic(name)
+		return t('obs', 'event', self.name, name)
+	end
+
+	function svc:obs_state_legacy_topic(name)
+		return t('obs', 'state', self.name, name)
+	end
+
+	-- New canonical obs/v1 forms
+	function svc:obs_event_topic(name)
+		return t('obs', 'v1', self.name, 'event', name)
+	end
+
+	function svc:obs_metric_topic(name)
+		return t('obs', 'v1', self.name, 'metric', name)
+	end
+
+	function svc:obs_counter_topic(name)
+		return t('obs', 'v1', self.name, 'counter', name)
+	end
+
+	-- Compatibility helper:
+	--   * legacy log plane remains as-is
+	--   * canonical plane treats logs as events named "log", with level attached
 	function svc:obs_log(level, payload)
-		self.conn:publish(t('obs', 'log', self.name, level), payload)
+		self.conn:publish(self:obs_log_legacy_topic(level), payload)
+
+		local v1_payload
+		if type(payload) == 'table' then
+			v1_payload = copy_table(payload)
+			v1_payload.level = level
+		else
+			v1_payload = { level = level, message = payload }
+		end
+		self.conn:publish(self:obs_event_topic('log'), v1_payload)
 	end
 
+	-- Compatibility helper:
+	--   * legacy event plane remains as-is
+	--   * canonical plane is obs/v1/<service>/event/<name>
 	function svc:obs_event(name, payload)
-		self.conn:publish(t('obs', 'event', self.name, name), payload)
+		self.conn:publish(self:obs_event_legacy_topic(name), payload)
+		self.conn:publish(self:obs_event_topic(name), payload)
 	end
 
+	-- Compatibility helper:
+	--   * legacy retained state plane remains as-is
+	--   * canonical plane is exposed as a retained metric summary
+	--
+	-- Note: this is a bridge. Over time, individual callers should migrate to
+	-- explicit obs_metric / obs_counter calls rather than using obs_state for
+	-- everything.
 	function svc:obs_state(name, payload)
-		self.conn:retain(t('obs', 'state', self.name, name), payload)
+		self.conn:retain(self:obs_state_legacy_topic(name), payload)
+		self.conn:retain(self:obs_metric_topic(name), payload)
 	end
+
+	function svc:obs_metric(name, payload)
+		self.conn:retain(self:obs_metric_topic(name), payload)
+	end
+
+	function svc:obs_counter(name, payload)
+		self.conn:publish(self:obs_counter_topic(name), payload)
+	end
+
+	----------------------------------------------------------------------
+	-- Lifecycle
+	----------------------------------------------------------------------
 
 	-- Compatibility path: keep the existing payload shape.
 	function svc:status(state, extra)
@@ -154,6 +229,7 @@ function M.new(conn, opts)
 		return payload
 	end
 
+	-- Canonical service metadata + legacy announce alias.
 	function svc:announce(meta)
 		local payload = {
 			name = self.name,
@@ -165,8 +241,15 @@ function M.new(conn, opts)
 		if type(meta) == 'table' then
 			for k, v in pairs(meta) do payload[k] = v end
 		end
+
 		self._announce_published = true
+		self._meta_published = true
+
+		-- New canonical metadata topic
+		self.conn:retain(self:meta_topic(), payload)
+		-- Legacy compatibility topic
 		self.conn:retain(self:announce_topic(), payload)
+
 		return payload
 	end
 
@@ -198,7 +281,12 @@ function M.new(conn, opts)
 	end
 
 	function svc:set_ready(ready, extra)
-		local state = self._lifecycle_state or 'running'
+		local state = self._lifecycle_state
+		if ready and (state == nil or state == 'starting') then
+			state = 'running'
+		elseif state == nil then
+			state = 'running'
+		end
 		local payload = merge_payload(self._lifecycle_extra or {}, extra)
 		payload.ready = not not ready
 		return self:lifecycle(state, payload)
@@ -217,7 +305,10 @@ function M.new(conn, opts)
 		end)
 	end
 
+	----------------------------------------------------------------------
 	-- Consumer-side helper: wait on retained service status rather than probing.
+	----------------------------------------------------------------------
+
 	function svc:wait_service_ready(name, opts_)
 		opts_ = opts_ or {}
 		local timeout = (type(opts_.timeout) == 'number') and opts_.timeout or 30.0
@@ -271,13 +362,20 @@ function M.new(conn, opts)
 		end
 	end
 
-	-- Scope-exit cleanup for lifecycle topics. This is additive and safe even if
-	-- the service never used the richer helpers.
+	----------------------------------------------------------------------
+	-- Scope-exit cleanup for lifecycle topics.
+	----------------------------------------------------------------------
+
 	if runtime.current_fiber() then
 		local current_scope = fibers.current_scope and fibers.current_scope() or nil
 		if current_scope and current_scope.finally then
 			current_scope:finally(function()
 				pcall(function() svc.conn:unretain(svc:status_topic()) end)
+
+				if svc._meta_published then
+					pcall(function() svc.conn:unretain(svc:meta_topic()) end)
+				end
+
 				if svc._announce_published then
 					pcall(function() svc.conn:unretain(svc:announce_topic()) end)
 				end

--- a/src/services/hal.lua
+++ b/src/services/hal.lua
@@ -45,7 +45,55 @@ local function t_cap_state(class, id)
     return { 'cap', class, id, 'state' }
 end
 
----@alias CapabilityEntry { inst: Capability, rpc: table<string, Endpoint> }
+---@param class CapabilityClass
+---@param id CapabilityId
+---@param method string
+---@return string[] topic
+local function t_cap_rpc(class, id, method)
+    return { 'cap', class, id, 'rpc', method }
+end
+
+local function path_token(s)
+    return tostring(s):gsub('_', '-')
+end
+
+-- Raw provenance source id.
+-- For current owned HAL managers, device.class is the fallback source id.
+-- Managers may override this via device.meta.raw_source_id / source_id / source.
+local function device_source_id(device)
+    local meta = device.meta or {}
+    return meta.raw_source_id or meta.source_id or meta.source or device.class
+end
+
+local function raw_host_source_meta(source)
+    return { 'raw', 'host', path_token(source), 'meta' }
+end
+
+local function raw_host_source_status(source)
+    return { 'raw', 'host', path_token(source), 'status' }
+end
+
+local function raw_host_cap_meta(source, class, id)
+    return { 'raw', 'host', path_token(source), 'cap', path_token(class), id, 'meta' }
+end
+
+local function raw_host_cap_status(source, class, id)
+    return { 'raw', 'host', path_token(source), 'cap', path_token(class), id, 'status' }
+end
+
+local function raw_host_cap_state(source, class, id, field)
+    return { 'raw', 'host', path_token(source), 'cap', path_token(class), id, 'state', field }
+end
+
+local function raw_host_cap_event(source, class, id, event)
+    return { 'raw', 'host', path_token(source), 'cap', path_token(class), id, 'event', event }
+end
+
+local function raw_host_cap_rpc(source, class, id, method)
+    return { 'raw', 'host', path_token(source), 'cap', path_token(class), id, 'rpc', method }
+end
+
+---@alias CapabilityEntry { inst: Capability, rpc: table<string, Endpoint>, raw_source?: string, raw_class?: string }
 
 ---@class HalService
 ---@field name string
@@ -107,6 +155,7 @@ function HalService.start(conn, opts)
     local managers = {}
     local devices = {}
     local capabilities = {}
+    local raw_source_refs = {}
 
     local function obs_emitter(level, payload)
         svc:obs_log(level, payload)
@@ -168,9 +217,6 @@ function HalService.start(conn, opts)
             return "capability already exists"
         end
         capabilities[class][id] = { inst = cap_inst, rpc = {} }
-        for offering, _ in pairs(cap_inst.offerings) do
-            capabilities[class][id].rpc[offering] = conn:bind({ 'cap', class, id, 'rpc', offering })
-        end
     end
 
     ---Removes the capability instance
@@ -205,6 +251,29 @@ function HalService.start(conn, opts)
             return
         end
 
+        local source = device_source_id(device)
+        raw_source_refs[source] = (raw_source_refs[source] or 0) + 1
+
+        if raw_source_refs[source] == 1 then
+            conn:retain(raw_host_source_meta(source), {
+                provider = device.meta and device.meta.provider or ('hal.' .. tostring(device.class)),
+                source = source,
+                device_class = device.class,
+                device_id = device.id,
+                legacy_device = {
+                    class = device.class,
+                    id = device.id,
+                },
+                meta = device.meta,
+            })
+        end
+
+        conn:retain(raw_host_source_status(source), {
+            state = 'available',
+            source = source,
+            id = device.id,
+        })
+
         for _, cap in ipairs(device.capabilities) do
             local cap_set_err = set_cap(cap.class, cap.id, cap)
             if cap_set_err then
@@ -215,12 +284,46 @@ function HalService.start(conn, opts)
                     id = cap.id,
                 })
             else
+                local cap_entry = get_cap(cap.class, cap.id)
+                if cap_entry then
+                    cap_entry.raw_source = source
+                    cap_entry.raw_class = cap.class
+
+                    for offering, _ in pairs(cap.offerings) do
+                        local legacy_key = 'legacy:' .. tostring(offering)
+                        local raw_key = 'raw:' .. tostring(source) .. ':' .. tostring(offering)
+
+                        -- Legacy public capability RPC for compatibility.
+                        cap_entry.rpc[legacy_key] = conn:bind(t_cap_rpc(cap.class, cap.id, offering))
+                        -- New raw-host capability RPC.
+                        cap_entry.rpc[raw_key] = conn:bind(raw_host_cap_rpc(source, cap.class, cap.id, offering))
+                    end
+                end
+
                 svc:obs_event('capability_registered', { class = cap.class, id = cap.id })
+
+                -- Legacy public capability registration state/meta for compatibility.
                 conn:retain(t_cap_state(cap.class, cap.id), event_type)
                 conn:retain(t_cap_meta(cap.class, cap.id), { offerings = cap.offerings })
+
+                -- New raw-host capability registration state/meta.
+                conn:retain(raw_host_cap_status(source, cap.class, cap.id), {
+                    state = 'available',
+                    source = source,
+                    class = cap.class,
+                    id = cap.id,
+                })
+
+                conn:retain(raw_host_cap_meta(source, cap.class, cap.id), {
+                    offerings = cap.offerings,
+                    provider = device.meta and device.meta.provider or ('hal.' .. tostring(device.class)),
+                    source = source,
+                    legacy_cap = { class = cap.class, id = cap.id },
+                })
             end
         end
 
+        -- Legacy device registry remains unchanged for compatibility.
         conn:retain(t_dev_meta(device.class, device.id), device.meta)
         conn:retain(t_dev_state(device.class, device.id), event_type)
         svc:obs_event('device_registered', { class = device.class, id = device.id, event_type = event_type })
@@ -230,6 +333,8 @@ function HalService.start(conn, opts)
     ---@param event_type EventType
     ---@param device Device
     local function unregister_device(event_type, device)
+        local source = device_source_id(device)
+
         for _, cap in ipairs(device.capabilities) do
             local cap_remove_err = remove_cap(cap.class, cap.id)
             if cap_remove_err then
@@ -241,8 +346,21 @@ function HalService.start(conn, opts)
                 })
             else
                 svc:obs_event('capability_unregistered', { class = cap.class, id = cap.id })
+
+                -- Legacy public capability registration state/meta for compatibility.
                 conn:retain(t_cap_state(cap.class, cap.id), event_type)
                 conn:unretain(t_cap_meta(cap.class, cap.id))
+
+                -- New raw-host capability registration state/meta.
+                conn:retain(raw_host_cap_status(source, cap.class, cap.id), {
+                    state = 'unavailable',
+                    reason = 'removed',
+                    source = source,
+                    class = cap.class,
+                    id = cap.id,
+                })
+
+                conn:unretain(raw_host_cap_meta(source, cap.class, cap.id))
             end
         end
 
@@ -257,6 +375,23 @@ function HalService.start(conn, opts)
             return
         end
 
+        if raw_source_refs[source] then
+            raw_source_refs[source] = raw_source_refs[source] - 1
+            if raw_source_refs[source] <= 0 then
+                raw_source_refs[source] = nil
+
+                conn:retain(raw_host_source_status(source), {
+                    state = 'unavailable',
+                    reason = 'removed',
+                    source = source,
+                    id = device.id,
+                })
+
+                conn:unretain(raw_host_source_meta(source))
+            end
+        end
+
+        -- Legacy device registry remains unchanged for compatibility.
         conn:unretain(t_dev_meta(device.class, device.id))
         conn:retain(t_dev_state(device.class, device.id), event_type)
         svc:obs_event('device_unregistered', { class = device.class, id = device.id, event_type = event_type })
@@ -265,7 +400,16 @@ function HalService.start(conn, opts)
     ---Handles running driver functions for control requests
     ---@param req Request
     local function on_cap_ctrl(req)
-        local class, id, verb = req.topic[2], req.topic[3], req.topic[5]
+        local class, id, verb
+
+        if req.topic[1] == 'raw' and req.topic[2] == 'host' and req.topic[4] == 'cap' then
+            class, id, verb = tostring(req.topic[5]):gsub('-', '_'), req.topic[6], req.topic[8]
+        elseif req.topic[1] == 'cap' and req.topic[4] == 'rpc' then
+            class, id, verb = req.topic[2], req.topic[3], req.topic[5]
+        else
+            req:fail('unsupported_cap_topic')
+            return
+        end
 
         if not class_valid(class) then
             svc:obs_log('warn', { what = 'invalid_cap_class', class = tostring(class) })
@@ -290,7 +434,6 @@ function HalService.start(conn, opts)
                 id = id,
                 verb = verb,
             })
-            -- ordinary publish traffic does not reach bound endpoints
             req:fail(tostring(ctrl_req_err))
             return
         end
@@ -336,12 +479,27 @@ function HalService.start(conn, opts)
             return
         end
 
+        -- Legacy public capability event/state plane remains for compatibility.
         local topic = { 'cap', emit.class, emit.id, emit.mode, emit.key }
+
+        local cap_entry = get_cap(emit.class, emit.id)
+        local raw_topic = nil
+        if cap_entry and cap_entry.raw_source then
+            if emit.mode == 'event' then
+                raw_topic = raw_host_cap_event(cap_entry.raw_source, emit.class, emit.id, emit.key)
+            elseif emit.mode == 'state' then
+                raw_topic = raw_host_cap_state(cap_entry.raw_source, emit.class, emit.id, emit.key)
+            elseif emit.mode == 'meta' then
+                raw_topic = raw_host_cap_meta(cap_entry.raw_source, emit.class, emit.id)
+            end
+        end
 
         if emit.mode == 'event' then
             conn:publish(topic, emit.data)
+            if raw_topic then conn:publish(raw_topic, emit.data) end
         else
             conn:retain(topic, emit.data)
+            if raw_topic then conn:retain(raw_topic, emit.data) end
         end
     end
 
@@ -521,8 +679,8 @@ function HalService.start(conn, opts)
         }
 
         local rpc_ops = {}
-        for _, class in pairs(capabilities) do
-            for _, cap in pairs(class) do
+        for _, class_caps in pairs(capabilities) do
+            for _, cap in pairs(class_caps) do
                 for _, rpc_sub in pairs(cap.rpc) do
                     table.insert(rpc_ops, rpc_sub:recv_op())
                 end

--- a/src/services/hal/sdk/cap.lua
+++ b/src/services/hal/sdk/cap.lua
@@ -7,21 +7,87 @@ local op = require 'fibers.op'
 
 local perform = fibers.perform
 
+----------------------------------------------------------------------
+-- Topic helpers
+----------------------------------------------------------------------
+
+-- Legacy public capability discovery surface.
 local function t_cap_listen(class, id)
-    return { 'cap', class, id, 'state' }
+	return { 'cap', class, id, 'state' }
 end
 
 local function t_cap_state(class, id, state)
-    return { 'cap', class, id, 'state', state }
+	return { 'cap', class, id, 'state', state }
 end
 
 local function t_cap_event(class, id, event)
-    return { 'cap', class, id, 'event', event }
+	return { 'cap', class, id, 'event', event }
 end
 
 local function t_cap_control(class, id, method)
-    return { 'cap', class, id, 'rpc', method }
+	return { 'cap', class, id, 'rpc', method }
 end
+
+-- New curated public capability surface.
+local function t_cap_meta(class, id)
+	return { 'cap', class, id, 'meta' }
+end
+
+local function t_cap_status(class, id)
+	return { 'cap', class, id, 'status' }
+end
+
+----------------------------------------------------------------------
+-- Raw host capability surface
+----------------------------------------------------------------------
+
+local function t_raw_host_cap_meta(source, class, id)
+	return { 'raw', 'host', source, 'cap', class, id, 'meta' }
+end
+
+local function t_raw_host_cap_status(source, class, id)
+	return { 'raw', 'host', source, 'cap', class, id, 'status' }
+end
+
+local function t_raw_host_cap_state(source, class, id, state)
+	return { 'raw', 'host', source, 'cap', class, id, 'state', state }
+end
+
+local function t_raw_host_cap_event(source, class, id, event)
+	return { 'raw', 'host', source, 'cap', class, id, 'event', event }
+end
+
+local function t_raw_host_cap_control(source, class, id, method)
+	return { 'raw', 'host', source, 'cap', class, id, 'rpc', method }
+end
+
+----------------------------------------------------------------------
+-- Raw member capability surface
+----------------------------------------------------------------------
+
+local function t_raw_member_cap_meta(source, class, id)
+	return { 'raw', 'member', source, 'cap', class, id, 'meta' }
+end
+
+local function t_raw_member_cap_status(source, class, id)
+	return { 'raw', 'member', source, 'cap', class, id, 'status' }
+end
+
+local function t_raw_member_cap_state(source, class, id, state)
+	return { 'raw', 'member', source, 'cap', class, id, 'state', state }
+end
+
+local function t_raw_member_cap_event(source, class, id, event)
+	return { 'raw', 'member', source, 'cap', class, id, 'event', event }
+end
+
+local function t_raw_member_cap_control(source, class, id, method)
+	return { 'raw', 'member', source, 'cap', class, id, 'rpc', method }
+end
+
+----------------------------------------------------------------------
+-- Capability reference
+----------------------------------------------------------------------
 
 ---@class CapabilityReference
 ---@field conn Connection
@@ -30,8 +96,58 @@ end
 local CapabilityReference = {}
 CapabilityReference.__index = CapabilityReference
 
+local function control_topic(self, method)
+	if self.raw_kind == 'host' then
+		return t_raw_host_cap_control(self.source, self.class, self.id, method)
+	elseif self.raw_kind == 'member' then
+		return t_raw_member_cap_control(self.source, self.class, self.id, method)
+	else
+		return t_cap_control(self.class, self.id, method)
+	end
+end
+
+local function state_topic(self, field)
+	if self.raw_kind == 'host' then
+		return t_raw_host_cap_state(self.source, self.class, self.id, field)
+	elseif self.raw_kind == 'member' then
+		return t_raw_member_cap_state(self.source, self.class, self.id, field)
+	else
+		return t_cap_state(self.class, self.id, field)
+	end
+end
+
+local function event_topic(self, name)
+	if self.raw_kind == 'host' then
+		return t_raw_host_cap_event(self.source, self.class, self.id, name)
+	elseif self.raw_kind == 'member' then
+		return t_raw_member_cap_event(self.source, self.class, self.id, name)
+	else
+		return t_cap_event(self.class, self.id, name)
+	end
+end
+
+local function meta_topic(self)
+	if self.raw_kind == 'host' then
+		return t_raw_host_cap_meta(self.source, self.class, self.id)
+	elseif self.raw_kind == 'member' then
+		return t_raw_member_cap_meta(self.source, self.class, self.id)
+	else
+		return t_cap_meta(self.class, self.id)
+	end
+end
+
+local function status_topic(self)
+	if self.raw_kind == 'host' then
+		return t_raw_host_cap_status(self.source, self.class, self.id)
+	elseif self.raw_kind == 'member' then
+		return t_raw_member_cap_status(self.source, self.class, self.id)
+	else
+		return t_cap_status(self.class, self.id)
+	end
+end
+
 function CapabilityReference:call_control_op(method, args, opts)
-    return self.conn:call_op(t_cap_control(self.class, self.id, method), args, opts)
+	return self.conn:call_op(control_topic(self, method), args, opts)
 end
 
 ---@param method string
@@ -39,90 +155,173 @@ end
 ---@return Reply?
 ---@return string error
 function CapabilityReference:call_control(method, args)
-    return perform(self:call_control_op(method, args))
+	return perform(self:call_control_op(method, args))
 end
 
 ---@param field string
 ---@param opts table?
 ---@return Subscription
 function CapabilityReference:get_state_sub(field, opts)
-    return self.conn:subscribe(t_cap_state(self.class, self.id, field), opts)
+	return self.conn:subscribe(state_topic(self, field), opts)
 end
 
----@param field string
+---@param name string
 ---@param opts table?
 ---@return Subscription
-function CapabilityReference:get_event_sub(field, opts)
-    return self.conn:subscribe(t_cap_event(self.class, self.id, field), opts)
+function CapabilityReference:get_event_sub(name, opts)
+	return self.conn:subscribe(event_topic(self, name), opts)
 end
+
+---@param opts table?
+---@return Subscription
+function CapabilityReference:get_meta_sub(opts)
+	return self.conn:subscribe(meta_topic(self), opts)
+end
+
+---@param opts table?
+---@return Subscription
+function CapabilityReference:get_status_sub(opts)
+	return self.conn:subscribe(status_topic(self), opts)
+end
+
+----------------------------------------------------------------------
+-- Listener
+----------------------------------------------------------------------
 
 ---@class CapListener
 ---@field conn Connection
 ---@field sub Subscription
 ---@field topic Topic
+---@field mode '"legacy-public"'|'"curated-public"'|'"raw-host"'|'"raw-member"'
 local CapListener = {}
 CapListener.__index = CapListener
 
---- Wait for a capability to be added matching the listener's topic, and return a reference to it.
-function CapListener:wait_for_cap_op()
-    -- scope.run_op yields (st, report, ...body_returns) so we wrap to extract
-    -- just the (cap_ref, err) pair that callers expect.
-    return scope.run_op(function()
-        while true do
-            local msg, err = self.sub:recv()
-            if err then return nil, err end
-            if not msg then return nil, 'subscription closed' end
+local function capability_ref_for_listener(self, class, id)
+	if self.mode == 'raw-host' then
+		return setmetatable({
+			conn = self.conn,
+			raw_kind = 'host',
+			source = self.source,
+			class = class,
+			id = id,
+		}, CapabilityReference)
+	elseif self.mode == 'raw-member' then
+		return setmetatable({
+			conn = self.conn,
+			raw_kind = 'member',
+			source = self.source,
+			class = class,
+			id = id,
+		}, CapabilityReference)
+	else
+		return setmetatable({
+			conn = self.conn,
+			class = class,
+			id = id,
+		}, CapabilityReference)
+	end
+end
 
-            local state = msg.payload
-            if state == 'added' then
-                local class, id = msg.topic[2], msg.topic[3]
-                return setmetatable({ conn = self.conn, class = class, id = id }, CapabilityReference), ''
-            end
-        end
-    end):wrap(function(st, report, cap, err)
-        if st == 'ok' then
-            return cap, err or ''
-        else
-            return nil, tostring(report)
-        end
-    end)
+local function listener_payload_is_ready(self, payload)
+	if self.mode == 'legacy-public' then
+		return payload == 'added'
+	end
+
+	if type(payload) == 'table' then
+		if payload.state == 'available' or payload.available == true then
+			return true
+		end
+		if payload.state == 'running' then
+			return true
+		end
+	end
+
+	-- Helpful transitional fallback if somebody mirrors old semantics.
+	if payload == 'added' then
+		return true
+	end
+
+	return false
+end
+
+--- Wait for a capability to be available matching the listener's topic, and
+--- return a reference to it.
+function CapListener:wait_for_cap_op()
+	return scope.run_op(function()
+		while true do
+			local msg, err = self.sub:recv()
+			if err then return nil, err end
+			if not msg then return nil, 'subscription closed' end
+
+			local payload = msg.payload
+			if listener_payload_is_ready(self, payload) then
+				local class, id
+				if self.mode == 'raw-host' or self.mode == 'raw-member' then
+					class, id = msg.topic[5], msg.topic[6]
+				else
+					class, id = msg.topic[2], msg.topic[3]
+				end
+				return capability_ref_for_listener(self, class, id), ''
+			end
+		end
+	end):wrap(function(st, report, cap, err)
+		if st == 'ok' then
+			return cap, err or ''
+		else
+			return nil, tostring(report)
+		end
+	end)
 end
 
 ---@param opts { timeout?: number }
 ---@return CapabilityReference?
 ---@return string error
 function CapListener:wait_for_cap(opts)
-    opts = opts or {}
-    local ops = { cap = self:wait_for_cap_op() }
-    if opts.timeout then
-        ops.timeout = sleep.sleep_op(opts.timeout)
-    end
-    local which, a, b = perform(op.named_choice(ops))
-    if which == 'cap' then
-        return a, b
-    elseif which == 'timeout' then
-        return nil, 'timeout'
-    end
-    return nil, 'unknown error'
+	opts = opts or {}
+	local ops = { cap = self:wait_for_cap_op() }
+	if opts.timeout then
+		ops.timeout = sleep.sleep_op(opts.timeout)
+	end
+	local which, a, b = perform(op.named_choice(ops))
+	if which == 'cap' then
+		return a, b
+	elseif which == 'timeout' then
+		return nil, 'timeout'
+	end
+	return nil, 'unknown error'
 end
 
 function CapListener:close()
-    self.sub:unsubscribe()
+	self.sub:unsubscribe()
 end
+
+----------------------------------------------------------------------
+-- SDK
+----------------------------------------------------------------------
 
 ---@class CapSDK
 local CapSDK = {
-    args = cap_args,
+	args = cap_args,
 }
 CapSDK.__index = CapSDK
+
+----------------------------------------------------------------------
+-- Legacy public helpers
+-- Keep these intact so existing services continue to work.
+----------------------------------------------------------------------
 
 ---@param conn Connection
 ---@param class CapabilityClass
 ---@param id CapabilityId
 function CapSDK.new_cap_listener(conn, class, id)
-    local topic = t_cap_listen(class, id)
-    local sub = conn:subscribe(topic)
-    return setmetatable({ conn = conn, sub = sub, topic = topic }, CapListener)
+	local topic = t_cap_listen(class, id)
+	local sub = conn:subscribe(topic)
+	return setmetatable({
+		conn = conn,
+		sub = sub,
+		topic = topic,
+		mode = 'legacy-public',
+	}, CapListener)
 end
 
 ---@param conn Connection
@@ -130,7 +329,103 @@ end
 ---@param id CapabilityId
 ---@return CapabilityReference
 function CapSDK.new_cap_ref(conn, class, id)
-    return setmetatable({ conn = conn, class = class, id = id }, CapabilityReference)
+	return setmetatable({ conn = conn, class = class, id = id }, CapabilityReference)
+end
+
+----------------------------------------------------------------------
+-- New curated public helpers
+----------------------------------------------------------------------
+
+---@param conn Connection
+---@param class CapabilityClass
+---@param id CapabilityId
+function CapSDK.new_curated_cap_listener(conn, class, id)
+	local topic = t_cap_status(class, id)
+	local sub = conn:subscribe(topic)
+	return setmetatable({
+		conn = conn,
+		sub = sub,
+		topic = topic,
+		mode = 'curated-public',
+	}, CapListener)
+end
+
+---@param conn Connection
+---@param class CapabilityClass
+---@param id CapabilityId
+---@return CapabilityReference
+function CapSDK.new_curated_cap_ref(conn, class, id)
+	return setmetatable({ conn = conn, class = class, id = id }, CapabilityReference)
+end
+
+----------------------------------------------------------------------
+-- Raw host helpers
+----------------------------------------------------------------------
+
+---@param conn Connection
+---@param source string
+---@param class CapabilityClass
+---@param id CapabilityId
+function CapSDK.new_raw_host_cap_listener(conn, source, class, id)
+	local topic = t_raw_host_cap_status(source, class, id)
+	local sub = conn:subscribe(topic)
+	return setmetatable({
+		conn = conn,
+		sub = sub,
+		topic = topic,
+		mode = 'raw-host',
+		source = source,
+	}, CapListener)
+end
+
+---@param conn Connection
+---@param source string
+---@param class CapabilityClass
+---@param id CapabilityId
+---@return CapabilityReference
+function CapSDK.new_raw_host_cap_ref(conn, source, class, id)
+	return setmetatable({
+		conn = conn,
+		raw_kind = 'host',
+		source = source,
+		class = class,
+		id = id,
+	}, CapabilityReference)
+end
+
+----------------------------------------------------------------------
+-- Raw member helpers
+----------------------------------------------------------------------
+
+---@param conn Connection
+---@param source string
+---@param class CapabilityClass
+---@param id CapabilityId
+function CapSDK.new_raw_member_cap_listener(conn, source, class, id)
+	local topic = t_raw_member_cap_status(source, class, id)
+	local sub = conn:subscribe(topic)
+	return setmetatable({
+		conn = conn,
+		sub = sub,
+		topic = topic,
+		mode = 'raw-member',
+		source = source,
+	}, CapListener)
+end
+
+---@param conn Connection
+---@param source string
+---@param class CapabilityClass
+---@param id CapabilityId
+---@return CapabilityReference
+function CapSDK.new_raw_member_cap_ref(conn, source, class, id)
+	return setmetatable({
+		conn = conn,
+		raw_kind = 'member',
+		source = source,
+		class = class,
+		id = id,
+	}, CapabilityReference)
 end
 
 return CapSDK

--- a/src/services/monitor.lua
+++ b/src/services/monitor.lua
@@ -1,8 +1,13 @@
 -- services/monitor.lua
 --
 -- Monitor service:
---   * subscribes to obs/# and prints messages
+--   * subscribes to obs/<ver>/# (canonical plane) and prints messages
+--   * subscribes to obs/# (legacy plane) to detect services not using canonical endpoints
 --   * bounded, drop-oldest
+
+-- Canonical obs version token. All function/variable names are version-agnostic;
+-- bumping the canonical plane to v2 etc. is a one-line change here.
+local OBS_VER = 'v1'
 
 local fibers  = require 'fibers'
 local runtime = require 'fibers.runtime'
@@ -101,23 +106,29 @@ local function fmt_time()
 	return os.date('%Y-%m-%d %H:%M:%S') .. string.format(' (mono=%.3f)', mono)
 end
 
-local function classify(msg)
+local function classify_canonical(msg)
 	local t = msg.topic or {}
-	local kind = t[2]
-	if kind == 'log' then
-		return 'log', t[3] or 'unknown', t[4] or 'info'
+	-- canonical shape: obs/<ver>/<svc>/<kind>[/<name>]
+	local svc  = t[3] or 'unknown'
+	local kind = t[4]
+	local name = t[5]
+
+	if kind == 'event' then
+		if name == 'log' then
+			local level = (type(msg.payload) == 'table' and msg.payload.level) or 'info'
+			return 'log', svc, level
+		end
+		return 'event', svc, name or 'event'
 	elseif kind == 'metric' then
-		return 'metric', t[3] or 'unknown', nil
-	elseif kind == 'event' then
-		return 'event', t[3] or 'unknown', t[4] or 'event'
-	elseif kind == 'state' then
-		return 'state', t[3] or 'unknown', t[4] or 'state'
+		return 'metric', svc, nil
+	elseif kind == 'counter' then
+		return 'counter', svc, name or 'counter'
 	end
-	return 'obs', t[2] or 'unknown', nil
+	return 'obs', svc, nil
 end
 
-local function format_line(msg)
-	local kind, svc, lvl_or_name = classify(msg)
+local function format_canonical_line(msg)
+	local kind, svc, lvl_or_name = classify_canonical(msg)
 
 	local payload = msg.payload
 	local payload_s = (type(payload) == 'string') and payload
@@ -138,13 +149,29 @@ local function format_line(msg)
 			fmt_time(), tostring(svc), tostring(lvl_or_name or 'event'), payload_s)
 	end
 
-	if kind == 'state' then
-		return string.format('%s  STA  %-10s %-12s  %s',
-			fmt_time(), tostring(svc), tostring(lvl_or_name or 'state'), payload_s)
+	if kind == 'counter' then
+		return string.format('%s  CNT  %-10s %-12s  %s',
+			fmt_time(), tostring(svc), tostring(lvl_or_name or 'counter'), payload_s)
 	end
 
 	return string.format('%s  OBS  %-10s %-24s  %s',
 		fmt_time(), tostring(svc), topic_to_string(msg.topic), payload_s)
+end
+
+-- Formats a warning line for traffic on the legacy obs plane that indicates
+-- a service is not publishing on the canonical plane.
+-- reason: 'legacy-only'       — topic is a known dual-publish target but no canonical seen
+--         'unknown-endpoint'  — topic is outside the known obs schema entirely
+local function format_legacy_warn(msg, reason)
+	local t   = msg.topic or {}
+	local svc = tostring(t[3] or 'unknown')
+
+	local payload = msg.payload
+	local payload_s = (type(payload) == 'string') and payload
+		or pretty(payload, { max_depth = 4, max_items = 20 })
+
+	return string.format('%s  WARN  %-10s %-20s  topic=%s  %s',
+		fmt_time(), svc, tostring(reason), topic_to_string(t), payload_s)
 end
 
 function M.start(conn, ctx)
@@ -157,7 +184,7 @@ function M.start(conn, ctx)
 
 	local function write_line(line)
 		local which, a, b = perform(named_choice {
-			wrote = out:write_op(line, '\n'),
+			wrote   = out:write_op(line, '\n'),
 			timeout = sleep.sleep_op(0.5):wrap(function () return nil, 'write timeout' end),
 		})
 		if which == 'wrote' then
@@ -166,20 +193,102 @@ function M.start(conn, ctx)
 		end
 	end
 
-	svc:status('running', { subscribed = 'obs/#' })
+	-- Tracks which (svc, canonical_kind) pairs have been seen on the canonical plane.
+	-- canonical_seen[svc_name][canonical_kind] = true
+	-- Granularity is per-kind so a service publishing only metrics on the canonical
+	-- plane does not suppress warnings about its legacy-only events/states.
+	local canonical_seen = {}
 
-	local sub = conn:subscribe({ 'obs', '#' }, { queue_len = 500, full = 'drop_oldest' })
+	-- Count of consecutive legacy-only messages per (svc, legacy_kind), for pairs
+	-- not yet seen on the canonical plane. Reset per-kind when canonical arrives.
+	-- A threshold of 2 tolerates the timing race in service_base (which publishes
+	-- legacy before canonical in the same obs_log/obs_event call).
+	local legacy_count = {}
+	local LEGACY_WARN_THRESHOLD = 2
+
+	-- Known dually-supported legacy topic kinds (service_base publishes both legacy
+	-- and canonical for these). Any other kind on the legacy plane is unknown.
+	-- Maps legacy kind → the canonical kind it corresponds to:
+	--   obs/log/<svc>/...   → obs/v1/<svc>/event/log  (canonical kind: 'event')
+	--   obs/event/<svc>/... → obs/v1/<svc>/event/<n>  (canonical kind: 'event')
+	--   obs/state/<svc>/... → obs/v1/<svc>/metric/<n> (canonical kind: 'metric')
+	local legacy_to_canonical_kind = { log = 'event', event = 'event', state = 'metric' }
+
+	local canonical_sub = conn:subscribe(
+		{ 'obs', OBS_VER, '#' },
+		{ queue_len = 500, full = 'drop_oldest' }
+	)
+	local legacy_sub = conn:subscribe(
+		{ 'obs', '#' },
+		{ queue_len = 200, full = 'drop_oldest' }
+	)
+
+	local canonical_topic = 'obs/' .. OBS_VER .. '/#'
+	svc:status('running', { subscribed = canonical_topic .. ',obs/#' })
 
 	write_line(string.format('%s  STA  %-10s %-12s  %s',
-		fmt_time(), name, 'start', 'subscribed to obs/#'))
+		fmt_time(), name, 'start',
+		'subscribed to ' .. canonical_topic .. ' (canonical) + obs/# (legacy-detect)'))
 
-	for msg in sub:iter() do
-		write_line(format_line(msg))
+	while true do
+		local which, msg, err = perform(named_choice {
+			canonical = canonical_sub:recv_op(),
+			legacy    = legacy_sub:recv_op(),
+		})
+
+		if which == 'canonical' then
+			if msg == nil then
+				local why = tostring(err or 'closed')
+				write_line(string.format('%s  STA  %-10s %-12s  %s',
+					fmt_time(), name, 'stop', 'canonical subscription ended: ' .. why))
+				break
+			end
+			local svc_name = msg.topic[3]
+			local can_kind = msg.topic[4]
+			if type(svc_name) == 'string' and type(can_kind) == 'string' then
+				canonical_seen[svc_name] = canonical_seen[svc_name] or {}
+				canonical_seen[svc_name][can_kind] = true
+				-- Reset legacy counts for all legacy kinds that map to this canonical kind.
+				if legacy_count[svc_name] then
+					legacy_count[svc_name][can_kind] = nil
+				end
+			end
+			write_line(format_canonical_line(msg))
+
+		elseif which == 'legacy' then
+			if msg == nil then
+				local why = tostring(err or 'closed')
+				write_line(string.format('%s  STA  %-10s %-12s  %s',
+					fmt_time(), name, 'stop', 'legacy subscription ended: ' .. why))
+				break
+			end
+
+			local topic    = msg.topic or {}
+			local kind     = topic[2]
+			local svc_name = topic[3]
+
+			-- Skip messages on the canonical plane arriving via the obs/# wildcard.
+			if kind == OBS_VER then
+				-- handled by canonical_sub; ignore here
+			elseif legacy_to_canonical_kind[kind] then
+				local can_kind = legacy_to_canonical_kind[kind]
+				local svc_seen = canonical_seen[svc_name]
+				if svc_seen and svc_seen[can_kind] then
+					-- Expected dual-publish from service_base for this specific kind; suppress.
+				else
+					local svc_counts = legacy_count[svc_name] or {}
+					legacy_count[svc_name] = svc_counts
+					local count = (svc_counts[kind] or 0) + 1
+					svc_counts[kind] = count
+					if count >= LEGACY_WARN_THRESHOLD then
+						write_line(format_legacy_warn(msg, 'legacy-only'))
+					end
+				end
+			else
+				write_line(format_legacy_warn(msg, 'unknown-endpoint'))
+			end
+		end
 	end
-
-	local why = tostring(sub:why() or 'closed')
-	write_line(string.format('%s  STA  %-10s %-12s  %s',
-		fmt_time(), name, 'stop', 'subscription ended: ' .. why))
 end
 
 return M

--- a/tests/run.lua
+++ b/tests/run.lua
@@ -23,6 +23,7 @@ local stdlib = require 'posix.stdlib'
 assert(stdlib.setenv('CONFIG_TARGET', 'services'))
 
 local files = {
+	'unit.devicecode.service_base_spec',
 	'unit.config.codec_spec',
 	'unit.config.state_spec',
 	'unit.main.service_spec',

--- a/tests/run.lua
+++ b/tests/run.lua
@@ -26,6 +26,7 @@ local files = {
 	'unit.devicecode.service_base_spec',
 	'unit.config.codec_spec',
 	'unit.config.state_spec',
+	'unit.hal.sdk_cap_spec',
 	'unit.main.service_spec',
 	'unit.config.service_spec',
 	'integration.devhost.main_failure_spec',

--- a/tests/run.lua
+++ b/tests/run.lua
@@ -27,6 +27,7 @@ local files = {
 	'unit.config.codec_spec',
 	'unit.config.state_spec',
 	'unit.hal.sdk_cap_spec',
+	'unit.hal.service_raw_host_spec',
 	'unit.main.service_spec',
 	'unit.config.service_spec',
 	'integration.devhost.main_failure_spec',

--- a/tests/unit/devicecode/service_base_spec.lua
+++ b/tests/unit/devicecode/service_base_spec.lua
@@ -1,0 +1,325 @@
+local busmod    = require 'bus'
+local fibers    = require 'fibers'
+local sleep_mod = require 'fibers.sleep'
+
+local probe     = require 'tests.support.bus_probe'
+local runfibers = require 'tests.support.run_fibers'
+
+local service_base = require 'devicecode.service_base'
+
+local T = {}
+
+local function wait_payload(conn, topic, timeout)
+	return probe.wait_payload(conn, topic, { timeout = timeout or 0.1 })
+end
+
+local function wait_until(fn, timeout, interval)
+	return probe.wait_until(fn, {
+		timeout = timeout or 1.0,
+		interval = interval or 0.01,
+	})
+end
+
+local function topic_equal(a, b)
+	if type(a) ~= 'table' or type(b) ~= 'table' or #a ~= #b then
+		return false
+	end
+	for i = 1, #a do
+		if a[i] ~= b[i] then return false end
+	end
+	return true
+end
+
+function T.service_base_status_preserves_legacy_shape()
+	runfibers.run(function()
+		local bus    = busmod.new()
+		local conn   = bus:connect()
+		local reader = bus:connect()
+
+		local svc = service_base.new(conn, { name = 'demo', env = 'test' })
+		svc:status('running', { note = 'legacy-path' })
+
+		local payload = wait_payload(reader, { 'svc', 'demo', 'status' }, 0.2)
+		assert(type(payload) == 'table')
+		assert(payload.state == 'running')
+		assert(payload.note == 'legacy-path')
+		assert(type(payload.ts) == 'number')
+		assert(type(payload.at) == 'string')
+
+		-- Legacy status() must not force the new lifecycle fields.
+		assert(payload.ready == nil)
+		assert(payload.run_id == nil)
+
+		local obs = wait_payload(reader, { 'obs', 'state', 'demo', 'status' }, 0.2)
+		assert(type(obs) == 'table')
+		assert(obs.state == 'running')
+		assert(obs.note == 'legacy-path')
+	end, { timeout = 2.0 })
+end
+
+function T.service_base_announce_publishes_retained_metadata()
+	runfibers.run(function()
+		local bus    = busmod.new()
+		local conn   = bus:connect()
+		local reader = bus:connect()
+
+		local svc = service_base.new(conn, { name = 'demo', env = 'test' })
+		local ann = svc:announce({
+			kind = 'example',
+			schema = 'devicecode.service/demo/1',
+		})
+
+		assert(type(ann) == 'table')
+		assert(ann.name == 'demo')
+		assert(ann.env == 'test')
+		assert(ann.kind == 'example')
+		assert(ann.schema == 'devicecode.service/demo/1')
+		assert(type(ann.run_id) == 'string')
+
+		local payload = wait_payload(reader, { 'svc', 'demo', 'announce' }, 0.2)
+		assert(type(payload) == 'table')
+		assert(payload.name == 'demo')
+		assert(payload.env == 'test')
+		assert(payload.kind == 'example')
+		assert(payload.schema == 'devicecode.service/demo/1')
+		assert(type(payload.run_id) == 'string')
+	end, { timeout = 2.0 })
+end
+
+function T.service_base_lifecycle_helpers_publish_ready_and_run_id()
+	runfibers.run(function()
+		local bus    = busmod.new()
+		local conn   = bus:connect()
+		local reader = bus:connect()
+
+		local svc = service_base.new(conn, { name = 'demo', env = 'test' })
+
+		local p1 = svc:starting({ boot = 'phase-1' })
+		assert(type(p1) == 'table')
+		assert(p1.state == 'starting')
+		assert(p1.ready == false)
+		assert(type(p1.run_id) == 'string')
+
+		local s1 = wait_payload(reader, { 'svc', 'demo', 'status' }, 0.2)
+		assert(type(s1) == 'table')
+		assert(s1.state == 'starting')
+		assert(s1.ready == false)
+		assert(s1.boot == 'phase-1')
+		assert(type(s1.run_id) == 'string')
+
+		local run_id = s1.run_id
+
+		local p2 = svc:running({ phase = 'bootstrap' })
+		assert(p2.state == 'running')
+		assert(p2.ready == false)
+		assert(p2.run_id == run_id)
+
+		local s2 = wait_payload(reader, { 'svc', 'demo', 'status' }, 0.2)
+		assert(type(s2) == 'table')
+		assert(s2.state == 'running')
+		assert(s2.ready == false)
+		assert(s2.phase == 'bootstrap')
+		assert(s2.run_id == run_id)
+
+		local p3 = svc:set_ready(true, { endpoint_bound = true })
+		assert(p3.state == 'running')
+		assert(p3.ready == true)
+		assert(p3.endpoint_bound == true)
+		assert(p3.run_id == run_id)
+
+		local s3 = wait_payload(reader, { 'svc', 'demo', 'status' }, 0.2)
+		assert(type(s3) == 'table')
+		assert(s3.state == 'running')
+		assert(s3.ready == true)
+		assert(s3.endpoint_bound == true)
+		assert(s3.run_id == run_id)
+
+		local p4 = svc:degraded({ ready = true, reason = 'link_lost' })
+		assert(p4.state == 'degraded')
+		assert(p4.ready == true)
+		assert(p4.reason == 'link_lost')
+		assert(p4.run_id == run_id)
+
+		local s4 = wait_payload(reader, { 'svc', 'demo', 'status' }, 0.2)
+		assert(type(s4) == 'table')
+		assert(s4.state == 'degraded')
+		assert(s4.ready == true)
+		assert(s4.reason == 'link_lost')
+		assert(s4.run_id == run_id)
+
+		local p5 = svc:failed('boom')
+		assert(p5.state == 'failed')
+		assert(p5.ready == false)
+		assert(p5.reason == 'boom')
+		assert(p5.run_id == run_id)
+
+		local s5 = wait_payload(reader, { 'svc', 'demo', 'status' }, 0.2)
+		assert(type(s5) == 'table')
+		assert(s5.state == 'failed')
+		assert(s5.ready == false)
+		assert(s5.reason == 'boom')
+		assert(s5.run_id == run_id)
+	end, { timeout = 2.0 })
+end
+
+function T.service_base_run_id_is_stable_within_one_instance_and_changes_across_instances()
+	runfibers.run(function()
+		local bus  = busmod.new()
+		local conn = bus:connect()
+
+		local svc1 = service_base.new(conn, { name = 'demo-a', env = 'test' })
+		local a1 = svc1:starting()
+		local a2 = svc1:running()
+		local a3 = svc1:set_ready(true)
+
+		assert(type(a1.run_id) == 'string')
+		assert(a1.run_id == a2.run_id)
+		assert(a2.run_id == a3.run_id)
+
+		local svc2 = service_base.new(conn, { name = 'demo-b', env = 'test' })
+		local b1 = svc2:starting()
+
+		assert(type(b1.run_id) == 'string')
+		assert(b1.run_id ~= a1.run_id)
+	end, { timeout = 2.0 })
+end
+
+function T.service_base_scope_exit_unretains_status_and_announce()
+	runfibers.run(function()
+		local bus    = busmod.new()
+		local reader = bus:connect()
+
+		local watch = reader:watch_retained({ 'svc', 'demo', '#' }, {
+			replay = true,
+			queue_len = 16,
+			full = 'drop_oldest',
+		})
+
+		local saw_status_retain = false
+		local saw_announce_retain = false
+		local saw_status_unretain = false
+		local saw_announce_unretain = false
+
+		local st, rep = fibers.run_scope(function()
+			local conn = bus:connect()
+			local svc = service_base.new(conn, { name = 'demo', env = 'test' })
+			svc:announce({ kind = 'example' })
+			svc:running()
+			svc:set_ready(true)
+
+			assert(wait_until(function()
+				local ev, err = watch:recv()
+				if not ev then return false end
+
+				if ev.op == 'retain' then
+					if topic_equal(ev.topic, { 'svc', 'demo', 'announce' }) then
+						saw_announce_retain = true
+					elseif topic_equal(ev.topic, { 'svc', 'demo', 'status' }) then
+						saw_status_retain = true
+					end
+				end
+
+				return saw_status_retain and saw_announce_retain
+			end, 1.0, 0.01))
+		end)
+
+		assert(st == 'ok', tostring(st))
+		assert(type(rep) == 'table')
+
+		assert(wait_until(function()
+			local ev, err = watch:recv()
+			if not ev then return false end
+
+			if ev.op == 'unretain' then
+				if topic_equal(ev.topic, { 'svc', 'demo', 'status' }) then
+					saw_status_unretain = true
+				elseif topic_equal(ev.topic, { 'svc', 'demo', 'announce' }) then
+					saw_announce_unretain = true
+				end
+			end
+
+			return saw_status_unretain and saw_announce_unretain
+		end, 1.0, 0.01))
+
+		watch:unwatch()
+	end, { timeout = 2.0 })
+end
+
+function T.service_base_wait_service_ready_returns_on_ready_true()
+	runfibers.run(function(scope)
+		local bus      = busmod.new()
+		local waiter_c = bus:connect()
+		local pub_c    = bus:connect()
+
+		local waiter = service_base.new(waiter_c, { name = 'waiter', env = 'test' })
+
+		local got
+		local ok, err = scope:spawn(function()
+			got = assert(waiter:wait_service_ready('dep', { timeout = 1.0 }))
+		end)
+		assert(ok, tostring(err))
+
+		sleep_mod.sleep(0.02)
+		pub_c:retain({ 'svc', 'dep', 'status' }, { state = 'running', ready = false })
+		sleep_mod.sleep(0.02)
+		pub_c:retain({ 'svc', 'dep', 'status' }, { state = 'running', ready = true, run_id = 'dep-run-1' })
+
+		assert(wait_until(function()
+			return type(got) == 'table' and got.ready == true and got.run_id == 'dep-run-1'
+		end, 1.0, 0.01))
+	end, { timeout = 2.0 })
+end
+
+function T.service_base_wait_service_ready_supports_legacy_running_mode()
+	runfibers.run(function(scope)
+		local bus      = busmod.new()
+		local waiter_c = bus:connect()
+		local pub_c    = bus:connect()
+
+		local waiter = service_base.new(waiter_c, { name = 'waiter', env = 'test' })
+
+		local got
+		local ok, err = scope:spawn(function()
+			got = assert(waiter:wait_service_ready('dep', {
+				timeout = 1.0,
+				accept_running_without_ready = true,
+			}))
+		end)
+		assert(ok, tostring(err))
+
+		sleep_mod.sleep(0.02)
+		pub_c:retain({ 'svc', 'dep', 'status' }, { state = 'running' })
+
+		assert(wait_until(function()
+			return type(got) == 'table' and got.state == 'running'
+		end, 1.0, 0.01))
+	end, { timeout = 2.0 })
+end
+
+function T.service_base_wait_service_ready_times_out_when_not_ready()
+	runfibers.run(function()
+		local bus      = busmod.new()
+		local waiter_c = bus:connect()
+
+		local waiter = service_base.new(waiter_c, { name = 'waiter', env = 'test' })
+		local payload, err = waiter:wait_service_ready('missing', { timeout = 0.05 })
+
+		assert(payload == nil)
+		assert(err == 'timeout')
+	end, { timeout = 2.0 })
+end
+
+function T.service_base_topic_helpers_build_canonical_topics()
+	runfibers.run(function()
+		local bus  = busmod.new()
+		local conn = bus:connect()
+
+		local svc = service_base.new(conn, { name = 'demo', env = 'test' })
+
+		assert(topic_equal(svc:service_topic('status'), { 'svc', 'demo', 'status' }))
+		assert(topic_equal(svc:status_topic(), { 'svc', 'demo', 'status' }))
+		assert(topic_equal(svc:announce_topic(), { 'svc', 'demo', 'announce' }))
+	end, { timeout = 2.0 })
+end
+
+return T

--- a/tests/unit/devicecode/service_base_spec.lua
+++ b/tests/unit/devicecode/service_base_spec.lua
@@ -57,7 +57,7 @@ function T.service_base_status_preserves_legacy_shape()
 	end, { timeout = 2.0 })
 end
 
-function T.service_base_announce_publishes_retained_metadata()
+function T.service_base_announce_publishes_meta_and_announce()
 	runfibers.run(function()
 		local bus    = busmod.new()
 		local conn   = bus:connect()
@@ -76,13 +76,78 @@ function T.service_base_announce_publishes_retained_metadata()
 		assert(ann.schema == 'devicecode.service/demo/1')
 		assert(type(ann.run_id) == 'string')
 
-		local payload = wait_payload(reader, { 'svc', 'demo', 'announce' }, 0.2)
-		assert(type(payload) == 'table')
-		assert(payload.name == 'demo')
-		assert(payload.env == 'test')
-		assert(payload.kind == 'example')
-		assert(payload.schema == 'devicecode.service/demo/1')
-		assert(type(payload.run_id) == 'string')
+		local meta = wait_payload(reader, { 'svc', 'demo', 'meta' }, 0.2)
+		assert(type(meta) == 'table')
+		assert(meta.name == 'demo')
+		assert(meta.env == 'test')
+		assert(meta.kind == 'example')
+		assert(meta.schema == 'devicecode.service/demo/1')
+		assert(type(meta.run_id) == 'string')
+
+		local announce = wait_payload(reader, { 'svc', 'demo', 'announce' }, 0.2)
+		assert(type(announce) == 'table')
+		assert(announce.name == 'demo')
+		assert(announce.env == 'test')
+		assert(announce.kind == 'example')
+		assert(announce.schema == 'devicecode.service/demo/1')
+		assert(type(announce.run_id) == 'string')
+
+		assert(meta.run_id == announce.run_id)
+	end, { timeout = 2.0 })
+end
+
+function T.service_base_obs_helpers_publish_legacy_and_v1_topics()
+	runfibers.run(function()
+		local bus    = busmod.new()
+		local conn   = bus:connect()
+		local reader = bus:connect()
+
+		local svc = service_base.new(conn, { name = 'demo', env = 'test' })
+
+		-- Subscribe BEFORE publishing non-retained events/logs.
+		local ev_legacy_sub = reader:subscribe({ 'obs', 'event', 'demo', 'started' })
+		local ev_v1_sub     = reader:subscribe({ 'obs', 'v1', 'demo', 'event', 'started' })
+
+		local log_legacy_sub = reader:subscribe({ 'obs', 'log', 'demo', 'info' })
+		local log_v1_sub     = reader:subscribe({ 'obs', 'v1', 'demo', 'event', 'log' })
+
+		svc:obs_event('started', { phase = 'boot' })
+		svc:obs_state('health', { ok = true })
+		svc:obs_log('info', { msg = 'hello' })
+
+		local ev_legacy, err = ev_legacy_sub:recv()
+		assert(ev_legacy, tostring(err))
+		assert(type(ev_legacy.payload) == 'table')
+		assert(ev_legacy.payload.phase == 'boot')
+
+		local ev_v1, err2 = ev_v1_sub:recv()
+		assert(ev_v1, tostring(err2))
+		assert(type(ev_v1.payload) == 'table')
+		assert(ev_v1.payload.phase == 'boot')
+
+		local st_legacy = wait_payload(reader, { 'obs', 'state', 'demo', 'health' }, 0.2)
+		assert(type(st_legacy) == 'table')
+		assert(st_legacy.ok == true)
+
+		local st_v1 = wait_payload(reader, { 'obs', 'v1', 'demo', 'metric', 'health' }, 0.2)
+		assert(type(st_v1) == 'table')
+		assert(st_v1.ok == true)
+
+		local log_legacy, err3 = log_legacy_sub:recv()
+		assert(log_legacy, tostring(err3))
+		assert(type(log_legacy.payload) == 'table')
+		assert(log_legacy.payload.msg == 'hello')
+
+		local log_v1, err4 = log_v1_sub:recv()
+		assert(log_v1, tostring(err4))
+		assert(type(log_v1.payload) == 'table')
+		assert(log_v1.payload.msg == 'hello')
+		assert(log_v1.payload.level == 'info')
+
+		ev_legacy_sub:unsubscribe()
+		ev_v1_sub:unsubscribe()
+		log_legacy_sub:unsubscribe()
+		log_v1_sub:unsubscribe()
 	end, { timeout = 2.0 })
 end
 
@@ -184,20 +249,22 @@ function T.service_base_run_id_is_stable_within_one_instance_and_changes_across_
 	end, { timeout = 2.0 })
 end
 
-function T.service_base_scope_exit_unretains_status_and_announce()
+function T.service_base_scope_exit_unretains_status_meta_and_announce()
 	runfibers.run(function()
 		local bus    = busmod.new()
 		local reader = bus:connect()
 
 		local watch = reader:watch_retained({ 'svc', 'demo', '#' }, {
 			replay = true,
-			queue_len = 16,
+			queue_len = 32,
 			full = 'drop_oldest',
 		})
 
-		local saw_status_retain = false
+		local saw_status_retain   = false
+		local saw_meta_retain     = false
 		local saw_announce_retain = false
-		local saw_status_unretain = false
+		local saw_status_unretain   = false
+		local saw_meta_unretain     = false
 		local saw_announce_unretain = false
 
 		local st, rep = fibers.run_scope(function()
@@ -208,18 +275,20 @@ function T.service_base_scope_exit_unretains_status_and_announce()
 			svc:set_ready(true)
 
 			assert(wait_until(function()
-				local ev, err = watch:recv()
+				local ev = watch:recv()
 				if not ev then return false end
 
 				if ev.op == 'retain' then
-					if topic_equal(ev.topic, { 'svc', 'demo', 'announce' }) then
-						saw_announce_retain = true
-					elseif topic_equal(ev.topic, { 'svc', 'demo', 'status' }) then
+					if topic_equal(ev.topic, { 'svc', 'demo', 'status' }) then
 						saw_status_retain = true
+					elseif topic_equal(ev.topic, { 'svc', 'demo', 'meta' }) then
+						saw_meta_retain = true
+					elseif topic_equal(ev.topic, { 'svc', 'demo', 'announce' }) then
+						saw_announce_retain = true
 					end
 				end
 
-				return saw_status_retain and saw_announce_retain
+				return saw_status_retain and saw_meta_retain and saw_announce_retain
 			end, 1.0, 0.01))
 		end)
 
@@ -227,18 +296,20 @@ function T.service_base_scope_exit_unretains_status_and_announce()
 		assert(type(rep) == 'table')
 
 		assert(wait_until(function()
-			local ev, err = watch:recv()
+			local ev = watch:recv()
 			if not ev then return false end
 
 			if ev.op == 'unretain' then
 				if topic_equal(ev.topic, { 'svc', 'demo', 'status' }) then
 					saw_status_unretain = true
+				elseif topic_equal(ev.topic, { 'svc', 'demo', 'meta' }) then
+					saw_meta_unretain = true
 				elseif topic_equal(ev.topic, { 'svc', 'demo', 'announce' }) then
 					saw_announce_unretain = true
 				end
 			end
 
-			return saw_status_unretain and saw_announce_unretain
+			return saw_status_unretain and saw_meta_unretain and saw_announce_unretain
 		end, 1.0, 0.01))
 
 		watch:unwatch()
@@ -316,9 +387,18 @@ function T.service_base_topic_helpers_build_canonical_topics()
 
 		local svc = service_base.new(conn, { name = 'demo', env = 'test' })
 
-		assert(topic_equal(svc:service_topic('status'), { 'svc', 'demo', 'status' }))
-		assert(topic_equal(svc:status_topic(), { 'svc', 'demo', 'status' }))
-		assert(topic_equal(svc:announce_topic(), { 'svc', 'demo', 'announce' }))
+		assert(topic_equal(svc:service_topic('status'),   { 'svc', 'demo', 'status' }))
+		assert(topic_equal(svc:status_topic(),            { 'svc', 'demo', 'status' }))
+		assert(topic_equal(svc:meta_topic(),              { 'svc', 'demo', 'meta' }))
+		assert(topic_equal(svc:announce_topic(),          { 'svc', 'demo', 'announce' }))
+
+		assert(topic_equal(svc:obs_event_topic('boot'),   { 'obs', 'v1', 'demo', 'event', 'boot' }))
+		assert(topic_equal(svc:obs_metric_topic('health'),{ 'obs', 'v1', 'demo', 'metric', 'health' }))
+		assert(topic_equal(svc:obs_counter_topic('ticks'),{ 'obs', 'v1', 'demo', 'counter', 'ticks' }))
+
+		assert(topic_equal(svc:obs_event_legacy_topic('boot'), { 'obs', 'event', 'demo', 'boot' }))
+		assert(topic_equal(svc:obs_state_legacy_topic('health'), { 'obs', 'state', 'demo', 'health' }))
+		assert(topic_equal(svc:obs_log_legacy_topic('info'), { 'obs', 'log', 'demo', 'info' }))
 	end, { timeout = 2.0 })
 end
 

--- a/tests/unit/hal/sdk_cap_spec.lua
+++ b/tests/unit/hal/sdk_cap_spec.lua
@@ -1,0 +1,254 @@
+local busmod    = require 'bus'
+local fibers    = require 'fibers'
+
+local probe     = require 'tests.support.bus_probe'
+local runfibers = require 'tests.support.run_fibers'
+
+local cap_sdk = require 'services.hal.sdk.cap'
+
+local T = {}
+
+local function wait_payload(conn, topic, timeout)
+	return probe.wait_payload(conn, topic, { timeout = timeout or 0.2 })
+end
+
+local function wait_until(fn, timeout, interval)
+	return probe.wait_until(fn, {
+		timeout = timeout or 1.0,
+		interval = interval or 0.01,
+	})
+end
+
+function T.cap_sdk_legacy_listener_accepts_added_on_public_state_topic()
+	runfibers.run(function(scope)
+		local bus      = busmod.new()
+		local pub      = bus:connect()
+		local client   = bus:connect()
+
+		local listener = cap_sdk.new_cap_listener(client, 'demo', 'one')
+
+		local got_cap, got_err
+		local ok, err = scope:spawn(function()
+			got_cap, got_err = listener:wait_for_cap({ timeout = 0.5 })
+		end)
+		assert(ok, tostring(err))
+
+		pub:retain({ 'cap', 'demo', 'one', 'state' }, 'added')
+
+		assert(wait_until(function()
+			return got_cap ~= nil
+		end, 1.0, 0.01))
+
+		assert(got_err == '')
+		assert(got_cap.class == 'demo')
+		assert(got_cap.id == 'one')
+
+		listener:close()
+	end, { timeout = 2.0 })
+end
+
+function T.cap_sdk_curated_listener_accepts_available_status_payload()
+	runfibers.run(function(scope)
+		local bus      = busmod.new()
+		local pub      = bus:connect()
+		local client   = bus:connect()
+
+		local listener = cap_sdk.new_curated_cap_listener(client, 'demo', 'one')
+
+		local got_cap, got_err
+		local ok, err = scope:spawn(function()
+			got_cap, got_err = listener:wait_for_cap({ timeout = 0.5 })
+		end)
+		assert(ok, tostring(err))
+
+		pub:retain({ 'cap', 'demo', 'one', 'status' }, { state = 'available', version = 1 })
+
+		assert(wait_until(function()
+			return got_cap ~= nil
+		end, 1.0, 0.01))
+
+		assert(got_err == '')
+		assert(got_cap.class == 'demo')
+		assert(got_cap.id == 'one')
+
+		listener:close()
+	end, { timeout = 2.0 })
+end
+
+function T.cap_sdk_curated_listener_accepts_available_true_payload()
+	runfibers.run(function(scope)
+		local bus      = busmod.new()
+		local pub      = bus:connect()
+		local client   = bus:connect()
+
+		local listener = cap_sdk.new_curated_cap_listener(client, 'demo', 'one')
+
+		local got_cap, got_err
+		local ok, err = scope:spawn(function()
+			got_cap, got_err = listener:wait_for_cap({ timeout = 0.5 })
+		end)
+		assert(ok, tostring(err))
+
+		pub:retain({ 'cap', 'demo', 'one', 'status' }, { available = true })
+
+		assert(wait_until(function()
+			return got_cap ~= nil
+		end, 1.0, 0.01))
+
+		assert(got_err == '')
+		assert(got_cap.class == 'demo')
+		assert(got_cap.id == 'one')
+
+		listener:close()
+	end, { timeout = 2.0 })
+end
+
+function T.cap_sdk_raw_host_listener_and_ref_follow_raw_host_topics()
+	runfibers.run(function(scope)
+		local bus      = busmod.new()
+		local pub      = bus:connect()
+		local client   = bus:connect()
+
+		local listener = cap_sdk.new_raw_host_cap_listener(client, 'platform', 'artifact-store', 'main')
+		local ref      = cap_sdk.new_raw_host_cap_ref(client, 'platform', 'artifact-store', 'main')
+
+		local got_cap, got_err
+		local ok, err = scope:spawn(function()
+			got_cap, got_err = listener:wait_for_cap({ timeout = 0.5 })
+		end)
+		assert(ok, tostring(err))
+
+		-- Subscribe BEFORE publishing.
+		local meta_sub   = ref:get_meta_sub()
+		local status_sub = ref:get_status_sub()
+		local state_sub  = ref:get_state_sub('mode')
+		local event_sub  = ref:get_event_sub('changed')
+
+		pub:retain(
+			{ 'raw', 'host', 'platform', 'cap', 'artifact-store', 'main', 'status' },
+			{ state = 'available' }
+		)
+
+		assert(wait_until(function()
+			return got_cap ~= nil
+		end, 1.0, 0.01))
+
+		assert(got_err == '')
+		assert(got_cap.class == 'artifact-store')
+		assert(got_cap.id == 'main')
+
+		pub:retain(
+			{ 'raw', 'host', 'platform', 'cap', 'artifact-store', 'main', 'meta' },
+			{ provider = 'hal' }
+		)
+		pub:retain(
+			{ 'raw', 'host', 'platform', 'cap', 'artifact-store', 'main', 'state', 'mode' },
+			'ready'
+		)
+		pub:publish(
+			{ 'raw', 'host', 'platform', 'cap', 'artifact-store', 'main', 'event', 'changed' },
+			{ what = 'mode' }
+		)
+
+		local status_ev, err1 = status_sub:recv()
+		assert(status_ev, tostring(err1))
+		assert(type(status_ev.payload) == 'table')
+		assert(status_ev.payload.state == 'available')
+
+		local meta_ev, err2 = meta_sub:recv()
+		assert(meta_ev, tostring(err2))
+		assert(type(meta_ev.payload) == 'table')
+		assert(meta_ev.payload.provider == 'hal')
+
+		local state_ev, err3 = state_sub:recv()
+		assert(state_ev, tostring(err3))
+		assert(state_ev.payload == 'ready')
+
+		local event_ev, err4 = event_sub:recv()
+		assert(event_ev, tostring(err4))
+		assert(type(event_ev.payload) == 'table')
+		assert(event_ev.payload.what == 'mode')
+
+		meta_sub:unsubscribe()
+		status_sub:unsubscribe()
+		state_sub:unsubscribe()
+		event_sub:unsubscribe()
+		listener:close()
+	end, { timeout = 2.0 })
+end
+
+function T.cap_sdk_raw_member_listener_and_ref_follow_raw_member_topics()
+	runfibers.run(function(scope)
+		local bus      = busmod.new()
+		local pub      = bus:connect()
+		local client   = bus:connect()
+
+		local listener = cap_sdk.new_raw_member_cap_listener(client, 'mcu', 'updater', 'main')
+		local ref      = cap_sdk.new_raw_member_cap_ref(client, 'mcu', 'updater', 'main')
+
+		local got_cap, got_err
+		local ok, err = scope:spawn(function()
+			got_cap, got_err = listener:wait_for_cap({ timeout = 0.5 })
+		end)
+		assert(ok, tostring(err))
+
+		-- Subscribe BEFORE publishing.
+		local meta_sub   = ref:get_meta_sub()
+		local status_sub = ref:get_status_sub()
+		local state_sub  = ref:get_state_sub('version')
+		local event_sub  = ref:get_event_sub('ready')
+
+		pub:retain(
+			{ 'raw', 'member', 'mcu', 'cap', 'updater', 'main', 'status' },
+			{ state = 'available' }
+		)
+
+		assert(wait_until(function()
+			return got_cap ~= nil
+		end, 1.0, 0.01))
+
+		assert(got_err == '')
+		assert(got_cap.class == 'updater')
+		assert(got_cap.id == 'main')
+
+		pub:retain(
+			{ 'raw', 'member', 'mcu', 'cap', 'updater', 'main', 'meta' },
+			{ backing = 'rp2350' }
+		)
+		pub:retain(
+			{ 'raw', 'member', 'mcu', 'cap', 'updater', 'main', 'state', 'version' },
+			'1.2.3'
+		)
+		pub:publish(
+			{ 'raw', 'member', 'mcu', 'cap', 'updater', 'main', 'event', 'ready' },
+			{ ok = true }
+		)
+
+		local status_ev, err1 = status_sub:recv()
+		assert(status_ev, tostring(err1))
+		assert(type(status_ev.payload) == 'table')
+		assert(status_ev.payload.state == 'available')
+
+		local meta_ev, err2 = meta_sub:recv()
+		assert(meta_ev, tostring(err2))
+		assert(type(meta_ev.payload) == 'table')
+		assert(meta_ev.payload.backing == 'rp2350')
+
+		local state_ev, err3 = state_sub:recv()
+		assert(state_ev, tostring(err3))
+		assert(state_ev.payload == '1.2.3')
+
+		local event_ev, err4 = event_sub:recv()
+		assert(event_ev, tostring(err4))
+		assert(type(event_ev.payload) == 'table')
+		assert(event_ev.payload.ok == true)
+
+		meta_sub:unsubscribe()
+		status_sub:unsubscribe()
+		state_sub:unsubscribe()
+		event_sub:unsubscribe()
+		listener:close()
+	end, { timeout = 2.0 })
+end
+
+return T

--- a/tests/unit/hal/service_raw_host_spec.lua
+++ b/tests/unit/hal/service_raw_host_spec.lua
@@ -1,0 +1,413 @@
+local busmod    = require 'bus'
+local fibers    = require 'fibers'
+local channel   = require 'fibers.channel'
+
+local probe     = require 'tests.support.bus_probe'
+local runfibers = require 'tests.support.run_fibers'
+
+local hal_service = require 'services.hal'
+local hal_types   = require 'services.hal.types.core'
+local cap_types   = require 'services.hal.types.capabilities'
+
+local T = {}
+
+local function wait_payload(conn, topic, timeout)
+	return probe.wait_payload(conn, topic, { timeout = timeout or 0.5 })
+end
+
+local function wait_until(fn, timeout, interval)
+	return probe.wait_until(fn, {
+		timeout = timeout or 1.0,
+		interval = interval or 0.01,
+	})
+end
+
+local function topic_equal(a, b)
+	if type(a) ~= 'table' or type(b) ~= 'table' or #a ~= #b then
+		return false
+	end
+	for i = 1, #a do
+		if a[i] ~= b[i] then return false end
+	end
+	return true
+end
+
+local function install_fake_hal_managers(state)
+	package.loaded['services.hal.managers.filesystem'] = nil
+	package.loaded['services.hal.managers.rawprobe'] = nil
+
+	package.preload['services.hal.managers.filesystem'] = function()
+		local manager = {
+			started = false,
+			scope = nil,
+			logger = nil,
+		}
+
+		function manager.start(logger, dev_ev_ch, cap_emit_ch)
+			manager.logger = logger
+			local scope_obj, err = fibers.current_scope():child()
+			if not scope_obj then
+				return tostring(err)
+			end
+			manager.scope = scope_obj
+			manager.started = true
+			return ""
+		end
+
+		function manager.stop()
+			if manager.scope then
+				manager.scope:cancel('test stop')
+				fibers.perform(manager.scope:join_op())
+			end
+			manager.started = false
+			return true, ""
+		end
+
+		function manager.apply_config(_cfg)
+			return true, ""
+		end
+
+		return manager
+	end
+
+	package.preload['services.hal.managers.rawprobe'] = function()
+		local manager = {
+			started = false,
+			scope = nil,
+			dev_ev_ch = nil,
+			logger = nil,
+			last_device = nil,
+		}
+
+		function manager.start(logger, dev_ev_ch, cap_emit_ch)
+			manager.logger = logger
+			manager.dev_ev_ch = dev_ev_ch
+
+			local scope_obj, err = fibers.current_scope():child()
+			if not scope_obj then
+				return tostring(err)
+			end
+			manager.scope = scope_obj
+			manager.started = true
+			return ""
+		end
+
+		function manager.stop()
+			if manager.scope then
+				manager.scope:cancel('test stop')
+				fibers.perform(manager.scope:join_op())
+			end
+			manager.started = false
+			return true, ""
+		end
+
+		function manager.apply_config(cfg)
+			cfg = cfg or {}
+			local op_name = cfg.op or 'add'
+
+			if op_name == 'add' then
+				local control_ch = channel.new()
+				local cap, cap_err = cap_types.new.Capability(
+					cfg.cap_class or 'uart',
+					cfg.cap_id or 'main',
+					control_ch,
+					cfg.offerings or { 'open' }
+				)
+				assert(cap, tostring(cap_err))
+
+				local dev_meta = {
+					provider = cfg.provider or 'hal.test.rawprobe',
+					raw_source_id = cfg.raw_source_id,
+					source_id = cfg.source_id,
+					source = cfg.source,
+					extra = cfg.extra,
+				}
+
+				local dev, dev_err = hal_types.new.Device(
+					cfg.device_class or 'uart',
+					cfg.device_id or 'main',
+					dev_meta,
+					{ cap }
+				)
+				assert(dev, tostring(dev_err))
+				manager.last_device = dev
+
+				local ev, ev_err = hal_types.new.DeviceEvent(
+					'added',
+					dev.class,
+					dev.id,
+					dev.meta,
+					dev.capabilities
+				)
+				assert(ev, tostring(ev_err))
+				manager.dev_ev_ch:put(ev)
+				return true, ""
+			end
+
+			if op_name == 'remove' then
+				local dev = manager.last_device
+				if not dev then
+					return true, ""
+				end
+
+				local ev, ev_err = hal_types.new.DeviceEvent(
+					'removed',
+					dev.class,
+					dev.id,
+					dev.meta,
+					dev.capabilities
+				)
+				assert(ev, tostring(ev_err))
+				manager.dev_ev_ch:put(ev)
+				return true, ""
+			end
+
+			return false, "unsupported op: " .. tostring(op_name)
+		end
+
+		return manager
+	end
+end
+
+local function start_hal(scope, bus)
+	local ok_spawn, err = scope:spawn(function()
+		hal_service.start(bus:connect(), {
+			name = 'hal',
+			env = 'test',
+			heartbeat_s = 60.0,
+		})
+	end)
+	assert(ok_spawn, tostring(err))
+end
+
+local function publish_hal_config(conn, cfg)
+	conn:retain({ 'cfg', 'hal' }, {
+		data = cfg,
+	})
+end
+
+function T.hal_publishes_raw_host_source_meta_and_status_on_add()
+	runfibers.run(function(scope)
+		local bus    = busmod.new()
+		local reader = bus:connect()
+		local cfgc   = bus:connect()
+
+		install_fake_hal_managers({})
+		start_hal(scope, bus)
+
+		publish_hal_config(cfgc, {
+			schema = 'devicecode.config/hal/1',
+			rawprobe = {
+				op = 'add',
+				raw_source_id = 'uart_main',
+				device_class = 'uart',
+				device_id = 'main',
+				cap_class = 'uart',
+				cap_id = 'main',
+				offerings = { 'open' },
+				provider = 'hal.test.rawprobe',
+			},
+		})
+
+		local meta = wait_payload(reader, { 'raw', 'host', 'uart-main', 'meta' }, 0.5)
+		assert(type(meta) == 'table')
+		assert(meta.provider == 'hal.test.rawprobe')
+		assert(meta.source == 'uart_main')
+		assert(meta.device_class == 'uart')
+		assert(meta.device_id == 'main')
+		assert(type(meta.legacy_device) == 'table')
+		assert(meta.legacy_device.class == 'uart')
+		assert(meta.legacy_device.id == 'main')
+
+		local status = wait_payload(reader, { 'raw', 'host', 'uart-main', 'status' }, 0.5)
+		assert(type(status) == 'table')
+		assert(status.state == 'available')
+		assert(status.source == 'uart_main')
+		assert(status.id == 'main')
+	end, { timeout = 2.0 })
+end
+
+function T.hal_publishes_structured_raw_host_cap_status_and_meta_on_add()
+	runfibers.run(function(scope)
+		local bus    = busmod.new()
+		local reader = bus:connect()
+		local cfgc   = bus:connect()
+
+		install_fake_hal_managers({})
+		start_hal(scope, bus)
+
+		publish_hal_config(cfgc, {
+			schema = 'devicecode.config/hal/1',
+			rawprobe = {
+				op = 'add',
+				raw_source_id = 'uart_main',
+				device_class = 'uart',
+				device_id = 'main',
+				cap_class = 'uart',
+				cap_id = 'main',
+				offerings = { 'open' },
+				provider = 'hal.test.rawprobe',
+			},
+		})
+
+		local status = wait_payload(reader, {
+			'raw', 'host', 'uart-main', 'cap', 'uart', 'main', 'status'
+		}, 0.5)
+
+		assert(type(status) == 'table')
+		assert(status.state == 'available')
+		assert(status.source == 'uart_main')
+		assert(status.class == 'uart')
+		assert(status.id == 'main')
+
+		local meta = wait_payload(reader, {
+			'raw', 'host', 'uart-main', 'cap', 'uart', 'main', 'meta'
+		}, 0.5)
+
+		assert(type(meta) == 'table')
+		assert(meta.provider == 'hal.test.rawprobe')
+		assert(meta.source == 'uart_main')
+		assert(type(meta.offerings) == 'table')
+		assert(meta.offerings.open == true)
+		assert(type(meta.legacy_cap) == 'table')
+		assert(meta.legacy_cap.class == 'uart')
+		assert(meta.legacy_cap.id == 'main')
+	end, { timeout = 2.0 })
+end
+
+function T.hal_marks_raw_host_source_and_capability_unavailable_on_remove()
+	runfibers.run(function(scope)
+		local bus    = busmod.new()
+		local reader = bus:connect()
+		local cfgc   = bus:connect()
+
+		install_fake_hal_managers({})
+		start_hal(scope, bus)
+
+		publish_hal_config(cfgc, {
+			schema = 'devicecode.config/hal/1',
+			rawprobe = {
+				op = 'add',
+				raw_source_id = 'uart_main',
+				device_class = 'uart',
+				device_id = 'main',
+				cap_class = 'uart',
+				cap_id = 'main',
+				offerings = { 'open' },
+				provider = 'hal.test.rawprobe',
+			},
+		})
+
+		assert(type(wait_payload(reader, { 'raw', 'host', 'uart-main', 'status' }, 0.5)) == 'table')
+		assert(type(wait_payload(reader, {
+			'raw', 'host', 'uart-main', 'cap', 'uart', 'main', 'status'
+		}, 0.5)) == 'table')
+
+		publish_hal_config(cfgc, {
+			schema = 'devicecode.config/hal/1',
+			rawprobe = {
+				op = 'remove',
+			},
+		})
+
+		assert(wait_until(function()
+			local ok1, source_status = pcall(function()
+				return wait_payload(reader, { 'raw', 'host', 'uart-main', 'status' }, 0.05)
+			end)
+			if not ok1 or type(source_status) ~= 'table' then return false end
+			if source_status.state ~= 'unavailable' then return false end
+			if source_status.reason ~= 'removed' then return false end
+
+			local ok2, cap_status = pcall(function()
+				return wait_payload(reader, {
+					'raw', 'host', 'uart-main', 'cap', 'uart', 'main', 'status'
+				}, 0.05)
+			end)
+			if not ok2 or type(cap_status) ~= 'table' then return false end
+			return cap_status.state == 'unavailable'
+				and cap_status.reason == 'removed'
+				and cap_status.source == 'uart_main'
+				and cap_status.class == 'uart'
+				and cap_status.id == 'main'
+		end, 1.0, 0.02))
+	end, { timeout = 2.0 })
+end
+
+function T.hal_keeps_legacy_public_capability_registration_topics_for_compatibility()
+	runfibers.run(function(scope)
+		local bus    = busmod.new()
+		local reader = bus:connect()
+		local cfgc   = bus:connect()
+
+		install_fake_hal_managers({})
+		start_hal(scope, bus)
+
+		publish_hal_config(cfgc, {
+			schema = 'devicecode.config/hal/1',
+			rawprobe = {
+				op = 'add',
+				raw_source_id = 'uart_main',
+				device_class = 'uart',
+				device_id = 'main',
+				cap_class = 'uart',
+				cap_id = 'main',
+				offerings = { 'open' },
+				provider = 'hal.test.rawprobe',
+			},
+		})
+
+		local legacy_state = wait_payload(reader, { 'cap', 'uart', 'main', 'state' }, 0.5)
+		assert(legacy_state == 'added')
+
+		local legacy_meta = wait_payload(reader, { 'cap', 'uart', 'main', 'meta' }, 0.5)
+		assert(type(legacy_meta) == 'table')
+		assert(type(legacy_meta.offerings) == 'table')
+		assert(legacy_meta.offerings.open == true)
+	end, { timeout = 2.0 })
+end
+
+function T.hal_legacy_cap_sdk_listener_still_works_end_to_end()
+	runfibers.run(function(scope)
+		local bus    = busmod.new()
+		local cfgc   = bus:connect()
+		local client = bus:connect()
+
+		install_fake_hal_managers({})
+		start_hal(scope, bus)
+
+		local cap_sdk = require 'services.hal.sdk.cap'
+		local listener = cap_sdk.new_cap_listener(client, 'uart', 'main')
+
+		local got_cap, got_err
+		local ok, err = scope:spawn(function()
+			got_cap, got_err = listener:wait_for_cap({ timeout = 0.5 })
+		end)
+		assert(ok, tostring(err))
+
+		publish_hal_config(cfgc, {
+			schema = 'devicecode.config/hal/1',
+			rawprobe = {
+				op = 'add',
+				raw_source_id = 'uart_main',
+				device_class = 'uart',
+				device_id = 'main',
+				cap_class = 'uart',
+				cap_id = 'main',
+				offerings = { 'open' },
+				provider = 'hal.test.rawprobe',
+			},
+		})
+
+		assert(wait_until(function()
+			return got_cap ~= nil
+		end, 1.0, 0.01))
+
+		assert(got_err == '')
+		assert(got_cap.class == 'uart')
+		assert(got_cap.id == 'main')
+
+		listener:close()
+	end, { timeout = 2.0 })
+end
+
+return T


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

* [x] 🍕 Feature
* [x] 🧑‍💻 Code Refactor
* [x] ✅ Test

## Description

Evolves `devicecode.service_base` from a thin convenience wrapper into a small, explicit service lifecycle contract, while preserving compatibility with existing callers.

This PR also extends `services.hal.sdk.cap` in a similarly compatible way, so services can begin migrating to newer capability naming and addressing patterns without breaking existing users.

In addition, this PR updates `services.hal` compatibly so HAL can begin publishing newer raw host provenance-bearing capability surfaces while preserving legacy public capability registration and control paths.

This change is deliberately additive. Existing services using `svc:status(...)` continue to work as before. Existing consumers of legacy `svc/.../announce` and legacy `obs/...` topics continue to work. Existing `cap_sdk` callers using the older public capability helpers also continue to work. Existing users of legacy HAL public capability registration and control topics also continue to work. New lifecycle and capability helpers are introduced in parallel so services can migrate incrementally.

Changes:

* add additive lifecycle helpers to `service_base`:

  * `announce`
  * `starting`
  * `running`
  * `degraded`
  * `failed`
  * `set_ready`
* add stable per-instance `run_id` publication on lifecycle payloads
* add service topic helpers:

  * `service_topic`
  * `status_topic`
  * `meta_topic`
  * `announce_topic`
* add observability topic helpers for both canonical and legacy forms
* add `wait_service_ready(...)` helper so services can wait on retained readiness signals
* preserve legacy `svc:status(...)` payload semantics for existing callers
* publish both:

  * `svc/<service>/meta` as the new canonical metadata surface
  * `svc/<service>/announce` as a compatibility alias
* publish both:

  * `obs/v1/...` as the new canonical observability surface
  * legacy `obs/log|event|state/...` topics as compatibility aliases
* automatically unretain retained service lifecycle topics on scope exit using scope finalisers
* extend `services.hal.sdk.cap` compatibly:

  * preserve existing legacy public capability helpers
  * add new curated public capability helpers based on `meta` / `status`
  * add raw host capability helpers
  * add raw member capability helpers
* preserve legacy capability listener semantics for existing callers during migration
* extend `services.hal` compatibly:

  * add raw host source metadata/status surfaces under `raw/host/<source>/meta` and `raw/host/<source>/status`
  * add raw host capability metadata/status/rpc surfaces under `raw/host/<source>/cap/...`
  * introduce explicit raw source id handling, with current HAL device class used as the fallback source id
  * publish structured raw host capability status payloads
  * preserve legacy public capability registration surfaces under `cap/<class>/<id>/state` and `cap/<class>/<id>/meta`
  * preserve legacy public capability RPC endpoints alongside new raw host RPC endpoints
  * preserve legacy public capability event/state emission while mirroring to raw host capability topics where provenance is known
* add unit coverage for:

  * legacy compatibility
  * lifecycle publication
  * dual publication of `meta`/`announce`
  * dual publication of canonical and legacy observability topics
  * `run_id` behaviour
  * scope-exit unretain behaviour
  * readiness wait semantics
  * topic helper behaviour
  * capability SDK compatibility across legacy, curated, raw-host and raw-member helpers
  * HAL raw host source publication
  * structured raw host capability status publication
  * HAL removal/unavailable behaviour on raw host topics
  * end-to-end compatibility of legacy `cap_sdk` listener behaviour against the revised HAL

This PR does **not** remove any existing service lifecycle or capability naming used elsewhere in the tree. It introduces canonical newer surfaces in parallel, so ongoing branches can migrate independently and safely.

## Related Issues, Tickets & Documents

N/A

## Screenshots/Recordings

N/A

## Manual test

* [x] 🙅 no

## Manual test description

Not manually exercised. Covered by unit tests for the new service lifecycle contract, the compatible `cap_sdk` additions, and the compatible HAL raw-host publication changes.

## Added tests?

* [x] 👍 yes

## Added to documentation?

* [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?

No deployment tasks required. Follow-up work will be to migrate services incrementally from legacy `svc:status(...)` / `svc/.../announce` / legacy `obs/...` usage to the new explicit lifecycle and observability helpers, to migrate capability consumers incrementally onto the newer curated/raw `cap_sdk` helpers where appropriate, and to migrate HAL consumers over time from legacy public capability registration/control paths to the newer raw host capability surfaces where that is the correct provenance-bearing abstraction.
