### PR TITLE
hal: add raw-host capability publication and storage/update/uart managers

### DIFF
--- a/src/configs/bigbox-v1-cm-2.json
+++ b/src/configs/bigbox-v1-cm-2.json
@@ -1,0 +1,1656 @@
+{
+    "hal": {
+        "managers": {
+            "modemcard": {},
+            "uci": {},
+            "ubus": {},
+            "wlan": {
+                "radios": {
+                    "radio0": {
+                        "type": "mac80211",
+                        "path": "axi/1000110000.pcie/pci0000:00/0000:00:00.0/0000:01:00.0"
+                    },
+                    "radio1": {
+                        "type": "mac80211",
+                        "path": "axi/1000110000.pcie/pci0000:00/0000:00:00.0/0000:01:00.0+1"
+                    }
+                }
+            },
+            "uart": {
+                "serial_ports": [
+                    {
+                        "name": "uart0",
+                        "path": "/dev/ttyAMA0",
+                        "baud": 115200,
+                        "mode": "8N1"
+                    }
+                ]
+            },
+            "artifact_store": {},
+            "control_store": {},
+            "signature_verify": {},
+            "updater": {}
+        }
+    },
+    "net": {
+        "report_period": 60,
+        "default": {
+            "backhauls": {
+                "network": {
+                    "ipv4": {
+                        "proto": "dhcp"
+                    },
+                    "firewall": {
+                        "zone": "wan"
+                    },
+                    "shaping": {
+                        "egress": {
+                            "qdisc": "fq_codel"
+                        },
+                        "ingress": {
+                            "qdisc": "fq_codel"
+                        }
+                    }
+                },
+                "multiwan": {
+                    "dynamic_weight": true,
+                    "metric": 1
+                }
+            }
+        },
+        "dns": {
+            "upstream_servers": [
+                "8.8.8.8",
+                "1.1.1.1"
+            ],
+            "default_cache_size": 1000
+        },
+        "dhcp": {
+            "domains": [
+                {
+                    "name": "unifi",
+                    "ip": "$UNIFI_IP"
+                },
+                {
+                    "name": "config.bigbox.home",
+                    "ip": "172.28.8.1"
+                }
+            ]
+        },
+        "network": [
+            {
+                "name": "Loopback",
+                "id": "loopback",
+                "type": "local",
+                "interfaces": [
+                    "lo"
+                ],
+                "ipv4": {
+                    "proto": "static",
+                    "ip_address": "127.0.0.1",
+                    "netmask": "255.0.0.0"
+                },
+                "dns_server": {
+                    "local_server": true,
+                    "default_hosts": []
+                }
+            },
+            {
+                "name": "Admin Network",
+                "id": "adm",
+                "type": "local",
+                "is_bridge": true,
+                "interfaces": [
+                    "eth0.8"
+                ],
+                "ipv4": {
+                    "proto": "static",
+                    "ip_address": "172.28.8.1",
+                    "netmask": "255.255.255.0"
+                },
+                "dhcp_server": {
+                    "range_skip": "10",
+                    "range_extent": "240",
+                    "lease_time": "12h"
+                },
+                "dns_server": {
+                    "local_server": true,
+                    "default_hosts": [
+                        "ads"
+                    ]
+                },
+                "firewall": {
+                    "zone": "lan"
+                }
+            },
+            {
+                "name": "Jangala Network",
+                "id": "jan",
+                "type": "local",
+                "is_bridge": true,
+                "interfaces": [
+                    "eth0.32"
+                ],
+                "ipv4": {
+                    "proto": "static",
+                    "ip_address": "172.28.32.1",
+                    "netmask": "255.255.255.0"
+                },
+                "dhcp_server": {
+                    "range_skip": "10",
+                    "range_extent": "240",
+                    "lease_time": "12h"
+                },
+                "dns_server": {
+                    "local_server": true,
+                    "default_hosts": [
+                        "ads",
+                        "adult"
+                    ]
+                },
+                "firewall": {
+                    "zone": "lan_rst"
+                },
+                "shaping": {
+                    "egress": {
+                        "qdisc": "htb",
+                        "filters": [
+                            {
+                                "id": "per_ip_filter",
+                                "kind": "u32",
+                                "hash_key": "dest_ip",
+                                "target_class_template": "per_ip_shapers"
+                            }
+                        ],
+                        "class_template": {
+                            "id": "per_ip_shapers",
+                            "kind": "per_dest_ip",
+                            "classes": [
+                                {
+                                    "qdisc": "htb",
+                                    "config": {
+                                        "rate": "2mbit",
+                                        "ceil": "8mbit",
+                                        "burst": "500k"
+                                    },
+                                    "classes": [
+                                        {
+                                            "qdisc": "fq_codel"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    "ingress": {
+                        "qdisc": "htb",
+                        "filters": [
+                            {
+                                "id": "per_ip_filter",
+                                "kind": "u32",
+                                "hash_key": "src_ip",
+                                "target_class_template": "per_ip_shapers"
+                            }
+                        ],
+                        "class_template": {
+                            "id": "per_ip_shapers",
+                            "kind": "per_src_ip",
+                            "classes": [
+                                {
+                                    "qdisc": "htb",
+                                    "config": {
+                                        "rate": "1.5mbit",
+                                        "ceil": "6mbit",
+                                        "burst": "225k"
+                                    },
+                                    "classes": [
+                                        {
+                                            "qdisc": "fq_codel"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            {
+                "name": "Internal Network",
+                "id": "int",
+                "type": "local",
+                "is_bridge": true,
+                "interfaces": [
+                    "eth0.100"
+                ],
+                "ipv4": {
+                    "proto": "static",
+                    "ip_address": "172.28.100.1",
+                    "netmask": "255.255.255.0"
+                },
+                "dhcp_server": {
+                    "range_skip": "10",
+                    "range_extent": "240",
+                    "lease_time": "12h"
+                },
+                "dns_server": {},
+                "firewall": {
+                    "zone": "lan"
+                },
+                "shaping": {
+                    "egress": {
+                        "qdisc": "fq_codel"
+                    },
+                    "ingress": {
+                        "qdisc": "fq_codel"
+                    }
+                }
+            },
+            {
+                "name": "Primary Modem",
+                "id": "mdm0",
+                "type": "backhaul",
+                "modem_id": "primary",
+                "ipv4": {
+                    "enabled": true,
+                    "proto": "dhcp",
+                    "peerdns": 0
+                },
+                "firewall": {
+                    "zone": "wan"
+                },
+                "shaping": {
+                    "egress": {
+                        "qdisc": "fq_codel"
+                    },
+                    "ingress": {
+                        "qdisc": "fq_codel"
+                    }
+                },
+                "multiwan": {
+                    "dynamic_weight": true,
+                    "metric": 1
+                }
+            },
+            {
+                "name": "Secondary Modem",
+                "id": "mdm1",
+                "type": "backhaul",
+                "modem_id": "secondary",
+                "ipv4": {
+                    "enabled": true,
+                    "proto": "dhcp"
+                },
+                "firewall": {
+                    "zone": "wan"
+                },
+                "shaping": {
+                    "egress": {
+                        "qdisc": "fq_codel"
+                    },
+                    "ingress": {
+                        "qdisc": "fq_codel"
+                    }
+                },
+                "multiwan": {
+                    "dynamic_weight": true,
+                    "metric": 1
+                }
+            },
+            {
+                "name": "Wired Internet",
+                "id": "wan",
+                "type": "backhaul",
+                "interfaces": [
+                    "eth0.4"
+                ],
+                "ipv4": {
+                    "enabled": true,
+                    "proto": "dhcp",
+                    "peerdns": 0
+                },
+                "firewall": {
+                    "zone": "wan"
+                },
+                "shaping": {
+                    "egress": {
+                        "qdisc": "fq_codel"
+                    },
+                    "ingress": {
+                        "qdisc": "fq_codel"
+                    }
+                },
+                "multiwan": {
+                    "dynamic_weight": true,
+                    "metric": 1
+                }
+            }
+        ],
+        "multiwan": {
+            "globals": {
+                "mmx_mask": "0x3F00"
+            },
+            "rules": {},
+            "default_strategy": "dynamic_weight",
+            "health_checks": {
+                "down": 2,
+                "up": 1,
+                "initial_state": "offline",
+                "track_method": "ping",
+                "track_ip": [
+                    "1.1.1.1",
+                    "8.8.8.8"
+                ],
+                "timeout": 2,
+                "interval": 1
+            }
+        },
+        "firewall": {
+            "defaults": {
+                "syn_flood": "1",
+                "input": "ACCEPT",
+                "forward": "REJECT",
+                "output": "ACCEPT",
+                "disable_ipv6": "1"
+            },
+            "zones": [
+                {
+                    "description": "Local Networks",
+                    "name": "lan",
+                    "config": {
+                        "name": "lan",
+                        "input": "ACCEPT",
+                        "output": "ACCEPT",
+                        "forward": "ACCEPT"
+                    },
+                    "forwarding": [
+                        {
+                            "dest": "wan"
+                        }
+                    ]
+                },
+                {
+                    "description": "Local Networks - restricted",
+                    "name": "lan_rst",
+                    "config": {
+                        "name": "lan_rst",
+                        "input": "REJECT",
+                        "output": "ACCEPT",
+                        "forward": "REJECT"
+                    },
+                    "forwarding": [
+                        {
+                            "dest": "wan"
+                        }
+                    ]
+                },
+                {
+                    "description": "Internet",
+                    "name": "wan",
+                    "config": {
+                        "name": "wan",
+                        "input": "REJECT",
+                        "output": "ACCEPT",
+                        "forward": "REJECT",
+                        "masq": 1,
+                        "mtu_fix": 1
+                    }
+                }
+            ],
+            "rules": [
+                {
+                    "description": "Allows for DHCP renewal from upstream routers",
+                    "config": {
+                        "name": "Allow-DHCP-Renew",
+                        "src": "wan",
+                        "proto": "udp",
+                        "dest_port": "68",
+                        "target": "ACCEPT"
+                    }
+                },
+                {
+                    "description": "Responds to pings from the Internet",
+                    "config": {
+                        "name": "Allow-Ping",
+                        "src": "wan",
+                        "proto": "icmp",
+                        "icmp_type": "echo-request",
+                        "target": "ACCEPT"
+                    }
+                },
+                {
+                    "description": "",
+                    "config": {
+                        "name": "Allow-IGMP",
+                        "src": "wan",
+                        "proto": "igmp",
+                        "target": "ACCEPT"
+                    }
+                },
+                {
+                    "description": "",
+                    "config": {
+                        "name": "Allow-IPSec-ESP",
+                        "src": "wan",
+                        "dest": "lan",
+                        "proto": "esp",
+                        "target": "ACCEPT"
+                    }
+                },
+                {
+                    "description": "",
+                    "config": {
+                        "name": "Allow-ISAKMP",
+                        "src": "wan",
+                        "dest": "lan",
+                        "proto": "udp",
+                        "dest_port": "500",
+                        "target": "ACCEPT"
+                    }
+                },
+                {
+                    "description": "",
+                    "config": {
+                        "name": "Allow-IPSec-ESP (RST)",
+                        "src": "wan",
+                        "dest": "lan_rst",
+                        "proto": "esp",
+                        "target": "ACCEPT"
+                    }
+                },
+                {
+                    "name": "",
+                    "config": {
+                        "name": "Allow-ISAKMP (RST)",
+                        "src": "wan",
+                        "dest": "lan_rst",
+                        "proto": "udp",
+                        "dest_port": "500",
+                        "target": "ACCEPT"
+                    }
+                },
+                {
+                    "name": "",
+                    "config": {
+                        "name": "Allow DHCP request (RST)",
+                        "src": "lan_rst",
+                        "proto": "udp",
+                        "src_port": "67-68",
+                        "dest_port": "67-68",
+                        "target": "ACCEPT"
+                    }
+                },
+                {
+                    "name": "",
+                    "config": {
+                        "name": "Allow DNS queries (RST)",
+                        "src": "lan_rst",
+                        "proto": "tcp udp",
+                        "dest_port": "53",
+                        "target": "ACCEPT"
+                    }
+                }
+            ]
+        },
+        "static_route": [
+            {
+                "target": "192.168.100.1",
+                "interface": "wan"
+            }
+        ]
+    },
+    "wifi": {
+        "report_period": 10,
+        "radios": [
+            {
+                "name": "radio0",
+                "band": "2g",
+                "channel": "auto",
+                "channels": [
+                    "1",
+                    "6",
+                    "11"
+                ],
+                "country": "GB",
+                "htmode": "HE20",
+                "txpower": "20",
+                "disabled": false
+            },
+            {
+                "name": "radio1",
+                "band": "5g",
+                "channel": "36",
+                "country": "GB",
+                "htmode": "HE80",
+                "txpower": "23",
+                "disabled": false
+            }
+        ],
+        "ssids": [
+            {
+                "mainflux_path": "config/mainflux",
+                "encryption": "psk2",
+                "mode": "access_point",
+                "radios": [
+                    "radio0",
+                    "radio1"
+                ]
+            },
+            {
+                "name": "Jangala",
+                "mode": "access_point",
+                "encryption": "none",
+                "network": "jan",
+                "radios": [
+                    "radio0",
+                    "radio1"
+                ]
+            }
+        ],
+        "band_steering": {
+            "log_level": 2,
+            "globals": {
+                "rrm_mode": "PAT",
+                "kicking": {
+                    "kick_mode": "both",
+                    "bandwidth_threshold": 0,
+                    "kicking_threshold": 15,
+                    "evals_before_kick": 3
+                },
+                "stations": {
+                    "use_station_count": false,
+                    "max_station_diff": 1
+                },
+                "neighbor_reports": {
+                    "dyn_report_num": 2,
+                    "disassoc_report_len": 6
+                },
+                "legacy": {
+                    "eval_probe_req": true,
+                    "eval_assoc_req": false,
+                    "eval_auth_req": false,
+                    "min_probe_count": 2,
+                    "deny_auth_reason": 1,
+                    "deny_assoc_reason": 17
+                }
+            },
+            "timings": {
+                "updates": {
+                    "client": 10,
+                    "chan_util": 5,
+                    "beacon_reports": 5,
+                    "hostapd": 10,
+                    "tcp_con": 10
+                },
+                "cleanup": {
+                    "client": 15,
+                    "probe": 40,
+                    "ap": 460
+                },
+                "inactive_client_kickoff": 60
+            },
+            "networking": {
+                "method": "tcp+umdns",
+                "ip": "0.0.0.0",
+                "port": 1026,
+                "broadcast_port": 1025,
+                "enable_encryption": false
+            },
+            "bands": {
+                "2g": {
+                    "initial_score": 90,
+                    "rssi_scoring": {
+                        "center": "-69",
+                        "weight": 2,
+                        "good_threshold": "-66",
+                        "good_reward": 12,
+                        "bad_threshold": "-75",
+                        "bad_penalty": "-15"
+                    },
+                    "chan_util_scoring": {
+                        "good_threshold": 140,
+                        "good_reward": 5,
+                        "bad_threshold": 170,
+                        "bad_penalty": "-20"
+                    },
+                    "support_bonuses": {
+                        "vht": 5,
+                        "ht": 5
+                    }
+                },
+                "5g": {
+                    "initial_score": 95,
+                    "rssi_scoring": {
+                        "center": "-64",
+                        "weight": 4,
+                        "good_threshold": "-62",
+                        "good_reward": 10,
+                        "bad_threshold": "-70",
+                        "bad_penalty": "-28"
+                    },
+                    "chan_util_scoring": {
+                        "good_threshold": 140,
+                        "good_reward": 5,
+                        "bad_threshold": 170,
+                        "bad_penalty": "-20"
+                    },
+                    "support_bonuses": {
+                        "vht": 2,
+                        "ht": 2
+                    }
+                }
+            }
+        }
+    },
+    "gsm": {
+        "modems": {
+            "default": {
+                "enabled": true
+            },
+            "known": [
+                {
+                    "name": "primary",
+                    "id_field": "device",
+                    "device": "/sys/devices/platform/axi/1000120000.pcie/1f00200000.usb/xhci-hcd.0/usb3/3-1",
+                    "autoconnect": true
+                },
+                {
+                    "name": "secondary",
+                    "id_field": "device",
+                    "device": "/sys/devices/platform/axi/1000480000.usb/usb1/1-1",
+                    "autoconnect": true
+                }
+            ]
+        }
+    },
+    "metrics": {
+        "cloud_url": "$CLOUD_URL",
+        "publish_period": 60,
+        "templates": {
+            "network_stat": {
+                "protocol": "http",
+                "process": [
+                    {
+                        "type": "DiffTrigger",
+                        "diff_method": "percent",
+                        "threshold": 5,
+                        "initial_val": 0
+                    },
+                    {
+                        "type": "DeltaValue"
+                    }
+                ]
+            },
+            "any_change": {
+                "protocol": "http",
+                "process": [
+                    {
+                        "type": "DiffTrigger",
+                        "diff_method": "any-change"
+                    }
+                ]
+            },
+            "percent_5": {
+                "protocol": "http",
+                "process": [
+                    {
+                        "type": "DiffTrigger",
+                        "diff_method": "percent",
+                        "threshold": 5
+                    }
+                ]
+            },
+            "absolute_10": {
+                "protocol": "http",
+                "process": [
+                    {
+                        "type": "DiffTrigger",
+                        "diff_method": "absolute",
+                        "threshold": 10
+                    }
+                ]
+            }
+        },
+        "collections": {
+            "net/adm/rx_bytes": {
+                "template": "network_stat"
+            },
+            "net/adm/rx_packets": {
+                "template": "network_stat"
+            },
+            "net/adm/rx_dropped": {
+                "template": "network_stat"
+            },
+            "net/adm/rx_errors": {
+                "template": "network_stat"
+            },
+            "net/adm/tx_bytes": {
+                "template": "network_stat"
+            },
+            "net/adm/tx_packets": {
+                "template": "network_stat"
+            },
+            "net/adm/tx_dropped": {
+                "template": "network_stat"
+            },
+            "net/adm/tx_errors": {
+                "template": "network_stat"
+            },
+            "net/jan/rx_bytes": {
+                "template": "network_stat"
+            },
+            "net/jan/rx_packets": {
+                "template": "network_stat"
+            },
+            "net/jan/rx_dropped": {
+                "template": "network_stat"
+            },
+            "net/jan/rx_errors": {
+                "template": "network_stat"
+            },
+            "net/jan/tx_bytes": {
+                "template": "network_stat"
+            },
+            "net/jan/tx_packets": {
+                "template": "network_stat"
+            },
+            "net/jan/tx_dropped": {
+                "template": "network_stat"
+            },
+            "net/jan/tx_errors": {
+                "template": "network_stat"
+            },
+            "net/mdm0/rx_bytes": {
+                "template": "network_stat"
+            },
+            "net/mdm0/rx_packets": {
+                "template": "network_stat"
+            },
+            "net/mdm0/rx_dropped": {
+                "template": "network_stat"
+            },
+            "net/mdm0/rx_errors": {
+                "template": "network_stat"
+            },
+            "net/mdm0/tx_bytes": {
+                "template": "network_stat"
+            },
+            "net/mdm0/tx_packets": {
+                "template": "network_stat"
+            },
+            "net/mdm0/tx_dropped": {
+                "template": "network_stat"
+            },
+            "net/mdm0/tx_errors": {
+                "template": "network_stat"
+            },
+            "net/mdm1/rx_bytes": {
+                "template": "network_stat"
+            },
+            "net/mdm1/rx_packets": {
+                "template": "network_stat"
+            },
+            "net/mdm1/rx_dropped": {
+                "template": "network_stat"
+            },
+            "net/mdm1/rx_errors": {
+                "template": "network_stat"
+            },
+            "net/mdm1/tx_bytes": {
+                "template": "network_stat"
+            },
+            "net/mdm1/tx_packets": {
+                "template": "network_stat"
+            },
+            "net/mdm1/tx_dropped": {
+                "template": "network_stat"
+            },
+            "net/mdm1/tx_errors": {
+                "template": "network_stat"
+            },
+            "net/wan/rx_bytes": {
+                "template": "network_stat"
+            },
+            "net/wan/rx_packets": {
+                "template": "network_stat"
+            },
+            "net/wan/rx_dropped": {
+                "template": "network_stat"
+            },
+            "net/wan/rx_errors": {
+                "template": "network_stat"
+            },
+            "net/wan/tx_bytes": {
+                "template": "network_stat"
+            },
+            "net/wan/tx_packets": {
+                "template": "network_stat"
+            },
+            "net/wan/tx_dropped": {
+                "template": "network_stat"
+            },
+            "net/wan/tx_errors": {
+                "template": "network_stat"
+            },
+            "gsm/modem/primary/firmware": {
+                "template": "any_change",
+                "rename": [
+                    "modem",
+                    "1",
+                    "fw_version"
+                ]
+            },
+            "gsm/modem/primary/band": {
+                "template": "any_change",
+                "rename": [
+                    "modem",
+                    "1",
+                    "band"
+                ]
+            },
+            "gsm/modem/primary/access-tech": {
+                "template": "any_change",
+                "rename": [
+                    "modem",
+                    "1",
+                    "access_tech"
+                ]
+            },
+            "gsm/modem/primary/access-family": {
+                "template": "any_change",
+                "rename": [
+                    "modem",
+                    "1",
+                    "access_fam"
+                ]
+            },
+            "gsm/modem/primary/imei": {
+                "template": "any_change",
+                "rename": [
+                    "modem",
+                    "1",
+                    "imei"
+                ]
+            },
+            "gsm/modem/primary/sim": {
+                "template": "any_change",
+                "rename": [
+                    "modem",
+                    "1",
+                    "sim"
+                ]
+            },
+            "gsm/modem/primary/signal/rssi": {
+                "template": "percent_5",
+                "rename": [
+                    "modem",
+                    "1",
+                    "rssi"
+                ]
+            },
+            "gsm/modem/primary/signal/rsrp": {
+                "template": "percent_5",
+                "rename": [
+                    "modem",
+                    "1",
+                    "rsrp"
+                ]
+            },
+            "gsm/modem/primary/signal/rsrq": {
+                "template": "percent_5",
+                "rename": [
+                    "modem",
+                    "1",
+                    "rsrq"
+                ]
+            },
+            "gsm/modem/primary/bars": {
+                "template": "any_change",
+                "rename": [
+                    "modem",
+                    "1",
+                    "bars"
+                ]
+            },
+            "gsm/modem/primary/operator": {
+                "template": "any_change",
+                "rename": [
+                    "modem",
+                    "1",
+                    "operator"
+                ]
+            },
+            "gsm/modem/primary/iccid": {
+                "template": "any_change",
+                "rename": [
+                    "modem",
+                    "1",
+                    "iccid"
+                ]
+            },
+            "gsm/modem/primary/state": {
+                "template": "any_change",
+                "field": "curr_state",
+                "rename": [
+                    "modem",
+                    "1",
+                    "state"
+                ]
+            },
+            "gsm/modem/primary/interface": {
+                "template": "any_change",
+                "rename": [
+                    "modem",
+                    "1",
+                    "wann_type"
+                ]
+            },
+            "gsm/modem/primary/rx_bytes": {
+                "template": "network_stat",
+                "rename": [
+                    "modem",
+                    "1",
+                    "rx_bytes"
+                ]
+            },
+            "gsm/modem/primary/tx_bytes": {
+                "template": "network_stat",
+                "rename": [
+                    "modem",
+                    "1",
+                    "tx_bytes"
+                ]
+            },
+            "gsm/modem/secondary/firmware": {
+                "template": "any_change",
+                "rename": [
+                    "modem",
+                    "2",
+                    "fw_version"
+                ]
+            },
+            "gsm/modem/secondary/band": {
+                "template": "any_change",
+                "rename": [
+                    "modem",
+                    "2",
+                    "band"
+                ]
+            },
+            "gsm/modem/secondary/access-tech": {
+                "template": "any_change",
+                "rename": [
+                    "modem",
+                    "2",
+                    "access_tech"
+                ]
+            },
+            "gsm/modem/secondary/access-family": {
+                "template": "any_change",
+                "rename": [
+                    "modem",
+                    "2",
+                    "access_fam"
+                ]
+            },
+            "gsm/modem/secondary/imei": {
+                "template": "any_change",
+                "rename": [
+                    "modem",
+                    "2",
+                    "imei"
+                ]
+            },
+            "gsm/modem/secondary/sim": {
+                "template": "any_change",
+                "rename": [
+                    "modem",
+                    "2",
+                    "sim"
+                ]
+            },
+            "gsm/modem/secondary/signal/rssi": {
+                "template": "percent_5",
+                "rename": [
+                    "modem",
+                    "2",
+                    "rssi"
+                ]
+            },
+            "gsm/modem/secondary/signal/rsrp": {
+                "template": "percent_5",
+                "rename": [
+                    "modem",
+                    "2",
+                    "rsrp"
+                ]
+            },
+            "gsm/modem/secondary/signal/rsrq": {
+                "template": "percent_5",
+                "rename": [
+                    "modem",
+                    "2",
+                    "rsrq"
+                ]
+            },
+            "gsm/modem/secondary/bars": {
+                "template": "any_change",
+                "rename": [
+                    "modem",
+                    "2",
+                    "bars"
+                ]
+            },
+            "gsm/modem/secondary/operator": {
+                "template": "any_change",
+                "rename": [
+                    "modem",
+                    "2",
+                    "operator"
+                ]
+            },
+            "gsm/modem/secondary/iccid": {
+                "template": "any_change",
+                "rename": [
+                    "modem",
+                    "2",
+                    "iccid"
+                ]
+            },
+            "gsm/modem/secondary/state": {
+                "template": "any_change",
+                "field": "curr_state",
+                "rename": [
+                    "modem",
+                    "2",
+                    "state"
+                ]
+            },
+            "gsm/modem/secondary/interface": {
+                "template": "any_change",
+                "rename": [
+                    "modem",
+                    "2",
+                    "wann_type"
+                ]
+            },
+            "gsm/modem/secondary/rx_bytes": {
+                "template": "network_stat",
+                "rename": [
+                    "modem",
+                    "2",
+                    "rx_bytes"
+                ]
+            },
+            "gsm/modem/secondary/tx_bytes": {
+                "template": "network_stat",
+                "rename": [
+                    "modem",
+                    "2",
+                    "tx_bytes"
+                ]
+            },
+            "system/info/boot_time": {
+                "protocol": "http",
+                "rename": [
+                    "system",
+                    "boot_time"
+                ],
+                "process": [
+                    {
+                        "type": "DiffTrigger",
+                        "diff_method": "absolute",
+                        "threshold": 1000
+                    }
+                ]
+            },
+            "system/info/firmware/version": {
+                "template": "any_change",
+                "rename": [
+                    "system",
+                    "fw_id"
+                ]
+            },
+            "system/info/hardware/revision": {
+                "template": "any_change",
+                "rename": [
+                    "system",
+                    "hw_id"
+                ]
+            },
+            "system/info/hardware/serial": {
+                "template": "any_change",
+                "rename": [
+                    "system",
+                    "serial"
+                ]
+            },
+            "system/info/hardware/board/revision": {
+                "template": "any_change",
+                "rename": [
+                    "system",
+                    "board_revision"
+                ]
+            },
+            "system/info/cpu/overall_utilisation": {
+                "template": "percent_5",
+                "rename": [
+                    "system",
+                    "cpu_util"
+                ]
+            },
+            "system/info/mem/util": {
+                "template": "percent_5",
+                "rename": [
+                    "system",
+                    "mem_util"
+                ]
+            },
+            "system/info/temperature": {
+                "protocol": "http",
+                "rename": [
+                    "system",
+                    "temp"
+                ],
+                "process": [
+                    {
+                        "type": "DiffTrigger",
+                        "diff_method": "absolute",
+                        "threshold": 2
+                    }
+                ]
+            },
+            "mcu/sys/mem/alloc": {
+                "protocol": "http",
+                "process": [
+                    {
+                        "type": "TimeTrigger",
+                        "duration": 60
+                    }
+                ]
+            },
+            "mcu/power/temperature/internal": {
+                "protocol": "http",
+                "process": [
+                    {
+                        "type": "DiffTrigger",
+                        "diff_method": "absolute",
+                        "threshold": 1
+                    }
+                ]
+            },
+            "mcu/env/temperature/core": {
+                "template": "percent_5"
+            },
+            "mcu/env/humidity/core": {
+                "template": "percent_5"
+            },
+            "mcu/power/battery/internal/vbat": {
+                "template": "absolute_10"
+            },
+            "mcu/power/battery/internal/ibat": {
+                "template": "absolute_10"
+            },
+            "mcu/power/charger/internal/vin": {
+                "template": "absolute_10"
+            },
+            "mcu/power/charger/internal/vsys": {
+                "template": "absolute_10"
+            },
+            "mcu/power/charger/internal/iin": {
+                "template": "absolute_10"
+            },
+            "mcu/power/charger/internal/system/charger_enabled": {
+                "template": "any_change"
+            },
+            "mcu/power/charger/internal/system/mppt_en_pin": {
+                "template": "any_change"
+            },
+            "mcu/power/charger/internal/system/equalize_req": {
+                "template": "any_change"
+            },
+            "mcu/power/charger/internal/system/drvcc_good": {
+                "template": "any_change"
+            },
+            "mcu/power/charger/internal/system/cell_count_error": {
+                "template": "any_change"
+            },
+            "mcu/power/charger/internal/system/ok_to_charge": {
+                "template": "any_change"
+            },
+            "mcu/power/charger/internal/system/no_rt": {
+                "template": "any_change"
+            },
+            "mcu/power/charger/internal/system/thermal_shutdown": {
+                "template": "any_change"
+            },
+            "mcu/power/charger/internal/system/vin_ovlo": {
+                "template": "any_change"
+            },
+            "mcu/power/charger/internal/system/vin_gt_vbat": {
+                "template": "any_change"
+            },
+            "mcu/power/charger/internal/system/intvcc_gt_4p3v": {
+                "template": "any_change"
+            },
+            "mcu/power/charger/internal/system/intvcc_gt_2p8v": {
+                "template": "any_change"
+            },
+            "mcu/power/charger/internal/status/iin_limited": {
+                "template": "any_change"
+            },
+            "mcu/power/charger/internal/status/uvcl_active": {
+                "template": "any_change"
+            },
+            "mcu/power/charger/internal/status/cc_phase": {
+                "template": "any_change"
+            },
+            "mcu/power/charger/internal/status/cv_phase": {
+                "template": "any_change"
+            },
+            "mcu/power/charger/internal/state/bat_short": {
+                "template": "any_change"
+            },
+            "mcu/power/charger/internal/state/bat_missing": {
+                "template": "any_change"
+            },
+            "mcu/power/charger/internal/state/max_charge_time_fault": {
+                "template": "any_change"
+            },
+            "mcu/power/charger/internal/state/c_over_x_term": {
+                "template": "any_change"
+            },
+            "mcu/power/charger/internal/state/timer_term": {
+                "template": "any_change"
+            },
+            "mcu/power/charger/internal/state/ntc_pause": {
+                "template": "any_change"
+            },
+            "mcu/power/charger/internal/state/precharge": {
+                "template": "any_change"
+            },
+            "mcu/power/charger/internal/state/cccv": {
+                "template": "any_change"
+            },
+            "mcu/power/charger/internal/state/absorb": {
+                "template": "any_change"
+            },
+            "mcu/power/charger/internal/state/equalize": {
+                "template": "any_change"
+            },
+            "mcu/power/charger/internal/state/suspended": {
+                "template": "any_change"
+            },
+            "wifi/clients/+/sessions/+/session_start": {
+                "protocol": "http",
+                "process": []
+            },
+            "wifi/clients/+/sessions/+/session_end": {
+                "protocol": "http",
+                "process": []
+            },
+            "wifi/clients/+/sessions/+/hostname": {
+                "template": "any_change"
+            },
+            "wifi/clients/+/sessions/+/rx_bytes": {
+                "template": "network_stat"
+            },
+            "wifi/clients/+/sessions/+/tx_bytes": {
+                "template": "network_stat"
+            },
+            "wifi/clients/+/sessions/+/signal": {
+                "template": "percent_5"
+            },
+            "wifi/hp/+/+/+/power": {
+                "protocol": "http",
+                "process": [
+                    {
+                        "type": "DiffTrigger",
+                        "diff_method": "percent",
+                        "threshold": 10,
+                        "initial_val": 0
+                    }
+                ]
+            },
+            "wifi/hp/+/+/+/channel": {
+                "template": "any_change"
+            },
+            "wifi/hp/+/+/+/noise": {
+                "protocol": "http",
+                "process": [
+                    {
+                        "type": "DiffTrigger",
+                        "diff_method": "percent",
+                        "threshold": 10,
+                        "initial_val": 0
+                    }
+                ]
+            },
+            "wifi/hp/+/+/+/rx_bytes": {
+                "template": "network_stat"
+            },
+            "wifi/hp/+/+/+/rx_packets": {
+                "template": "network_stat"
+            },
+            "wifi/hp/+/+/+/rx_dropped": {
+                "template": "network_stat"
+            },
+            "wifi/hp/+/+/+/rx_errors": {
+                "template": "network_stat"
+            },
+            "wifi/hp/+/+/+/tx_bytes": {
+                "template": "network_stat"
+            },
+            "wifi/hp/+/+/+/tx_packets": {
+                "template": "network_stat"
+            },
+            "wifi/hp/+/+/+/tx_dropped": {
+                "template": "network_stat"
+            },
+            "wifi/hp/+/+/+/tx_errors": {
+                "template": "network_stat"
+            },
+            "wifi/hp/+/+/+/num_sta": {
+                "template": "percent_5"
+            },
+            "wifi/num_sta": {
+                "template": "percent_5"
+            },
+            "wifi/hp/+/num_sta": {
+                "template": "percent_5"
+            },
+            "switch/system/mem": {
+                "template": "any_change"
+            },
+            "switch/system/cpu": {
+                "template": "any_change"
+            },
+            "switch/system/temp": {
+                "template": "any_change"
+            },
+            "switch/system/power": {
+                "template": "any_change"
+            },
+            "switch/system/curr_time": {
+                "template": "any_change"
+            }
+        }
+    },
+    "system": {
+        "report_period": 60,
+        "usb3_enabled": true,
+        "alarms": [
+            {
+                "time": "5:00",
+                "repeats": "daily",
+                "payload": {
+                    "name": "daily reboot",
+                    "type": "reboot"
+                }
+            }
+        ]
+    },
+    "switch": {
+        "report_period": 10,
+        "host": "172.28.100.9",
+        "username": "$SWITCH_USERNAME",
+        "password": "$SWITCH_PASSWORD",
+        "type": "rtl8380m"
+    },
+    "fabric": {
+        "links": {
+            "cm5-uart-mcu": {
+                "id": "cm5-uart-mcu",
+                "node_id": "cm5",
+                "member_class": "mcu",
+                "link_class": "member_uart",
+                "transport": {
+                    "class": "uart",
+                    "id": "uart0",
+                    "terminator": "\n"
+                },
+                "import_rules": [
+                    {
+                        "local": [
+                            "raw",
+                            "member",
+                            "mcu",
+                            "state"
+                        ],
+                        "remote": [
+                            "state",
+                            "self"
+                        ]
+                    },
+                    {
+                        "local": [
+                            "raw",
+                            "member",
+                            "mcu",
+                            "cap",
+                            "telemetry",
+                            "main",
+                            "event"
+                        ],
+                        "remote": [
+                            "event",
+                            "self"
+                        ]
+                    }
+                ],
+                "outbound_call_rules": [
+                    {
+                        "local": [
+                            "raw",
+                            "member",
+                            "mcu",
+                            "cap",
+                            "updater",
+                            "main",
+                            "rpc"
+                        ],
+                        "remote": [
+                            "cmd",
+                            "self",
+                            "updater"
+                        ],
+                        "timeout": 2.0
+                    }
+                ],
+                "hello_interval_s": 2.0,
+                "ping_interval_s": 10.0,
+                "liveness_timeout_s": 30.0,
+                "chunk_size": 2048,
+                "transfer_phase_timeout_s": 15.0
+            }
+        }
+    },
+    "device": {
+        "schema": "devicecode.config/device/1",
+        "components": {
+            "mcu": {
+                "class": "member",
+                "subtype": "mcu",
+                "role": "member",
+                "member": "mcu",
+                "member_class": "mcu",
+                "link_class": "member_uart",
+                "actions": {
+                    "prepare-update": [
+                        "raw",
+                        "member",
+                        "mcu",
+                        "cap",
+                        "updater",
+                        "main",
+                        "rpc",
+                        "prepare"
+                    ],
+                    "commit-update": [
+                        "raw",
+                        "member",
+                        "mcu",
+                        "cap",
+                        "updater",
+                        "main",
+                        "rpc",
+                        "commit"
+                    ],
+                    "stage-update": {
+                        "kind": "fabric_stage",
+                        "artifact_store": "main",
+                        "link_id": "cm5-uart-mcu",
+                        "receiver": [
+                            "raw",
+                            "member",
+                            "mcu",
+                            "cap",
+                            "updater",
+                            "main",
+                            "rpc",
+                            "receive"
+                        ],
+                        "timeout_s": 60.0
+                    }
+                },
+                "facts": {
+                    "software": [
+                        "raw",
+                        "member",
+                        "mcu",
+                        "state",
+                        "software"
+                    ],
+                    "updater": [
+                        "raw",
+                        "member",
+                        "mcu",
+                        "state",
+                        "updater"
+                    ],
+                    "health": [
+                        "raw",
+                        "member",
+                        "mcu",
+                        "state",
+                        "health"
+                    ],
+                    "power_battery": [
+                        "raw",
+                        "member",
+                        "mcu",
+                        "state",
+                        "power",
+                        "battery"
+                    ],
+                    "power_charger": [
+                        "raw",
+                        "member",
+                        "mcu",
+                        "state",
+                        "power",
+                        "charger"
+                    ],
+                    "power_charger_config": [
+                        "raw",
+                        "member",
+                        "mcu",
+                        "state",
+                        "power",
+                        "charger",
+                        "config"
+                    ],
+                    "environment_temperature": [
+                        "raw",
+                        "member",
+                        "mcu",
+                        "state",
+                        "environment",
+                        "temperature"
+                    ],
+                    "environment_humidity": [
+                        "raw",
+                        "member",
+                        "mcu",
+                        "state",
+                        "environment",
+                        "humidity"
+                    ],
+                    "runtime_memory": [
+                        "raw",
+                        "member",
+                        "mcu",
+                        "state",
+                        "runtime",
+                        "memory"
+                    ]
+                },
+                "events": {
+                    "charger_alert": [
+                        "raw",
+                        "member",
+                        "mcu",
+                        "cap",
+                        "telemetry",
+                        "main",
+                        "event",
+                        "power",
+                        "charger",
+                        "alert"
+                    ]
+                }
+            }
+        }
+    },
+    "update": {
+        "schema": "devicecode.config/update/1",
+        "jobs_namespace": "update/jobs",
+        "components": {
+            "mcu": {
+                "backend": "mcu_component"
+            }
+        },
+        "artifacts": {
+            "default_policy": "transient_only",
+            "policies": {
+                "mcu": "transient_only"
+            }
+        },
+        "reconcile": {
+            "interval_s": 10.0,
+            "timeout_s": 180.0
+        },
+        "admission": {
+            "mode": "global_single"
+        },
+        "bundled": {
+            "components": {
+                "mcu": {
+                    "enabled": true,
+                    "follow_mode_default": "auto",
+                    "source": {
+                        "kind": "bundled",
+                        "path": "/rom/mcu/current.dcmcu",
+                        "target": {
+                            "product_family": "bigbox",
+                            "hardware_profile": "bb-v1-cm5-2",
+                            "mcu_board_family": "rp2354a"
+                        },
+                        "preflight": {
+                            "trusted_keys": {},
+                            "require_signature": false
+                        }
+                    },
+                    "target": {
+                        "product_family": "bigbox",
+                        "hardware_profile": "bb-v1-cm5-2",
+                        "mcu_board_family": "rp2354a"
+                    },
+                    "cm5_release_id_field": "image_id",
+                    "auto_start": true,
+                    "auto_commit": true,
+                    "retry_on_boot": true
+                }
+            }
+        }
+    }
+}

--- a/src/configs/config.json
+++ b/src/configs/config.json
@@ -17,7 +17,11 @@
             "sysmon": {},
             "platform": {},
             "power": {},
-            "usb": {}
+            "usb": {},
+            "artifact_store": {},
+            "control_store": {},
+            "signature_verify": {},
+            "updater": {}
         }
     },
     "gsm": {
@@ -389,6 +393,163 @@
                 "curr_time": {
                     "template": "any_change"
                 }
+            }
+        }
+    },
+    "device": {
+        "rev": 1,
+        "data": {
+            "schema": "devicecode.config/device/1",
+            "components": {
+                "cm5": {
+                    "class": "host",
+                    "subtype": "cm5",
+                    "facts": {
+                        "software": [
+                            "raw",
+                            "host",
+                            "updater",
+                            "cap",
+                            "updater",
+                            "cm5",
+                            "state",
+                            "software"
+                        ],
+                        "updater": [
+                            "raw",
+                            "host",
+                            "updater",
+                            "cap",
+                            "updater",
+                            "cm5",
+                            "state",
+                            "updater"
+                        ],
+                        "health": [
+                            "raw",
+                            "host",
+                            "updater",
+                            "cap",
+                            "updater",
+                            "cm5",
+                            "state",
+                            "health"
+                        ]
+                    },
+                    "actions": {
+                        "prepare-update": [
+                            "raw",
+                            "host",
+                            "updater",
+                            "cap",
+                            "updater",
+                            "cm5",
+                            "rpc",
+                            "prepare"
+                        ],
+                        "stage-update": [
+                            "raw",
+                            "host",
+                            "updater",
+                            "cap",
+                            "updater",
+                            "cm5",
+                            "rpc",
+                            "stage"
+                        ],
+                        "commit-update": [
+                            "raw",
+                            "host",
+                            "updater",
+                            "cap",
+                            "updater",
+                            "cm5",
+                            "rpc",
+                            "commit"
+                        ]
+                    }
+                },
+                "mcu": {
+                    "class": "member",
+                    "subtype": "mcu",
+                    "actions": {
+                        "prepare-update": [
+                            "raw",
+                            "member",
+                            "mcu",
+                            "cap",
+                            "updater",
+                            "main",
+                            "rpc",
+                            "prepare"
+                        ],
+                        "commit-update": [
+                            "raw",
+                            "member",
+                            "mcu",
+                            "cap",
+                            "updater",
+                            "main",
+                            "rpc",
+                            "commit"
+                        ]
+                    },
+                    "facts": {
+                        "software": [
+                            "raw",
+                            "member",
+                            "mcu",
+                            "state",
+                            "software"
+                        ],
+                        "updater": [
+                            "raw",
+                            "member",
+                            "mcu",
+                            "state",
+                            "updater"
+                        ],
+                        "health": [
+                            "raw",
+                            "member",
+                            "mcu",
+                            "state",
+                            "health"
+                        ]
+                    }
+                }
+            }
+        }
+    },
+    "update": {
+        "rev": 1,
+        "data": {
+            "schema": "devicecode.config/update/1",
+            "jobs_namespace": "update/jobs",
+            "components": {
+                "cm5": {
+                    "backend": "cm5_swupdate"
+                },
+                "mcu": {
+                    "backend": "mcu_component"
+                }
+            },
+            "artifacts": {
+                "default_policy": "transient_only",
+                "policies": {
+                    "cm5": "transient_only",
+                    "mcu": "transient_only"
+                }
+            },
+            "reconcile": {
+                "interval_s": 10.0,
+                "timeout_s": 180.0
+            },
+            "admission": {
+                "mode": "global_single"
+            },
+            "bundled": {
+                "components": {}
             }
         }
     }

--- a/src/devicecode/profile_contract.lua
+++ b/src/devicecode/profile_contract.lua
@@ -1,0 +1,58 @@
+local cjson = require 'cjson.safe'
+
+local M = {}
+
+local function read_file(path)
+  local f = assert(io.open(path, 'rb'))
+  local s = assert(f:read('*a'))
+  f:close()
+  return s
+end
+
+function M.load_profile(path)
+  local chunk = assert(loadfile(path))
+  local rec = assert(chunk())
+  assert(type(rec) == 'table', 'profile must return table')
+  return rec
+end
+
+function M.load_config_json(path)
+  local cfg = assert(cjson.decode(read_file(path)))
+  assert(type(cfg) == 'table', 'config must decode to table')
+  return cfg
+end
+
+function M.validate_profile_services(profile, spec)
+  local services = type(profile) == 'table' and profile.services or nil
+  if type(services) ~= 'table' then
+    return nil, 'profile_missing_services'
+  end
+  local seen = {}
+  for i = 1, #services do
+    local name = services[i]
+    if seen[name] then return nil, 'duplicate_service:' .. tostring(name) end
+    seen[name] = true
+  end
+  spec = type(spec) == 'table' and spec or {}
+  for i = 1, #(spec.required or {}) do
+    local name = spec.required[i]
+    if not seen[name] then return nil, 'missing_required_service:' .. tostring(name) end
+  end
+  for i = 1, #(spec.forbidden or {}) do
+    local name = spec.forbidden[i]
+    if seen[name] then return nil, 'forbidden_service_present:' .. tostring(name) end
+  end
+  return seen, nil
+end
+
+function M.require_path(tbl, path)
+  local cur = tbl
+  for i = 1, #path do
+    if type(cur) ~= 'table' then return nil, 'missing_path:' .. table.concat(path, '.') end
+    cur = cur[path[i]]
+  end
+  if cur == nil then return nil, 'missing_path:' .. table.concat(path, '.') end
+  return cur, nil
+end
+
+return M

--- a/src/devices/bigbox-v1-cm-2.lua
+++ b/src/devices/bigbox-v1-cm-2.lua
@@ -1,0 +1,14 @@
+-- Big Box CM v1.0 (phase 2) device configuration
+
+return {
+    services = {
+        "config",
+        "hal",
+        "system",
+        "monitor",
+        "fabric",
+        "device",
+        "update",
+        "ui"
+    }
+}

--- a/src/services/hal/drivers/artifact_store.lua
+++ b/src/services/hal/drivers/artifact_store.lua
@@ -1,0 +1,465 @@
+local fibers      = require 'fibers'
+local file        = require 'fibers.io.file'
+local cjson       = require 'cjson.safe'
+local uuid        = require 'uuid'
+local checksum    = require 'shared.hash.xxhash32'
+local blob_source = require 'shared.blob_source'
+
+local perform = fibers.perform
+
+local M = {}
+local Store = {}
+Store.__index = Store
+
+local function dlog(logger, level, payload)
+    if logger and logger[level] then
+        logger[level](logger, payload)
+    end
+end
+
+local function join_path(...)
+    local parts = { ... }
+    return table.concat(parts, '/')
+end
+
+local function dirname(path)
+    local d = tostring(path or ''):match('^(.*)/[^/]+$')
+    if d == nil or d == '' then return '.' end
+    return d
+end
+
+local function ensure_dir(path)
+    local ok, err = file.mkdir_p(path)
+    if not ok then
+        return false, tostring(err or 'mkdir_failed')
+    end
+    return true, ''
+end
+
+local function remove_tree(path)
+    local cmd = require('fibers.io.exec').command('rm', '-rf', path)
+    local st = perform(cmd:run_op())
+    return st == 'exited'
+end
+
+local function xxhash32_stream(stream)
+    local st = checksum.new()
+    while true do
+        local chunk, err = stream:read_some(64 * 1024)
+        if err ~= nil then return nil, tostring(err) end
+        if chunk == nil then break end
+        checksum.update(st, chunk)
+    end
+    return checksum.digest_hex_state(st), ''
+end
+
+local function read_file(path)
+    local f, err = file.open(path, 'r')
+    if not f then return nil, tostring(err) end
+    local raw, rerr = f:read_all()
+    f:close()
+    if raw == nil then return nil, tostring(rerr or 'read_failed') end
+    return raw, ''
+end
+
+local function write_file(path, data)
+    local ok, derr = ensure_dir(dirname(path))
+    if not ok then return false, derr end
+    local tmp, terr = file.tmpfile(384, dirname(path))
+    if not tmp then return false, tostring(terr) end
+    local n, werr = tmp:write(data)
+    if n == nil then
+        tmp:close()
+        return false, tostring(werr or 'write_failed')
+    end
+    local okf, ferr = tmp:flush()
+    if okf == nil then
+        tmp:close()
+        return false, tostring(ferr or 'flush_failed')
+    end
+    local okr, rerr = tmp:rename(path)
+    if not okr then
+        tmp:close()
+        return false, tostring(rerr)
+    end
+    local okc, cerr = tmp:close()
+    if okc == nil then return false, tostring(cerr) end
+    return true, ''
+end
+
+local function read_json(path)
+    local raw, err = read_file(path)
+    if raw == nil then return nil, err end
+    local obj, derr = cjson.decode(raw)
+    if obj == nil then return nil, tostring(derr or 'decode_failed') end
+    return obj, ''
+end
+
+local function write_json(path, obj)
+    local raw, err = cjson.encode(obj)
+    if not raw then return false, tostring(err or 'encode_failed') end
+    return write_file(path, raw)
+end
+
+local function copy_table(t)
+    local out = {}
+    if type(t) ~= 'table' then return out end
+    for k, v in pairs(t) do out[k] = v end
+    return out
+end
+
+local function valid_ref(ref)
+    return type(ref) == 'string' and ref ~= '' and ref:match('^[A-Za-z0-9_.-]+$') ~= nil
+end
+
+local function choose_durability(self, policy)
+    policy = policy or 'transient_only'
+    if policy == 'require_durable' then
+        if not self.durable_enabled then return nil, 'durable_disabled' end
+        return 'durable', ''
+    elseif policy == 'prefer_durable' then
+        if self.durable_enabled then return 'durable', '' end
+        return 'transient', ''
+    elseif policy == 'transient_only' then
+        return 'transient', ''
+    end
+    return nil, 'invalid_policy'
+end
+
+local function root_for(self, durability)
+    if durability == 'durable' then return self.durable_root end
+    return self.transient_root
+end
+
+local function artifact_dir(self, ref, durability)
+    return join_path(root_for(self, durability), ref)
+end
+
+local function meta_path(self, ref, durability)
+    return join_path(artifact_dir(self, ref, durability), 'meta.json')
+end
+
+local function blob_path(self, ref, durability)
+    return join_path(artifact_dir(self, ref, durability), 'blob.bin')
+end
+
+local function clone_record(rec)
+    local out = copy_table(rec)
+    out.meta = copy_table(rec.meta)
+    return out
+end
+
+local FileArtefactSource = {}
+FileArtefactSource.__index = FileArtefactSource
+
+function FileArtefactSource:size()
+    return self._size
+end
+
+function FileArtefactSource:checksum()
+    if self._checksum then return self._checksum end
+    local f, err = file.open(self._path, 'r')
+    if not f then error(tostring(err), 0) end
+    local sum, serr = xxhash32_stream(f)
+    f:close()
+    if not sum then error(tostring(serr), 0) end
+    self._checksum = sum
+    return self._checksum
+end
+
+function FileArtefactSource:read_chunk(offset, max_bytes)
+    offset = offset or 0
+    max_bytes = max_bytes or self._size
+    if offset < 0 then return nil, 'invalid_offset' end
+    if offset >= self._size then return '', nil end
+    local f, err = file.open(self._path, 'r')
+    if not f then return nil, tostring(err) end
+    local pos, serr = f:seek('set', offset)
+    if pos == nil then
+        f:close()
+        return nil, tostring(serr or 'seek_failed')
+    end
+    local n = math.min(max_bytes, self._size - offset)
+    local data, rerr = f:read_exactly(n)
+    f:close()
+    if data == nil then return nil, tostring(rerr or 'read_failed') end
+    return data, nil
+end
+
+function FileArtefactSource:close()
+    return true
+end
+
+local Artifact = {}
+Artifact.__index = Artifact
+
+function Artifact:ref()
+    return self._rec.artifact_ref
+end
+
+function Artifact:meta()
+    return copy_table(self._rec.meta)
+end
+
+function Artifact:size()
+    return self._rec.size
+end
+
+function Artifact:checksum()
+    return self._rec.checksum
+end
+
+function Artifact:open_source()
+    return setmetatable({
+        _path = self._blob_path,
+        _size = self._rec.size,
+        _checksum = self._rec.checksum,
+    }, FileArtefactSource)
+end
+
+function Artifact:delete()
+    return self._store:delete(self._rec.artifact_ref)
+end
+
+function Artifact:describe()
+    return clone_record(self._rec)
+end
+
+function Artifact:local_path()
+    return self._blob_path
+end
+
+local ArtifactSink = {}
+ArtifactSink.__index = ArtifactSink
+
+function ArtifactSink:write_chunk(offset, data)
+    if self._closed then return nil, 'closed' end
+    if self._committed then return nil, 'committed' end
+    if type(data) ~= 'string' then return nil, 'invalid_chunk' end
+    if offset ~= self._rec.size then return nil, 'unexpected_offset' end
+    local f, err = file.open(self._blob_path, 'a+')
+    if not f then return nil, tostring(err) end
+    local n, werr = f:write(data)
+    f:close()
+    if n == nil then return nil, tostring(werr or 'write_failed') end
+    self._rec.size = self._rec.size + #data
+    self._rec.updated_at = os.time()
+    local mok, merr = write_json(self._meta_path, self._rec)
+    if not mok then return nil, merr end
+    self._checksum = nil
+    return true
+end
+
+function ArtifactSink:size()
+    return self._rec.size
+end
+
+function ArtifactSink:checksum()
+    if self._checksum then return self._checksum end
+    local src = setmetatable({
+        _path = self._blob_path,
+        _size = self._rec.size,
+    }, FileArtefactSource)
+    self._checksum = src:checksum()
+    return self._checksum
+end
+
+function ArtifactSink:commit()
+    if self._closed then return nil, 'closed' end
+    if self._committed then return nil, 'committed' end
+    self._rec.state = 'ready'
+    self._rec.checksum = self:checksum()
+    self._rec.updated_at = os.time()
+    local ok, err = write_json(self._meta_path, self._rec)
+    if not ok then return nil, err end
+    self._committed = true
+    self._closed = true
+    return setmetatable({
+        _store = self._store,
+        _rec = clone_record(self._rec),
+        _blob_path = self._blob_path,
+    }, Artifact), ''
+end
+
+function ArtifactSink:abort()
+    if self._closed then return true end
+    self._closed = true
+    self._aborted = true
+    remove_tree(self._dir)
+    return true
+end
+
+function ArtifactSink:close()
+    if self._closed then return true end
+    self._closed = true
+    return true
+end
+
+function ArtifactSink:status()
+    return {
+        artifact_ref = self._rec.artifact_ref,
+        state = self._rec.state,
+        durability = self._rec.durability,
+        size = self._rec.size,
+        checksum = self._rec.checksum,
+        committed = self._committed,
+        aborted = self._aborted,
+    }
+end
+
+function Store:create_sink(meta, opts)
+    opts = opts or {}
+    local durability, err = choose_durability(self, opts.policy)
+    if not durability then return nil, err end
+    local ref = tostring(uuid.new()):gsub('[^A-Za-z0-9_.-]', '-')
+    local dir = artifact_dir(self, ref, durability)
+    local ok, derr = ensure_dir(dir)
+    if not ok then return nil, derr end
+    local blob = blob_path(self, ref, durability)
+    local f, ferr = file.open(blob, 'w+')
+    if not f then
+        remove_tree(dir)
+        return nil, tostring(ferr)
+    end
+    f:close()
+    local rec = {
+        artifact_ref = ref,
+        state = 'writing',
+        durability = durability,
+        size = 0,
+        checksum = nil,
+        created_at = os.time(),
+        updated_at = os.time(),
+        meta = type(meta) == 'table' and copy_table(meta) or {},
+    }
+    local mp = meta_path(self, ref, durability)
+    local mok, merr = write_json(mp, rec)
+    if not mok then
+        remove_tree(dir)
+        return nil, merr
+    end
+    return setmetatable({
+        _store = self,
+        _rec = rec,
+        _dir = dir,
+        _blob_path = blob,
+        _meta_path = mp,
+        _committed = false,
+        _aborted = false,
+        _closed = false,
+        _checksum = nil,
+    }, ArtifactSink), ''
+end
+
+function Store:open(ref)
+    if not valid_ref(ref) then return nil, 'invalid_artifact_ref' end
+    for _, durability in ipairs({ 'transient', 'durable' }) do
+        local rec, err = read_json(meta_path(self, ref, durability))
+        if rec then
+            if rec.state ~= 'ready' then return nil, 'artifact_not_ready' end
+            return setmetatable({
+                _store = self,
+                _rec = rec,
+                _blob_path = blob_path(self, ref, durability),
+            }, Artifact), ''
+        end
+    end
+    return nil, 'not_found'
+end
+
+function Store:import_source(source, meta, opts)
+    local sink, err = self:create_sink(meta, opts)
+    if not sink then return nil, err end
+    local artefact, cerr = blob_source.copy(source, sink)
+    if not artefact then return nil, cerr end
+    return artefact, ''
+end
+
+function Store:import_path(path, meta, opts)
+    if type(path) ~= 'string' or path == '' then return nil, 'invalid_path' end
+    if path:sub(1, 1) ~= '/' then
+        if path:find('..', 1, true) or path:find('/', 1, true) or path:find('\\', 1, true) then
+            return nil, 'invalid_path'
+        end
+        local import_root = os.getenv('DEVICECODE_IMPORT_ARTIFACT_ROOT') or os.getenv('DEVICECODE_ARTIFACT_DIR') or self.durable_root or self.transient_root
+        path = join_path(import_root, path)
+    end
+    local f, err = file.open(path, 'r')
+    if not f then return nil, tostring(err) end
+    local sz, serr = f:seek('end')
+    if sz == nil then f:close(); return nil, tostring(serr or 'seek_failed') end
+    f:close()
+    local src = setmetatable({ _path = path, _size = sz }, FileArtefactSource)
+    return self:import_source(src, meta, opts)
+end
+
+function Store:describe(ref)
+    local art, err = self:open(ref)
+    if not art then return nil, err end
+    return art:describe(), ''
+end
+
+function Store:resolve_local(ref)
+    local art, err = self:open(ref)
+    if not art then return nil, err end
+    local rec = art:describe()
+    return {
+        artifact_ref = rec.artifact_ref,
+        durability = rec.durability,
+        path = art:local_path(),
+        meta = rec.meta,
+        size = rec.size,
+        checksum = rec.checksum,
+        state = rec.state,
+    }, ''
+end
+
+function Store:delete(ref)
+    if not valid_ref(ref) then return nil, 'invalid_artifact_ref' end
+    local rec, err = self:describe(ref)
+    if not rec then
+        if err == 'not_found' then return true, '' end
+        return false, err
+    end
+    remove_tree(artifact_dir(self, ref, rec.durability))
+    return true, ''
+end
+
+function Store:status()
+    return {
+        transient_root = self.transient_root,
+        durable_root = self.durable_root,
+        durable_enabled = self.durable_enabled,
+    }
+end
+
+function M.new(opts, logger)
+    opts = opts or {}
+    local transient_root = opts.transient_root or os.getenv('DEVICECODE_ARTIFACT_TRANSIENT_ROOT') or '/run/devicecode/artifacts'
+    local durable_root = opts.durable_root or os.getenv('DEVICECODE_ARTIFACT_DURABLE_ROOT') or '/data/devicecode/artifacts'
+    local durable_enabled = opts.durable_enabled
+    if durable_enabled == nil then
+        local env = os.getenv('DEVICECODE_DURABLE_ARTIFACTS')
+        durable_enabled = not (env == '0' or env == 'false' or env == 'FALSE')
+    end
+    local ok, err = ensure_dir(transient_root)
+    if not ok then
+        dlog(logger, 'error', { what = 'artifact_store_transient_root_failed', err = tostring(err), root = transient_root })
+        return nil, err
+    end
+    if durable_enabled then
+        local dok, derr = ensure_dir(durable_root)
+        if not dok then
+            dlog(logger, 'warn', { what = 'artifact_store_durable_root_failed', err = tostring(derr), root = durable_root })
+            durable_enabled = false
+        end
+    end
+    return setmetatable({
+        transient_root = transient_root,
+        durable_root = durable_root,
+        durable_enabled = durable_enabled,
+        logger = logger,
+    }, Store), ''
+end
+
+return M

--- a/src/services/hal/drivers/artifact_store_provider.lua
+++ b/src/services/hal/drivers/artifact_store_provider.lua
@@ -1,0 +1,131 @@
+local fibers = require 'fibers'
+local op = require 'fibers.op'
+local sleep = require 'fibers.sleep'
+local channel = require 'fibers.channel'
+
+local hal_types = require 'services.hal.types.core'
+local cap_types = require 'services.hal.types.capabilities'
+local cap_args = require 'services.hal.types.capability_args'
+local store_mod = require 'services.hal.drivers.artifact_store'
+
+local CONTROL_Q_LEN = 8
+local Driver = {}
+Driver.__index = Driver
+
+local function dlog(logger, level, payload)
+    if logger and logger[level] then logger[level](logger, payload) end
+end
+
+local function run_control_loop(ch, methods, logger, what)
+    fibers.current_scope():finally(function() dlog(logger, 'debug', { what = tostring(what or 'control_loop') .. '_exiting' }) end)
+    while true do
+        local request, req_err = ch:get()
+        if not request then
+            dlog(logger, 'debug', { what = tostring(what or 'control_loop') .. '_closed', err = tostring(req_err) })
+            break
+        end
+        local fn = methods[request.verb]
+        local ok, value_or_err
+        if type(fn) ~= 'function' then
+            ok, value_or_err = false, 'unsupported verb: ' .. tostring(request.verb)
+        else
+            local st, _, r1, r2 = fibers.run_scope(function() return fn(request.opts) end)
+            if st ~= 'ok' then ok, value_or_err = false, 'internal error: ' .. tostring(r1) else ok, value_or_err = r1, r2 end
+        end
+        local reply = hal_types.new.Reply(ok, value_or_err)
+        if reply then request.reply_ch:put(reply) end
+    end
+end
+
+function Driver:init()
+    if self.initialised then return 'already initialised' end
+    local st, err = store_mod.new(self.opts or {}, self.logger)
+    if not st then return tostring(err or 'artifact_store_init_failed') end
+    self.store = st
+    self.initialised = true
+    return ''
+end
+
+function Driver:create_sink(opts)
+    if opts == nil or getmetatable(opts) ~= cap_args.ArtifactStoreCreateSinkOpts then return false, 'invalid opts' end
+    local sink, err = self.store:create_sink(opts.meta, { policy = opts.policy })
+    if not sink then return false, err end
+    return true, sink
+end
+
+function Driver:import_path(opts)
+    if opts == nil or getmetatable(opts) ~= cap_args.ArtifactStoreImportPathOpts then return false, 'invalid opts' end
+    local art, err = self.store:import_path(opts.path, opts.meta, { policy = opts.policy })
+    if not art then return false, err end
+    return true, art
+end
+
+function Driver:import_source(opts)
+    if opts == nil or getmetatable(opts) ~= cap_args.ArtifactStoreImportSourceOpts then return false, 'invalid opts' end
+    local art, err = self.store:import_source(opts.source, opts.meta, { policy = opts.policy })
+    if not art then return false, err end
+    return true, art
+end
+
+function Driver:open(opts)
+    if opts == nil or getmetatable(opts) ~= cap_args.ArtifactStoreOpenOpts then return false, 'invalid opts' end
+    local art, err = self.store:open(opts.artifact_ref)
+    if not art then return false, err end
+    return true, art
+end
+
+function Driver:delete(opts)
+    if opts == nil or getmetatable(opts) ~= cap_args.ArtifactStoreDeleteOpts then return false, 'invalid opts' end
+    local ok, err = self.store:delete(opts.artifact_ref)
+    if not ok then return false, err end
+    return true, { ok = true }
+end
+
+function Driver:status(opts)
+    if opts ~= nil and getmetatable(opts) ~= cap_args.ArtifactStoreStatusOpts then return false, 'invalid opts' end
+    return true, self.store:status()
+end
+
+function Driver:capabilities(emit_ch)
+    if not self.initialised then return nil, 'artifact_store provider not initialised' end
+    self.cap_emit_ch = emit_ch
+    local cap, err = cap_types.new.ArtifactStoreCapability(self.id, self.control_ch)
+    if not cap then return nil, err end
+    return { cap }, ''
+end
+
+function Driver:start()
+    if not self.initialised then return false, 'artifact_store provider not initialised' end
+    if self.cap_emit_ch then
+        local meta, err = hal_types.new.Emit('artifact_store', self.id, 'meta', 'info', { provider = 'hal.artifact_store', version = 2 })
+        if meta then self.cap_emit_ch:put(meta) else dlog(self.logger, 'debug', { what = 'artifact_store_meta_emit_failed', id = self.id, err = tostring(err) }) end
+    end
+    local methods = {
+        create_sink = function(opts) return self:create_sink(opts) end,
+        import_path = function(opts) return self:import_path(opts) end,
+        import_source = function(opts) return self:import_source(opts) end,
+        open = function(opts) return self:open(opts) end,
+        delete = function(opts) return self:delete(opts) end,
+        status = function(opts) return self:status(opts) end,
+    }
+    local ok, err = self.scope:spawn(function() run_control_loop(self.control_ch, methods, self.logger, 'artifact_store_control_manager') end)
+    if not ok then return false, 'failed to spawn artifact_store control manager: ' .. tostring(err) end
+    return true, ''
+end
+
+function Driver:stop(timeout)
+    timeout = timeout or 5
+    self.scope:cancel('artifact_store provider stopped')
+    local source = fibers.perform(op.named_choice { join = self.scope:join_op(), timeout = sleep.sleep_op(timeout) })
+    if source == 'timeout' then return false, 'artifact_store provider stop timeout' end
+    return true, ''
+end
+
+local function new(id, opts, logger)
+    if type(id) ~= 'string' or id == '' then return nil, 'invalid id' end
+    local scope, err = fibers.current_scope():child()
+    if not scope then return nil, 'failed to create child scope: ' .. tostring(err) end
+    return setmetatable({ id = id, opts = opts or {}, logger = logger, scope = scope, store = nil, initialised = false, control_ch = channel.new(CONTROL_Q_LEN), cap_emit_ch = nil }, Driver), ''
+end
+
+return { new = new, Driver = Driver }

--- a/src/services/hal/drivers/control_store.lua
+++ b/src/services/hal/drivers/control_store.lua
@@ -1,0 +1,218 @@
+local fibers = require "fibers"
+local file   = require "fibers.io.file"
+local cjson  = require "cjson.safe"
+local safe = require 'coxpcall'
+
+local perform = fibers.perform
+
+local M = {}
+local Store = {}
+Store.__index = Store
+
+local function dlog(logger, level, payload)
+    if logger and logger[level] then
+        logger[level](logger, payload)
+    end
+end
+
+local function trim(s)
+    return (s or ''):match('^%s*(.-)%s*$') or ''
+end
+
+local function join_path(...)
+    local parts = { ... }
+    return table.concat(parts, '/')
+end
+
+local function dirname(path)
+    local d = tostring(path or ''):match('^(.*)/[^/]+$')
+    if d == nil or d == '' then return '.' end
+    return d
+end
+
+local function ensure_dir(path)
+    local ok, err = file.mkdir_p(path)
+    if not ok then return false, tostring(err or 'mkdir_failed') end
+    return true, ''
+end
+
+local function read_file(path)
+    local f, err = file.open(path, 'r')
+    if not f then return nil, tostring(err) end
+    local raw, rerr = f:read_all()
+    f:close()
+    if raw == nil then return nil, tostring(rerr) end
+    return raw, ''
+end
+
+local function write_file(path, data)
+    local ok, derr = ensure_dir(dirname(path))
+    if not ok then return false, derr end
+    local tmp = path .. '.tmp-' .. tostring(os.time()) .. '-' .. tostring(math.random(1000000))
+    local f, err = file.open(tmp, 'w')
+    if not f then return false, tostring(err) end
+    local n, werr = f:write(data)
+    f:close()
+    if n == nil then
+        safe.pcall(function() file.unlink(tmp) end)
+        return false, tostring(werr)
+    end
+    local ok_rename, rerr = file.rename(tmp, path)
+    if not ok_rename then
+        safe.pcall(function() file.unlink(tmp) end)
+        return false, tostring(rerr)
+    end
+    return true, ''
+end
+
+local function read_json(path)
+    local raw, err = read_file(path)
+    if raw == nil then return nil, err end
+    local obj, derr = cjson.decode(raw)
+    if obj == nil then return nil, tostring(derr or 'decode_failed') end
+    return obj, ''
+end
+
+local function write_json(path, obj)
+    local raw, err = cjson.encode(obj)
+    if not raw then return false, tostring(err or 'encode_failed') end
+    return write_file(path, raw)
+end
+
+local function valid_part(part)
+    return type(part) == 'string' and part ~= '' and part:match('^[A-Za-z0-9_.-]+$') ~= nil
+end
+
+local function valid_ns(ns)
+    if type(ns) ~= 'string' or ns == '' then return false end
+    for part in ns:gmatch('[^/]+') do
+        if not valid_part(part) then return false end
+    end
+    return true
+end
+
+local function valid_key(key)
+    return valid_part(key)
+end
+
+local function ns_dir(self, ns)
+    return join_path(self.root, ns)
+end
+
+local function index_path(self, ns)
+    return join_path(ns_dir(self, ns), '.index.json')
+end
+
+local function record_path(self, ns, key)
+    return join_path(ns_dir(self, ns), key .. '.json')
+end
+
+local function load_index(self, ns)
+    local obj, err = read_json(index_path(self, ns))
+    if not obj then
+        local msg = tostring(err or '')
+        if msg:find('No such file', 1, true) or msg:find('ENOENT', 1, true) or msg:find('no such file', 1, true) then
+            return {}, ''
+        end
+        return nil, err
+    end
+    if type(obj) ~= 'table' then return {}, '' end
+    local out = {}
+    for _, key in ipairs(obj) do
+        if valid_key(key) then out[#out + 1] = key end
+    end
+    return out, ''
+end
+
+local function save_index(self, ns, keys)
+    return write_json(index_path(self, ns), keys)
+end
+
+function Store:get(ns, key)
+    if not valid_ns(ns) then return nil, 'invalid_namespace' end
+    if not valid_key(key) then return nil, 'invalid_key' end
+    local obj, err = read_json(record_path(self, ns, key))
+    if not obj then
+        local msg = tostring(err or '')
+        if msg:find('No such file', 1, true) or msg:find('ENOENT', 1, true) or msg:find('no such file', 1, true) then
+            return nil, 'not_found'
+        end
+        return nil, err
+    end
+    return obj, ''
+end
+
+function Store:put(ns, key, value)
+    if not valid_ns(ns) then return false, 'invalid_namespace' end
+    if not valid_key(key) then return false, 'invalid_key' end
+    if type(value) ~= 'table' then return false, 'invalid_value' end
+
+    local encoded, eerr = cjson.encode(value)
+    if not encoded then return false, tostring(eerr or 'encode_failed') end
+    if self.max_record_bytes and #encoded > self.max_record_bytes then
+        return false, 'record_too_large'
+    end
+
+    local ok, err = write_file(record_path(self, ns, key), encoded)
+    if not ok then return false, err end
+
+    local keys, kerr = load_index(self, ns)
+    if not keys then return false, kerr end
+    local found = false
+    for _, existing in ipairs(keys) do
+        if existing == key then found = true break end
+    end
+    if not found then
+        keys[#keys + 1] = key
+        table.sort(keys)
+        local iok, ierr = save_index(self, ns, keys)
+        if not iok then return false, ierr end
+    end
+
+    return true, ''
+end
+
+function Store:delete(ns, key)
+    if not valid_ns(ns) then return false, 'invalid_namespace' end
+    if not valid_key(key) then return false, 'invalid_key' end
+    safe.pcall(function() file.unlink(record_path(self, ns, key)) end)
+    local keys, err = load_index(self, ns)
+    if not keys then return false, err end
+    local out = {}
+    for _, existing in ipairs(keys) do
+        if existing ~= key then out[#out + 1] = existing end
+    end
+    local ok, ierr = save_index(self, ns, out)
+    if not ok then return false, ierr end
+    return true, ''
+end
+
+function Store:list(ns)
+    if not valid_ns(ns) then return nil, 'invalid_namespace' end
+    return load_index(self, ns)
+end
+
+function Store:status()
+    return {
+        root = self.root,
+        max_record_bytes = self.max_record_bytes,
+    }
+end
+
+function M.new(opts, logger)
+    opts = opts or {}
+    local root = opts.root or os.getenv('DEVICECODE_CONTROL_ROOT') or '/data/devicecode/control'
+    local max_record_bytes = opts.max_record_bytes or 65536
+    local ok, err = ensure_dir(root)
+    if not ok then
+        dlog(logger, 'error', { what = 'control_store_root_failed', err = tostring(err), root = root })
+        return nil, err
+    end
+    return setmetatable({
+        root = root,
+        max_record_bytes = max_record_bytes,
+        logger = logger,
+    }, Store), ''
+end
+
+return M

--- a/src/services/hal/drivers/control_store_provider.lua
+++ b/src/services/hal/drivers/control_store_provider.lua
@@ -1,0 +1,123 @@
+local fibers = require 'fibers'
+local op = require 'fibers.op'
+local sleep = require 'fibers.sleep'
+local channel = require 'fibers.channel'
+
+local hal_types = require 'services.hal.types.core'
+local cap_types = require 'services.hal.types.capabilities'
+local cap_args = require 'services.hal.types.capability_args'
+local store_mod = require 'services.hal.drivers.control_store'
+
+local CONTROL_Q_LEN = 8
+local Driver = {}
+Driver.__index = Driver
+
+local function dlog(logger, level, payload)
+    if logger and logger[level] then logger[level](logger, payload) end
+end
+
+local function run_control_loop(ch, methods, logger, what)
+    fibers.current_scope():finally(function() dlog(logger, 'debug', { what = tostring(what or 'control_loop') .. '_exiting' }) end)
+    while true do
+        local request, req_err = ch:get()
+        if not request then
+            dlog(logger, 'debug', { what = tostring(what or 'control_loop') .. '_closed', err = tostring(req_err) })
+            break
+        end
+        local fn = methods[request.verb]
+        local ok, value_or_err
+        if type(fn) ~= 'function' then
+            ok, value_or_err = false, 'unsupported verb: ' .. tostring(request.verb)
+        else
+            local st, _, r1, r2 = fibers.run_scope(function() return fn(request.opts) end)
+            if st ~= 'ok' then ok, value_or_err = false, 'internal error: ' .. tostring(r1) else ok, value_or_err = r1, r2 end
+        end
+        local reply = hal_types.new.Reply(ok, value_or_err)
+        if reply then request.reply_ch:put(reply) end
+    end
+end
+
+function Driver:init()
+    if self.initialised then return 'already initialised' end
+    local st, err = store_mod.new(self.opts or {}, self.logger)
+    if not st then return tostring(err or 'control_store_init_failed') end
+    self.store = st
+    self.initialised = true
+    return ''
+end
+
+function Driver:get(opts)
+    if opts == nil or getmetatable(opts) ~= cap_args.ControlStoreGetOpts then return false, 'invalid opts' end
+    local value, err = self.store:get(opts.ns, opts.key)
+    if value == nil then return false, err end
+    return true, value
+end
+
+function Driver:put(opts)
+    if opts == nil or getmetatable(opts) ~= cap_args.ControlStorePutOpts then return false, 'invalid opts' end
+    local ok, err = self.store:put(opts.ns, opts.key, opts.value)
+    if not ok then return false, err end
+    return true, { ok = true }
+end
+
+function Driver:delete(opts)
+    if opts == nil or getmetatable(opts) ~= cap_args.ControlStoreDeleteOpts then return false, 'invalid opts' end
+    local ok, err = self.store:delete(opts.ns, opts.key)
+    if not ok then return false, err end
+    return true, { ok = true }
+end
+
+function Driver:list(opts)
+    if opts == nil or getmetatable(opts) ~= cap_args.ControlStoreListOpts then return false, 'invalid opts' end
+    local keys, err = self.store:list(opts.ns)
+    if not keys then return false, err end
+    return true, { ns = opts.ns, keys = keys }
+end
+
+function Driver:status(opts)
+    if opts ~= nil and getmetatable(opts) ~= cap_args.ControlStoreStatusOpts then return false, 'invalid opts' end
+    return true, self.store:status()
+end
+
+function Driver:capabilities(emit_ch)
+    if not self.initialised then return nil, 'control_store provider not initialised' end
+    self.cap_emit_ch = emit_ch
+    local cap, err = cap_types.new.ControlStoreCapability(self.id, self.control_ch)
+    if not cap then return nil, err end
+    return { cap }, ''
+end
+
+function Driver:start()
+    if not self.initialised then return false, 'control_store provider not initialised' end
+    if self.cap_emit_ch then
+        local meta, err = hal_types.new.Emit('control_store', self.id, 'meta', 'info', { provider = 'hal.control_store', version = 2 })
+        if meta then self.cap_emit_ch:put(meta) else dlog(self.logger, 'debug', { what = 'control_store_meta_emit_failed', id = self.id, err = tostring(err) }) end
+    end
+    local methods = {
+        get = function(opts) return self:get(opts) end,
+        put = function(opts) return self:put(opts) end,
+        delete = function(opts) return self:delete(opts) end,
+        list = function(opts) return self:list(opts) end,
+        status = function(opts) return self:status(opts) end,
+    }
+    local ok, err = self.scope:spawn(function() run_control_loop(self.control_ch, methods, self.logger, 'control_store_control_manager') end)
+    if not ok then return false, 'failed to spawn control_store control manager: ' .. tostring(err) end
+    return true, ''
+end
+
+function Driver:stop(timeout)
+    timeout = timeout or 5
+    self.scope:cancel('control_store provider stopped')
+    local source = fibers.perform(op.named_choice { join = self.scope:join_op(), timeout = sleep.sleep_op(timeout) })
+    if source == 'timeout' then return false, 'control_store provider stop timeout' end
+    return true, ''
+end
+
+local function new(id, opts, logger)
+    if type(id) ~= 'string' or id == '' then return nil, 'invalid id' end
+    local scope, err = fibers.current_scope():child()
+    if not scope then return nil, 'failed to create child scope: ' .. tostring(err) end
+    return setmetatable({ id = id, opts = opts or {}, logger = logger, scope = scope, store = nil, initialised = false, control_ch = channel.new(CONTROL_Q_LEN), cap_emit_ch = nil }, Driver), ''
+end
+
+return { new = new, Driver = Driver }

--- a/src/services/hal/drivers/signature_verify_openssl.lua
+++ b/src/services/hal/drivers/signature_verify_openssl.lua
@@ -1,0 +1,93 @@
+local fibers = require 'fibers'
+local file = require 'fibers.io.file'
+local exec = require 'fibers.io.exec'
+
+local perform = fibers.perform
+
+local M = {}
+local Driver = {}
+Driver.__index = Driver
+
+local function close_best_effort(stream)
+	if not stream then return end
+	pcall(function() stream:close() end)
+end
+
+local function tmpfile_path(stream)
+	if stream and type(stream.filename) == 'function' then
+		return stream:filename()
+	end
+	return nil
+end
+
+local function write_temp_bytes(self, label, data)
+	local stream, err = self.file.tmpfile(384, self.tmpdir)
+	if not stream then return nil, 'tmpfile_failed:' .. tostring(err) end
+	local path = tmpfile_path(stream)
+	if type(path) ~= 'string' or path == '' then
+		close_best_effort(stream)
+		return nil, 'tmpfile_path_unavailable'
+	end
+	local n, werr = stream:write(data)
+	if n == nil then
+		close_best_effort(stream)
+		return nil, label .. '_write_failed:' .. tostring(werr or 'write_failed')
+	end
+	local ok, ferr = stream:flush()
+	if ok == nil then
+		close_best_effort(stream)
+		return nil, label .. '_flush_failed:' .. tostring(ferr or 'flush_failed')
+	end
+	return { stream = stream, path = path }, nil
+end
+
+function Driver:verify_ed25519(pubkey_pem, message, signature)
+	if type(pubkey_pem) ~= 'string' or pubkey_pem == '' then return nil, 'public_key_required' end
+	if type(message) ~= 'string' then return nil, 'message_required' end
+	if type(signature) ~= 'string' or signature == '' then return nil, 'signature_required' end
+
+	local pubf, perr = write_temp_bytes(self, 'pubkey', pubkey_pem)
+	if not pubf then return nil, perr end
+	local msgf, merr = write_temp_bytes(self, 'message', message)
+	if not msgf then close_best_effort(pubf.stream); return nil, merr end
+	local sigf, serr = write_temp_bytes(self, 'signature', signature)
+	if not sigf then close_best_effort(pubf.stream); close_best_effort(msgf.stream); return nil, serr end
+
+	local out, st, code, sig, cerr
+	local cmd = self.exec.command('openssl', 'pkeyutl', '-verify', '-pubin', '-inkey', pubf.path, '-sigfile', sigf.path, '-in', msgf.path, '-rawin')
+	out, st, code, sig, cerr = perform(cmd:combined_output_op())
+
+	close_best_effort(pubf.stream)
+	close_best_effort(msgf.stream)
+	close_best_effort(sigf.stream)
+
+	if st == 'exited' and code == 0 then
+		return true, nil
+	end
+
+	local detail = tostring(cerr or out or '')
+	local low = detail:lower()
+	if st == 'exited' and code == 1 and (low:find('signature verification failure', 1, true) or low:find('signature verify failure', 1, true) or low:find('verification failure', 1, true)) then
+		return false, 'signature_verify_failed'
+	end
+	if st == 'signalled' then
+		return nil, 'openssl_signalled:' .. tostring(sig)
+	end
+	if st == 'exited' then
+		if detail == '' then detail = 'exit_' .. tostring(code) end
+		return nil, 'openssl_verify_failed:' .. detail
+	end
+	if detail == '' then detail = tostring(st or 'unknown') end
+	return nil, 'openssl_verify_failed:' .. detail
+end
+
+function M.new(opts)
+	opts = opts or {}
+	return setmetatable({
+		file = opts.file or file,
+		exec = opts.exec or exec,
+		tmpdir = opts.tmpdir or os.getenv('TMPDIR') or '/tmp',
+	}, Driver)
+end
+
+return M

--- a/src/services/hal/drivers/signature_verify_provider.lua
+++ b/src/services/hal/drivers/signature_verify_provider.lua
@@ -1,0 +1,87 @@
+local fibers = require 'fibers'
+local op = require 'fibers.op'
+local sleep = require 'fibers.sleep'
+local channel = require 'fibers.channel'
+
+local hal_types = require 'services.hal.types.core'
+local cap_types = require 'services.hal.types.capabilities'
+local cap_args = require 'services.hal.types.capability_args'
+local openssl = require 'services.hal.drivers.signature_verify_openssl'
+
+local CONTROL_Q_LEN = 8
+local Driver = {}
+Driver.__index = Driver
+
+local function dlog(logger, level, payload)
+    if logger and logger[level] then logger[level](logger, payload) end
+end
+
+local function run_control_loop(ch, methods, logger, what)
+    fibers.current_scope():finally(function() dlog(logger, 'debug', { what = tostring(what or 'control_loop') .. '_exiting' }) end)
+    while true do
+        local request, req_err = ch:get()
+        if not request then
+            dlog(logger, 'debug', { what = tostring(what or 'control_loop') .. '_closed', err = tostring(req_err) })
+            break
+        end
+        local fn = methods[request.verb]
+        local ok, value_or_err
+        if type(fn) ~= 'function' then
+            ok, value_or_err = false, 'unsupported verb: ' .. tostring(request.verb)
+        else
+            local st, _, r1, r2 = fibers.run_scope(function() return fn(request.opts) end)
+            if st ~= 'ok' then ok, value_or_err = false, 'internal error: ' .. tostring(r1) else ok, value_or_err = r1, r2 end
+        end
+        local reply = hal_types.new.Reply(ok, value_or_err)
+        if reply then request.reply_ch:put(reply) end
+    end
+end
+
+function Driver:init()
+    if self.initialised then return 'already initialised' end
+    self.verifier = openssl.new(self.opts or {})
+    self.initialised = true
+    return ''
+end
+
+function Driver:verify_ed25519(opts)
+    if opts == nil or getmetatable(opts) ~= cap_args.SignatureVerifyEd25519Opts then return false, 'invalid opts' end
+    return self.verifier:verify_ed25519(opts.pubkey_pem, opts.message, opts.signature)
+end
+
+function Driver:capabilities(emit_ch)
+    if not self.initialised then return nil, 'signature_verify provider not initialised' end
+    self.cap_emit_ch = emit_ch
+    local cap, err = cap_types.new.SignatureVerifyCapability(self.id, self.control_ch)
+    if not cap then return nil, err end
+    return { cap }, ''
+end
+
+function Driver:start()
+    if not self.initialised then return false, 'signature_verify provider not initialised' end
+    if self.cap_emit_ch then
+        local meta, err = hal_types.new.Emit('signature_verify', self.id, 'meta', 'info', { provider = 'hal.signature_verify', backend = 'openssl-cli', version = 2 })
+        if meta then self.cap_emit_ch:put(meta) else dlog(self.logger, 'debug', { what = 'signature_verify_meta_emit_failed', id = self.id, err = tostring(err) }) end
+    end
+    local methods = { verify_ed25519 = function(opts) return self:verify_ed25519(opts) end }
+    local ok, err = self.scope:spawn(function() run_control_loop(self.control_ch, methods, self.logger, 'signature_verify_control_manager') end)
+    if not ok then return false, 'failed to spawn signature_verify control manager: ' .. tostring(err) end
+    return true, ''
+end
+
+function Driver:stop(timeout)
+    timeout = timeout or 5
+    self.scope:cancel('signature_verify provider stopped')
+    local source = fibers.perform(op.named_choice { join = self.scope:join_op(), timeout = sleep.sleep_op(timeout) })
+    if source == 'timeout' then return false, 'signature_verify provider stop timeout' end
+    return true, ''
+end
+
+local function new(id, opts, logger)
+    if type(id) ~= 'string' or id == '' then return nil, 'invalid id' end
+    local scope, err = fibers.current_scope():child()
+    if not scope then return nil, 'failed to create child scope: ' .. tostring(err) end
+    return setmetatable({ id = id, opts = opts or {}, logger = logger, scope = scope, verifier = nil, initialised = false, control_ch = channel.new(CONTROL_Q_LEN), cap_emit_ch = nil }, Driver), ''
+end
+
+return { new = new, Driver = Driver }

--- a/src/services/hal/drivers/uart.lua
+++ b/src/services/hal/drivers/uart.lua
@@ -1,0 +1,616 @@
+-- services/hal/drivers/uart.lua
+--
+-- UART HAL driver.
+--
+-- Native dev-branch behaviour:
+--   * exposes a uart capability with control verb 'open'
+--   * returns a real fibers Stream in Reply.reason
+--   * the caller uses that stream directly in-process
+--
+-- The legacy bus-level byte relay is deliberately not used here.
+
+local fibers  = require 'fibers'
+local op      = require 'fibers.op'
+local sleep   = require 'fibers.sleep'
+local file    = require 'fibers.io.file'
+local exec    = require 'fibers.io.exec'
+local channel = require 'fibers.channel'
+local safe    = require 'coxpcall'
+
+local hal_types = require 'services.hal.types.core'
+local cap_types = require 'services.hal.types.capabilities'
+local cap_args  = require 'services.hal.types.capability_args'
+
+local perform = fibers.perform
+local unpack  = rawget(table, 'unpack') or _G.unpack
+
+local CONTROL_Q_LEN        = 8
+local DEFAULT_STOP_TIMEOUT = 5.0
+local TRACE_MAX            = 128
+
+local function dlog(logger, level, payload)
+	if logger and logger[level] then
+		logger[level](logger, payload)
+	end
+end
+
+local function trace_push(self, what, fields)
+	self._trace_seq = (self._trace_seq or 0) + 1
+
+	local rec = {
+		seq    = self._trace_seq,
+		t      = fibers.now(),
+		what   = what,
+		cap_id = self.cap_id,
+	}
+
+	for k, v in pairs(fields or {}) do
+		rec[k] = v
+	end
+
+	local tr = self._trace or {}
+	tr[#tr + 1] = rec
+	if #tr > TRACE_MAX then
+		table.remove(tr, 1)
+	end
+	self._trace = tr
+end
+
+local function copy_trace(trace)
+	local out = {}
+	for i = 1, #(trace or {}) do
+		local src = trace[i]
+		local rec = {}
+		for k, v in pairs(src or {}) do
+			rec[k] = v
+		end
+		out[i] = rec
+	end
+	return out
+end
+
+---@class UARTDriver
+---@field cap_id string
+---@field device_path string
+---@field baud integer|nil
+---@field mode string|nil
+---@field scope Scope
+---@field control_ch Channel
+---@field cap_emit_ch Channel|nil
+---@field logger Logger|nil
+---@field initialised boolean
+---@field active_stream Stream|nil
+---@field _trace table[]
+---@field _trace_seq integer
+local UARTDriver = {}
+UARTDriver.__index = UARTDriver
+
+local function emit_state(emit_ch, cap_id, payload, logger)
+	if not emit_ch then return end
+	local msg, err = hal_types.new.Emit('uart', cap_id, 'state', 'stream', payload)
+	if not msg then
+		dlog(logger, 'warn', { what = 'uart_emit_failed', err = tostring(err), cap_id = cap_id })
+		return
+	end
+	emit_ch:put(msg)
+end
+
+local function emit_event(emit_ch, cap_id, key, payload, logger)
+	if not emit_ch then return end
+	local msg, err = hal_types.new.Emit('uart', cap_id, 'event', key, payload)
+	if not msg then
+		dlog(logger, 'warn', { what = 'uart_emit_failed', err = tostring(err), cap_id = cap_id, key = key })
+		return
+	end
+	emit_ch:put(msg)
+end
+
+local function parse_mode(mode)
+	mode = mode or '8N1'
+	local db, par, sb = tostring(mode):match('^(%d)([NEO])(%d)$')
+	if not db then
+		return nil, 'unsupported serial mode: ' .. tostring(mode)
+	end
+
+	db = tonumber(db)
+	sb = tonumber(sb)
+
+	local parity
+	if par == 'N' then
+		parity = 'none'
+	elseif par == 'E' then
+		parity = 'even'
+	elseif par == 'O' then
+		parity = 'odd'
+	else
+		return nil, 'unsupported parity in mode: ' .. tostring(mode)
+	end
+
+	return {
+		data_bits = db,
+		stop_bits = sb,
+		parity    = parity,
+	}, nil
+end
+
+local function stty_argv(device_path, baud, mode)
+	local argv = { 'stty', '-F', tostring(device_path), 'raw', '-echo' }
+
+	if baud ~= nil then
+		argv[#argv + 1] = tostring(baud)
+	end
+
+	local pmode, err = parse_mode(mode or '8N1')
+	if not pmode then
+		return nil, err
+	end
+
+	argv[#argv + 1] = 'cs' .. tostring(pmode.data_bits)
+
+	if pmode.stop_bits == 2 then
+		argv[#argv + 1] = 'cstopb'
+	else
+		argv[#argv + 1] = '-cstopb'
+	end
+
+	if pmode.parity == 'none' then
+		argv[#argv + 1] = '-parenb'
+		argv[#argv + 1] = '-parodd'
+	elseif pmode.parity == 'even' then
+		argv[#argv + 1] = 'parenb'
+		argv[#argv + 1] = '-parodd'
+	elseif pmode.parity == 'odd' then
+		argv[#argv + 1] = 'parenb'
+		argv[#argv + 1] = 'parodd'
+	end
+
+	return argv, nil
+end
+
+local function configure_port(device_path, baud, mode)
+	local argv, err = stty_argv(device_path, baud, mode)
+	if not argv then return nil, err end
+
+	local cmd = exec.command(unpack(argv))
+	local out, st, code, sig, cerr = perform(cmd:combined_output_op())
+	if st == 'exited' and code == 0 then
+		return true, nil
+	end
+
+	local detail = cerr or out or ('status=' .. tostring(st))
+	if st == 'exited' then
+		detail = tostring(detail) .. ' (exit ' .. tostring(code) .. ')'
+	elseif st == 'signalled' then
+		detail = tostring(detail) .. ' (signal ' .. tostring(sig) .. ')'
+	end
+	return nil, detail
+end
+
+local function open_mode_from_opts(opts)
+	if opts.read and opts.write then return 'r+' end
+	if opts.read then return 'r' end
+	return 'w'
+end
+
+local function close_stream_best_effort(stream)
+	if not (stream and stream.close_op) then
+		return true, nil
+	end
+
+	local ok, a, b = safe.pcall(function()
+		return op.perform_raw(stream:close_op())
+	end)
+	if not ok then
+		return nil, tostring(a)
+	end
+	return a, b
+end
+
+local function unregister_stream(self, stream)
+	if self.active_stream ~= stream then return end
+
+	trace_push(self, 'driver.stream.unregister', {
+		path = self.device_path,
+	})
+
+	self.active_stream = nil
+	emit_state(self.cap_emit_ch, self.cap_id, {
+		open = false,
+		path = self.device_path,
+		baud = self.baud,
+		mode = self.mode,
+	}, self.logger)
+	emit_event(self.cap_emit_ch, self.cap_id, 'closed', {
+		path = self.device_path,
+	}, self.logger)
+end
+
+local function wrap_stream_close(self, stream)
+	if stream._devicecode_uart_wrapped then
+		return stream
+	end
+	stream._devicecode_uart_wrapped = true
+
+	local old_close_op = assert(stream.close_op, 'uart stream missing close_op()')
+
+	stream.close_op = function(s)
+		return op.guard(function()
+			return old_close_op(s):wrap(function(ok, err)
+				trace_push(self, 'driver.stream.close_op.done', {
+					ok  = (ok ~= nil),
+					err = (ok == nil) and tostring(err) or nil,
+				})
+
+				if ok ~= nil then
+					unregister_stream(self, s)
+				end
+				return ok, err
+			end)
+		end)
+	end
+
+	return stream
+end
+
+---@param parent_scope Scope
+---@param cap_id string
+---@param device_path string
+---@param opts table|nil
+---@param logger Logger|nil
+---@return UARTDriver?|nil
+---@return string error
+local function new(parent_scope, cap_id, device_path, opts, logger)
+	opts = opts or {}
+
+	if type(cap_id) ~= 'string' or cap_id == '' then
+		return nil, 'invalid capability id'
+	end
+	if type(device_path) ~= 'string' or device_path == '' then
+		return nil, 'invalid device path'
+	end
+
+	local scope, err = parent_scope:child()
+	if not scope then
+		return nil, 'failed to create UART driver scope: ' .. tostring(err)
+	end
+
+	local self = setmetatable({
+		cap_id        = cap_id,
+		device_path   = device_path,
+		baud          = (type(opts.baud) == 'number') and math.floor(opts.baud) or nil,
+		mode          = (type(opts.mode) == 'string' and opts.mode ~= '') and opts.mode or nil,
+		scope         = scope,
+		control_ch    = channel.new(CONTROL_Q_LEN),
+		cap_emit_ch   = nil,
+		logger        = logger,
+		initialised   = false,
+		active_stream = nil,
+		_trace        = {},
+		_trace_seq    = 0,
+	}, UARTDriver)
+
+	trace_push(self, 'driver.new', {
+		path = device_path,
+		baud = self.baud,
+		mode = self.mode,
+	})
+
+	return self, ''
+end
+
+function UARTDriver:debug_snapshot()
+	return {
+		cap_id        = self.cap_id,
+		device_path   = self.device_path,
+		baud          = self.baud,
+		mode          = self.mode,
+		initialised   = self.initialised,
+		active_stream = self.active_stream ~= nil,
+		trace         = copy_trace(self._trace),
+	}
+end
+
+function UARTDriver:init()
+	trace_push(self, 'driver.init.begin', {
+		initialised = self.initialised,
+	})
+
+	if self.initialised then
+		trace_push(self, 'driver.init.already_initialised')
+		return 'already initialised'
+	end
+
+	self.initialised = true
+	trace_push(self, 'driver.init.ok')
+	return ''
+end
+
+---@param emit_ch Channel
+---@return Capability[]?
+---@return string error
+function UARTDriver:capabilities(emit_ch)
+	trace_push(self, 'driver.capabilities.begin', {
+		initialised = self.initialised,
+	})
+
+	if not self.initialised then
+		trace_push(self, 'driver.capabilities.not_initialised')
+		return nil, 'uart driver not initialised'
+	end
+
+	self.cap_emit_ch = emit_ch
+	local cap, err = cap_types.new.UARTCapability(self.cap_id, self.control_ch)
+	if not cap then
+		trace_push(self, 'driver.capabilities.failed', {
+			err = tostring(err),
+		})
+		return nil, tostring(err)
+	end
+
+	trace_push(self, 'driver.capabilities.ok')
+	return { cap }, ''
+end
+
+---@param opts UARTOpenOpts?
+---@return boolean ok
+---@return any value_or_err
+function UARTDriver:open(opts)
+	trace_push(self, 'driver.open.begin', {
+		active_stream = self.active_stream ~= nil,
+		read          = opts and opts.read or nil,
+		write         = opts and opts.write or nil,
+	})
+
+	if opts == nil or getmetatable(opts) ~= cap_args.UARTOpenOpts then
+		trace_push(self, 'driver.open.invalid_opts')
+		return false, 'invalid options'
+	end
+
+	if self.active_stream ~= nil then
+		trace_push(self, 'driver.open.already_open')
+		return false, 'uart already open'
+	end
+
+	local ok_cfg, cfg_err = configure_port(self.device_path, self.baud, self.mode)
+	if ok_cfg ~= true then
+		trace_push(self, 'driver.open.configure_failed', {
+			err = tostring(cfg_err),
+		})
+		dlog(self.logger, 'warn', {
+			what   = 'uart_configure_failed',
+			cap_id = self.cap_id,
+			path   = self.device_path,
+			err    = tostring(cfg_err),
+		})
+		return false, 'stty failed: ' .. tostring(cfg_err)
+	end
+
+	local stream, open_err = file.open(self.device_path, open_mode_from_opts(opts))
+	if not stream then
+		trace_push(self, 'driver.open.file_open_failed', {
+			err = tostring(open_err),
+		})
+		return false, 'open failed: ' .. tostring(open_err)
+	end
+
+	if stream.setvbuf then stream:setvbuf('no') end
+
+	stream = wrap_stream_close(self, stream)
+	self.active_stream = stream
+
+	trace_push(self, 'driver.open.ok', {
+		path = self.device_path,
+	})
+
+	emit_state(self.cap_emit_ch, self.cap_id, {
+		open = true,
+		path = self.device_path,
+		baud = self.baud,
+		mode = self.mode,
+	}, self.logger)
+	emit_event(self.cap_emit_ch, self.cap_id, 'opened', {
+		path = self.device_path,
+		baud = self.baud,
+		mode = self.mode,
+	}, self.logger)
+
+	return true, stream
+end
+
+---@param _opts any
+---@return boolean ok
+---@return any value_or_err
+function UARTDriver:close(_opts)
+	trace_push(self, 'driver.close.begin', {
+		active_stream = self.active_stream ~= nil,
+	})
+
+	local s = self.active_stream
+	if not s then
+		trace_push(self, 'driver.close.noop')
+		return true, nil
+	end
+
+	local ok, err = perform(s:close_op())
+	if ok == nil then
+		trace_push(self, 'driver.close.failed', {
+			err = tostring(err),
+		})
+		return false, err
+	end
+
+	trace_push(self, 'driver.close.ok')
+	return true, nil
+end
+
+---@param opts UARTWriteOpts?
+---@return boolean ok
+---@return any value_or_err
+function UARTDriver:write(opts)
+	trace_push(self, 'driver.write.begin', {
+		active_stream = self.active_stream ~= nil,
+		n             = opts and opts.data and #opts.data or nil,
+	})
+
+	if opts == nil or getmetatable(opts) ~= cap_args.UARTWriteOpts then
+		trace_push(self, 'driver.write.invalid_opts')
+		return false, 'invalid options'
+	end
+
+	local s = self.active_stream
+	if not s then
+		trace_push(self, 'driver.write.not_open')
+		return false, 'uart is not open'
+	end
+
+	local n, err = perform(s:write_op(opts.data))
+	if n == nil then
+		trace_push(self, 'driver.write.failed', {
+			err = tostring(err),
+		})
+		return false, err
+	end
+
+	trace_push(self, 'driver.write.ok', {
+		n = n,
+	})
+	return true, n
+end
+
+function UARTDriver:control_manager()
+	trace_push(self, 'driver.control_manager.enter')
+
+	fibers.current_scope():finally(function()
+		trace_push(self, 'driver.control_manager.exit')
+		dlog(self.logger, 'debug', { what = 'control_manager_exiting', cap_id = self.cap_id })
+	end)
+
+	while true do
+		local request, req_err = self.control_ch:get()
+		if not request then
+			trace_push(self, 'driver.control_manager.channel_closed', {
+				err = tostring(req_err),
+			})
+			dlog(self.logger, 'debug', {
+				what   = 'control_ch_closed',
+				cap_id = self.cap_id,
+				err    = tostring(req_err),
+			})
+			break
+		end
+
+		trace_push(self, 'driver.control_manager.request', {
+			verb = request.verb,
+		})
+
+		local fn = self[request.verb]
+		local ok, value_or_err
+		if type(fn) ~= 'function' then
+			ok, value_or_err = false, 'unsupported verb: ' .. tostring(request.verb)
+		else
+			local st, _, r1, r2 = fibers.run_scope(function()
+				return fn(self, request.opts)
+			end)
+			if st ~= 'ok' then
+				ok, value_or_err = false, 'internal error: ' .. tostring(r1)
+			else
+				ok, value_or_err = r1, r2
+			end
+		end
+
+		trace_push(self, 'driver.control_manager.reply', {
+			verb     = request.verb,
+			ok       = (ok == true),
+			err      = (ok ~= true) and tostring(value_or_err) or nil,
+			has_value = (ok == true and value_or_err ~= nil) or false,
+		})
+
+		local reply = hal_types.new.Reply(ok, value_or_err)
+		if reply then
+			request.reply_ch:put(reply)
+		end
+	end
+end
+
+---@return boolean ok
+---@return string error
+function UARTDriver:start()
+	trace_push(self, 'driver.start.begin', {
+		initialised = self.initialised,
+	})
+
+	if not self.initialised then
+		trace_push(self, 'driver.start.not_initialised')
+		return false, 'uart driver not initialised'
+	end
+
+	self.scope:finally(function()
+		trace_push(self, 'driver.scope.finally.begin', {
+			active_stream = self.active_stream ~= nil,
+		})
+
+		if self.active_stream then
+			close_stream_best_effort(self.active_stream)
+			self.active_stream = nil
+		end
+
+		trace_push(self, 'driver.scope.finally.end')
+	end)
+
+	self.scope:spawn(function() self:control_manager() end)
+
+	emit_state(self.cap_emit_ch, self.cap_id, {
+		open = false,
+		path = self.device_path,
+		baud = self.baud,
+		mode = self.mode,
+	}, self.logger)
+
+	trace_push(self, 'driver.start.ok')
+	return true, ''
+end
+
+---@param timeout number?
+---@return boolean ok
+---@return string error
+function UARTDriver:stop(timeout)
+	timeout = timeout or DEFAULT_STOP_TIMEOUT
+
+	trace_push(self, 'driver.stop.begin', {
+		timeout       = timeout,
+		active_stream = self.active_stream ~= nil,
+	})
+
+	if self.active_stream then
+		close_stream_best_effort(self.active_stream)
+		self.active_stream = nil
+	end
+
+	if self.control_ch and type(self.control_ch.close) == 'function' then
+		trace_push(self, 'driver.stop.control_close.begin')
+		self.control_ch:close('uart driver stopped')
+		trace_push(self, 'driver.stop.control_close.end')
+	else
+		trace_push(self, 'driver.stop.control_close.unsupported')
+	end
+
+	self.scope:cancel('uart driver stopped')
+
+	local source = perform(op.named_choice {
+		join    = self.scope:join_op(),
+		timeout = sleep.sleep_op(timeout),
+	})
+
+	if source == 'timeout' then
+		trace_push(self, 'driver.stop.timeout')
+		return false, 'uart driver stop timeout'
+	end
+
+	trace_push(self, 'driver.stop.ok')
+	return true, ''
+end
+
+return {
+	new        = new,
+	UARTDriver = UARTDriver,
+}

--- a/src/services/hal/drivers/updater_cm5.lua
+++ b/src/services/hal/drivers/updater_cm5.lua
@@ -1,0 +1,347 @@
+local fibers = require 'fibers'
+local op = require 'fibers.op'
+local sleep = require 'fibers.sleep'
+local file = require 'fibers.io.file'
+local exec = require 'fibers.io.exec'
+local channel = require 'fibers.channel'
+
+local hal_types = require 'services.hal.types.core'
+local cap_types = require 'services.hal.types.capabilities'
+local cap_args = require 'services.hal.types.capability_args'
+local control_store_mod = require 'services.hal.drivers.control_store'
+local artifact_store_mod = require 'services.hal.drivers.artifact_store'
+
+local perform = fibers.perform
+local CONTROL_Q_LEN = 8
+
+local Driver = {}
+Driver.__index = Driver
+
+local function dlog(logger, level, payload)
+    if logger and logger[level] then logger[level](logger, payload) end
+end
+
+local function read_file(path)
+    local f, open_err = file.open(path, 'r')
+    if not f then return nil, tostring(open_err) end
+    local content, read_err = f:read_all()
+    f:close()
+    if not content then return nil, tostring(read_err) end
+    return content, ''
+end
+
+local function trim(s)
+    return (s or ''):match('^%s*(.-)%s*$') or ''
+end
+
+local function updater_script_path(opts)
+    return (opts and opts.script) or os.getenv('DEVICECODE_UPDATE_SCRIPT') or '/root/scripts/update.sh'
+end
+
+local function read_fw_printenv(varname)
+    local cmd = exec.command('fw_printenv', varname)
+    local out, _, code = perform(cmd:output_op())
+    if code ~= 0 or not out then return '' end
+    return trim(out:match(varname .. '=(.+)$') or '')
+end
+
+local function read_identity()
+    local function safe_read(path)
+        local v, _ = read_file(path)
+        return trim(v or '')
+    end
+
+    return {
+        hw_revision    = safe_read('/etc/hwrevision'),
+        fw_version     = safe_read('/etc/fwversion'),
+        serial         = safe_read('/data/serial'),
+        board_revision = read_fw_printenv('board_revision'),
+    }
+end
+
+local function default_updater_state()
+    return {
+        state = 'idle',
+        staged = false,
+        artifact_ref = nil,
+        artifact_meta = nil,
+        expected_image_id = nil,
+        last_error = nil,
+        updated_at = nil,
+    }
+end
+
+local function normalized_updater_state(raw_state, current_image_id)
+    raw_state = type(raw_state) == 'table' and raw_state or default_updater_state()
+    local state = raw_state.state or 'idle'
+    if state == 'staged' then return 'staged' end
+    if state == 'committing' or state == 'awaiting_reboot' then
+        if raw_state.expected_image_id and current_image_id == raw_state.expected_image_id then return 'running' end
+        return 'awaiting_reboot'
+    end
+    if state == 'failed' or state == 'rollback_detected' then return state end
+    if current_image_id and current_image_id ~= '' then return 'running' end
+    return state
+end
+
+local function health_from_status(status)
+    status = type(status) == 'table' and status or {}
+    local state = tostring(status.state or '')
+    if state == 'failed' or state == 'rollback_detected' then
+        return { state = 'degraded', reason = tostring(status.last_error or state) }
+    end
+    if state == 'unavailable' then
+        return { state = 'unknown', reason = tostring(status.last_error or state) }
+    end
+    return { state = 'ok', reason = nil }
+end
+
+local function run_control_loop(ch, methods, logger, what)
+    fibers.current_scope():finally(function() dlog(logger, 'debug', { what = tostring(what or 'control_loop') .. '_exiting' }) end)
+    while true do
+        local request, req_err = ch:get()
+        if not request then
+            dlog(logger, 'debug', { what = tostring(what or 'control_loop') .. '_closed', err = tostring(req_err) })
+            break
+        end
+        local fn = methods[request.verb]
+        local ok, value_or_err
+        if type(fn) ~= 'function' then
+            ok, value_or_err = false, 'unsupported verb: ' .. tostring(request.verb)
+        else
+            local st, _, r1, r2 = fibers.run_scope(function() return fn(request.opts) end)
+            if st ~= 'ok' then ok, value_or_err = false, 'internal error: ' .. tostring(r1) else ok, value_or_err = r1, r2 end
+        end
+        local reply = hal_types.new.Reply(ok, value_or_err)
+        if reply then request.reply_ch:put(reply) end
+    end
+end
+
+function Driver:_read_updater_state()
+    local obj, err = self.control_store:get('updater/cm5', 'state')
+    if not obj then
+        if err == 'not_found' then return default_updater_state(), '' end
+        return default_updater_state(), err
+    end
+    if type(obj) ~= 'table' then return default_updater_state(), 'invalid_state' end
+    return obj, ''
+end
+
+function Driver:_write_updater_state(state)
+    state = state or default_updater_state()
+    state.updated_at = state.updated_at or os.time()
+    return self.control_store:put('updater/cm5', 'state', state)
+end
+
+function Driver:_emit_updater_facts()
+    if not self.cap_emit_ch then return end
+    local ok, status = self:status(cap_args.new.UpdaterStatusOpts(false))
+    if not ok then return end
+
+    local software_payload, software_err = hal_types.new.Emit('updater', self.id, 'state', 'software', {
+        version = status.fw_version,
+        build = nil,
+        image_id = status.targetfw or status.fw_version,
+        boot_id = status.bootedfw,
+        bootedfw = status.bootedfw,
+        targetfw = status.targetfw,
+        upgrade_available = status.upgrade_available,
+        hw_revision = status.hw_revision,
+        serial = status.serial,
+        board_revision = status.board_revision,
+    })
+    if software_payload then self.cap_emit_ch:put(software_payload) else dlog(self.logger, 'debug', { what = 'updater_software_emit_failed', err = tostring(software_err) }) end
+
+    local updater_payload, updater_err = hal_types.new.Emit('updater', self.id, 'state', 'updater', {
+        state = status.state,
+        raw_state = status.raw_state,
+        staged = status.staged,
+        artifact_ref = status.artifact_ref,
+        artifact_meta = status.artifact_meta,
+        expected_image_id = status.expected_image_id,
+        last_error = status.last_error,
+        updated_at = status.updated_at,
+    })
+    if updater_payload then self.cap_emit_ch:put(updater_payload) else dlog(self.logger, 'debug', { what = 'updater_fact_emit_failed', err = tostring(updater_err) }) end
+
+    local health_payload, health_err = hal_types.new.Emit('updater', self.id, 'state', 'health', health_from_status(status))
+    if health_payload then self.cap_emit_ch:put(health_payload) else dlog(self.logger, 'debug', { what = 'updater_health_emit_failed', err = tostring(health_err) }) end
+end
+
+function Driver:init()
+    if self.initialised then return 'already initialised' end
+
+    local cs, cerr = control_store_mod.new(self.opts.control_store or {}, self.logger)
+    if not cs then return 'control store init failed: ' .. tostring(cerr) end
+    self.control_store = cs
+
+    local as, aerr = artifact_store_mod.new(self.opts.artifact_store or {}, self.logger)
+    if not as then return 'artifact store init failed: ' .. tostring(aerr) end
+    self.artifact_store = as
+
+    self.identity = read_identity()
+    self.initialised = true
+    return ''
+end
+
+function Driver:status(opts)
+    if opts ~= nil and getmetatable(opts) ~= cap_args.UpdaterStatusOpts then return false, 'invalid opts' end
+
+    local raw_state, _ = self:_read_updater_state()
+    local artifact_meta = nil
+    if type(raw_state.artifact_ref) == 'string' and raw_state.artifact_ref ~= '' then
+        artifact_meta = self.artifact_store:describe(raw_state.artifact_ref)
+        if type(artifact_meta) ~= 'table' then artifact_meta = nil end
+    end
+
+    local bootedfw = read_fw_printenv('bootedfw')
+    local targetfw = read_fw_printenv('targetfw')
+    local upgrade_available = read_fw_printenv('upgrade_available')
+    local current_image_id = (targetfw ~= '' and targetfw) or self.identity.fw_version
+    local state = normalized_updater_state(raw_state, current_image_id)
+
+    return true, {
+        state = state,
+        raw_state = raw_state.state or 'idle',
+        staged = raw_state.staged == true,
+        artifact_ref = raw_state.artifact_ref,
+        artifact_meta = artifact_meta or raw_state.artifact_meta,
+        expected_image_id = raw_state.expected_image_id,
+        last_error = raw_state.last_error,
+        updated_at = raw_state.updated_at,
+        fw_version = self.identity.fw_version,
+        hw_revision = self.identity.hw_revision,
+        serial = self.identity.serial,
+        board_revision = self.identity.board_revision,
+        bootedfw = bootedfw,
+        targetfw = targetfw,
+        upgrade_available = upgrade_available,
+    }
+end
+
+function Driver:prepare(opts)
+    if opts ~= nil and getmetatable(opts) ~= cap_args.UpdaterPrepareOpts then return false, 'invalid opts' end
+    local _, status = self:status(cap_args.new.UpdaterStatusOpts(false))
+    return true, status
+end
+
+function Driver:stage(opts)
+    if opts == nil or getmetatable(opts) ~= cap_args.UpdaterStageOpts then return false, 'invalid opts' end
+
+    local artifact, err = self.artifact_store:describe(opts.artifact_ref)
+    if not artifact then return false, err end
+    if artifact.state ~= 'ready' then return false, 'artifact_not_ready' end
+
+    local state = {
+        state = 'staged',
+        staged = true,
+        artifact_ref = opts.artifact_ref,
+        artifact_meta = artifact,
+        expected_image_id = opts.expected_image_id,
+        metadata = opts.metadata,
+        last_error = nil,
+        updated_at = os.time(),
+    }
+    local ok, werr = self:_write_updater_state(state)
+    if not ok then return false, werr end
+
+    self:_emit_updater_facts()
+    return true, {
+        staged = true,
+        artifact_ref = opts.artifact_ref,
+        artifact_meta = artifact,
+        expected_image_id = opts.expected_image_id,
+        artifact_retention = 'keep',
+    }
+end
+
+function Driver:commit(opts)
+    if opts ~= nil and getmetatable(opts) ~= cap_args.UpdaterCommitOpts then return false, 'invalid opts' end
+
+    local state = self:_read_updater_state()
+    if state.state ~= 'staged' or type(state.artifact_ref) ~= 'string' or state.artifact_ref == '' then
+        return false, 'no_staged_artifact'
+    end
+
+    local resolved, rerr = self.artifact_store:resolve_local(state.artifact_ref)
+    if not resolved then return false, rerr end
+
+    local script = updater_script_path(self.opts)
+    local sf, ferr = file.open(script, 'r')
+    if not sf then return false, 'update script unavailable: ' .. tostring(ferr) end
+    sf:close()
+
+    state.state = 'awaiting_reboot'
+    state.updated_at = os.time()
+    local ok, err = self:_write_updater_state(state)
+    if not ok then return false, err end
+    self:_emit_updater_facts()
+
+    local env = {
+        DEVICECODE_STAGED_ARTIFACT = resolved.path,
+        DEVICECODE_STAGED_ARTIFACT_REF = state.artifact_ref,
+        DEVICECODE_UPDATE_KIND = (opts and opts.mode) or 'cm5',
+    }
+
+    local spawn_ok, spawn_err = fibers.spawn(function()
+        local cmd = exec.command({ script, env = env, stdout = 'inherit', stderr = 'inherit' })
+        perform(cmd:run_op())
+    end)
+    if not spawn_ok then return false, tostring(spawn_err) end
+
+    return true, { started = true, artifact_ref = state.artifact_ref, artifact_meta = state.artifact_meta }
+end
+
+function Driver:capabilities(emit_ch)
+    if not self.initialised then return nil, 'cm5 updater provider not initialised' end
+    self.cap_emit_ch = emit_ch
+    local cap, err = cap_types.new.UpdaterCapability(self.id, self.control_ch)
+    if not cap then return nil, err end
+    return { cap }, ''
+end
+
+function Driver:start()
+    if not self.initialised then return false, 'cm5 updater provider not initialised' end
+    if self.cap_emit_ch then
+        local meta, err = hal_types.new.Emit('updater', self.id, 'meta', 'info', { provider = 'hal.updater_cm5', version = 2 })
+        if meta then self.cap_emit_ch:put(meta) else dlog(self.logger, 'debug', { what = 'updater_meta_emit_failed', id = self.id, err = tostring(err) }) end
+        self:_emit_updater_facts()
+    end
+    local methods = {
+        prepare = function(opts) return self:prepare(opts) end,
+        stage = function(opts) return self:stage(opts) end,
+        commit = function(opts) return self:commit(opts) end,
+        status = function(opts) return self:status(opts) end,
+    }
+    local ok, err = self.scope:spawn(function() run_control_loop(self.control_ch, methods, self.logger, 'updater_cm5_control_manager') end)
+    if not ok then return false, 'failed to spawn updater_cm5 control manager: ' .. tostring(err) end
+    return true, ''
+end
+
+function Driver:stop(timeout)
+    timeout = timeout or 5
+    self.scope:cancel('cm5 updater provider stopped')
+    local source = perform(op.named_choice { join = self.scope:join_op(), timeout = sleep.sleep_op(timeout) })
+    if source == 'timeout' then return false, 'cm5 updater provider stop timeout' end
+    return true, ''
+end
+
+local function new(id, opts, logger)
+    if type(id) ~= 'string' or id == '' then return nil, 'invalid id' end
+    local scope, err = fibers.current_scope():child()
+    if not scope then return nil, 'failed to create child scope: ' .. tostring(err) end
+    return setmetatable({
+        id = id,
+        opts = opts or {},
+        logger = logger,
+        scope = scope,
+        control_store = nil,
+        artifact_store = nil,
+        identity = {},
+        initialised = false,
+        control_ch = channel.new(CONTROL_Q_LEN),
+        cap_emit_ch = nil,
+    }, Driver), ''
+end
+
+return { new = new, Driver = Driver }

--- a/src/services/hal/managers/artifact_store.lua
+++ b/src/services/hal/managers/artifact_store.lua
@@ -1,0 +1,145 @@
+-- services/hal/managers/artifact_store.lua
+--
+-- HAL manager for artifact_store providers. Each provider is a normal
+-- manager-owned driver that advertises one capability of the same class.
+
+local driver_mod = require 'services.hal.drivers.artifact_store_provider'
+local hal_types = require 'services.hal.types.core'
+
+local fibers = require 'fibers'
+local op = require 'fibers.op'
+local sleep = require 'fibers.sleep'
+
+local STOP_TIMEOUT = 5.0
+
+local function dlog(logger, level, payload)
+    if logger and logger[level] then logger[level](logger, payload) end
+end
+
+local Manager = {
+    started = false,
+    scope = nil,
+    logger = nil,
+    dev_ev_ch = nil,
+    cap_emit_ch = nil,
+    drivers = {},
+}
+
+local function child_logger(id)
+    if Manager.logger and Manager.logger.child then
+        return Manager.logger:child({ component = 'driver', driver = 'artifact_store', id = id })
+    end
+    return Manager.logger
+end
+
+local function normalise_config(cfg)
+    cfg = cfg or {}
+    if type(cfg) ~= 'table' then return nil, 'artifact_store config must be a table' end
+
+    local specs = cfg.stores
+    if specs == nil and cfg[1] == nil then
+        specs = { { id = 'main' } }
+    elseif specs == nil then
+        specs = cfg
+    end
+    if type(specs) ~= 'table' then return nil, 'artifact_store.stores must be a table' end
+
+    local out = {}
+    for i = 1, #specs do
+        local rec = specs[i]
+        if type(rec) ~= 'table' then return nil, ('artifact_store.stores[%d] must be a table'):format(i) end
+        local id = rec.id or rec.name or 'main'
+        if type(id) ~= 'string' or id == '' then return nil, ('artifact_store.stores[%d].id must be a non-empty string'):format(i) end
+        if out[id] ~= nil then return nil, 'duplicate artifact_store provider id: ' .. id end
+        local opts = {}
+        for k, v in pairs(rec) do if k ~= 'id' and k ~= 'name' then opts[k] = v end end
+        out[id] = { id = id, opts = opts }
+    end
+    return out, ''
+end
+
+local function register_driver(id, opts)
+    if Manager.drivers[id] then return true, '' end
+
+    local driver, err = driver_mod.new(id, opts, child_logger(id))
+    if not driver then return false, tostring(err) end
+
+    local init_err = driver:init()
+    if init_err ~= '' then return false, tostring(init_err) end
+
+    local caps, cap_err = driver:capabilities(Manager.cap_emit_ch)
+    if cap_err ~= '' then return false, tostring(cap_err) end
+
+    local ok, start_err = driver:start()
+    if not ok then return false, tostring(start_err) end
+
+    local ev, ev_err = hal_types.new.DeviceEvent('added', 'artifact_store', id, { provider = 'hal.artifact_store' }, caps)
+    if not ev then return false, tostring(ev_err) end
+    Manager.dev_ev_ch:put(ev)
+
+    Manager.drivers[id] = { driver = driver, opts = opts }
+    dlog(Manager.logger, 'info', { what = 'device_registered', class = 'artifact_store', id = id })
+    return true, ''
+end
+
+local function unregister_driver(id)
+    local rec = Manager.drivers[id]
+    if not rec then return end
+    Manager.drivers[id] = nil
+
+    local ev = hal_types.new.DeviceEvent('removed', 'artifact_store', id, { provider = 'hal.artifact_store' }, {})
+    if ev then Manager.dev_ev_ch:put(ev) end
+
+    fibers.current_scope():spawn(function() rec.driver:stop(STOP_TIMEOUT) end)
+end
+
+function Manager.start(logger, dev_ev_ch, cap_emit_ch)
+    if Manager.started then return 'Already started' end
+
+    local scope, err = fibers.current_scope():child()
+    if not scope then return 'Failed to create child scope: ' .. tostring(err) end
+
+    Manager.scope = scope
+    Manager.logger = logger
+    Manager.dev_ev_ch = dev_ev_ch
+    Manager.cap_emit_ch = cap_emit_ch
+    Manager.drivers = {}
+
+    scope:finally(function()
+        local st, primary = scope:status()
+        if st == 'failed' then dlog(Manager.logger, 'error', { what = 'scope_failed', err = tostring(primary), status = st }) end
+        dlog(Manager.logger, 'debug', { what = 'stopped' })
+    end)
+
+    Manager.started = true
+    dlog(Manager.logger, 'debug', { what = 'start_called' })
+    return ''
+end
+
+function Manager.stop(timeout)
+    if not Manager.started then return false, 'Not started' end
+    timeout = timeout or STOP_TIMEOUT
+    Manager.scope:cancel('artifact_store manager stopped')
+    local source = fibers.perform(op.named_choice { join = Manager.scope:join_op(), timeout = sleep.sleep_op(timeout) })
+    if source == 'timeout' then return false, 'artifact_store manager stop timeout' end
+    Manager.started = false
+    return true, ''
+end
+
+function Manager.apply_config(cfg)
+    local specs, err = normalise_config(cfg)
+    if not specs then return false, err end
+
+    for id, spec in pairs(specs) do
+        local ok, reg_err = register_driver(id, spec.opts)
+        if not ok then return false, reg_err end
+    end
+
+    for id in pairs(Manager.drivers) do
+        if not specs[id] then unregister_driver(id) end
+    end
+
+    return true, ''
+end
+
+return Manager

--- a/src/services/hal/managers/control_store.lua
+++ b/src/services/hal/managers/control_store.lua
@@ -1,0 +1,145 @@
+-- services/hal/managers/control_store.lua
+--
+-- HAL manager for control_store providers. Each provider is a normal
+-- manager-owned driver that advertises one capability of the same class.
+
+local driver_mod = require 'services.hal.drivers.control_store_provider'
+local hal_types = require 'services.hal.types.core'
+
+local fibers = require 'fibers'
+local op = require 'fibers.op'
+local sleep = require 'fibers.sleep'
+
+local STOP_TIMEOUT = 5.0
+
+local function dlog(logger, level, payload)
+    if logger and logger[level] then logger[level](logger, payload) end
+end
+
+local Manager = {
+    started = false,
+    scope = nil,
+    logger = nil,
+    dev_ev_ch = nil,
+    cap_emit_ch = nil,
+    drivers = {},
+}
+
+local function child_logger(id)
+    if Manager.logger and Manager.logger.child then
+        return Manager.logger:child({ component = 'driver', driver = 'control_store', id = id })
+    end
+    return Manager.logger
+end
+
+local function normalise_config(cfg)
+    cfg = cfg or {}
+    if type(cfg) ~= 'table' then return nil, 'control_store config must be a table' end
+
+    local specs = cfg.stores
+    if specs == nil and cfg[1] == nil then
+        specs = { { id = 'update' } }
+    elseif specs == nil then
+        specs = cfg
+    end
+    if type(specs) ~= 'table' then return nil, 'control_store.stores must be a table' end
+
+    local out = {}
+    for i = 1, #specs do
+        local rec = specs[i]
+        if type(rec) ~= 'table' then return nil, ('control_store.stores[%d] must be a table'):format(i) end
+        local id = rec.id or rec.name or 'update'
+        if type(id) ~= 'string' or id == '' then return nil, ('control_store.stores[%d].id must be a non-empty string'):format(i) end
+        if out[id] ~= nil then return nil, 'duplicate control_store provider id: ' .. id end
+        local opts = {}
+        for k, v in pairs(rec) do if k ~= 'id' and k ~= 'name' then opts[k] = v end end
+        out[id] = { id = id, opts = opts }
+    end
+    return out, ''
+end
+
+local function register_driver(id, opts)
+    if Manager.drivers[id] then return true, '' end
+
+    local driver, err = driver_mod.new(id, opts, child_logger(id))
+    if not driver then return false, tostring(err) end
+
+    local init_err = driver:init()
+    if init_err ~= '' then return false, tostring(init_err) end
+
+    local caps, cap_err = driver:capabilities(Manager.cap_emit_ch)
+    if cap_err ~= '' then return false, tostring(cap_err) end
+
+    local ok, start_err = driver:start()
+    if not ok then return false, tostring(start_err) end
+
+    local ev, ev_err = hal_types.new.DeviceEvent('added', 'control_store', id, { provider = 'hal.control_store' }, caps)
+    if not ev then return false, tostring(ev_err) end
+    Manager.dev_ev_ch:put(ev)
+
+    Manager.drivers[id] = { driver = driver, opts = opts }
+    dlog(Manager.logger, 'info', { what = 'device_registered', class = 'control_store', id = id })
+    return true, ''
+end
+
+local function unregister_driver(id)
+    local rec = Manager.drivers[id]
+    if not rec then return end
+    Manager.drivers[id] = nil
+
+    local ev = hal_types.new.DeviceEvent('removed', 'control_store', id, { provider = 'hal.control_store' }, {})
+    if ev then Manager.dev_ev_ch:put(ev) end
+
+    fibers.current_scope():spawn(function() rec.driver:stop(STOP_TIMEOUT) end)
+end
+
+function Manager.start(logger, dev_ev_ch, cap_emit_ch)
+    if Manager.started then return 'Already started' end
+
+    local scope, err = fibers.current_scope():child()
+    if not scope then return 'Failed to create child scope: ' .. tostring(err) end
+
+    Manager.scope = scope
+    Manager.logger = logger
+    Manager.dev_ev_ch = dev_ev_ch
+    Manager.cap_emit_ch = cap_emit_ch
+    Manager.drivers = {}
+
+    scope:finally(function()
+        local st, primary = scope:status()
+        if st == 'failed' then dlog(Manager.logger, 'error', { what = 'scope_failed', err = tostring(primary), status = st }) end
+        dlog(Manager.logger, 'debug', { what = 'stopped' })
+    end)
+
+    Manager.started = true
+    dlog(Manager.logger, 'debug', { what = 'start_called' })
+    return ''
+end
+
+function Manager.stop(timeout)
+    if not Manager.started then return false, 'Not started' end
+    timeout = timeout or STOP_TIMEOUT
+    Manager.scope:cancel('control_store manager stopped')
+    local source = fibers.perform(op.named_choice { join = Manager.scope:join_op(), timeout = sleep.sleep_op(timeout) })
+    if source == 'timeout' then return false, 'control_store manager stop timeout' end
+    Manager.started = false
+    return true, ''
+end
+
+function Manager.apply_config(cfg)
+    local specs, err = normalise_config(cfg)
+    if not specs then return false, err end
+
+    for id, spec in pairs(specs) do
+        local ok, reg_err = register_driver(id, spec.opts)
+        if not ok then return false, reg_err end
+    end
+
+    for id in pairs(Manager.drivers) do
+        if not specs[id] then unregister_driver(id) end
+    end
+
+    return true, ''
+end
+
+return Manager

--- a/src/services/hal/managers/signature_verify.lua
+++ b/src/services/hal/managers/signature_verify.lua
@@ -1,0 +1,145 @@
+-- services/hal/managers/signature_verify.lua
+--
+-- HAL manager for signature_verify providers. Each provider is a normal
+-- manager-owned driver that advertises one capability of the same class.
+
+local driver_mod = require 'services.hal.drivers.signature_verify_provider'
+local hal_types = require 'services.hal.types.core'
+
+local fibers = require 'fibers'
+local op = require 'fibers.op'
+local sleep = require 'fibers.sleep'
+
+local STOP_TIMEOUT = 5.0
+
+local function dlog(logger, level, payload)
+    if logger and logger[level] then logger[level](logger, payload) end
+end
+
+local Manager = {
+    started = false,
+    scope = nil,
+    logger = nil,
+    dev_ev_ch = nil,
+    cap_emit_ch = nil,
+    drivers = {},
+}
+
+local function child_logger(id)
+    if Manager.logger and Manager.logger.child then
+        return Manager.logger:child({ component = 'driver', driver = 'signature_verify', id = id })
+    end
+    return Manager.logger
+end
+
+local function normalise_config(cfg)
+    cfg = cfg or {}
+    if type(cfg) ~= 'table' then return nil, 'signature_verify config must be a table' end
+
+    local specs = cfg.providers
+    if specs == nil and cfg[1] == nil then
+        specs = { { id = 'main' } }
+    elseif specs == nil then
+        specs = cfg
+    end
+    if type(specs) ~= 'table' then return nil, 'signature_verify.providers must be a table' end
+
+    local out = {}
+    for i = 1, #specs do
+        local rec = specs[i]
+        if type(rec) ~= 'table' then return nil, ('signature_verify.providers[%d] must be a table'):format(i) end
+        local id = rec.id or rec.name or 'main'
+        if type(id) ~= 'string' or id == '' then return nil, ('signature_verify.providers[%d].id must be a non-empty string'):format(i) end
+        if out[id] ~= nil then return nil, 'duplicate signature_verify provider id: ' .. id end
+        local opts = {}
+        for k, v in pairs(rec) do if k ~= 'id' and k ~= 'name' then opts[k] = v end end
+        out[id] = { id = id, opts = opts }
+    end
+    return out, ''
+end
+
+local function register_driver(id, opts)
+    if Manager.drivers[id] then return true, '' end
+
+    local driver, err = driver_mod.new(id, opts, child_logger(id))
+    if not driver then return false, tostring(err) end
+
+    local init_err = driver:init()
+    if init_err ~= '' then return false, tostring(init_err) end
+
+    local caps, cap_err = driver:capabilities(Manager.cap_emit_ch)
+    if cap_err ~= '' then return false, tostring(cap_err) end
+
+    local ok, start_err = driver:start()
+    if not ok then return false, tostring(start_err) end
+
+    local ev, ev_err = hal_types.new.DeviceEvent('added', 'signature_verify', id, { provider = 'hal.signature_verify' }, caps)
+    if not ev then return false, tostring(ev_err) end
+    Manager.dev_ev_ch:put(ev)
+
+    Manager.drivers[id] = { driver = driver, opts = opts }
+    dlog(Manager.logger, 'info', { what = 'device_registered', class = 'signature_verify', id = id })
+    return true, ''
+end
+
+local function unregister_driver(id)
+    local rec = Manager.drivers[id]
+    if not rec then return end
+    Manager.drivers[id] = nil
+
+    local ev = hal_types.new.DeviceEvent('removed', 'signature_verify', id, { provider = 'hal.signature_verify' }, {})
+    if ev then Manager.dev_ev_ch:put(ev) end
+
+    fibers.current_scope():spawn(function() rec.driver:stop(STOP_TIMEOUT) end)
+end
+
+function Manager.start(logger, dev_ev_ch, cap_emit_ch)
+    if Manager.started then return 'Already started' end
+
+    local scope, err = fibers.current_scope():child()
+    if not scope then return 'Failed to create child scope: ' .. tostring(err) end
+
+    Manager.scope = scope
+    Manager.logger = logger
+    Manager.dev_ev_ch = dev_ev_ch
+    Manager.cap_emit_ch = cap_emit_ch
+    Manager.drivers = {}
+
+    scope:finally(function()
+        local st, primary = scope:status()
+        if st == 'failed' then dlog(Manager.logger, 'error', { what = 'scope_failed', err = tostring(primary), status = st }) end
+        dlog(Manager.logger, 'debug', { what = 'stopped' })
+    end)
+
+    Manager.started = true
+    dlog(Manager.logger, 'debug', { what = 'start_called' })
+    return ''
+end
+
+function Manager.stop(timeout)
+    if not Manager.started then return false, 'Not started' end
+    timeout = timeout or STOP_TIMEOUT
+    Manager.scope:cancel('signature_verify manager stopped')
+    local source = fibers.perform(op.named_choice { join = Manager.scope:join_op(), timeout = sleep.sleep_op(timeout) })
+    if source == 'timeout' then return false, 'signature_verify manager stop timeout' end
+    Manager.started = false
+    return true, ''
+end
+
+function Manager.apply_config(cfg)
+    local specs, err = normalise_config(cfg)
+    if not specs then return false, err end
+
+    for id, spec in pairs(specs) do
+        local ok, reg_err = register_driver(id, spec.opts)
+        if not ok then return false, reg_err end
+    end
+
+    for id in pairs(Manager.drivers) do
+        if not specs[id] then unregister_driver(id) end
+    end
+
+    return true, ''
+end
+
+return Manager

--- a/src/services/hal/managers/uart.lua
+++ b/src/services/hal/managers/uart.lua
@@ -1,0 +1,570 @@
+-- services/hal/managers/uart.lua
+--
+-- UART HAL manager.
+--
+-- Config shape:
+--   uart = {
+--     serial_ports = {
+--       { name = 'uart0', path = '/dev/ttyAMA0', baud = 115200, mode = '8N1' },
+--       ...
+--     }
+--   }
+
+local uart_driver = require 'services.hal.drivers.uart'
+local hal_types   = require 'services.hal.types.core'
+
+local fibers = require 'fibers'
+local op     = require 'fibers.op'
+local sleep  = require 'fibers.sleep'
+
+local STOP_TIMEOUT = 5.0
+local TRACE_MAX    = 256
+
+local function dlog(logger, level, payload)
+	if logger and logger[level] then
+		logger[level](logger, payload)
+	end
+end
+
+local function shallow_copy(t)
+	local out = {}
+	for k, v in pairs(t or {}) do out[k] = v end
+	return out
+end
+
+local function copy_trace(trace)
+	local out = {}
+	for i = 1, #(trace or {}) do
+		local src = trace[i]
+		local rec = {}
+		for k, v in pairs(src or {}) do
+			rec[k] = v
+		end
+		out[i] = rec
+	end
+	return out
+end
+
+local function count_drivers(drivers)
+	local n = 0
+	for _ in pairs(drivers or {}) do n = n + 1 end
+	return n
+end
+
+local UARTManager = {
+	started     = false,
+	scope       = nil,
+	logger      = nil,
+	dev_ev_ch   = nil,
+	cap_emit_ch = nil,
+	drivers     = {},
+	_trace      = {},
+	_trace_seq  = 0,
+}
+
+local function trace_push(self, what, fields)
+	self._trace_seq = (self._trace_seq or 0) + 1
+
+	local rec = {
+		seq  = self._trace_seq,
+		t    = fibers.now(),
+		what = what,
+	}
+
+	for k, v in pairs(fields or {}) do
+		rec[k] = v
+	end
+
+	local tr = self._trace or {}
+	tr[#tr + 1] = rec
+	if #tr > TRACE_MAX then
+		table.remove(tr, 1)
+	end
+	self._trace = tr
+end
+
+local function reset_runtime_state(scope_ref)
+	if scope_ref ~= nil and UARTManager.scope ~= scope_ref then
+		return
+	end
+
+	trace_push(UARTManager, 'manager.reset_runtime_state', {
+		started      = UARTManager.started,
+		driver_count = count_drivers(UARTManager.drivers),
+	})
+
+	UARTManager.started     = false
+	UARTManager.scope       = nil
+	UARTManager.logger      = nil
+	UARTManager.dev_ev_ch   = nil
+	UARTManager.cap_emit_ch = nil
+	UARTManager.drivers     = {}
+end
+
+local function same_spec(a, b)
+	if not a or not b then return false end
+	return a.name == b.name
+		and a.path == b.path
+		and a.baud == b.baud
+		and a.mode == b.mode
+end
+
+local function normalise_config(cfg)
+	if type(cfg) ~= 'table' then
+		return nil, 'uart config must be a table'
+	end
+
+	local serial_ports = cfg.serial_ports
+	if type(serial_ports) ~= 'table' then
+		return nil, 'uart.serial_ports must be an array'
+	end
+
+	local out = {}
+	for i = 1, #serial_ports do
+		local rec = serial_ports[i]
+		if type(rec) ~= 'table' then
+			return nil, ('uart.serial_ports[%d] must be a table'):format(i)
+		end
+
+		local name = rec.name
+		local path = rec.path
+		if type(name) ~= 'string' or name == '' then
+			return nil, ('uart.serial_ports[%d].name must be a non-empty string'):format(i)
+		end
+		if type(path) ~= 'string' or path == '' then
+			return nil, ('uart.serial_ports[%d].path must be a non-empty string'):format(i)
+		end
+		if out[name] ~= nil then
+			return nil, ('uart serial port name duplicated: %s'):format(name)
+		end
+
+		local baud = rec.baud
+		if baud ~= nil then
+			if type(baud) ~= 'number' or baud <= 0 or baud % 1 ~= 0 then
+				return nil, ('uart.serial_ports[%d].baud must be a positive integer'):format(i)
+			end
+			baud = math.floor(baud)
+		end
+
+		local mode = rec.mode
+		if mode ~= nil then
+			if type(mode) ~= 'string' or mode == '' then
+				return nil, ('uart.serial_ports[%d].mode must be a non-empty string'):format(i)
+			end
+		end
+
+		out[name] = {
+			name = name,
+			path = path,
+			baud = baud,
+			mode = mode,
+		}
+	end
+
+	return out, ''
+end
+
+---@class UARTManagerRecord
+---@field driver any
+---@field spec table
+---@field capabilities Capability[]
+
+local function debug_driver_snapshot(rec)
+	if not rec then return nil end
+
+	local driver_snapshot
+	if rec.driver and type(rec.driver.debug_snapshot) == 'function' then
+		driver_snapshot = rec.driver:debug_snapshot()
+	end
+
+	return {
+		spec = rec.spec and {
+			name = rec.spec.name,
+			path = rec.spec.path,
+			baud = rec.spec.baud,
+			mode = rec.spec.mode,
+		} or nil,
+		has_driver = rec.driver ~= nil,
+		has_caps   = rec.capabilities ~= nil,
+		driver     = driver_snapshot,
+	}
+end
+
+function UARTManager.debug_snapshot()
+	local drivers = {}
+
+	for name, rec in pairs(UARTManager.drivers or {}) do
+		drivers[name] = debug_driver_snapshot(rec)
+	end
+
+	local scope_status = nil
+	if UARTManager.scope and UARTManager.scope.status then
+		local st, primary = UARTManager.scope:status()
+		scope_status = {
+			state   = st,
+			primary = tostring(primary),
+		}
+	end
+
+	return {
+		started      = UARTManager.started,
+		scope_status = scope_status,
+		driver_count = count_drivers(UARTManager.drivers),
+		drivers      = drivers,
+		trace        = copy_trace(UARTManager._trace),
+	}
+end
+
+local function emit_added(name, spec, capabilities)
+	trace_push(UARTManager, 'manager.emit_added.begin', {
+		cap_id = name,
+		path   = spec.path,
+	})
+
+	local ev, err = hal_types.new.DeviceEvent('added', 'uart', name, {
+		path = spec.path,
+		baud = spec.baud,
+		mode = spec.mode,
+	}, capabilities)
+
+	if not ev then
+		trace_push(UARTManager, 'manager.emit_added.failed', {
+			cap_id = name,
+			err    = tostring(err),
+		})
+		return nil, tostring(err)
+	end
+
+	UARTManager.dev_ev_ch:put(ev)
+
+	trace_push(UARTManager, 'manager.emit_added.ok', {
+		cap_id = name,
+	})
+	return true, nil
+end
+
+local function emit_removed(name)
+	trace_push(UARTManager, 'manager.emit_removed.begin', {
+		cap_id = name,
+	})
+
+	local ev, err = hal_types.new.DeviceEvent('removed', 'uart', name, {}, {})
+	if not ev then
+		trace_push(UARTManager, 'manager.emit_removed.failed', {
+			cap_id = name,
+			err    = tostring(err),
+		})
+		return nil, tostring(err)
+	end
+
+	UARTManager.dev_ev_ch:put(ev)
+
+	trace_push(UARTManager, 'manager.emit_removed.ok', {
+		cap_id = name,
+	})
+	return true, nil
+end
+
+local function stop_driver(name, rec)
+	trace_push(UARTManager, 'driver.stop.begin', {
+		cap_id = name,
+	})
+
+	local ok_rm, rm_err = emit_removed(name)
+	if ok_rm ~= true then
+		trace_push(UARTManager, 'driver.stop.emit_removed_failed', {
+			cap_id = name,
+			err    = tostring(rm_err),
+		})
+		dlog(UARTManager.logger, 'warn', {
+			what   = 'uart_emit_removed_failed',
+			cap_id = name,
+			err    = tostring(rm_err),
+		})
+	end
+
+	local ok, err = rec.driver:stop()
+	if ok ~= true then
+		trace_push(UARTManager, 'driver.stop.failed', {
+			cap_id = name,
+			err    = tostring(err),
+		})
+		dlog(UARTManager.logger, 'warn', {
+			what   = 'uart_driver_stop_failed',
+			cap_id = name,
+			err    = tostring(err),
+		})
+	else
+		trace_push(UARTManager, 'driver.stop.ok', {
+			cap_id = name,
+		})
+	end
+
+	UARTManager.drivers[name] = nil
+end
+
+local function start_driver(name, spec)
+	trace_push(UARTManager, 'driver.start.begin', {
+		cap_id = name,
+		path   = spec.path,
+		baud   = spec.baud,
+		mode   = spec.mode,
+	})
+
+	local driver_logger = UARTManager.logger
+	if driver_logger and driver_logger.child then
+		driver_logger = driver_logger:child({ component = 'driver', driver = 'uart', id = name })
+	end
+
+	local driver, drv_err = uart_driver.new(UARTManager.scope, name, spec.path, spec, driver_logger)
+	if not driver then
+		trace_push(UARTManager, 'driver.start.new_failed', {
+			cap_id = name,
+			err    = tostring(drv_err),
+		})
+		return nil, tostring(drv_err)
+	end
+
+	local init_err = driver:init()
+	if init_err ~= '' then
+		trace_push(UARTManager, 'driver.start.init_failed', {
+			cap_id = name,
+			err    = tostring(init_err),
+		})
+		return nil, tostring(init_err)
+	end
+
+	local capabilities, cap_err = driver:capabilities(UARTManager.cap_emit_ch)
+	if cap_err ~= '' then
+		trace_push(UARTManager, 'driver.start.capabilities_failed', {
+			cap_id = name,
+			err    = tostring(cap_err),
+		})
+		return nil, tostring(cap_err)
+	end
+
+	local ok, start_err = driver:start()
+	if not ok then
+		trace_push(UARTManager, 'driver.start.driver_start_failed', {
+			cap_id = name,
+			err    = tostring(start_err),
+		})
+		return nil, tostring(start_err)
+	end
+
+	local ok_add, add_err = emit_added(name, spec, capabilities)
+	if ok_add ~= true then
+		trace_push(UARTManager, 'driver.start.emit_added_failed', {
+			cap_id = name,
+			err    = tostring(add_err),
+		})
+		local _ = driver:stop()
+		return nil, tostring(add_err)
+	end
+
+	UARTManager.drivers[name] = {
+		driver       = driver,
+		spec         = shallow_copy(spec),
+		capabilities = capabilities,
+	}
+
+	trace_push(UARTManager, 'driver.start.ok', {
+		cap_id = name,
+	})
+
+	dlog(UARTManager.logger, 'info', {
+		what   = 'uart_driver_started',
+		cap_id = name,
+		path   = spec.path,
+	})
+
+	return true, nil
+end
+
+---@param logger Logger?
+---@param dev_ev_ch Channel
+---@param cap_emit_ch Channel
+---@return string error
+function UARTManager.start(logger, dev_ev_ch, cap_emit_ch)
+	trace_push(UARTManager, 'manager.start.begin', {
+		started = UARTManager.started,
+	})
+
+	if UARTManager.started then
+		trace_push(UARTManager, 'manager.start.already_started')
+		return 'Already started'
+	end
+
+	local scope, err = fibers.current_scope():child()
+	if not scope then
+		trace_push(UARTManager, 'manager.start.child_failed', {
+			err = tostring(err),
+		})
+		return 'Failed to create child scope: ' .. tostring(err)
+	end
+
+	UARTManager.scope       = scope
+	UARTManager.logger      = logger
+	UARTManager.dev_ev_ch   = dev_ev_ch
+	UARTManager.cap_emit_ch = cap_emit_ch
+	UARTManager.started     = true
+	UARTManager.drivers     = {}
+
+	scope:finally(function()
+		local st, primary = scope:status()
+
+		trace_push(UARTManager, 'manager.scope.finally', {
+			status  = st,
+			primary = tostring(primary),
+		})
+
+		if st == 'failed' then
+			dlog(UARTManager.logger, 'error', {
+				what   = 'scope_failed',
+				err    = tostring(primary),
+				status = st,
+			})
+		end
+
+		dlog(UARTManager.logger, 'debug', { what = 'stopped' })
+		reset_runtime_state(scope)
+	end)
+
+	trace_push(UARTManager, 'manager.start.ok')
+
+	dlog(UARTManager.logger, 'debug', { what = 'start_called' })
+	return ''
+end
+
+---@param timeout number?
+---@return boolean ok
+---@return string error
+function UARTManager.stop(timeout)
+	trace_push(UARTManager, 'manager.stop.begin', {
+		started      = UARTManager.started,
+		driver_count = count_drivers(UARTManager.drivers),
+	})
+
+	if not UARTManager.started then
+		trace_push(UARTManager, 'manager.stop.not_started')
+		return false, 'Not started'
+	end
+
+	timeout = timeout or STOP_TIMEOUT
+
+	local scope_ref = UARTManager.scope
+	if not scope_ref then
+		trace_push(UARTManager, 'manager.stop.missing_scope')
+		reset_runtime_state(nil)
+		return false, 'uart manager missing scope'
+	end
+
+	local names = {}
+	for name in pairs(UARTManager.drivers) do
+		names[#names + 1] = name
+	end
+	table.sort(names)
+
+	for i = 1, #names do
+		local name = names[i]
+		local rec = UARTManager.drivers[name]
+		if rec then
+			stop_driver(name, rec)
+		end
+	end
+
+	scope_ref:cancel('uart manager stopped')
+
+	local source = fibers.perform(op.named_choice {
+		join    = scope_ref:join_op(),
+		timeout = sleep.sleep_op(timeout),
+	})
+
+	if source == 'timeout' then
+		trace_push(UARTManager, 'manager.stop.timeout')
+		return false, 'uart manager stop timeout'
+	end
+
+	reset_runtime_state(scope_ref)
+
+	trace_push(UARTManager, 'manager.stop.ok')
+	return true, ''
+end
+
+---@param cfg table
+---@return boolean ok
+---@return string error
+function UARTManager.apply_config(cfg)
+	trace_push(UARTManager, 'manager.apply_config.begin', {
+		started      = UARTManager.started,
+		driver_count = count_drivers(UARTManager.drivers),
+	})
+
+	if not UARTManager.started then
+		trace_push(UARTManager, 'manager.apply_config.not_started')
+		return false, 'uart manager not started'
+	end
+
+	local desired, err = normalise_config(cfg)
+	if not desired then
+		trace_push(UARTManager, 'manager.apply_config.normalise_failed', {
+			err = tostring(err),
+		})
+		return false, tostring(err)
+	end
+
+	trace_push(UARTManager, 'manager.apply_config.normalised', {
+		desired_count = count_drivers(desired),
+	})
+
+	local existing_names = {}
+	for name in pairs(UARTManager.drivers) do existing_names[#existing_names + 1] = name end
+	table.sort(existing_names)
+
+	for i = 1, #existing_names do
+		local name = existing_names[i]
+		local rec  = UARTManager.drivers[name]
+		local want = desired[name]
+		if rec and (not want or not same_spec(rec.spec, want)) then
+			trace_push(UARTManager, 'manager.apply_config.stop_mismatch', {
+				cap_id = name,
+				had    = rec.spec and rec.spec.path or nil,
+				want   = want and want.path or nil,
+			})
+			stop_driver(name, rec)
+		end
+	end
+
+	local desired_names = {}
+	for name in pairs(desired) do desired_names[#desired_names + 1] = name end
+	table.sort(desired_names)
+
+	for i = 1, #desired_names do
+		local name = desired_names[i]
+		local want = desired[name]
+		local rec  = UARTManager.drivers[name]
+		if not rec then
+			local ok, start_err = start_driver(name, want)
+			if ok ~= true then
+				trace_push(UARTManager, 'manager.apply_config.start_failed', {
+					cap_id = name,
+					err    = tostring(start_err),
+				})
+				return false, 'failed to start uart ' .. tostring(name) .. ': ' .. tostring(start_err)
+			end
+		else
+			trace_push(UARTManager, 'manager.apply_config.keep_existing', {
+				cap_id = name,
+				path   = rec.spec and rec.spec.path or nil,
+			})
+		end
+	end
+
+	trace_push(UARTManager, 'manager.apply_config.ok', {
+		driver_count = count_drivers(UARTManager.drivers),
+	})
+
+	return true, ''
+end
+
+return UARTManager

--- a/src/services/hal/managers/updater.lua
+++ b/src/services/hal/managers/updater.lua
@@ -1,0 +1,145 @@
+-- services/hal/managers/updater.lua
+--
+-- HAL manager for updater providers. Each provider is a normal
+-- manager-owned driver that advertises one capability of the same class.
+
+local driver_mod = require 'services.hal.drivers.updater_cm5'
+local hal_types = require 'services.hal.types.core'
+
+local fibers = require 'fibers'
+local op = require 'fibers.op'
+local sleep = require 'fibers.sleep'
+
+local STOP_TIMEOUT = 5.0
+
+local function dlog(logger, level, payload)
+    if logger and logger[level] then logger[level](logger, payload) end
+end
+
+local Manager = {
+    started = false,
+    scope = nil,
+    logger = nil,
+    dev_ev_ch = nil,
+    cap_emit_ch = nil,
+    drivers = {},
+}
+
+local function child_logger(id)
+    if Manager.logger and Manager.logger.child then
+        return Manager.logger:child({ component = 'driver', driver = 'updater', id = id })
+    end
+    return Manager.logger
+end
+
+local function normalise_config(cfg)
+    cfg = cfg or {}
+    if type(cfg) ~= 'table' then return nil, 'updater config must be a table' end
+
+    local specs = cfg.providers
+    if specs == nil and cfg[1] == nil then
+        specs = { { id = 'cm5' } }
+    elseif specs == nil then
+        specs = cfg
+    end
+    if type(specs) ~= 'table' then return nil, 'updater.providers must be a table' end
+
+    local out = {}
+    for i = 1, #specs do
+        local rec = specs[i]
+        if type(rec) ~= 'table' then return nil, ('updater.providers[%d] must be a table'):format(i) end
+        local id = rec.id or rec.name or 'cm5'
+        if type(id) ~= 'string' or id == '' then return nil, ('updater.providers[%d].id must be a non-empty string'):format(i) end
+        if out[id] ~= nil then return nil, 'duplicate updater provider id: ' .. id end
+        local opts = {}
+        for k, v in pairs(rec) do if k ~= 'id' and k ~= 'name' then opts[k] = v end end
+        out[id] = { id = id, opts = opts }
+    end
+    return out, ''
+end
+
+local function register_driver(id, opts)
+    if Manager.drivers[id] then return true, '' end
+
+    local driver, err = driver_mod.new(id, opts, child_logger(id))
+    if not driver then return false, tostring(err) end
+
+    local init_err = driver:init()
+    if init_err ~= '' then return false, tostring(init_err) end
+
+    local caps, cap_err = driver:capabilities(Manager.cap_emit_ch)
+    if cap_err ~= '' then return false, tostring(cap_err) end
+
+    local ok, start_err = driver:start()
+    if not ok then return false, tostring(start_err) end
+
+    local ev, ev_err = hal_types.new.DeviceEvent('added', 'updater', id, { provider = 'hal.updater' }, caps)
+    if not ev then return false, tostring(ev_err) end
+    Manager.dev_ev_ch:put(ev)
+
+    Manager.drivers[id] = { driver = driver, opts = opts }
+    dlog(Manager.logger, 'info', { what = 'device_registered', class = 'updater', id = id })
+    return true, ''
+end
+
+local function unregister_driver(id)
+    local rec = Manager.drivers[id]
+    if not rec then return end
+    Manager.drivers[id] = nil
+
+    local ev = hal_types.new.DeviceEvent('removed', 'updater', id, { provider = 'hal.updater' }, {})
+    if ev then Manager.dev_ev_ch:put(ev) end
+
+    fibers.current_scope():spawn(function() rec.driver:stop(STOP_TIMEOUT) end)
+end
+
+function Manager.start(logger, dev_ev_ch, cap_emit_ch)
+    if Manager.started then return 'Already started' end
+
+    local scope, err = fibers.current_scope():child()
+    if not scope then return 'Failed to create child scope: ' .. tostring(err) end
+
+    Manager.scope = scope
+    Manager.logger = logger
+    Manager.dev_ev_ch = dev_ev_ch
+    Manager.cap_emit_ch = cap_emit_ch
+    Manager.drivers = {}
+
+    scope:finally(function()
+        local st, primary = scope:status()
+        if st == 'failed' then dlog(Manager.logger, 'error', { what = 'scope_failed', err = tostring(primary), status = st }) end
+        dlog(Manager.logger, 'debug', { what = 'stopped' })
+    end)
+
+    Manager.started = true
+    dlog(Manager.logger, 'debug', { what = 'start_called' })
+    return ''
+end
+
+function Manager.stop(timeout)
+    if not Manager.started then return false, 'Not started' end
+    timeout = timeout or STOP_TIMEOUT
+    Manager.scope:cancel('updater manager stopped')
+    local source = fibers.perform(op.named_choice { join = Manager.scope:join_op(), timeout = sleep.sleep_op(timeout) })
+    if source == 'timeout' then return false, 'updater manager stop timeout' end
+    Manager.started = false
+    return true, ''
+end
+
+function Manager.apply_config(cfg)
+    local specs, err = normalise_config(cfg)
+    if not specs then return false, err end
+
+    for id, spec in pairs(specs) do
+        local ok, reg_err = register_driver(id, spec.opts)
+        if not ok then return false, reg_err end
+    end
+
+    for id in pairs(Manager.drivers) do
+        if not specs[id] then unregister_driver(id) end
+    end
+
+    return true, ''
+end
+
+return Manager

--- a/src/services/hal/types/capabilities.lua
+++ b/src/services/hal/types/capabilities.lua
@@ -201,6 +201,33 @@ function new.FilesystemCapability(id, control_ch)
     return new.Capability('fs', id, control_ch, offerings)
 end
 
+
+---@param id CapabilityId
+---@param control_ch Channel
+---@return Capability?
+---@return string error
+function new.ControlStoreCapability(id, control_ch)
+    return new.Capability('control_store', id, control_ch, { 'get', 'put', 'delete', 'list', 'status' })
+end
+
+---@param id CapabilityId
+---@param control_ch Channel
+---@return Capability?
+---@return string error
+function new.ArtifactStoreCapability(id, control_ch)
+    return new.Capability('artifact_store', id, control_ch, { 'create_sink', 'import_path', 'import_source', 'open', 'delete', 'status' })
+end
+
+
+---@param id CapabilityId
+---@param control_ch Channel
+---@return Capability?
+---@return string error
+function new.SignatureVerifyCapability(id, control_ch)
+    return new.Capability('signature_verify', id, control_ch, { 'verify_ed25519' })
+end
+
+
 ---@param id CapabilityId
 ---@param control_ch Channel
 ---@return Capability?
@@ -242,6 +269,22 @@ end
 ---@return string error
 function new.PlatformCapability(id, control_ch)
     return new.Capability('platform', id, control_ch, { 'get' })
+end
+
+
+
+---@param id CapabilityId
+---@param control_ch Channel
+---@return Capability?
+---@return string error
+function new.UpdaterCapability(id, control_ch)
+    local offerings = {
+        'prepare',
+        'stage',
+        'commit',
+        'status',
+    }
+    return new.Capability('updater', id, control_ch, offerings)
 end
 
 ---@param id CapabilityId

--- a/src/services/hal/types/capability_args.lua
+++ b/src/services/hal/types/capability_args.lua
@@ -264,11 +264,254 @@ function new.PowerActionOpts(delay)
     return setmetatable({ delay = delay }, PowerActionOpts), ""
 end
 
+
+
+
+---@class ControlStoreGetOpts
+---@field ns string
+---@field key string
+local ControlStoreGetOpts = {}
+ControlStoreGetOpts.__index = ControlStoreGetOpts
+
+function new.ControlStoreGetOpts(ns, key)
+    if type(ns) ~= 'string' or ns == '' then return nil, 'invalid ns' end
+    if type(key) ~= 'string' or key == '' then return nil, 'invalid key' end
+    return setmetatable({ ns = ns, key = key }, ControlStoreGetOpts), ''
+end
+
+---@class ControlStorePutOpts
+---@field ns string
+---@field key string
+---@field value table
+local ControlStorePutOpts = {}
+ControlStorePutOpts.__index = ControlStorePutOpts
+
+function new.ControlStorePutOpts(ns, key, value)
+    if type(ns) ~= 'string' or ns == '' then return nil, 'invalid ns' end
+    if type(key) ~= 'string' or key == '' then return nil, 'invalid key' end
+    if type(value) ~= 'table' then return nil, 'invalid value' end
+    return setmetatable({ ns = ns, key = key, value = value }, ControlStorePutOpts), ''
+end
+
+---@class ControlStoreDeleteOpts
+---@field ns string
+---@field key string
+local ControlStoreDeleteOpts = {}
+ControlStoreDeleteOpts.__index = ControlStoreDeleteOpts
+
+function new.ControlStoreDeleteOpts(ns, key)
+    if type(ns) ~= 'string' or ns == '' then return nil, 'invalid ns' end
+    if type(key) ~= 'string' or key == '' then return nil, 'invalid key' end
+    return setmetatable({ ns = ns, key = key }, ControlStoreDeleteOpts), ''
+end
+
+---@class ControlStoreListOpts
+---@field ns string
+local ControlStoreListOpts = {}
+ControlStoreListOpts.__index = ControlStoreListOpts
+
+function new.ControlStoreListOpts(ns)
+    if type(ns) ~= 'string' or ns == '' then return nil, 'invalid ns' end
+    return setmetatable({ ns = ns }, ControlStoreListOpts), ''
+end
+
+---@class ControlStoreStatusOpts
+---@field verbose boolean|nil
+local ControlStoreStatusOpts = {}
+ControlStoreStatusOpts.__index = ControlStoreStatusOpts
+
+function new.ControlStoreStatusOpts(verbose)
+    if verbose ~= nil and type(verbose) ~= 'boolean' then return nil, 'invalid verbose' end
+    return setmetatable({ verbose = verbose }, ControlStoreStatusOpts), ''
+end
+
+
+---@class ArtifactStoreCreateSinkOpts
+---@field meta table|nil
+---@field policy string|nil
+local ArtifactStoreCreateSinkOpts = {}
+ArtifactStoreCreateSinkOpts.__index = ArtifactStoreCreateSinkOpts
+
+function new.ArtifactStoreCreateSinkOpts(meta, policy)
+    if meta ~= nil and type(meta) ~= 'table' then return nil, 'invalid meta' end
+    if policy ~= nil and type(policy) ~= 'string' then return nil, 'invalid policy' end
+    return setmetatable({ meta = meta, policy = policy }, ArtifactStoreCreateSinkOpts), ''
+end
+
+---@class ArtifactStoreImportPathOpts
+---@field path string
+---@field meta table|nil
+---@field policy string|nil
+local ArtifactStoreImportPathOpts = {}
+ArtifactStoreImportPathOpts.__index = ArtifactStoreImportPathOpts
+
+function new.ArtifactStoreImportPathOpts(path, meta, policy)
+    if type(path) ~= 'string' or path == '' then return nil, 'invalid path' end
+    if meta ~= nil and type(meta) ~= 'table' then return nil, 'invalid meta' end
+    if policy ~= nil and type(policy) ~= 'string' then return nil, 'invalid policy' end
+    return setmetatable({ path = path, meta = meta, policy = policy }, ArtifactStoreImportPathOpts), ''
+end
+
+---@class ArtifactStoreImportSourceOpts
+---@field source table
+---@field meta table|nil
+---@field policy string|nil
+local ArtifactStoreImportSourceOpts = {}
+ArtifactStoreImportSourceOpts.__index = ArtifactStoreImportSourceOpts
+
+function new.ArtifactStoreImportSourceOpts(source, meta, policy)
+    if type(source) ~= 'table' then return nil, 'invalid source' end
+    if meta ~= nil and type(meta) ~= 'table' then return nil, 'invalid meta' end
+    if policy ~= nil and type(policy) ~= 'string' then return nil, 'invalid policy' end
+    return setmetatable({ source = source, meta = meta, policy = policy }, ArtifactStoreImportSourceOpts), ''
+end
+
+---@class ArtifactStoreOpenOpts
+---@field artifact_ref string
+local ArtifactStoreOpenOpts = {}
+ArtifactStoreOpenOpts.__index = ArtifactStoreOpenOpts
+
+function new.ArtifactStoreOpenOpts(artifact_ref)
+    if type(artifact_ref) ~= 'string' or artifact_ref == '' then return nil, 'invalid artifact_ref' end
+    return setmetatable({ artifact_ref = artifact_ref }, ArtifactStoreOpenOpts), ''
+end
+
+---@class ArtifactStoreDeleteOpts
+---@field artifact_ref string
+local ArtifactStoreDeleteOpts = {}
+ArtifactStoreDeleteOpts.__index = ArtifactStoreDeleteOpts
+
+function new.ArtifactStoreDeleteOpts(artifact_ref)
+    if type(artifact_ref) ~= 'string' or artifact_ref == '' then return nil, 'invalid artifact_ref' end
+    return setmetatable({ artifact_ref = artifact_ref }, ArtifactStoreDeleteOpts), ''
+end
+
+---@class ArtifactStoreStatusOpts
+---@field verbose boolean|nil
+local ArtifactStoreStatusOpts = {}
+ArtifactStoreStatusOpts.__index = ArtifactStoreStatusOpts
+
+function new.ArtifactStoreStatusOpts(verbose)
+    if verbose ~= nil and type(verbose) ~= 'boolean' then return nil, 'invalid verbose' end
+    return setmetatable({ verbose = verbose }, ArtifactStoreStatusOpts), ''
+end
+
+---@class SignatureVerifyEd25519Opts
+---@field pubkey_pem string
+---@field message string
+---@field signature string
+local SignatureVerifyEd25519Opts = {}
+SignatureVerifyEd25519Opts.__index = SignatureVerifyEd25519Opts
+
+function new.SignatureVerifyEd25519Opts(pubkey_pem, message, signature)
+    if type(pubkey_pem) ~= 'string' or pubkey_pem == '' then return nil, 'invalid public_key' end
+    if type(message) ~= 'string' then return nil, 'invalid message' end
+    if type(signature) ~= 'string' or signature == '' then return nil, 'invalid signature' end
+    return setmetatable({ pubkey_pem = pubkey_pem, message = message, signature = signature }, SignatureVerifyEd25519Opts), ''
+end
+
+
+---@class UpdaterPrepareOpts
+---@field target string|nil
+---@field metadata table|nil
+local UpdaterPrepareOpts = {}
+UpdaterPrepareOpts.__index = UpdaterPrepareOpts
+
+---Create a new UpdaterPrepareOpts.
+---@param target string|nil
+---@param metadata table|nil
+---@return UpdaterPrepareOpts?
+---@return string error
+function new.UpdaterPrepareOpts(target, metadata)
+    if target ~= nil and (type(target) ~= 'string' or target == '') then
+        return nil, "invalid target"
+    end
+    if metadata ~= nil and type(metadata) ~= 'table' then
+        return nil, "invalid metadata"
+    end
+    return setmetatable({ target = target, metadata = metadata }, UpdaterPrepareOpts), ""
+end
+
+---@class UpdaterStageOpts
+---@field artifact_ref string
+---@field metadata table|nil
+---@field expected_image_id string|nil
+local UpdaterStageOpts = {}
+UpdaterStageOpts.__index = UpdaterStageOpts
+
+---Create a new UpdaterStageOpts.
+---@param artifact_ref string
+---@param metadata table|nil
+---@param expected_image_id string|nil
+---@return UpdaterStageOpts?
+---@return string error
+function new.UpdaterStageOpts(artifact_ref, metadata, expected_image_id)
+    if type(artifact_ref) ~= 'string' or artifact_ref == '' then
+        return nil, "invalid artifact_ref"
+    end
+    if metadata ~= nil and type(metadata) ~= 'table' then
+        return nil, "invalid metadata"
+    end
+    if expected_image_id ~= nil and type(expected_image_id) ~= 'string' then
+        return nil, "invalid expected_image_id"
+    end
+    return setmetatable({ artifact_ref = artifact_ref, metadata = metadata, expected_image_id = expected_image_id }, UpdaterStageOpts), ""
+end
+
+---@class UpdaterCommitOpts
+---@field mode string|nil
+---@field metadata table|nil
+local UpdaterCommitOpts = {}
+UpdaterCommitOpts.__index = UpdaterCommitOpts
+
+---Create a new UpdaterCommitOpts.
+---@param mode string|nil
+---@param metadata table|nil
+---@return UpdaterCommitOpts?
+---@return string error
+function new.UpdaterCommitOpts(mode, metadata)
+    if mode ~= nil and type(mode) ~= 'string' then
+        return nil, "invalid mode"
+    end
+    if metadata ~= nil and type(metadata) ~= 'table' then
+        return nil, "invalid metadata"
+    end
+    return setmetatable({ mode = mode, metadata = metadata }, UpdaterCommitOpts), ""
+end
+
+---@class UpdaterStatusOpts
+---@field verbose boolean|nil
+local UpdaterStatusOpts = {}
+UpdaterStatusOpts.__index = UpdaterStatusOpts
+
+---Create a new UpdaterStatusOpts.
+---@param verbose boolean|nil
+---@return UpdaterStatusOpts?
+---@return string error
+function new.UpdaterStatusOpts(verbose)
+    if verbose ~= nil and type(verbose) ~= 'boolean' then
+        return nil, "invalid verbose"
+    end
+    return setmetatable({ verbose = verbose }, UpdaterStatusOpts), ""
+end
+
 return {
     ModemGetOpts = ModemGetOpts,
     ModemConnectOpts = ModemConnectOpts,
     FilesystemReadOpts = FilesystemReadOpts,
     FilesystemWriteOpts = FilesystemWriteOpts,
+    ControlStoreGetOpts = ControlStoreGetOpts,
+    ControlStorePutOpts = ControlStorePutOpts,
+    ControlStoreDeleteOpts = ControlStoreDeleteOpts,
+    ControlStoreListOpts = ControlStoreListOpts,
+    ControlStoreStatusOpts = ControlStoreStatusOpts,
+    ArtifactStoreCreateSinkOpts = ArtifactStoreCreateSinkOpts,
+    ArtifactStoreImportPathOpts = ArtifactStoreImportPathOpts,
+    ArtifactStoreImportSourceOpts = ArtifactStoreImportSourceOpts,
+    ArtifactStoreOpenOpts = ArtifactStoreOpenOpts,
+    ArtifactStoreDeleteOpts = ArtifactStoreDeleteOpts,
+    ArtifactStoreStatusOpts = ArtifactStoreStatusOpts,
+    SignatureVerifyEd25519Opts = SignatureVerifyEd25519Opts,
     UARTOpenOpts = UARTOpenOpts,
     UARTWriteOpts = UARTWriteOpts,
     MemoryGetOpts = MemoryGetOpts,
@@ -276,5 +519,9 @@ return {
     ThermalGetOpts = ThermalGetOpts,
     PlatformGetOpts = PlatformGetOpts,
     PowerActionOpts = PowerActionOpts,
+    UpdaterPrepareOpts = UpdaterPrepareOpts,
+    UpdaterStageOpts = UpdaterStageOpts,
+    UpdaterCommitOpts = UpdaterCommitOpts,
+    UpdaterStatusOpts = UpdaterStatusOpts,
     new = new,
 }

--- a/src/shared/blob_source.lua
+++ b/src/shared/blob_source.lua
@@ -1,0 +1,336 @@
+-- shared/blob_source.lua
+--
+-- Small, OS-agnostic object source/sink helpers shared by fabric transfer
+-- and higher-level services.
+--
+-- File-backed artefacts belong behind HAL/host capabilities; this module only
+-- defines abstract sources/sinks plus small in-memory helpers for tests and
+-- simple local flows.
+--
+-- Design notes:
+--   * sources and sinks are synchronous interfaces
+--   * copy discipline is strict:
+--       - abort sink on any read/write/validation/commit failure
+--       - re-raise unexpected exceptions after abort
+--   * copy_op(...) is provided for algebraic composition
+--   * copy(...) remains as the ordinary blocking wrapper
+--   * DeviceCode always runs inside fibres, so the blocking wrapper simply
+--     performs the op
+
+local fibers   = require 'fibers'
+local checksum = require 'shared.hash.xxhash32'
+local safe     = require 'coxpcall'
+local scope    = require 'fibers.scope'
+
+local M = {}
+
+local function shallow_copy(t)
+	local out = {}
+	if type(t) ~= 'table' then return out end
+	for k, v in pairs(t) do
+		out[k] = v
+	end
+	return out
+end
+
+----------------------------------------------------------------------
+-- String source
+----------------------------------------------------------------------
+
+local StringSource = {}
+StringSource.__index = StringSource
+
+function StringSource:size()
+	return #self._data
+end
+
+function StringSource:checksum()
+	return checksum.digest_hex(self._data)
+end
+
+function StringSource:read_chunk(offset, max_bytes)
+	offset = offset or 0
+	max_bytes = max_bytes or #self._data
+
+	if offset < 0 then
+		return nil, 'invalid_offset'
+	end
+	if offset >= #self._data then
+		return '', nil
+	end
+
+	local from = offset + 1
+	local to_ = math.min(#self._data, offset + max_bytes)
+	return self._data:sub(from, to_), nil
+end
+
+function StringSource:close()
+	return true
+end
+
+function M.from_string(s)
+	assert(type(s) == 'string', 'blob_source.from_string expects string')
+	return setmetatable({ _data = s }, StringSource)
+end
+
+----------------------------------------------------------------------
+-- In-memory artefact and sink
+----------------------------------------------------------------------
+
+local MemoryArtefact = {}
+MemoryArtefact.__index = MemoryArtefact
+
+function MemoryArtefact:ref()
+	return nil
+end
+
+function MemoryArtefact:meta()
+	return shallow_copy(self._meta)
+end
+
+function MemoryArtefact:size()
+	return #self._data
+end
+
+function MemoryArtefact:checksum()
+	if not self._checksum then
+		self._checksum = checksum.digest_hex(self._data)
+	end
+	return self._checksum
+end
+
+function MemoryArtefact:open_source()
+	return M.from_string(self._data)
+end
+
+function MemoryArtefact:delete()
+	self._deleted = true
+	return true
+end
+
+function MemoryArtefact:describe()
+	return {
+		artifact_ref = nil,
+		state = 'ready',
+		durability = 'memory',
+		size = #self._data,
+		checksum = self:checksum(),
+		meta = shallow_copy(self._meta),
+		kind = 'memory',
+	}
+end
+
+local MemorySink = {}
+MemorySink.__index = MemorySink
+
+function MemorySink:write_chunk(offset, data)
+	if self._closed then return nil, 'closed' end
+	if offset ~= self._size then return nil, 'unexpected_offset' end
+	if type(data) ~= 'string' then return nil, 'invalid_chunk' end
+
+	self._parts[#self._parts + 1] = data
+	self._size = self._size + #data
+	self._checksum = nil
+	return true
+end
+
+function MemorySink:size()
+	return self._size
+end
+
+function MemorySink:checksum()
+	if not self._checksum then
+		self._checksum = checksum.digest_hex(table.concat(self._parts))
+	end
+	return self._checksum
+end
+
+function MemorySink:commit()
+	if self._closed then return nil, 'closed' end
+	if self._committed then return nil, 'committed' end
+
+	self._committed = true
+	self._closed = true
+
+	return setmetatable({
+		_data = table.concat(self._parts),
+		_meta = shallow_copy(self._meta),
+	}, MemoryArtefact), nil
+end
+
+function MemorySink:abort()
+	if self._closed then return true end
+	self._closed = true
+	self._aborted = true
+	return true
+end
+
+function MemorySink:close()
+	if self._closed then return true end
+	self._closed = true
+	return true
+end
+
+function MemorySink:status()
+	return {
+		size = self._size,
+		committed = self._committed,
+		aborted = self._aborted,
+		kind = 'memory',
+	}
+end
+
+function M.memory_sink(meta)
+	return setmetatable({
+		_parts = {},
+		_size = 0,
+		_closed = false,
+		_committed = false,
+		_aborted = false,
+		_meta = shallow_copy(meta),
+		_checksum = nil,
+	}, MemorySink)
+end
+
+----------------------------------------------------------------------
+-- Predicates and normalisation
+----------------------------------------------------------------------
+
+function M.is_source(v)
+	return type(v) == 'table'
+		and type(v.read_chunk) == 'function'
+		and type(v.size) == 'function'
+		and type(v.checksum) == 'function'
+end
+
+function M.is_sink(v)
+	return type(v) == 'table'
+		and type(v.write_chunk) == 'function'
+		and type(v.commit) == 'function'
+		and type(v.abort) == 'function'
+end
+
+function M.is_stored_artefact(v)
+	return type(v) == 'table'
+		and type(v.open_source) == 'function'
+		and type(v.ref) == 'function'
+		and type(v.describe) == 'function'
+end
+
+function M.normalise_source(source)
+	if source == nil then
+		return nil, 'missing_source'
+	end
+	if type(source) == 'string' then
+		return M.from_string(source), nil
+	end
+	if M.is_stored_artefact(source) then
+		return source:open_source(), nil
+	end
+	if M.is_source(source) then
+		return source, nil
+	end
+	return nil, 'unsupported_source'
+end
+
+----------------------------------------------------------------------
+-- Copy
+----------------------------------------------------------------------
+
+local function copy_blocking(source, sink, opts)
+	opts = opts or {}
+
+	local src, err = M.normalise_source(source)
+	if not src then
+		return nil, err
+	end
+
+	assert(M.is_sink(sink), 'blob_source.copy expects sink')
+
+	local offset = 0
+	local chunk_size = tonumber(opts.chunk_size) or (64 * 1024)
+	local expected_size = opts.expected_size or src:size()
+	local expected_checksum = opts.expected_checksum or src:checksum()
+
+	local committed = false
+
+	local function abort_uncommitted()
+		if not committed then
+			sink:abort()
+		end
+	end
+
+	local function run_copy()
+		while true do
+			local chunk, rerr = src:read_chunk(offset, chunk_size)
+			if chunk == nil then
+				abort_uncommitted()
+				return nil, rerr or 'read_failed'
+			end
+			if chunk == '' then
+				break
+			end
+
+			local ok, werr = sink:write_chunk(offset, chunk)
+			if not ok then
+				abort_uncommitted()
+				return nil, werr or 'write_failed'
+			end
+
+			offset = offset + #chunk
+		end
+
+		if offset ~= expected_size then
+			abort_uncommitted()
+			return nil, 'size_mismatch'
+		end
+
+		if sink:checksum() ~= expected_checksum then
+			abort_uncommitted()
+			return nil, 'checksum_mismatch'
+		end
+
+		local artefact, cerr = sink:commit()
+		if artefact == nil then
+			abort_uncommitted()
+			return nil, cerr
+		end
+
+		committed = true
+		return artefact, nil
+	end
+
+	local ok, artefact, copy_err = safe.xpcall(run_copy, function(e)
+		abort_uncommitted()
+		return e
+	end)
+
+	if not ok then
+		error(artefact, 0)
+	end
+
+	return artefact, copy_err
+end
+
+function M.copy_op(source, sink, opts)
+	return fibers.run_scope_op(function()
+		return copy_blocking(source, sink, opts)
+	end):wrap(function(st, _report, ...)
+		if st == 'ok' then
+			return ...
+		end
+
+		local primary = ...
+		if st == 'cancelled' then
+			error(scope.cancelled(primary), 0)
+		end
+
+		error(primary or 'copy_failed', 0)
+	end)
+end
+
+function M.copy(source, sink, opts)
+	return fibers.perform(M.copy_op(source, sink, opts))
+end
+
+return M

--- a/src/shared/hash/xxhash32.lua
+++ b/src/shared/hash/xxhash32.lua
@@ -1,0 +1,192 @@
+-- shared/hash/xxhash32.lua
+--
+-- Small, dependency-free xxHash32 helpers.
+--
+-- This provides a deterministic non-cryptographic integrity checksum for
+-- transfer protocol use and tests without pulling in an external dependency.
+-- It is not a security primitive.
+
+local ok_bit32, bit32_mod = pcall(require, 'bit32')
+local ok_bit, bit_mod = pcall(require, 'bit')
+
+local bitops = ok_bit32 and bit32_mod or bit_mod
+assert(bitops, 'shared.hash.xxhash32 requires bit32 or bit')
+
+local band   = assert(bitops.band,   'bit library missing band')
+local bor    = assert(bitops.bor,    'bit library missing bor')
+local bxor   = assert(bitops.bxor,   'bit library missing bxor')
+local lshift = assert(bitops.lshift, 'bit library missing lshift')
+local rshift = assert(bitops.rshift, 'bit library missing rshift')
+
+local rol
+if bitops.lrotate then
+	rol = bitops.lrotate
+elseif bitops.rol then
+	rol = bitops.rol
+else
+	rol = function (x, n)
+		n = n % 32
+		return band(bor(lshift(x, n), rshift(x, 32 - n)), 0xffffffff)
+	end
+end
+
+local M = {}
+
+local P1 = 0x9E3779B1
+local P2 = 0x85EBCA77
+local P3 = 0xC2B2AE3D
+local P4 = 0x27D4EB2F
+local P5 = 0x165667B1
+
+local TWO32 = 4294967296
+
+local function u32(n)
+	return band(n, 0xffffffff)
+end
+
+local function hex8(n)
+	n = u32(n)
+	-- LuaJIT/bit may format signed 32-bit values as negative unless adjusted.
+	if n < 0 then
+		n = n + TWO32
+	end
+	return ('%08x'):format(n)
+end
+
+-- Exact 32-bit multiplication modulo 2^32 using 16-bit limbs.
+local function mul32(a, b)
+	a = u32(a)
+	b = u32(b)
+
+	local a_lo = band(a, 0xffff)
+	local a_hi = band(rshift(a, 16), 0xffff)
+	local b_lo = band(b, 0xffff)
+	local b_hi = band(rshift(b, 16), 0xffff)
+
+	local lo  = a_lo * b_lo
+	local mid = a_hi * b_lo + a_lo * b_hi
+
+	return u32(lo + lshift(band(mid, 0xffff), 16))
+end
+
+local function read_u32_le(s, i)
+	local b1, b2, b3, b4 = s:byte(i, i + 3)
+	return bor(
+		b1 or 0,
+		lshift(b2 or 0, 8),
+		lshift(b3 or 0, 16),
+		lshift(b4 or 0, 24)
+	)
+end
+
+local function round_lane(acc, lane)
+	acc = u32(acc + mul32(lane, P2))
+	acc = rol(acc, 13)
+	acc = mul32(acc, P1)
+	return acc
+end
+
+local function avalanche(h)
+	h = bxor(h, rshift(h, 15))
+	h = mul32(h, P2)
+	h = bxor(h, rshift(h, 13))
+	h = mul32(h, P3)
+	h = bxor(h, rshift(h, 16))
+	return u32(h)
+end
+
+function M.new(seed)
+	seed = u32(seed or 0)
+	return {
+		seed = seed,
+		total_len = 0,
+		mem = '',
+		v1 = u32(seed + P1 + P2),
+		v2 = u32(seed + P2),
+		v3 = seed,
+		v4 = u32(seed - P1),
+		large = false,
+	}
+end
+
+function M.update(state, s)
+	assert(type(state) == 'table', 'checksum.update expects state')
+	assert(type(s) == 'string', 'checksum.update expects string')
+	if s == '' then
+		return state
+	end
+
+	state.total_len = state.total_len + #s
+	local buf = state.mem .. s
+	local idx = 1
+	local n = #buf
+
+	if n >= 16 then
+		state.large = true
+		while idx + 15 <= n do
+			state.v1 = round_lane(state.v1, read_u32_le(buf, idx)); idx = idx + 4
+			state.v2 = round_lane(state.v2, read_u32_le(buf, idx)); idx = idx + 4
+			state.v3 = round_lane(state.v3, read_u32_le(buf, idx)); idx = idx + 4
+			state.v4 = round_lane(state.v4, read_u32_le(buf, idx)); idx = idx + 4
+		end
+	end
+
+	state.mem = buf:sub(idx)
+	return state
+end
+
+function M.digest(state)
+	assert(type(state) == 'table', 'checksum.digest expects state')
+
+	local h
+	if state.large then
+		h = u32(
+			rol(state.v1, 1) +
+			rol(state.v2, 7) +
+			rol(state.v3, 12) +
+			rol(state.v4, 18)
+		)
+	else
+		h = u32(state.seed + P5)
+	end
+
+	h = u32(h + state.total_len)
+
+	local i = 1
+	local n = #state.mem
+
+	while i + 3 <= n do
+		h = u32(h + mul32(read_u32_le(state.mem, i), P3))
+		h = mul32(rol(h, 17), P4)
+		i = i + 4
+	end
+
+	while i <= n do
+		h = u32(h + mul32(state.mem:byte(i) or 0, P5))
+		h = mul32(rol(h, 11), P1)
+		i = i + 1
+	end
+
+	return avalanche(h)
+end
+
+function M.digest_hex_state(state)
+	return hex8(M.digest(state))
+end
+
+function M.xxhash32(s, seed)
+	assert(type(s) == 'string', 'checksum.xxhash32 expects string')
+	local st = M.new(seed)
+	M.update(st, s)
+	return M.digest(st)
+end
+
+function M.digest_hex(s)
+	return hex8(M.xxhash32(s))
+end
+
+function M.verify_hex(s, expected)
+	return M.digest_hex(s) == tostring(expected)
+end
+
+return M

--- a/tests/integration/devhost/hal_uart_spec.lua
+++ b/tests/integration/devhost/hal_uart_spec.lua
@@ -1,0 +1,516 @@
+-- tests/integration/devhost/hal_uart_spec.lua
+
+local fibers    = require 'fibers'
+local channel   = require 'fibers.channel'
+local sleep     = require 'fibers.sleep'
+local op        = require 'fibers.op'
+
+local hal_types = require 'services.hal.types.core'
+local cap_args  = require 'services.hal.types.capability_args'
+local uart_mgr  = require 'services.hal.managers.uart'
+
+local runfibers = require 'tests.support.run_fibers'
+local pty       = require 'tests.support.pty'
+local safe      = require 'coxpcall'
+
+local perform = fibers.perform
+
+local T = {}
+
+local function dummy_logger()
+	local logger = {}
+	for _, k in ipairs({ 'debug', 'info', 'warn', 'error' }) do
+		logger[k] = function() end
+	end
+	function logger:child()
+		return self
+	end
+	return logger
+end
+
+local function wait_channel_get(ch, timeout_s, what)
+	local which, a, b = perform(op.named_choice({
+		item = ch:get_op(),
+		timeout = sleep.sleep_op(timeout_s or 1.0):wrap(function()
+			return true
+		end),
+	}))
+
+	if which == 'timeout' then
+		error(('timed out waiting for %s'):format(what or 'channel item'), 0)
+	end
+
+	if a == nil then
+		error(('channel closed while waiting for %s: %s'):format(what or 'channel item', tostring(b)), 0)
+	end
+
+	return a
+end
+
+local function wait_channel_maybe_get(ch, timeout_s)
+	local which, a, b = perform(op.named_choice({
+		item = ch:get_op(),
+		timeout = sleep.sleep_op(timeout_s or 0.1):wrap(function()
+			return true
+		end),
+	}))
+
+	if which == 'timeout' then
+		return nil, 'timeout'
+	end
+
+	if a == nil then
+		return nil, b or 'closed'
+	end
+
+	return a, nil
+end
+
+local function wait_device_event(dev_ev_ch, event_type, class, id, timeout_s)
+	local deadline = fibers.now() + (timeout_s or 1.0)
+
+	while fibers.now() < deadline do
+		local ev = wait_channel_get(dev_ev_ch, deadline - fibers.now(), 'device event')
+		if ev.event_type == event_type and ev.class == class and ev.id == id then
+			return ev
+		end
+	end
+
+	error(('timed out waiting for device event %s %s/%s'):format(
+		tostring(event_type), tostring(class), tostring(id)
+	), 0)
+end
+
+local function wait_cap_emit(cap_emit_ch, class, id, mode, key, timeout_s)
+	local deadline = fibers.now() + (timeout_s or 1.0)
+
+	while fibers.now() < deadline do
+		local ev = wait_channel_get(cap_emit_ch, deadline - fibers.now(), 'cap emit')
+		if ev.class == class and ev.id == id and ev.mode == mode and ev.key == key then
+			return ev
+		end
+	end
+
+	error(('timed out waiting for cap emit %s/%s %s %s'):format(
+		tostring(class), tostring(id), tostring(mode), tostring(key)
+	), 0)
+end
+
+local function request_control(cap, verb, opts)
+	local reply_ch = channel.new(1)
+	local req, err = hal_types.new.ControlRequest(verb, opts or {}, reply_ch)
+	assert(req, tostring(err))
+
+	cap.control_ch:put(req)
+
+	local reply = wait_channel_get(reply_ch, 1.0, 'control reply')
+	return reply
+end
+
+local function control_call_ok(cap, verb, opts)
+	local reply = request_control(cap, verb, opts)
+	assert(reply.ok == true, tostring(reply.reason))
+	return reply
+end
+
+local function start_manager(scope)
+	local dev_ev_ch   = channel.new(16)
+	local cap_emit_ch = channel.new(32)
+
+	local start_err = uart_mgr.start(dummy_logger(), dev_ev_ch, cap_emit_ch)
+	assert(start_err == '', tostring(start_err))
+
+	scope:finally(function()
+		safe.pcall(function()
+			uart_mgr.stop()
+		end)
+	end)
+
+	return dev_ev_ch, cap_emit_ch
+end
+
+local function apply_uart_config(serial_ports)
+	local ok, err = uart_mgr.apply_config({
+		serial_ports = serial_ports,
+	})
+	assert(ok == true, tostring(err))
+end
+
+local function apply_uart_config_fail(serial_ports)
+	local ok, err = uart_mgr.apply_config({
+		serial_ports = serial_ports,
+	})
+	assert(ok == false, 'expected config apply to fail')
+	return tostring(err)
+end
+
+local function open_uart_stream(cap)
+	local open_opts, err = cap_args.new.UARTOpenOpts(true, true)
+	assert(open_opts, tostring(err))
+
+	local reply = control_call_ok(cap, 'open', open_opts)
+	assert(type(reply.reason) == 'table', 'expected open to return a Stream in Reply.reason')
+
+	local stream = reply.reason
+	stream:setvbuf('no')
+	return stream
+end
+
+local function assert_stream_write_fails(stream, label)
+	label = label or 'stream'
+
+	local ok, a, b = safe.pcall(function()
+		return perform(stream:write_op('x'))
+	end)
+
+	if ok then
+		local n, err = a, b
+		assert(n == nil, ('expected closed stream write to fail for %s'):format(label))
+		assert(err ~= nil, ('expected error for %s'):format(label))
+		return
+	end
+
+	local err = tostring(a)
+	assert(
+		err:match('stream is not writable')
+			or err:match('not writable')
+			or err:match('closed'),
+		('expected closed/non-writable failure for %s, got: %s'):format(label, err)
+	)
+end
+
+function T.devhost_hal_uart_open_returns_real_stream_and_allows_reopen()
+	runfibers.run(function(scope)
+		local dev_ev_ch = start_manager(scope)
+		local port = pty.open(scope)
+
+		apply_uart_config({
+			{
+				name = 'uart0',
+				path = port.slave_name,
+				baud = 115200,
+				mode = '8N1',
+			},
+		})
+
+		local added = wait_device_event(dev_ev_ch, 'added', 'uart', 'uart0', 1.5)
+		assert(type(added.capabilities) == 'table' and #added.capabilities == 1, 'expected one uart capability')
+		local cap = added.capabilities[1]
+		assert(cap.class == 'uart')
+		assert(cap.id == 'uart0')
+
+		local stream1 = open_uart_stream(cap)
+
+		local ok_w1, err_w1 = port:write('abc')
+		assert(ok_w1 == true, tostring(err_w1))
+		local got1 = pty.expect_some(stream1, 3, 1.0, 'read from UART stream')
+		assert(got1 == 'abc', ('expected "abc", got %q'):format(tostring(got1)))
+
+		local n1, swerr1 = perform(stream1:write_op('xyz'))
+		assert(n1 ~= nil, tostring(swerr1))
+		local got2 = port:expect_some(3, 1.0, 'read from PTY master')
+		assert(got2 == 'xyz', ('expected "xyz", got %q'):format(tostring(got2)))
+
+		local ok_c1, cerr1 = perform(stream1:close_op())
+		assert(ok_c1 ~= nil, tostring(cerr1))
+
+		local stream2 = open_uart_stream(cap)
+		local n2, swerr2 = perform(stream2:write_op('q'))
+		assert(n2 ~= nil, tostring(swerr2))
+		local got3 = port:expect_some(1, 1.0, 'read from reopened UART stream')
+		assert(got3 == 'q', ('expected "q", got %q'):format(tostring(got3)))
+
+		local ok_c2, cerr2 = perform(stream2:close_op())
+		assert(ok_c2 ~= nil, tostring(cerr2))
+	end, { timeout = 4.0 })
+end
+
+function T.devhost_hal_uart_reconfigures_when_the_port_changes()
+	runfibers.run(function(scope)
+		local dev_ev_ch = start_manager(scope)
+		local port1 = pty.open(scope)
+		local port2 = pty.open(scope)
+
+		apply_uart_config({
+			{
+				name = 'uart0',
+				path = port1.slave_name,
+				baud = 115200,
+				mode = '8N1',
+			},
+		})
+
+		local added1 = wait_device_event(dev_ev_ch, 'added', 'uart', 'uart0', 1.5)
+		local cap1 = added1.capabilities[1]
+		local stream1 = open_uart_stream(cap1)
+
+		local n1, err1 = perform(stream1:write_op('first'))
+		assert(n1 ~= nil, tostring(err1))
+		local got1 = port1:expect_some(5, 1.0, 'read from first PTY master')
+		assert(got1 == 'first', ('expected "first", got %q'):format(tostring(got1)))
+
+		local ok_c1, cerr1 = perform(stream1:close_op())
+		assert(ok_c1 ~= nil, tostring(cerr1))
+
+		apply_uart_config({
+			{
+				name = 'uart0',
+				path = port2.slave_name,
+				baud = 115200,
+				mode = '8N1',
+			},
+		})
+
+		wait_device_event(dev_ev_ch, 'removed', 'uart', 'uart0', 1.5)
+		local added2 = wait_device_event(dev_ev_ch, 'added', 'uart', 'uart0', 1.5)
+		local cap2 = added2.capabilities[1]
+		local stream2 = open_uart_stream(cap2)
+
+		local n2, err2 = perform(stream2:write_op('second'))
+		assert(n2 ~= nil, tostring(err2))
+
+		local got2 = port2:expect_some(6, 1.0, 'read from second PTY master')
+		assert(got2 == 'second', ('expected "second", got %q'):format(tostring(got2)))
+
+		port1:expect_no_data(0.15, 'old PTY master after reconfigure')
+
+		local ok_c2, cerr2 = perform(stream2:close_op())
+		assert(ok_c2 ~= nil, tostring(cerr2))
+	end, { timeout = 4.5 })
+end
+
+function T.devhost_hal_uart_emits_open_and_close_state_transitions()
+	runfibers.run(function(scope)
+		local dev_ev_ch, cap_emit_ch = start_manager(scope)
+		local port = pty.open(scope)
+
+		apply_uart_config({
+			{
+				name = 'uart0',
+				path = port.slave_name,
+				baud = 115200,
+				mode = '8N1',
+			},
+		})
+
+		local added = wait_device_event(dev_ev_ch, 'added', 'uart', 'uart0', 1.5)
+		local cap = added.capabilities[1]
+
+		local initial_state = wait_cap_emit(cap_emit_ch, 'uart', 'uart0', 'state', 'stream', 1.0)
+		assert(type(initial_state.data) == 'table')
+		assert(initial_state.data.open == false)
+		assert(initial_state.data.path == port.slave_name)
+
+		local stream = open_uart_stream(cap)
+
+		local opened_state = wait_cap_emit(cap_emit_ch, 'uart', 'uart0', 'state', 'stream', 1.0)
+		assert(type(opened_state.data) == 'table')
+		assert(opened_state.data.open == true)
+
+		local opened_event = wait_cap_emit(cap_emit_ch, 'uart', 'uart0', 'event', 'opened', 1.0)
+		assert(type(opened_event.data) == 'table')
+		assert(opened_event.data.path == port.slave_name)
+
+		local ok_c, cerr = perform(stream:close_op())
+		assert(ok_c ~= nil, tostring(cerr))
+
+		local closed_state = wait_cap_emit(cap_emit_ch, 'uart', 'uart0', 'state', 'stream', 1.0)
+		assert(type(closed_state.data) == 'table')
+		assert(closed_state.data.open == false)
+
+		local closed_event = wait_cap_emit(cap_emit_ch, 'uart', 'uart0', 'event', 'closed', 1.0)
+		assert(type(closed_event.data) == 'table')
+		assert(closed_event.data.path == port.slave_name)
+	end, { timeout = 4.0 })
+end
+
+function T.devhost_hal_uart_rejects_duplicate_open_and_invalid_control_requests()
+	runfibers.run(function(scope)
+		local dev_ev_ch = start_manager(scope)
+		local port = pty.open(scope)
+
+		apply_uart_config({
+			{
+				name = 'uart0',
+				path = port.slave_name,
+				baud = 115200,
+				mode = '8N1',
+			},
+		})
+
+		local added = wait_device_event(dev_ev_ch, 'added', 'uart', 'uart0', 1.5)
+		local cap = added.capabilities[1]
+
+		local stream = open_uart_stream(cap)
+
+		local open_opts, oerr = cap_args.new.UARTOpenOpts(true, true)
+		assert(open_opts, tostring(oerr))
+
+		local dup_reply = request_control(cap, 'open', open_opts)
+		assert(dup_reply.ok == false)
+		assert(tostring(dup_reply.reason):match('already open'))
+
+		local bad_open_reply = request_control(cap, 'open', {})
+		assert(bad_open_reply.ok == false)
+		assert(tostring(bad_open_reply.reason):match('invalid options'))
+
+		local bad_verb_reply = request_control(cap, 'explode', {})
+		assert(bad_verb_reply.ok == false)
+		assert(tostring(bad_verb_reply.reason):match('unsupported verb'))
+
+		local n, err = perform(stream:write_op('still-ok'))
+		assert(n ~= nil, tostring(err))
+		local got = port:expect_some(8, 1.0, 'read from PTY after rejected control calls')
+		assert(got == 'still-ok', ('expected "still-ok", got %q'):format(tostring(got)))
+
+		local ok_c, cerr = perform(stream:close_op())
+		assert(ok_c ~= nil, tostring(cerr))
+	end, { timeout = 4.0 })
+end
+
+function T.devhost_hal_uart_invalid_config_does_not_disturb_live_driver()
+	runfibers.run(function(scope)
+		local dev_ev_ch = start_manager(scope)
+		local port = pty.open(scope)
+
+		apply_uart_config({
+			{
+				name = 'uart0',
+				path = port.slave_name,
+				baud = 115200,
+				mode = '8N1',
+			},
+		})
+
+		local added = wait_device_event(dev_ev_ch, 'added', 'uart', 'uart0', 1.5)
+		local cap = added.capabilities[1]
+		local stream = open_uart_stream(cap)
+
+		local err = apply_uart_config_fail({
+			{
+				name = 'uart0',
+				path = port.slave_name,
+				baud = 115200,
+				mode = '8N1',
+			},
+			{
+				name = 'uart0',
+				path = port.slave_name,
+				baud = 115200,
+				mode = '8N1',
+			},
+		})
+		assert(err:match('duplicated'))
+
+		local snap = uart_mgr.debug_snapshot()
+		assert(snap.started == true)
+		assert(snap.driver_count == 1)
+		assert(type(snap.drivers.uart0) == 'table')
+		assert(snap.drivers.uart0.spec.path == port.slave_name)
+
+		local ev, _ = wait_channel_maybe_get(dev_ev_ch, 0.10)
+		assert(ev == nil, 'did not expect add/remove device events after normalise failure')
+
+		local n, werr = perform(stream:write_op('after-bad-config'))
+		assert(n ~= nil, tostring(werr))
+		local got = port:expect_some(16, 1.0, 'read after invalid config')
+		assert(got == 'after-bad-config', ('expected "after-bad-config", got %q'):format(tostring(got)))
+
+		local ok_c, cerr = perform(stream:close_op())
+		assert(ok_c ~= nil, tostring(cerr))
+	end, { timeout = 4.0 })
+end
+
+function T.devhost_hal_uart_open_fails_for_missing_device_path()
+	runfibers.run(function(scope)
+		local dev_ev_ch = start_manager(scope)
+
+		apply_uart_config({
+			{
+				name = 'uart0',
+				path = '/definitely/not/a/tty/device',
+				baud = 115200,
+				mode = '8N1',
+			},
+		})
+
+		local added = wait_device_event(dev_ev_ch, 'added', 'uart', 'uart0', 1.5)
+		local cap = added.capabilities[1]
+
+		local open_opts, err = cap_args.new.UARTOpenOpts(true, true)
+		assert(open_opts, tostring(err))
+
+		local reply = request_control(cap, 'open', open_opts)
+		assert(reply.ok == false)
+		assert(tostring(reply.reason):match('stty failed'))
+	end, { timeout = 4.0 })
+end
+
+function T.devhost_hal_uart_removing_port_closes_active_stream()
+	runfibers.run(function(scope)
+		local dev_ev_ch = start_manager(scope)
+		local port = pty.open(scope)
+
+		apply_uart_config({
+			{
+				name = 'uart0',
+				path = port.slave_name,
+				baud = 115200,
+				mode = '8N1',
+			},
+		})
+
+		local added = wait_device_event(dev_ev_ch, 'added', 'uart', 'uart0', 1.5)
+		local cap = added.capabilities[1]
+		local stream = open_uart_stream(cap)
+
+		local n1, err1 = perform(stream:write_op('before-remove'))
+		assert(n1 ~= nil, tostring(err1))
+		local got1 = port:expect_some(13, 1.0, 'read before remove')
+		assert(got1 == 'before-remove', ('expected "before-remove", got %q'):format(tostring(got1)))
+
+		apply_uart_config({})
+
+		wait_device_event(dev_ev_ch, 'removed', 'uart', 'uart0', 1.5)
+
+		assert_stream_write_fails(stream, 'stream after config removal')
+		port:expect_no_data(0.10, 'PTY master after config removal')
+	end, { timeout = 4.5 })
+end
+
+function T.devhost_hal_uart_manager_stop_closes_active_stream_and_resets_runtime_state()
+	runfibers.run(function(scope)
+		local dev_ev_ch = start_manager(scope)
+		local port = pty.open(scope)
+
+		apply_uart_config({
+			{
+				name = 'uart0',
+				path = port.slave_name,
+				baud = 115200,
+				mode = '8N1',
+			},
+		})
+
+		local added = wait_device_event(dev_ev_ch, 'added', 'uart', 'uart0', 1.5)
+		local cap = added.capabilities[1]
+		local stream = open_uart_stream(cap)
+
+		local n1, err1 = perform(stream:write_op('before-stop'))
+		assert(n1 ~= nil, tostring(err1))
+		local got1 = port:expect_some(11, 1.0, 'read before manager stop')
+		assert(got1 == 'before-stop', ('expected "before-stop", got %q'):format(tostring(got1)))
+
+		local ok_stop, stop_err = uart_mgr.stop()
+		assert(ok_stop == true, tostring(stop_err))
+
+		local snap = uart_mgr.debug_snapshot()
+		assert(snap.started == false)
+		assert(snap.driver_count == 0)
+
+		assert_stream_write_fails(stream, 'stream after manager stop')
+		port:expect_no_data(0.10, 'PTY master after manager stop')
+	end, { timeout = 4.5 })
+end
+
+return T

--- a/tests/run.lua
+++ b/tests/run.lua
@@ -24,14 +24,17 @@ assert(stdlib.setenv('CONFIG_TARGET', 'services'))
 
 local files = {
 	'unit.devicecode.service_base_spec',
-	'unit.config.codec_spec',
-	'unit.config.state_spec',
+	'unit.hal.artifact_store_driver_spec',
+	'unit.hal.control_store_driver_spec',
 	'unit.hal.sdk_cap_spec',
 	'unit.hal.service_raw_host_spec',
+	'unit.hal.signature_verify_openssl_spec',
+	'unit.main.profile_config_spec',
+	'unit.main.profile_contract_spec',
 	'unit.main.service_spec',
-	'unit.config.service_spec',
+	'integration.devhost.config_recovery_spec',
+	'integration.devhost.hal_uart_spec',
 	'integration.devhost.main_failure_spec',
-	'integration.devhost.config_recovery_spec'
 }
 
 local function monotonic_now()

--- a/tests/support/bus_probe.lua
+++ b/tests/support/bus_probe.lua
@@ -59,6 +59,46 @@ function M.wait_payload(conn, topic, opts)
 	return msg.payload, msg
 end
 
+function M.wait_retained_message(conn, topic, opts)
+	opts = opts or {}
+	local timeout = opts.timeout or 1.0
+	local watch = conn:watch_retained(topic, {
+		replay = true,
+		queue_len = opts.queue_len or 8,
+		full = opts.full or 'drop_oldest',
+	})
+
+	local pred = opts.predicate
+	local deadline = fibers.now() + timeout
+	while fibers.now() < deadline do
+		local remaining = deadline - fibers.now()
+		local which, a, b = fibers.perform(op.named_choice({
+			ev = watch:recv_op(),
+			timeout = sleep.sleep_op(remaining):wrap(function() return true end),
+		}))
+		if which == 'timeout' then
+			pcall(function() watch:unwatch() end)
+			fail(('timed out waiting for retained topic %s'):format(tostring(topic[1] or '?')))
+		end
+		local ev, err = a, b
+		if not ev then
+			pcall(function() watch:unwatch() end)
+			fail('retained watch ended: ' .. tostring(err))
+		end
+		if ev.op == 'retain' and (pred == nil or pred(ev.payload, ev)) then
+			pcall(function() watch:unwatch() end)
+			return ev
+		end
+	end
+	pcall(function() watch:unwatch() end)
+	fail(('timed out waiting for retained topic %s'):format(tostring(topic[1] or '?')))
+end
+
+function M.wait_retained_payload(conn, topic, opts)
+	local ev = M.wait_retained_message(conn, topic, opts)
+	return ev.payload, ev
+end
+
 function M.collect_messages(conn, topic, count, opts)
 	opts = opts or {}
 	local timeout = opts.timeout or 1.0
@@ -91,6 +131,231 @@ function M.collect_messages(conn, topic, count, opts)
 
 	sub:unsubscribe()
 	return out
+end
+
+
+local function topic_string(topic)
+	if type(topic) ~= 'table' then return tostring(topic) end
+	local parts = {}
+	for i = 1, #topic do parts[i] = tostring(topic[i]) end
+	return table.concat(parts, '/')
+end
+
+local function fail_with_context(prefix, topic, describe)
+	local msg = prefix
+	if topic ~= nil then
+		msg = msg .. ' [' .. topic_string(topic) .. ']'
+	end
+	if type(describe) == 'function' then
+		local ok, extra = pcall(describe)
+		if ok and extra and extra ~= '' then
+			msg = msg .. '\n' .. tostring(extra)
+		end
+	elseif describe ~= nil then
+		msg = msg .. '\n' .. tostring(describe)
+	end
+	fail(msg)
+end
+
+function M.wait_retained_state(conn, topic, pred, opts)
+	opts = opts or {}
+	pred = pred or function() return true end
+	local timeout = opts.timeout or 1.0
+	local watch = conn:watch_retained(topic, {
+		replay = (opts.replay ~= false),
+		queue_len = opts.queue_len or 16,
+		full = opts.full or 'drop_oldest',
+	})
+	local deadline = fibers.now() + timeout
+	local last_predicate_err
+	while true do
+		local remaining = deadline - fibers.now()
+		if remaining <= 0 then
+			pcall(function() watch:unwatch() end)
+			local function describe()
+				local parts = {}
+				if last_predicate_err ~= nil then
+					parts[#parts + 1] = 'last predicate error: ' .. tostring(last_predicate_err)
+				end
+				if type(opts.describe) == 'function' then
+					local ok, extra = pcall(opts.describe)
+					if ok and extra and extra ~= '' then parts[#parts + 1] = tostring(extra) end
+				elseif opts.describe ~= nil then
+					parts[#parts + 1] = tostring(opts.describe)
+				end
+				return table.concat(parts, '\n')
+			end
+			fail_with_context('timed out waiting for retained state', topic, describe)
+		end
+		local which, a, b = fibers.perform(op.named_choice({
+			ev = watch:recv_op(),
+			timeout = sleep.sleep_op(remaining):wrap(function() return true end),
+		}))
+		if which == 'timeout' then
+			pcall(function() watch:unwatch() end)
+			local function describe()
+				local parts = {}
+				if last_predicate_err ~= nil then
+					parts[#parts + 1] = 'last predicate error: ' .. tostring(last_predicate_err)
+				end
+				if type(opts.describe) == 'function' then
+					local ok, extra = pcall(opts.describe)
+					if ok and extra and extra ~= '' then parts[#parts + 1] = tostring(extra) end
+				elseif opts.describe ~= nil then
+					parts[#parts + 1] = tostring(opts.describe)
+				end
+				return table.concat(parts, '\n')
+			end
+			fail_with_context('timed out waiting for retained state', topic, describe)
+		end
+		local ev, err = a, b
+		if not ev then
+			pcall(function() watch:unwatch() end)
+			fail_with_context('retained watch ended: ' .. tostring(err), topic, opts.describe)
+		end
+		if ev.op == 'retain' then
+			local ok, matched = pcall(pred, ev.payload, ev)
+			if ok then
+				last_predicate_err = nil
+				if matched then
+					pcall(function() watch:unwatch() end)
+					return ev.payload, ev
+				end
+			else
+				last_predicate_err = matched
+			end
+		end
+	end
+end
+
+function M.wait_service_running(conn, service_or_topic, opts)
+	local topic = service_or_topic
+	if type(service_or_topic) == 'string' then
+		topic = { 'svc', service_or_topic, 'status' }
+	end
+	return M.wait_retained_state(conn, topic, function(payload)
+		return type(payload) == 'table' and payload.state == 'running' and payload.ready == true
+	end, opts)
+end
+
+function M.wait_workflow(conn, family, id, pred, opts)
+	return M.wait_retained_state(conn, { 'state', 'workflow', family, id }, pred, opts)
+end
+
+function M.wait_update_job(conn, id, pred, opts)
+	return M.wait_workflow(conn, 'update-job', id, function(payload, ev)
+		return type(payload) == 'table' and type(payload.job) == 'table' and (pred == nil or pred(payload, ev))
+	end, opts)
+end
+
+function M.wait_artifact_ingest(conn, id, pred, opts)
+	return M.wait_workflow(conn, 'artifact-ingest', id, function(payload, ev)
+		return type(payload) == 'table' and type(payload.ingest) == 'table' and (pred == nil or pred(payload, ev))
+	end, opts)
+end
+
+function M.wait_device_component(conn, component, pred, opts)
+	return M.wait_retained_state(conn, { 'state', 'device', 'component', component }, function(payload, ev)
+		return type(payload) == 'table' and (pred == nil or pred(payload, ev))
+	end, opts)
+end
+
+function M.wait_update_component(conn, component, pred, opts)
+	return M.wait_retained_state(conn, { 'state', 'update', 'component', component }, function(payload, ev)
+		return type(payload) == 'table' and (pred == nil or pred(payload, ev))
+	end, opts)
+end
+
+
+function M.wait_raw_source_status(conn, kind, source, pred, opts)
+	return M.wait_retained_state(conn, { 'raw', kind, source, 'status' }, function(payload, ev)
+		return type(payload) == 'table' and (pred == nil or pred(payload, ev))
+	end, opts)
+end
+
+function M.wait_raw_source_state(conn, kind, source, suffix, pred, opts)
+	local topic = { 'raw', kind, source, 'state' }
+	if type(suffix) == 'table' then
+		for i = 1, #suffix do topic[#topic + 1] = suffix[i] end
+	elseif suffix ~= nil then
+		topic[#topic + 1] = suffix
+	else
+		pred, opts = pred or function() return true end, opts
+	end
+	return M.wait_retained_state(conn, topic, function(payload, ev)
+		return type(payload) == 'table' and (pred == nil or pred(payload, ev))
+	end, opts)
+end
+
+function M.wait_fabric_summary(conn, pred, opts)
+	return M.wait_retained_state(conn, { 'state', 'fabric' }, function(payload, ev)
+		return type(payload) == 'table' and (pred == nil or pred(payload, ev))
+	end, opts)
+end
+
+function M.wait_fabric_link_component(conn, link_id, component, pred, opts)
+	return M.wait_retained_state(conn, { 'state', 'fabric', 'link', link_id, component }, function(payload, ev)
+		return type(payload) == 'table' and (pred == nil or pred(payload, ev))
+	end, opts)
+end
+
+function M.wait_fabric_link_ready(conn, link_id, opts)
+	return M.wait_fabric_link_component(conn, link_id, 'session', function(payload)
+		local s = payload and payload.status
+		return type(s) == 'table' and s.ready == true and s.state == 'ready'
+	end, opts)
+end
+
+
+function M.wait_fabric_ready(conn, link_id, opts)
+	return M.wait_fabric_link_session(conn, link_id, function(payload)
+		local s = payload and payload.status
+		return type(s) == 'table' and s.ready == true
+	end, opts)
+end
+
+function M.wait_transfer_manager_status(conn, pred, opts)
+	return M.wait_cap_status(conn, 'transfer-manager', 'main', pred, opts)
+end
+
+function M.wait_fabric_link_session(conn, link_id, pred, opts)
+	return M.wait_retained_state(conn, { 'state', 'fabric', 'link', link_id, 'session' }, function(payload, ev)
+		return type(payload) == 'table' and (pred == nil or pred(payload, ev))
+	end, opts)
+end
+
+function M.wait_cap_status(conn, class, id, pred, opts)
+	return M.wait_retained_state(conn, { 'cap', class, id, 'status' }, function(payload, ev)
+		return type(payload) == 'table' and (pred == nil or pred(payload, ev))
+	end, opts)
+end
+
+function M.wait_cap_event(conn, class, id, event_name, pred, opts)
+	opts = opts or {}
+	local msg = M.wait_message(conn, { 'cap', class, id, 'event', event_name }, {
+		timeout = opts.timeout or 1.0,
+		queue_len = opts.queue_len or 8,
+		full = opts.full or 'drop_oldest',
+	})
+	local payload = msg.payload
+	if pred and not pred(payload, msg) then
+		fail_with_context('unexpected cap event payload', { 'cap', class, id, 'event', event_name }, opts.describe)
+	end
+	return payload, msg
+end
+
+function M.wait_component_cap_status(conn, component, pred, opts)
+	return M.wait_cap_status(conn, 'component', component, pred, opts)
+end
+
+function M.wait_component_event(conn, component, event_name, pred, opts)
+	return M.wait_cap_event(conn, 'component', component, event_name, pred, opts)
+end
+
+function M.wait_ui_summary(conn, pred, opts)
+	return M.wait_retained_state(conn, { 'state', 'ui', 'summary' }, function(payload, ev)
+		return type(payload) == 'table' and (pred == nil or pred(payload, ev))
+	end, opts)
 end
 
 return M

--- a/tests/support/diag_plugins/device.lua
+++ b/tests/support/diag_plugins/device.lua
@@ -4,7 +4,7 @@ return {
   name = 'device',
   topic_groups = {
     { label = 'device', topic = { 'state', 'device', '#' } },
-    { label = 'dcmd', topic = { 'cmd', 'device', '#' } },
+    { label = 'dcmd', topic = { 'cap', 'component', '#' } },
   },
   section = function(helper, opts)
     opts = opts or {}

--- a/tests/support/diag_registry.lua
+++ b/tests/support/diag_registry.lua
@@ -1,7 +1,7 @@
 return {
   plugins = {
-    config = require 'tests.support.diag_plugins.config',
     device = require 'tests.support.diag_plugins.device',
+    config = require 'tests.support.diag_plugins.config',
     obs    = require 'tests.support.diag_plugins.obs',
     rpc    = require 'tests.support.diag_plugins.rpc',
   },

--- a/tests/support/fake_hal.lua
+++ b/tests/support/fake_hal.lua
@@ -4,6 +4,14 @@ local fibers = require 'fibers'
 
 local M = {}
 
+local function svc_meta_topic(name)
+	return { 'svc', name, 'meta' }
+end
+
+local function svc_announce_topic(name)
+	return { 'svc', name, 'announce' }
+end
+
 local function cap_state_topic(class, id)
 	return { 'cap', class, id, 'state' }
 end
@@ -14,6 +22,23 @@ end
 
 local function cap_rpc_topic(class, id, method)
 	return { 'cap', class, id, 'rpc', method }
+end
+
+
+local function path_token(s)
+	return tostring(s):gsub('_', '-')
+end
+
+local function raw_host_cap_status_topic(source, class, id)
+	return { 'raw', 'host', path_token(source), 'cap', path_token(class), id, 'status' }
+end
+
+local function raw_host_cap_meta_topic(source, class, id)
+	return { 'raw', 'host', path_token(source), 'cap', path_token(class), id, 'meta' }
+end
+
+local function raw_host_cap_rpc_topic(source, class, id, method)
+	return { 'raw', 'host', path_token(source), 'cap', path_token(class), id, 'rpc', method }
 end
 
 local function strip_json_suffix(filename)
@@ -62,6 +87,7 @@ end
 local function method_offerings(method)
 	if method == 'read_state' then return 'fs', 'config', { read = true } end
 	if method == 'write_state' then return 'fs', 'state', { write = true } end
+	if method == 'verify_ed25519' then return 'signature_verify', 'main', { verify_ed25519 = true } end
 	return nil, nil, nil
 end
 
@@ -106,30 +132,38 @@ function FakeHal:_start_capability_rpc(conn, class, id, offering, legacy_method)
 	conn:retain(cap_state_topic(class, id), 'added')
 	conn:retain(cap_meta_topic(class, id), { offerings = { [offering] = true } })
 
-	local ep = conn:bind(cap_rpc_topic(class, id, offering), { queue_len = 16 })
+	local source = class
+	conn:retain(raw_host_cap_status_topic(source, class, id), { state = 'available', source = source, class = class, id = id })
+	conn:retain(raw_host_cap_meta_topic(source, class, id), { offerings = { [offering] = true }, provider = 'fakehal' })
 
-	fibers.spawn(function()
-		while true do
-			local req, err = ep:recv()
-			if not req then return end
+	local function bind(topic)
+		local ep = conn:bind(topic, { queue_len = 16 })
+		fibers.spawn(function()
+			while true do
+				local req, err = ep:recv()
+				if not req then return end
 
-			local raw_req = req.payload or {}
-			local method, mapped_req = map_cap_call(class, id, offering, raw_req)
-			method = legacy_method or method
+				local raw_req = req.payload or {}
+				local method, mapped_req = map_cap_call(class, id, offering, raw_req)
+				method = legacy_method or method
 
-			self:_record_call(method, mapped_req, req)
+				self:_record_call(method, mapped_req, req)
 
-			local reply = self:_next_reply(method, mapped_req, req)
-			reply = map_cap_reply(method, reply)
-			if type(reply) ~= 'table' then
-				req:fail(reply)
-			elseif reply.ok == true then
-				req:reply(reply)
-			else
-				req:reply(reply)
+				local reply = self:_next_reply(method, mapped_req, req)
+				reply = map_cap_reply(method, reply)
+				if type(reply) ~= 'table' then
+					req:fail(reply)
+				elseif reply.ok == true then
+					req:reply(reply)
+				else
+					req:reply(reply)
+				end
 			end
-		end
-	end)
+		end)
+	end
+
+	bind(cap_rpc_topic(class, id, offering))
+	bind(raw_host_cap_rpc_topic(source, class, id, offering))
 end
 
 function FakeHal:_start_capabilities(conn)
@@ -151,11 +185,18 @@ end
 function FakeHal:start(conn, opts)
 	opts = opts or {}
 	local name = opts.name or 'hal'
-	conn:retain({ 'svc', name, 'announce' }, {
+
+	local payload = {
 		role = 'hal',
 		backend = self.backend,
 		caps = self.caps,
-	})
+	}
+
+	-- Canonical metadata surface
+	conn:retain(svc_meta_topic(name), payload)
+	-- Legacy compatibility surface
+	conn:retain(svc_announce_topic(name), payload)
+
 	self:_start_capabilities(conn)
 end
 

--- a/tests/support/pty.lua
+++ b/tests/support/pty.lua
@@ -1,0 +1,365 @@
+-- tests/support/pty.lua
+--
+-- PTY helpers for devhost integration tests.
+--
+-- Goals:
+--   * stay inside fibers where practical
+--   * expose PTY masters as real fibers Streams
+--   * provide bounded raw-byte reads
+--   * provide a simple cross-wire bridge for two PTYs
+--   * provide a slave-side round-trip smoke test
+--
+-- Important behaviour:
+--   * the bridge is tolerant of transient PTY conditions while one slave side
+--     is not yet opened by HAL
+--   * it does not tear the whole bridge down on a temporary read/write error
+--   * each PTY keeps an internal slave-anchor fd open so the master side does
+--     not observe "no slave attached yet" during bridge startup
+
+local posix  = require 'posix'
+local file   = require 'fibers.io.file'
+local exec   = require 'fibers.io.exec'
+local fibers = require 'fibers'
+local sleep  = require 'fibers.sleep'
+local op     = require 'fibers.op'
+local safe   = require 'coxpcall'
+
+local perform = fibers.perform
+
+local M = {}
+
+local BRIDGE_RETRY_S = 0.01
+
+local function close_fd(fd)
+	local fn = posix.close
+	if type(fn) ~= 'function' then
+		local ok, unistd = pcall(require, 'posix.unistd')
+		if ok and type(unistd.close) == 'function' then
+			fn = unistd.close
+		end
+	end
+	if type(fn) == 'function' and fd ~= nil then
+		pcall(function() fn(fd) end)
+	end
+end
+
+
+local function close_stream_best_effort(stream)
+	if not (stream and stream.close_op) then
+		return true, nil
+	end
+
+	local ok, a, b = safe.pcall(function()
+		return perform(stream:close_op())
+	end)
+	if not ok then
+		return nil, tostring(a)
+	end
+	return a, b
+end
+
+local function wait_read_some(stream, max_n, timeout_s)
+	local which, a, b = perform(op.named_choice({
+		data = stream:read_some_op(max_n),
+		timeout = sleep.sleep_op(timeout_s or 1.0):wrap(function()
+			return true
+		end),
+	}))
+
+	if which == 'timeout' then
+		return nil, 'timeout'
+	end
+
+	return a, b
+end
+
+local function write_all(stream, data)
+	local off = 1
+	while off <= #data do
+		local n, err = perform(stream:write_op(data:sub(off)))
+		if n == nil then
+			return nil, err
+		end
+		if n == 0 then
+			sleep.sleep(BRIDGE_RETRY_S)
+		else
+			off = off + n
+		end
+	end
+	return true, nil
+end
+
+local function read_exact(stream, nbytes, timeout_s)
+	local deadline = fibers.now() + (timeout_s or 1.0)
+	local parts = {}
+	local got = 0
+
+	while got < nbytes do
+		local remain = deadline - fibers.now()
+		if remain <= 0 then
+			return nil, 'timeout'
+		end
+
+		local chunk, err = wait_read_some(stream, nbytes - got, remain)
+		if chunk == nil then
+			return nil, err
+		end
+
+		parts[#parts + 1] = chunk
+		got = got + #chunk
+	end
+
+	return table.concat(parts), nil
+end
+
+local function stty_raw_noecho(path)
+	local cmd = exec.command('stty', '-F', tostring(path), 'raw', '-echo')
+	local out, st, code, sig, err = perform(cmd:combined_output_op())
+
+	if st == 'exited' and code == 0 then
+		return true, nil
+	end
+
+	local detail = err or out or ('status=' .. tostring(st))
+	if st == 'exited' then
+		detail = tostring(detail) .. ' (exit ' .. tostring(code) .. ')'
+	elseif st == 'signalled' then
+		detail = tostring(detail) .. ' (signal ' .. tostring(sig) .. ')'
+	end
+	return nil, detail
+end
+
+---@class TestPTY
+---@field master Stream
+---@field slave_name string
+---@field _anchor_fd integer|nil
+local PTY = {}
+PTY.__index = PTY
+
+function PTY:write(data)
+	local ok, err = write_all(self.master, data)
+	if ok ~= true then
+		return nil, err
+	end
+	return true, nil
+end
+
+function PTY:read_some(max_n, timeout_s)
+	return wait_read_some(self.master, max_n, timeout_s)
+end
+
+function PTY:expect_some(max_n, timeout_s, label)
+	local data, err = self:read_some(max_n, timeout_s)
+	if data == nil then
+		error(('%s timed out: %s'):format(label or 'PTY read', tostring(err)), 0)
+	end
+	return data
+end
+
+function PTY:expect_no_data(timeout_s, label)
+	local data, _err = self:read_some(4096, timeout_s or 0.10)
+	if data ~= nil then
+		error(('%s unexpectedly received data: %q'):format(label or 'PTY read', tostring(data)), 0)
+	end
+	return true
+end
+
+function PTY:close()
+	if self.master then
+		close_stream_best_effort(self.master)
+		self.master = nil
+	end
+
+	if self._anchor_fd ~= nil then
+		close_fd(self._anchor_fd)
+		self._anchor_fd = nil
+	end
+
+	return true
+end
+
+---@param scope Scope|nil
+---@return TestPTY
+function M.open(scope)
+	local master_fd, slave_fd, slave_name, err = posix.openpty()
+	if not master_fd then
+		error('openpty failed: ' .. tostring(slave_fd or err), 0)
+	end
+
+	local master = file.fdopen(master_fd, 'r+', 'pty-master:' .. tostring(slave_name))
+	master:setvbuf('no')
+
+	-- Keep the slave fd open as an internal anchor until PTY:close().
+	-- This prevents the master side from seeing a transient "no slave attached"
+	-- condition before HAL opens the real slave path.
+	local rec = setmetatable({
+		master     = master,
+		slave_name = slave_name,
+		_anchor_fd = slave_fd,
+	}, PTY)
+
+	if scope and scope.finally then
+		scope:finally(function()
+			rec:close()
+		end)
+	end
+
+	return rec
+end
+
+function M.open_slave_stream(path, opts)
+	opts = opts or {}
+
+	if opts.raw ~= false then
+		local ok, err = stty_raw_noecho(path)
+		if ok ~= true then
+			return nil, 'stty failed: ' .. tostring(err)
+		end
+	end
+
+	local s, err = file.open(path, 'r+')
+	if not s then
+		return nil, err
+	end
+
+	pcall(function()
+		if s.setvbuf then s:setvbuf('no') end
+	end)
+
+	return s, nil
+end
+
+function M.read_some(stream, max_n, timeout_s)
+	return wait_read_some(stream, max_n, timeout_s)
+end
+
+function M.expect_some(stream, max_n, timeout_s, label)
+	local data, err = wait_read_some(stream, max_n, timeout_s)
+	if data == nil then
+		error(('%s timed out: %s'):format(label or 'stream read', tostring(err)), 0)
+	end
+	return data
+end
+
+function M.expect_no_data(stream, timeout_s, label)
+	local data, _err = wait_read_some(stream, 4096, timeout_s or 0.10)
+	if data ~= nil then
+		error(('%s unexpectedly received data: %q'):format(label or 'stream read', tostring(data)), 0)
+	end
+	return true
+end
+
+function M.expect_exact(stream, nbytes, timeout_s, label)
+	local data, err = read_exact(stream, nbytes, timeout_s)
+	if data == nil then
+		error(('%s timed out: %s'):format(label or 'stream read exact', tostring(err)), 0)
+	end
+	return data
+end
+
+function M.preflight_bridge_pair(scope, left, right, opts)
+	opts = opts or {}
+
+	local timeout_s = opts.timeout_s or 1.0
+	local bytes_ab = opts.bytes_ab or '\001preflight-a-to-b\002'
+	local bytes_ba = opts.bytes_ba or '\003preflight-b-to-a\004'
+
+	local left_slave, lerr = M.open_slave_stream(left.slave_name, { raw = true })
+	if not left_slave then
+		error('failed to open left PTY slave: ' .. tostring(lerr), 0)
+	end
+
+	local right_slave, rerr = M.open_slave_stream(right.slave_name, { raw = true })
+	if not right_slave then
+		close_stream_best_effort(left_slave)
+		error('failed to open right PTY slave: ' .. tostring(rerr), 0)
+	end
+
+	if scope and scope.finally then
+		scope:finally(function()
+			close_stream_best_effort(left_slave)
+			close_stream_best_effort(right_slave)
+		end)
+	end
+
+	local ok, err = write_all(left_slave, bytes_ab)
+	if ok ~= true then
+		error('PTY preflight write A->B failed: ' .. tostring(err), 0)
+	end
+
+	local got_ab = M.expect_exact(right_slave, #bytes_ab, timeout_s, 'PTY preflight read A->B')
+	if got_ab ~= bytes_ab then
+		error(
+			('PTY preflight mismatch A->B: expected %q got %q')
+				:format(bytes_ab, tostring(got_ab)),
+			0
+		)
+	end
+
+	ok, err = write_all(right_slave, bytes_ba)
+	if ok ~= true then
+		error('PTY preflight write B->A failed: ' .. tostring(err), 0)
+	end
+
+	local got_ba = M.expect_exact(left_slave, #bytes_ba, timeout_s, 'PTY preflight read B->A')
+	if got_ba ~= bytes_ba then
+		error(
+			('PTY preflight mismatch B->A: expected %q got %q')
+				:format(bytes_ba, tostring(got_ba)),
+			0
+		)
+	end
+
+	close_stream_best_effort(left_slave)
+	close_stream_best_effort(right_slave)
+
+	return true
+end
+
+local function as_stream(x)
+	if type(x) == 'table' and x.master ~= nil then
+		return x.master
+	end
+	return x
+end
+
+local function bridge_one_way(src_stream, dst_stream)
+	while true do
+		local chunk, _err = perform(src_stream:read_some_op(4096))
+
+		if chunk == nil then
+			sleep.sleep(BRIDGE_RETRY_S)
+		elseif #chunk == 0 then
+			sleep.sleep(BRIDGE_RETRY_S)
+		else
+			local off = 1
+			while off <= #chunk do
+				local n, _werr = perform(dst_stream:write_op(chunk:sub(off)))
+				if n == nil or n == 0 then
+					sleep.sleep(BRIDGE_RETRY_S)
+				else
+					off = off + n
+				end
+			end
+		end
+	end
+end
+
+function M.bridge_pair(scope, left, right)
+	local left_stream  = as_stream(left)
+	local right_stream = as_stream(right)
+
+	local ok1, err1 = scope:spawn(function()
+		return bridge_one_way(left_stream, right_stream)
+	end)
+	assert(ok1, tostring(err1))
+
+	local ok2, err2 = scope:spawn(function()
+		return bridge_one_way(right_stream, left_stream)
+	end)
+	assert(ok2, tostring(err2))
+
+	return true
+end
+
+return M

--- a/tests/support/storage_caps.lua
+++ b/tests/support/storage_caps.lua
@@ -1,0 +1,267 @@
+local checksum    = require 'shared.hash.xxhash32'
+local blob_source = require 'shared.blob_source'
+local cjson       = require 'cjson.safe'
+
+local M = {}
+
+local function clone(v)
+  if type(v) ~= 'table' then return v end
+  local out = {}
+  for k, val in pairs(v) do out[k] = clone(val) end
+  return out
+end
+
+local function bind_reply_loop(scope, ep, handler)
+  local ok, err = scope:spawn(function()
+    while true do
+      local req = ep:recv()
+      if not req then return end
+      local reply, ferr = handler(req.payload or {}, req)
+      if reply == nil then req:fail(ferr or 'failed') else req:reply(reply) end
+    end
+  end)
+  assert(ok, tostring(err))
+end
+
+local function mk_mem_artifact(backing, rec)
+  local art = {}
+  function art:ref() return rec.artifact_ref end
+  function art:meta() return clone(rec.meta) end
+  function art:size() return rec.size end
+  function art:checksum() return rec.checksum end
+  function art:open_source() return blob_source.from_string(rec.data) end
+  function art:delete() rec.deleted = true backing.artifacts[rec.artifact_ref] = nil return true end
+  function art:describe()
+    local out = clone(rec)
+    out.data = nil
+    out.deleted = nil
+    return out
+  end
+  return art
+end
+
+function M.start_control_store_cap(scope, conn, backing)
+  backing = backing or { namespaces = {}, max_record_bytes = 65536 }
+  backing.namespaces = backing.namespaces or {}
+  backing.max_record_bytes = backing.max_record_bytes or 65536
+
+  conn:retain({ 'raw', 'host', 'control-store', 'cap', 'control-store', 'update', 'status' }, 'added')
+  conn:retain({ 'raw', 'host', 'control-store', 'cap', 'control-store', 'update', 'meta' }, {
+    offerings = { get = true, put = true, delete = true, list = true, status = true }
+  })
+
+  local function ns_table(ns)
+    local t = backing.namespaces[ns]
+    if not t then
+      t = {}
+      backing.namespaces[ns] = t
+    end
+    return t
+  end
+
+  local get_ep = conn:bind({ 'raw', 'host', 'control-store', 'cap', 'control-store', 'update', 'rpc', 'get' }, { queue_len = 32 })
+  local put_ep = conn:bind({ 'raw', 'host', 'control-store', 'cap', 'control-store', 'update', 'rpc', 'put' }, { queue_len = 32 })
+  local del_ep = conn:bind({ 'raw', 'host', 'control-store', 'cap', 'control-store', 'update', 'rpc', 'delete' }, { queue_len = 32 })
+  local list_ep = conn:bind({ 'raw', 'host', 'control-store', 'cap', 'control-store', 'update', 'rpc', 'list' }, { queue_len = 32 })
+  local status_ep = conn:bind({ 'raw', 'host', 'control-store', 'cap', 'control-store', 'update', 'rpc', 'status' }, { queue_len = 32 })
+
+  bind_reply_loop(scope, get_ep, function(payload)
+    local ns = backing.namespaces[payload.ns]
+    local value = ns and ns[payload.key] or nil
+    if value == nil then return { ok = false, reason = 'not_found' } end
+    return { ok = true, reason = clone(value) }
+  end)
+
+  bind_reply_loop(scope, put_ep, function(payload)
+    local raw, err = cjson.encode(payload.value)
+    if not raw then return { ok = false, reason = 'encode_failed:' .. tostring(err) } end
+    if backing.max_record_bytes and #raw > backing.max_record_bytes then
+      return { ok = false, reason = 'record_too_large' }
+    end
+    local ns = ns_table(payload.ns)
+    ns[payload.key] = clone(payload.value)
+    return { ok = true, reason = { ok = true } }
+  end)
+
+  bind_reply_loop(scope, del_ep, function(payload)
+    local ns = ns_table(payload.ns)
+    ns[payload.key] = nil
+    return { ok = true, reason = { ok = true } }
+  end)
+
+  bind_reply_loop(scope, list_ep, function(payload)
+    local ns = backing.namespaces[payload.ns] or {}
+    local keys = {}
+    for k in pairs(ns) do keys[#keys + 1] = k end
+    table.sort(keys)
+    return { ok = true, reason = { ns = payload.ns, keys = keys } }
+  end)
+
+  bind_reply_loop(scope, status_ep, function()
+    return { ok = true, reason = { root = 'mem://control', max_record_bytes = backing.max_record_bytes } }
+  end)
+
+  return backing
+end
+
+function M.start_artifact_store_cap(scope, conn, backing)
+  backing = backing or { artifacts = {}, next_id = 0, import_paths = {}, durable_enabled = true }
+  backing.artifacts = backing.artifacts or {}
+  backing.import_paths = backing.import_paths or {}
+  if backing.durable_enabled == nil then backing.durable_enabled = true end
+
+  conn:retain({ 'raw', 'host', 'artifact-store', 'cap', 'artifact-store', 'main', 'status' }, 'added')
+  conn:retain({ 'raw', 'host', 'artifact-store', 'cap', 'artifact-store', 'main', 'meta' }, {
+    offerings = {
+      create_sink = true, import_path = true, import_source = true, open = true,
+      delete = true, status = true,
+    }
+  })
+
+  local function mkref()
+    backing.next_id = (backing.next_id or 0) + 1
+    return ('art-%d'):format(backing.next_id)
+  end
+
+  local function choose(policy)
+    policy = policy or 'transient_only'
+    if policy == 'require_durable' then
+      if not backing.durable_enabled then return nil, 'durable_disabled' end
+      return 'durable'
+    elseif policy == 'prefer_durable' then
+      return backing.durable_enabled and 'durable' or 'transient'
+    elseif policy == 'transient_only' then
+      return 'transient'
+    end
+    return nil, 'invalid_policy'
+  end
+
+  local create_sink_ep = conn:bind({ 'raw', 'host', 'artifact-store', 'cap', 'artifact-store', 'main', 'rpc', 'create_sink' }, { queue_len = 32 })
+  local import_path_ep = conn:bind({ 'raw', 'host', 'artifact-store', 'cap', 'artifact-store', 'main', 'rpc', 'import_path' }, { queue_len = 32 })
+  local import_source_ep = conn:bind({ 'raw', 'host', 'artifact-store', 'cap', 'artifact-store', 'main', 'rpc', 'import_source' }, { queue_len = 32 })
+  local open_ep = conn:bind({ 'raw', 'host', 'artifact-store', 'cap', 'artifact-store', 'main', 'rpc', 'open' }, { queue_len = 32 })
+  local delete_ep = conn:bind({ 'raw', 'host', 'artifact-store', 'cap', 'artifact-store', 'main', 'rpc', 'delete' }, { queue_len = 32 })
+  local status_ep = conn:bind({ 'raw', 'host', 'artifact-store', 'cap', 'artifact-store', 'main', 'rpc', 'status' }, { queue_len = 32 })
+
+  local function store_blob(source, meta, policy)
+    local durability, err = choose(policy)
+    if not durability then return nil, err end
+    local src, serr = blob_source.normalise_source(source)
+    if not src then return nil, serr end
+    local data = ''
+    local offset = 0
+    while true do
+      local chunk, cerr = src:read_chunk(offset, 64 * 1024)
+      if chunk == nil then return nil, cerr or 'read_failed' end
+      if chunk == '' then break end
+      data = data .. chunk
+      offset = offset + #chunk
+    end
+    local ref = mkref()
+    local rec = {
+      artifact_ref = ref,
+      state = 'ready',
+      durability = durability,
+      size = #data,
+      checksum = checksum.digest_hex(data),
+      meta = clone(meta or {}),
+      data = data,
+      created_at = os.time(),
+      updated_at = os.time(),
+    }
+    backing.artifacts[ref] = rec
+    return mk_mem_artifact(backing, rec), ''
+  end
+
+  bind_reply_loop(scope, create_sink_ep, function(payload)
+    local durability, err = choose(payload.policy)
+    if not durability then return { ok = false, reason = err } end
+    local ref = mkref()
+    local rec = {
+      artifact_ref = ref,
+      state = 'writing',
+      durability = durability,
+      size = 0,
+      checksum = nil,
+      meta = clone(payload.meta or {}),
+      data = '',
+      created_at = os.time(),
+      updated_at = os.time(),
+    }
+    local sink = {
+      write_chunk = function(_, offset, data)
+        if type(data) ~= 'string' then return nil, 'invalid_chunk' end
+        if offset ~= #rec.data then return nil, 'unexpected_offset' end
+        rec.data = rec.data .. data
+        rec.size = #rec.data
+        rec.updated_at = os.time()
+        return true
+      end,
+      size = function() return rec.size end,
+      checksum = function() return checksum.digest_hex(rec.data) end,
+      commit = function()
+        rec.state = 'ready'
+        rec.checksum = checksum.digest_hex(rec.data)
+        rec.updated_at = os.time()
+        backing.artifacts[ref] = rec
+        return mk_mem_artifact(backing, rec), ''
+      end,
+      abort = function()
+        backing.artifacts[ref] = nil
+        return true
+      end,
+      status = function()
+        return { artifact_ref = ref, state = rec.state, durability = rec.durability, size = rec.size }
+      end,
+    }
+    return { ok = true, reason = sink }
+  end)
+
+  bind_reply_loop(scope, import_path_ep, function(payload)
+    local data = backing.import_paths[payload.path]
+    if type(data) ~= 'string' then return { ok = false, reason = 'not_found' } end
+    local art, err = store_blob(blob_source.from_string(data), payload.meta, payload.policy)
+    if not art then return { ok = false, reason = err } end
+    return { ok = true, reason = art }
+  end)
+
+  bind_reply_loop(scope, import_source_ep, function(payload)
+    local art, err = store_blob(payload.source, payload.meta, payload.policy)
+    if not art then return { ok = false, reason = err } end
+    return { ok = true, reason = art }
+  end)
+
+  bind_reply_loop(scope, open_ep, function(payload)
+    local rec = backing.artifacts[payload.artifact_ref]
+    if not rec or rec.deleted then return { ok = false, reason = 'not_found' } end
+    return { ok = true, reason = mk_mem_artifact(backing, rec) }
+  end)
+
+  bind_reply_loop(scope, delete_ep, function(payload)
+    local rec = backing.artifacts[payload.artifact_ref]
+    if rec then rec.deleted = true end
+    backing.artifacts[payload.artifact_ref] = nil
+    return { ok = true, reason = { ok = true } }
+  end)
+
+  bind_reply_loop(scope, status_ep, function()
+    return { ok = true, reason = {
+      transient_root = 'mem://transient',
+      durable_root = 'mem://durable',
+      durable_enabled = backing.durable_enabled,
+    } }
+  end)
+
+  return backing
+end
+
+function M.seed_import_path(backing, path, data)
+  assert(type(backing) == 'table', 'backing required')
+  assert(type(path) == 'string' and path ~= '', 'path required')
+  assert(type(data) == 'string', 'data must be a string')
+  backing.import_paths = backing.import_paths or {}
+  backing.import_paths[path] = data
+  return path
+end
+
+return M

--- a/tests/unit/hal/artifact_store_driver_spec.lua
+++ b/tests/unit/hal/artifact_store_driver_spec.lua
@@ -1,0 +1,131 @@
+local runfibers    = require 'tests.support.run_fibers'
+local store_mod    = require 'services.hal.drivers.artifact_store'
+local blob_source  = require 'shared.blob_source'
+local file         = require 'fibers.io.file'
+local exec         = require 'fibers.io.exec'
+local fibers       = require 'fibers'
+
+local T = {}
+
+local function rmtree(path)
+  local cmd = exec.command('rm', '-rf', path)
+  fibers.perform(cmd:run_op())
+end
+
+function T.artifact_store_driver_imports_source_opens_and_deletes_transient_artefact()
+  runfibers.run(function()
+    local base = ('/tmp/devicecode-artifact-store-%d'):format(math.random(1000000))
+    local transient_root = base .. '/transient'
+    local durable_root = base .. '/durable'
+    rmtree(base)
+    local store = assert(store_mod.new({ transient_root = transient_root, durable_root = durable_root, durable_enabled = false }))
+
+    local artefact = assert(store:import_source(blob_source.from_string('hello'), { kind = 'update', target = 'mcu' }, { policy = 'transient_only' }))
+    local rec = artefact:describe()
+    assert(rec.durability == 'transient')
+    assert(rec.state == 'ready')
+    assert(rec.size == 5)
+    assert(type(rec.checksum) == 'string')
+
+    local opened = assert(store:open(artefact:ref()))
+    assert(opened:ref() == artefact:ref())
+    local src = opened:open_source()
+    assert((assert(src:read_chunk(0, 99))) == 'hello')
+
+    local resolved = assert(store:resolve_local(artefact:ref()))
+    assert(type(resolved.path) == 'string')
+
+    assert(store:delete(artefact:ref()) == true)
+    local missing, err = store:open(artefact:ref())
+    assert(missing == nil)
+    assert(err == 'not_found')
+
+    rmtree(base)
+  end, { timeout = 3.0 })
+end
+
+function T.artifact_store_driver_honours_durability_policy()
+  runfibers.run(function()
+    local base = ('/tmp/devicecode-artifact-store-%d'):format(math.random(1000000))
+    local transient_root = base .. '/transient'
+    local durable_root = base .. '/durable'
+    rmtree(base)
+
+    local store = assert(store_mod.new({ transient_root = transient_root, durable_root = durable_root, durable_enabled = false }))
+    local art = assert(store:import_source(blob_source.from_string('a'), { kind = 'update' }, { policy = 'prefer_durable' }))
+    assert(art:describe().durability == 'transient')
+    local none, err = store:create_sink({ kind = 'update' }, { policy = 'require_durable' })
+    assert(none == nil)
+    assert(err == 'durable_disabled')
+
+    local store2 = assert(store_mod.new({ transient_root = transient_root, durable_root = durable_root, durable_enabled = true }))
+    local art2 = assert(store2:import_source(blob_source.from_string('b'), { kind = 'update' }, { policy = 'require_durable' }))
+    assert(art2:describe().durability == 'durable')
+
+    rmtree(base)
+  end, { timeout = 3.0 })
+end
+
+function T.artifact_store_driver_imports_path_into_transient_store_when_durable_is_disabled()
+  runfibers.run(function()
+    local base = ('/tmp/devicecode-artifact-store-%d'):format(math.random(1000000))
+    local transient_root = base .. '/transient'
+    local durable_root = base .. '/durable'
+    local import_root = base .. '/incoming'
+    rmtree(base)
+    assert(file.mkdir_p(import_root))
+
+    local f = assert(file.open(import_root .. '/fw.bin', 'w'))
+    assert(f:write('firmware-bytes'))
+    assert(f:close())
+
+    local store = assert(store_mod.new({
+      transient_root = transient_root,
+      durable_root = durable_root,
+      durable_enabled = false,
+    }))
+
+    local artefact = assert(store:import_path(import_root .. '/fw.bin', {
+      kind = 'firmware',
+      target = 'cm5',
+    }, {
+      policy = 'prefer_durable',
+    }))
+
+    local rec = artefact:describe()
+    assert(rec.durability == 'transient')
+    assert(rec.state == 'ready')
+    local resolved = assert(store:resolve_local(artefact:ref()))
+    assert(resolved.durability == 'transient')
+    assert(resolved.path:match('^' .. transient_root:gsub('([%%%^%$%(%)%%.%[%]%*%+%-%?])','%%%1')))
+
+    local status = store:status()
+    assert(status.durable_enabled == false)
+    assert(status.transient_root == transient_root)
+    assert(status.durable_root == durable_root)
+
+    rmtree(base)
+  end, { timeout = 3.0 })
+end
+
+function T.artifact_store_driver_require_durable_rejection_leaves_no_artifact_dirs()
+  runfibers.run(function()
+    local base = ('/tmp/devicecode-artifact-store-%d'):format(math.random(1000000))
+    local transient_root = base .. '/transient'
+    local durable_root = base .. '/durable'
+    rmtree(base)
+
+    local store = assert(store_mod.new({ transient_root = transient_root, durable_root = durable_root, durable_enabled = false }))
+    local sink, err = store:create_sink({ kind = 'firmware', target = 'cm5' }, { policy = 'require_durable' })
+    assert(sink == nil)
+    assert(err == 'durable_disabled')
+
+    local status = store:status()
+    assert(status.transient_root == transient_root)
+    assert(status.durable_root == durable_root)
+
+    rmtree(base)
+  end, { timeout = 3.0 })
+end
+
+return T

--- a/tests/unit/hal/control_store_driver_spec.lua
+++ b/tests/unit/hal/control_store_driver_spec.lua
@@ -1,0 +1,89 @@
+local runfibers = require 'tests.support.run_fibers'
+local store_mod = require 'services.hal.drivers.control_store'
+local exec      = require 'fibers.io.exec'
+local fibers    = require 'fibers'
+
+local T = {}
+
+local function rmtree(path)
+  local cmd = exec.command('rm', '-rf', path)
+  fibers.perform(cmd:run_op())
+end
+
+function T.control_store_driver_put_get_list_and_delete_records()
+  runfibers.run(function()
+    local root = ('/tmp/devicecode-control-store-%d'):format(math.random(1000000))
+    rmtree(root)
+    local store, err = store_mod.new({ root = root, max_record_bytes = 1024 })
+    assert(store ~= nil, tostring(err))
+
+    local ok, perr = store:put('update/jobs', 'j-1', { job_id = 'j-1', state = 'available' })
+    assert(ok == true)
+    assert(perr == '')
+
+    local value, gerr = store:get('update/jobs', 'j-1')
+    assert(gerr == '')
+    assert(type(value) == 'table')
+    assert(value.job_id == 'j-1')
+
+    local keys, lerr = store:list('update/jobs')
+    assert(lerr == '')
+    assert(#keys == 1 and keys[1] == 'j-1')
+
+    local dok, derr = store:delete('update/jobs', 'j-1')
+    assert(dok == true)
+    assert(derr == '')
+
+    local missing, merr = store:get('update/jobs', 'j-1')
+    assert(missing == nil)
+    assert(merr == 'not_found')
+
+    rmtree(root)
+  end, { timeout = 3.0 })
+end
+
+function T.control_store_driver_rejects_oversized_record()
+  runfibers.run(function()
+    local root = ('/tmp/devicecode-control-store-%d'):format(math.random(1000000))
+    rmtree(root)
+    local store = assert(store_mod.new({ root = root, max_record_bytes = 32 }))
+    local ok, err = store:put('update/jobs', 'j-big', { payload = string.rep('x', 256) })
+    assert(ok == false)
+    assert(err == 'record_too_large')
+    rmtree(root)
+  end, { timeout = 3.0 })
+end
+
+function T.control_store_driver_rejects_oversized_record_without_clobbering_existing_record_or_index()
+  runfibers.run(function()
+    local root = ('/tmp/devicecode-control-store-%d'):format(math.random(1000000))
+    rmtree(root)
+    local store = assert(store_mod.new({ root = root, max_record_bytes = 96 }))
+
+    local ok1, err1 = store:put('update/jobs', 'j-keep', { job_id = 'j-keep', state = 'available' })
+    assert(ok1 == true)
+    assert(err1 == '')
+
+    local ok2, err2 = store:put('update/jobs', 'j-keep', { payload = string.rep('x', 512) })
+    assert(ok2 == false)
+    assert(err2 == 'record_too_large')
+
+    local value, verr = store:get('update/jobs', 'j-keep')
+    assert(verr == '')
+    assert(type(value) == 'table')
+    assert(value.job_id == 'j-keep')
+    assert(value.state == 'available')
+
+    local missing, merr = store:get('update/jobs', 'j-big')
+    assert(missing == nil)
+    assert(merr == 'not_found')
+
+    local keys, lerr = store:list('update/jobs')
+    assert(lerr == '')
+    assert(#keys == 1 and keys[1] == 'j-keep')
+
+    rmtree(root)
+  end, { timeout = 3.0 })
+end
+
+return T

--- a/tests/unit/hal/signature_verify_openssl_spec.lua
+++ b/tests/unit/hal/signature_verify_openssl_spec.lua
@@ -1,0 +1,96 @@
+local runfibers = require 'tests.support.run_fibers'
+local op = require 'fibers.op'
+local driver_mod = require 'services.hal.drivers.signature_verify_openssl'
+
+local T = {}
+
+local function make_stream(path, sink)
+  return {
+    filename = function() return path end,
+    write = function(_, data) sink.data = (sink.data or '') .. data return #data end,
+    flush = function() return true, nil end,
+    close = function() sink.closed = true return true, nil end,
+  }
+end
+
+function T.driver_writes_temp_files_invokes_openssl_and_maps_success()
+  runfibers.run(function()
+    local sinks = {}
+    local idx = 0
+    local seen_argv
+    local drv = driver_mod.new({
+      tmpdir = '/tmp/test-sig',
+      file = {
+        tmpfile = function()
+          idx = idx + 1
+          local sink = {}
+          sinks[idx] = sink
+          return make_stream('/tmp/test-sig/f' .. idx, sink), nil
+        end,
+      },
+      exec = {
+        command = function(...)
+          seen_argv = { ... }
+          return { combined_output_op = function() return op.always('Signature Verified Successfully', 'exited', 0, nil, nil) end }
+        end,
+      },
+    })
+
+    local ok, err = drv:verify_ed25519('PUB', 'MSG', 'SIG')
+    assert(ok == true)
+    assert(err == nil)
+    assert(seen_argv[1] == 'openssl')
+    assert(seen_argv[2] == 'pkeyutl')
+    assert(seen_argv[3] == '-verify')
+    assert(seen_argv[4] == '-pubin')
+    assert(seen_argv[5] == '-inkey')
+    assert(seen_argv[7] == '-sigfile')
+    assert(seen_argv[9] == '-in')
+    assert(seen_argv[11] == '-rawin')
+    assert(sinks[1].data == 'PUB')
+    assert(sinks[2].data == 'MSG')
+    assert(sinks[3].data == 'SIG')
+    assert(sinks[1].closed == true and sinks[2].closed == true and sinks[3].closed == true)
+  end, { timeout = 2.0 })
+end
+
+function T.driver_maps_verification_failure_and_exec_failure()
+  runfibers.run(function()
+    local idx = 0
+    local drv = driver_mod.new({
+      file = {
+        tmpfile = function()
+          idx = idx + 1
+          return make_stream('/tmp/test-sig/f' .. idx, {}), nil
+        end,
+      },
+      exec = {
+        command = function()
+          return { combined_output_op = function() return op.always('Signature Verification Failure', 'exited', 1, nil, nil) end }
+        end,
+      },
+    })
+    local ok1, err1 = drv:verify_ed25519('PUB', 'MSG', 'SIG')
+    assert(ok1 == false)
+    assert(err1 == 'signature_verify_failed')
+
+    local drv2 = driver_mod.new({
+      file = {
+        tmpfile = function()
+          idx = idx + 1
+          return make_stream('/tmp/test-sig/g' .. idx, {}), nil
+        end,
+      },
+      exec = {
+        command = function()
+          return { combined_output_op = function() return op.always('bad options', 'exited', 1, nil, nil) end }
+        end,
+      },
+    })
+    local ok2, err2 = drv2:verify_ed25519('PUB', 'MSG', 'SIG')
+    assert(ok2 == nil)
+    assert(tostring(err2):match('^openssl_verify_failed:'))
+  end, { timeout = 2.0 })
+end
+
+return T

--- a/tests/unit/main/profile_config_spec.lua
+++ b/tests/unit/main/profile_config_spec.lua
@@ -1,0 +1,90 @@
+local cjson = require 'cjson.safe'
+
+local T = {}
+
+local function read_file(path)
+  local f = assert(io.open(path, 'rb'))
+  local s = assert(f:read('*a'))
+  f:close()
+  return s
+end
+
+function T.bigbox_v1_cm_2_profile_activates_fabric_device_update_and_not_mcu_bridge()
+  local chunk = assert(loadfile('../src/devices/bigbox-v1-cm-2.lua'))
+  local rec = assert(chunk())
+  assert(type(rec) == 'table' and type(rec.services) == 'table')
+
+  local seen = {}
+  for i = 1, #rec.services do seen[rec.services[i]] = true end
+
+  assert(seen.fabric == true)
+  assert(seen.device == true)
+  assert(seen.update == true)
+  assert(seen.mcu_bridge ~= true)
+end
+
+function T.bigbox_v1_cm_2_config_defines_fabric_device_and_mcu_only_update_backend()
+  local cfg = assert(cjson.decode(read_file('../src/configs/bigbox-v1-cm-2.json')))
+  assert(type(cfg) == 'table')
+
+  assert(type(cfg.fabric) == 'table')
+  assert(type(cfg.fabric.links) == 'table')
+  local link = cfg.fabric.links['cm5-uart-mcu']
+  assert(type(link) == 'table')
+  assert(link.member_class == 'mcu')
+  assert(link.link_class == 'member_uart')
+  assert(type(link.import_rules) == 'table' and #link.import_rules >= 1)
+  assert(type(link.outbound_call_rules) == 'table' and #link.outbound_call_rules >= 1)
+
+  assert(type(cfg.device) == 'table')
+  assert(cfg.device.schema == 'devicecode.config/device/1')
+  assert(type(cfg.device.components) == 'table')
+  local mcu = cfg.device.components.mcu
+  assert(type(mcu) == 'table')
+  assert(mcu.member_class == 'mcu')
+  assert(mcu.link_class == 'member_uart')
+  assert(type(mcu.facts) == 'table')
+  assert(type(mcu.facts.software) == 'table')
+  assert(type(mcu.facts.updater) == 'table')
+  assert(type(mcu.facts.health) == 'table')
+  assert(mcu.status_topic == nil)
+  assert(mcu.get_topic == nil)
+  assert(type(mcu.actions) == 'table')
+  assert(type(mcu.actions['prepare-update']) == 'table')
+  assert(type(mcu.actions['stage-update']) == 'table')
+  assert(mcu.actions['stage-update'].kind == 'fabric_stage')
+  assert(mcu.actions['stage-update'].link_id == 'cm5-uart-mcu')
+  assert(type(mcu.actions['commit-update']) == 'table')
+
+  assert(type(cfg.update) == 'table')
+  assert(cfg.update.schema == 'devicecode.config/update/1')
+  assert(type(cfg.update.components) == 'table')
+  assert(type(cfg.update.components.mcu) == 'table')
+  assert(cfg.update.components.mcu.backend == 'mcu_component')
+  assert(cfg.update.components.mcu.transfer == nil)
+  assert(type(cfg.update.bundled) == 'table')
+  assert(type(cfg.update.bundled.components.mcu) == 'table')
+  assert(cfg.update.bundled.components.mcu.enabled == true)
+  assert(cfg.update.bundled.components.mcu.source.kind == 'bundled')
+  assert(cfg.update.components.cm5 == nil)
+
+  assert(cfg.bridge == nil)
+end
+
+
+function T.default_config_models_cm5_as_fact_backed_component()
+  local cfg = assert(cjson.decode(read_file('../src/configs/config.json')))
+  assert(type(cfg) == 'table')
+  assert(type(cfg.device) == 'table')
+  assert(type(cfg.device.data) == 'table')
+  local cm5 = cfg.device.data.components.cm5
+  assert(type(cm5) == 'table')
+  assert(type(cm5.facts) == 'table')
+  assert(type(cm5.facts.software) == 'table')
+  assert(type(cm5.facts.updater) == 'table')
+  assert(type(cm5.facts.health) == 'table')
+  assert(cm5.status_topic == nil)
+  assert(cm5.get_topic == nil)
+end
+
+return T

--- a/tests/unit/main/profile_contract_spec.lua
+++ b/tests/unit/main/profile_contract_spec.lua
@@ -1,0 +1,28 @@
+local contract = require 'devicecode.profile_contract'
+
+local T = {}
+
+function T.profile_contract_validates_bigbox_v1_cm_2_services()
+  local profile = contract.load_profile('../src/devices/bigbox-v1-cm-2.lua')
+  local seen, err = contract.validate_profile_services(profile, {
+    required = { 'fabric', 'device', 'update' },
+    forbidden = { 'mcu_bridge' },
+  })
+  assert(err == nil)
+  assert(seen.fabric == true and seen.device == true and seen.update == true)
+end
+
+function T.profile_contract_loads_bigbox_v1_cm_2_config_and_paths()
+  local cfg = contract.load_config_json('../src/configs/bigbox-v1-cm-2.json')
+  local link, err = contract.require_path(cfg, { 'fabric', 'links', 'cm5-uart-mcu' })
+  assert(err == nil)
+  assert(type(link) == 'table')
+  local comp, err2 = contract.require_path(cfg, { 'device', 'components', 'mcu' })
+  assert(err2 == nil)
+  assert(type(comp) == 'table')
+  local upd, err3 = contract.require_path(cfg, { 'update', 'components', 'mcu' })
+  assert(err3 == nil)
+  assert(type(upd) == 'table')
+end
+
+return T


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] 🍕 Feature
- [x] ✅ Test

## Description
This PR expands the HAL service so it can act as the foundational host-side capability provider for the rest of the new Devicecode stack.

In practical terms, this introduces a set of concrete HAL drivers and managers for storage, signature verification, UART access and CM5-local updating, and wires them into configuration and profile handling so later services can depend on stable capability surfaces rather than bespoke host logic.

This is an intentionally foundational PR. It does not yet introduce the higher-level `fabric`, `device`, `update` or `ui` services, but it lands the host-side primitives those services require in order to be added cleanly in later PRs.

Changes in this PR include:

- adds HAL drivers and providers for:
  - artefact storage
  - control-record storage
  - OpenSSL-backed signature verification
  - UART access
  - CM5 updater functionality
- adds HAL managers for:
  - `artifact_store`
  - `control_store`
  - `signature_verify`
  - `uart`
  - `updater`
- extends HAL capability type definitions and argument metadata so these new managers can be surfaced consistently through HAL capability publication
- adds the new Big Box V1 CM5 target profile and profile contract support:
  - `bigbox-v1-cm-2.json`
  - `bigbox-v1-cm-2.lua`
  - `profile_contract.lua`
- updates the shared config baseline so the new HAL managers and target profile can be configured and validated in-tree
- adds shared support code used by later service layers and tests:
  - pseudo-terminal support for UART/integration testing
  - storage capability test helpers
  - blob/checksum utilities now needed by the broader stack
- updates the test runner and support helpers to recognise and exercise the new HAL/profile capabilities
- adds unit coverage for:
  - artefact store driver
  - control store driver
  - OpenSSL signature verification driver
  - profile config and profile contract validation
- adds devhost integration coverage for the UART manager lifecycle and behaviour

Architecturally, this PR establishes HAL as the host-facing capability boundary for:
- durable artefact and control persistence
- cryptographic verification
- UART-backed device links
- local CM5 update actions

That lets later PRs build higher-level orchestration entirely in terms of capabilities and retained control-plane state, instead of reaching into host implementation details directly.

## Related Issues, Tickets & Documents

Depends on #201 
Unlocks #207 

## Manual test
<!-- Have you manually tested this code and confirmed it is working? -->
- [x] 👍 yes

Ran the testing suite 10 times, 46/46 tests pass with both PUC Lua and LuaJIT

## Added tests?
- [x] 👍 yes

## Added to documentation?
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?
No post-deployment tasks are expected.

Follow-on PRs will build on these HAL and profile foundations by introducing the higher-level services that consume them.