### PR TITLE
Added versioning and metrics endpoint to svc base methods

### DIFF
--- a/src/devicecode/service_base.lua
+++ b/src/devicecode/service_base.lua
@@ -12,6 +12,8 @@ local fibers  = require 'fibers'
 local runtime = require 'fibers.runtime'
 local sleep   = require 'fibers.sleep'
 
+local DEFAULT_OBS_VERSION = 'v1'
+
 local M = {}
 
 local function t(...) return { ... } end
@@ -28,7 +30,7 @@ local function topic_to_string(topic)
 end
 
 ---@param conn any
----@param opts? { name?: string, env?: string }
+---@param opts? { name?: string, env?: string, version?: string }
 ---@return ServiceBase
 function M.new(conn, opts)
 	opts = opts or {}
@@ -39,6 +41,7 @@ function M.new(conn, opts)
 	svc.conn = conn
 	svc.name = opts.name or 'service'
 	svc.env  = opts.env or (os.getenv('DEVICECODE_ENV') or 'dev')
+	svc.version = opts.version or DEFAULT_OBS_VERSION
 
 	function svc:now() return runtime.now() end
 	function svc:wall() return wall() end
@@ -46,15 +49,19 @@ function M.new(conn, opts)
 	function svc:topic_to_string(topic) return topic_to_string(topic) end
 
 	function svc:obs_log(level, payload)
-		self.conn:publish(t('obs', 'log', self.name, level), payload)
+		self.conn:publish(t('obs', self.version, 'log', self.name, level), payload)
 	end
 
 	function svc:obs_event(name, payload)
-		self.conn:publish(t('obs', 'event', self.name, name), payload)
+		self.conn:publish(t('obs', self.version, 'event', self.name, name), payload)
+	end
+
+	function svc:obs_metric(name, payload)
+		self.conn:publish(t('obs', self.version, 'metric', self.name, name), payload)
 	end
 
 	function svc:obs_state(name, payload)
-		self.conn:retain(t('obs', 'state', self.name, name), payload)
+		self.conn:retain(t('obs', self.version, 'state', self.name, name), payload)
 	end
 
 	function svc:status(state, extra)

--- a/src/devicecode/service_base.lua
+++ b/src/devicecode/service_base.lua
@@ -57,7 +57,7 @@ function M.new(conn, opts)
 	end
 
 	function svc:obs_metric(name, payload)
-		self.conn:publish(t('obs', self.version, 'metric', self.name, name), payload)
+		self.conn:retain(t('obs', self.version, 'metric', self.name, name), payload)
 	end
 
 	function svc:obs_state(name, payload)

--- a/src/services/monitor.lua
+++ b/src/services/monitor.lua
@@ -103,17 +103,17 @@ end
 
 local function classify(msg)
 	local t = msg.topic or {}
-	local kind = t[2]
+	local kind = t[3]
 	if kind == 'log' then
-		return 'log', t[3] or 'unknown', t[4] or 'info'
+		return 'log', t[4] or 'unknown', t[5] or 'info'
 	elseif kind == 'metric' then
-		return 'metric', t[3] or 'unknown', nil
+		return 'metric', t[4] or 'unknown', nil
 	elseif kind == 'event' then
-		return 'event', t[3] or 'unknown', t[4] or 'event'
+		return 'event', t[4] or 'unknown', t[5] or 'event'
 	elseif kind == 'state' then
-		return 'state', t[3] or 'unknown', t[4] or 'state'
+		return 'state', t[4] or 'unknown', t[5] or 'state'
 	end
-	return 'obs', t[2] or 'unknown', nil
+	return 'obs', t[3] or 'unknown', nil
 end
 
 local function format_line(msg)

--- a/src/services/system.lua
+++ b/src/services/system.lua
@@ -148,14 +148,14 @@ end
 
 -- ── publish helpers ───────────────────────────────
 
----@param conn Connection
+---@param svc ServiceBase
 ---@param key string
 ---@param value number|string
 ---@param namespace? string
-local function publish_metric(conn, key, value, namespace)
+local function publish_metric(svc, key, value, namespace)
     local payload = { value = value }
     if namespace then payload.namespace = namespace end
-    conn:retain(t_obs_metric(key), payload)
+    svc:obs_metric(key, payload)
 end
 
 -- ── sysinfo fiber ────────────────────────────────
@@ -246,7 +246,7 @@ local function sysinfo_fiber(_, svc, report_period_ch)
             local id = identity_msg.payload
             for _, metric in ipairs(PLATFORM_IDENTITY_METRICS) do
                 if id[metric.field] ~= nil then
-                    publish_metric(conn, metric.metric_key, id[metric.field])
+                    publish_metric(svc, metric.metric_key, id[metric.field])
                 end
             end
             svc:obs_log('debug', 'sysinfo: published platform identity metrics')
@@ -311,7 +311,7 @@ local function sysinfo_fiber(_, svc, report_period_ch)
                                 err = err
                             })
                         else
-                            publish_metric(conn, m.metric_key, value)
+                            publish_metric(svc, m.metric_key, value)
                         end
                     end
                 end
@@ -327,7 +327,7 @@ local function sysinfo_fiber(_, svc, report_period_ch)
                     if uptime == nil or uptime_err ~= "" then
                         svc:obs_log('warn', { what = 'uptime_get_failed', err = uptime_err })
                     else
-                        publish_metric(conn, 'boot_time', os.time() - math.floor(uptime))
+                        publish_metric(svc, 'boot_time', os.time() - math.floor(uptime))
                     end
                 end
             end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [x] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description
The service base was using the incorrect endpoints, missing out the versioning level of the topic hierarchy. I have added back the versioning level (default of `v1`) and have added a new obs_metric method for easier reporting of service metrics.

## Manual test
<!-- Have you manually tested this code and confirmed it is working? -->
- [x] 👍 yes
- [ ] 🙅 no

## Manual test description
Run the code and make sure the system service reports metrics to the correct metrics point and that the formatting of the remaining monitor logs are the same as before 

## Added tests?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?
- [ ] 📜 README.md
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?

