### PR TITLE
config: activates forgotten config unit tests

### DIFF
--- a/tests/run.lua
+++ b/tests/run.lua
@@ -24,6 +24,9 @@ assert(stdlib.setenv('CONFIG_TARGET', 'services'))
 
 local files = {
 	'unit.devicecode.service_base_spec',
+	'unit.config.codec_spec',
+	'unit.config.service_spec',
+	'unit.config.state_spec',
 	'unit.device.availability_spec',
 	'unit.device.component_host_spec',
 	'unit.device.component_mcu_spec',


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] ✅ Test

## Description
This PR is a small test-runner update to include the existing config unit tests in the main `tests/run.lua` suite.

It does not introduce new runtime behaviour. It simply ensures that config coverage is exercised consistently when the standard test runner is used.

Changes in this PR include:

- adds `unit.config.codec_spec`
- adds `unit.config.service_spec`
- adds `unit.config.state_spec`

to the main test file list in `tests/run.lua`

This keeps config behaviour covered alongside the rest of the service stack, rather than depending on those tests being run separately or ad hoc.

## Related Issues, Tickets & Documents

Depends on #208 
Unlocks #210 

## Manual test
<!-- Have you manually tested this code and confirmed it is working? -->
- [x] 👍 yes

## Manual test description

Ran the testing suite 10 times, 124/124 tests pass with both PUC Lua and LuaJIT


## Added tests?
- [x] 👍 yes

## Added to documentation?
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?
No post-deployment tasks are expected.