### PR TITLE
fabric-update: bringup-loop changes on top of rt-ui

### DIFF
--- a/src/configs/mcu-dev.json
+++ b/src/configs/mcu-dev.json
@@ -11,7 +11,9 @@
         "serial_ports": [
           { "name": "uart-0", "path": "/dev/ttyAMA0", "baud": 115200 }
         ]
-      }
+      },
+      "artifact_store": {},
+      "control_store": {}
     }
   },
   "fabric": {

--- a/src/configs/mcu-dev.json
+++ b/src/configs/mcu-dev.json
@@ -1,0 +1,73 @@
+{
+  "hal": {
+    "rev": 1,
+    "data": {
+      "schema": "devicecode.config/hal/1",
+      "filesystem": [
+        {
+          "name": "config",
+          "root": "/data/configs/"
+        },
+        {
+          "name": "state",
+          "root": "/tmp/dc-states/"
+        }
+      ],
+      "uart": {
+        "serial_ports": [
+          {
+            "name": "uart-0",
+            "path": "/dev/ttyAMA0",
+            "baud": 115200
+          }
+        ]
+      }
+    }
+  },
+  "fabric": {
+    "rev": 1,
+    "data": {
+      "schema": "devicecode.fabric/1",
+      "links": {
+        "mcu0": {
+          "node_id": "cm5",
+          "member_class": "cm5",
+          "link_class": "member_uart",
+          "hello_interval_s": 1.0,
+          "ping_interval_s": 10.0,
+          "liveness_timeout_s": 30.0,
+          "transport": {
+            "id": "uart-0"
+          },
+          "chunk_size": 2048,
+          "transfer_phase_timeout_s": 15.0,
+          "export_publish_rules": [],
+          "export_retained_rules": [],
+          "import_rules": [
+            {
+              "local": ["peer", "mcu-1", "state"],
+              "remote": ["state"]
+            },
+            {
+              "local": ["peer", "mcu-1", "event"],
+              "remote": ["event"]
+            }
+          ],
+          "inbound_call_rules": [],
+          "outbound_call_rules": [
+            {
+              "local": ["raw", "member", "mcu", "cap", "updater", "main", "rpc", "prepare"],
+              "remote": ["cmd", "self", "updater", "prepare"],
+              "timeout": 2.0
+            },
+            {
+              "local": ["raw", "member", "mcu", "cap", "updater", "main", "rpc", "commit"],
+              "remote": ["cmd", "self", "updater", "commit"],
+              "timeout": 2.0
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/src/configs/mcu-dev.json
+++ b/src/configs/mcu-dev.json
@@ -4,22 +4,12 @@
     "data": {
       "schema": "devicecode.config/hal/1",
       "filesystem": [
-        {
-          "name": "config",
-          "root": "/data/configs/"
-        },
-        {
-          "name": "state",
-          "root": "/tmp/dc-states/"
-        }
+        { "name": "config", "root": "/data/configs/" },
+        { "name": "state",  "root": "/tmp/dc-states/" }
       ],
       "uart": {
         "serial_ports": [
-          {
-            "name": "uart-0",
-            "path": "/dev/ttyAMA0",
-            "baud": 115200
-          }
+          { "name": "uart-0", "path": "/dev/ttyAMA0", "baud": 115200 }
         ]
       }
     }
@@ -36,37 +26,88 @@
           "hello_interval_s": 1.0,
           "ping_interval_s": 10.0,
           "liveness_timeout_s": 30.0,
-          "transport": {
-            "id": "uart-0"
-          },
+          "transport": { "id": "uart-0" },
           "chunk_size": 2048,
           "transfer_phase_timeout_s": 15.0,
           "export_publish_rules": [],
           "export_retained_rules": [],
           "import_rules": [
             {
-              "local": ["peer", "mcu-1", "state"],
-              "remote": ["state"]
+              "local":  ["raw", "member", "mcu", "state"],
+              "remote": ["state", "self"]
             },
             {
-              "local": ["peer", "mcu-1", "event"],
-              "remote": ["event"]
+              "local":  ["raw", "member", "mcu", "cap", "telemetry", "main", "event"],
+              "remote": ["event", "self"]
             }
           ],
           "inbound_call_rules": [],
           "outbound_call_rules": [
             {
-              "local": ["raw", "member", "mcu", "cap", "updater", "main", "rpc", "prepare"],
-              "remote": ["cmd", "self", "updater", "prepare"],
+              "local":   ["raw", "member", "mcu", "cap", "updater", "main", "rpc", "prepare"],
+              "remote":  ["cmd", "self", "updater", "prepare"],
               "timeout": 2.0
             },
             {
-              "local": ["raw", "member", "mcu", "cap", "updater", "main", "rpc", "commit"],
-              "remote": ["cmd", "self", "updater", "commit"],
+              "local":   ["raw", "member", "mcu", "cap", "updater", "main", "rpc", "commit"],
+              "remote":  ["cmd", "self", "updater", "commit"],
               "timeout": 2.0
             }
           ]
         }
+      }
+    }
+  },
+  "device": {
+    "rev": 1,
+    "data": {
+      "schema": "devicecode.config/device/1",
+      "components": {
+        "mcu": {
+          "class": "member",
+          "subtype": "mcu",
+          "role": "member",
+          "member": "mcu",
+          "member_class": "mcu",
+          "link_class": "member_uart",
+          "actions": {
+            "prepare-update": ["raw", "member", "mcu", "cap", "updater", "main", "rpc", "prepare"],
+            "commit-update":  ["raw", "member", "mcu", "cap", "updater", "main", "rpc", "commit"],
+            "stage-update": {
+              "kind": "fabric_stage",
+              "artifact_store": "main",
+              "link_id": "mcu0",
+              "receiver": ["raw", "member", "mcu", "cap", "updater", "main", "rpc", "receive"],
+              "timeout_s": 60.0
+            }
+          },
+          "facts": {
+            "software": ["raw", "member", "mcu", "state", "software"],
+            "updater":  ["raw", "member", "mcu", "state", "updater"],
+            "health":   ["raw", "member", "mcu", "state", "health"]
+          }
+        }
+      }
+    }
+  },
+  "update": {
+    "rev": 1,
+    "data": {
+      "schema": "devicecode.config/update/1",
+      "jobs_namespace": "update/jobs",
+      "components": {
+        "mcu": { "backend": "mcu_component" }
+      },
+      "artifacts": {
+        "default_policy": "transient_only",
+        "policies": { "mcu": "transient_only" }
+      },
+      "reconcile": {
+        "interval_s": 10.0,
+        "timeout_s": 180.0
+      },
+      "admission": {
+        "mode": "global_single"
       }
     }
   }

--- a/src/configs/mcu-dev.json
+++ b/src/configs/mcu-dev.json
@@ -80,7 +80,7 @@
               "artifact_store": "main",
               "link_id": "mcu0",
               "receiver": ["raw", "member", "mcu", "cap", "updater", "main", "rpc", "receive"],
-              "timeout_s": 60.0
+              "timeout_s": 900.0
             }
           },
           "facts": {
@@ -98,7 +98,13 @@
       "schema": "devicecode.config/update/1",
       "jobs_namespace": "update/jobs",
       "components": {
-        "mcu": { "backend": "mcu_component" }
+        "mcu": {
+          "backend": "mcu_component",
+          "transfer": {
+            "link_id": "mcu0"
+          },
+          "timeout_stage": 900.0
+        }
       },
       "artifacts": {
         "default_policy": "transient_only",

--- a/src/services/device.lua
+++ b/src/services/device.lua
@@ -261,11 +261,23 @@ local function perform_fabric_stage(conn, rec, action_name, args, timeout)
 
   local desc = type(artifact.describe) == 'function' and artifact:describe() or nil
   local meta = type(args.metadata) == 'table' and model.copy_value(args.metadata) or nil
+  local chunk_size = nil
+  if type(meta) == 'table' then
+    local transfer_meta = type(meta.transfer) == 'table' and meta.transfer or nil
+    chunk_size = tonumber(meta.transfer_chunk_raw)
+      or tonumber(meta.transfer_chunk_size)
+      or tonumber(transfer_meta and transfer_meta.chunk_size)
+  end
+  if chunk_size ~= nil and (chunk_size <= 0 or chunk_size % 1 ~= 0) then
+    chunk_size = nil
+  end
+
   local payload = {
     op = 'send_blob',
     link_id = op.link_id,
     receiver = model.copy_array(op.receiver),
     source = artifact,
+    chunk_size = chunk_size,
     meta = {
       kind = 'firmware',
       component = rec.name,

--- a/src/services/fabric/protocol.lua
+++ b/src/services/fabric/protocol.lua
@@ -13,6 +13,7 @@
 
 local cjson  = require 'cjson.safe'
 local b64url = require 'shared.encoding.b64url'
+local xxhash = require 'shared.hash.xxhash32'
 
 local M = {}
 
@@ -316,11 +317,17 @@ function M.make_xfer_chunk(xfer_id, offset, raw)
 		return nil, err
 	end
 
+	-- Per-chunk xxHash32 over the raw bytes. Catches single-byte UART
+	-- corruption inside the base64 data string -- those flips don't
+	-- break JSON parsing, so without this the receiver silently
+	-- absorbs the wrong bytes and only notices at xfer_commit's
+	-- whole-payload checksum (after the entire transfer is wasted).
 	local frame = {
 		type = 'xfer_chunk',
 		xfer_id = xfer_id,
 		offset = offset,
 		data = data,
+		crc = xxhash.digest_hex(raw),
 	}
 
 	return validate(frame)

--- a/src/services/fabric/transfer_mgr.lua
+++ b/src/services/fabric/transfer_mgr.lua
@@ -106,7 +106,7 @@ function M.run(ctx)
 	local tx_bulk = assert(ctx.tx_bulk, 'transfer_mgr requires tx_bulk')
 	local transfer_ctl_rx = assert(ctx.transfer_ctl_rx, 'transfer_mgr requires transfer_ctl_rx')
 	local link_id = assert(ctx.link_id, 'transfer_mgr requires link_id')
-	local chunk_size = tonumber(ctx.chunk_size) or 2048
+	local default_chunk_size = tonumber(ctx.chunk_size) or 2048
 	local phase_timeout = tonumber(ctx.transfer_phase_timeout_s) or 15.0
 
 	local transfer_topic = statefmt.component_topic(link_id, 'transfer')
@@ -218,6 +218,7 @@ function M.run(ctx)
 			source = source,
 			size = source:size(),
 			checksum = source:checksum(),
+			chunk_size = tonumber(payload.chunk_size) or default_chunk_size,
 			offset = 0,
 			state = 'waiting_ready',
 			deadline = runtime.now() + phase_timeout,
@@ -255,7 +256,7 @@ function M.run(ctx)
 			return
 		end
 
-		local raw, err = active.source:read_chunk(active.offset, chunk_size)
+		local raw, err = active.source:read_chunk(active.offset, active.chunk_size)
 		if raw == nil then
 			clear_active(err or 'source_error')
 			return
@@ -482,6 +483,19 @@ function M.run(ctx)
 
 		elseif frame.type == 'xfer_need' then
 			if active and active.direction == 'out' and frame.xfer_id == active.xfer_id then
+				-- xfer_need is the receiver's authoritative next-byte
+				-- request. Always honour it -- including rewinding the
+				-- send cursor when the receiver dropped a corrupted
+				-- chunk and asked to resume from earlier than where
+				-- our streaming cursor has reached. Without this the
+				-- maybe_send_outgoing_chunk's offset-equality guard
+				-- silently dropped backward needs and the transfer
+				-- stalled at the gap until phase_timeout.
+				if frame.next ~= active.offset then
+					active.offset = frame.next
+					active.state = 'sending'
+					active.deadline = runtime.now() + phase_timeout
+				end
 				maybe_send_outgoing_chunk(frame.next)
 			end
 

--- a/src/services/smoke.lua
+++ b/src/services/smoke.lua
@@ -1,0 +1,175 @@
+-- services/smoke.lua
+--
+-- Hardware bring-up smoke tests for the devicecode-go fabric-update
+-- branch. Enable by setting
+--   DEVICECODE_SERVICES=monitor,hal,config,fabric,smoke
+-- and the service will, after the mcu0 fabric link reaches ready=true,
+-- run scripted canary tests against the real MCU and print [smoke]
+-- lines on stdout.
+--
+-- Tests
+--   1. Observe state/self/software retain. The W5 identity fact must
+--      arrive on every newly established session (W10 republish edge).
+--      Verifies fabric exports + the new state/self/* surface end to
+--      end on the wire.
+--   2. Call cmd/self/updater/prepare via outbound_call_rules. Replies
+--      {ok=true, accepted=true} on success per W4.
+--   3. Drive a synthetic transfer with meta.receiver. The default
+--      MCU build's stub verifier rejects every artefact; expect
+--      xfer_abort with the verifier_stub sentinel string.
+--
+-- Notes
+-- - Pre-W12 smoke pushed config/mcu retain and used rpc/hal/dump.
+--   Both paths are gone. The new surface is what this file targets.
+
+local runtime = require 'fibers.runtime'
+local sleep   = require 'fibers.sleep'
+local base    = require 'devicecode.service_base'
+
+local M = {}
+
+local LINK_ID = 'mcu0'
+local LINK_TOPIC = { 'state', 'fabric', 'link', LINK_ID, 'session' }
+
+-- Imported MCU state lands at peer/mcu-1/state/self/* per the
+-- mcu-dev.json import_rules ([peer mcu-1 state] <- remote [state]).
+local SOFTWARE_FACT_TOPIC = { 'peer', 'mcu-1', 'state', 'self', 'software' }
+local UPDATER_FACT_TOPIC  = { 'peer', 'mcu-1', 'state', 'self', 'updater' }
+
+-- Outbound RPC routing (mcu-dev.json outbound_call_rules):
+-- [raw member mcu cap updater main rpc *] -> remote [cmd self updater *]
+local PREPARE_TOPIC = { 'raw', 'member', 'mcu', 'cap', 'updater', 'main', 'rpc', 'prepare' }
+local XFER_TOPIC    = { 'cmd', 'fabric', 'transfer' }
+
+local READY_TIMEOUT_S = 30
+local FACT_TIMEOUT_S  = 10
+local RPC_TIMEOUT_S   = 2.0
+local XFER_TIMEOUT_S  = 30.0
+local XFER_SIZE       = 4 * 1024
+
+local function log(line)
+	io.write('[smoke] ', line, '\n')
+	io.flush()
+end
+
+local function wait_for_ready(conn, timeout_s)
+	local sub = conn:subscribe(LINK_TOPIC, { queue_len = 8, full = 'drop_oldest' })
+	local deadline = runtime.now() + timeout_s
+	while runtime.now() < deadline do
+		local msg = sub:recv()
+		if msg and type(msg.payload) == 'table' then
+			local status = msg.payload.status
+			if type(status) == 'table' and status.ready == true then
+				return true, status
+			end
+			if msg.payload.ready == true then
+				return true, msg.payload
+			end
+		end
+	end
+	return false, 'timeout waiting for link ready'
+end
+
+local function wait_for_software_fact(conn, timeout_s)
+	local sub = conn:subscribe(SOFTWARE_FACT_TOPIC, { queue_len = 4, full = 'drop_oldest' })
+	local deadline = runtime.now() + timeout_s
+	while runtime.now() < deadline do
+		local msg = sub:recv()
+		if msg and type(msg.payload) == 'table' then
+			return true, msg.payload
+		end
+	end
+	return false, 'timeout waiting for state/self/software'
+end
+
+function M.start(conn, ctx)
+	ctx = ctx or {}
+	local svc = base.new(conn, { name = ctx.name or 'smoke', env = ctx.env })
+	svc:status('running', { phase = 'waiting_for_link' })
+
+	log('waiting for fabric link ' .. LINK_ID .. ' to reach ready...')
+	local ok, info = wait_for_ready(conn, READY_TIMEOUT_S)
+	if not ok then
+		log('FAIL: ' .. tostring(info))
+		svc:status('degraded', { reason = 'link_timeout' })
+		return
+	end
+	log(string.format('link ready; peer_sid=%s peer_node=%s',
+		tostring(info.peer_sid), tostring(info.peer_node)))
+
+	-- Test 1: observe state/self/software retain.
+	log('test 1: observing peer/mcu-1/state/self/software (W5 identity fact)')
+	local got, sw = wait_for_software_fact(conn, FACT_TIMEOUT_S)
+	if not got then
+		log('test 1 FAIL: ' .. tostring(sw))
+		svc:status('degraded', { reason = 'no_software_fact' })
+		return
+	end
+	log(string.format('test 1 OK: version=%s build=%s image_id=%s boot_id=%s',
+		tostring(sw.version), tostring(sw.build), tostring(sw.image_id), tostring(sw.boot_id)))
+	if type(sw.boot_id) ~= 'string' or #sw.boot_id ~= 16 then
+		log('test 1 WARN: boot_id length != 16: ' .. tostring(sw.boot_id))
+	end
+
+	-- Test 2: call cmd/self/updater/prepare via outbound_call_rules.
+	log('test 2: calling cmd/self/updater/prepare via outbound_call_rules')
+	local reply, err = conn:call(PREPARE_TOPIC, { target = 'img-test', metadata = nil },
+		{ timeout = RPC_TIMEOUT_S })
+	if err then
+		log('test 2 FAIL: ' .. tostring(err))
+		svc:status('degraded', { reason = 'prepare_failed', err = tostring(err) })
+		return
+	end
+	if type(reply) ~= 'table' or not reply.ok or not reply.accepted then
+		log('test 2 FAIL: bad reply: ' .. tostring(reply))
+		svc:status('degraded', { reason = 'prepare_bad_reply' })
+		return
+	end
+	log('test 2 OK: prepare ok=true accepted=true')
+
+	-- Test 3: synthetic transfer with meta.receiver; expect rejection
+	-- via the safe-default stub verifier.
+	log(string.format('test 3: sending synthetic %d-byte transfer with meta.receiver', XFER_SIZE))
+	local payload = string.rep('A', XFER_SIZE)
+	local xreply, xerr = conn:call(XFER_TOPIC, {
+		link_id = LINK_ID,
+		op = 'send_blob',
+		source = payload,
+		meta = {
+			kind = 'smoke-test',
+			receiver = { 'raw', 'member', 'mcu', 'cap', 'updater', 'main', 'rpc', 'receive' },
+		},
+	}, { timeout = XFER_TIMEOUT_S })
+
+	if xerr then
+		log(string.format('test 3 result: err=%s (expected on stub-verifier build)', tostring(xerr)))
+	elseif type(xreply) == 'table' and xreply.ok then
+		log(string.format('test 3 OK: xfer_id=%s size=%s', tostring(xreply.xfer_id), tostring(xreply.size)))
+	else
+		log('test 3 unexpected reply: ' .. tostring(xreply))
+	end
+
+	-- Optional follow-up: observe state/self/updater for the staged
+	-- transition. With the stub verifier this stays at running/idle;
+	-- with fakeVerifierAccept (from fabric-security) it would flip to
+	-- staged after test 3.
+	local upSub = conn:subscribe(UPDATER_FACT_TOPIC, { queue_len = 4, full = 'drop_oldest' })
+	local upDeadline = runtime.now() + 2
+	while runtime.now() < upDeadline do
+		local msg = upSub:recv()
+		if msg and type(msg.payload) == 'table' then
+			log(string.format('updater fact: state=%s last_error=%s pending_version=%s',
+				tostring(msg.payload.state), tostring(msg.payload.last_error),
+				tostring(msg.payload.pending_version)))
+			break
+		end
+	end
+
+	log('all tests done')
+	svc:status('running', { phase = 'tests_done' })
+
+	-- Idle forever; exiting would propagate as a service failure.
+	while true do sleep.sleep(60) end
+end
+
+return M

--- a/src/services/smoke.lua
+++ b/src/services/smoke.lua
@@ -31,10 +31,12 @@ local M = {}
 local LINK_ID = 'mcu0'
 local LINK_TOPIC = { 'state', 'fabric', 'link', LINK_ID, 'session' }
 
--- Imported MCU state lands at peer/mcu-1/state/self/* per the
--- mcu-dev.json import_rules ([peer mcu-1 state] <- remote [state]).
-local SOFTWARE_FACT_TOPIC = { 'peer', 'mcu-1', 'state', 'self', 'software' }
-local UPDATER_FACT_TOPIC  = { 'peer', 'mcu-1', 'state', 'self', 'updater' }
+-- Imported MCU state lands at raw/member/mcu/state/* per the
+-- mcu-dev.json import_rules ([raw member mcu state] <- remote [state self]).
+-- Same shape as bigbox-v1-cm-2.json so the device/update services find
+-- the facts at their canonical CM5-local addresses.
+local SOFTWARE_FACT_TOPIC = { 'raw', 'member', 'mcu', 'state', 'software' }
+local UPDATER_FACT_TOPIC  = { 'raw', 'member', 'mcu', 'state', 'updater' }
 
 -- Outbound RPC routing (mcu-dev.json outbound_call_rules):
 -- [raw member mcu cap updater main rpc *] -> remote [cmd self updater *]

--- a/src/services/ui/service.lua
+++ b/src/services/ui/service.lua
@@ -162,8 +162,16 @@ function M.start(conn, opts)
 		local changed = false
 		local sessions_n = session_store:count()
 		local model_ready = model and model:is_ready() or false
-		local model_seq = model and model:seq() or 0
 		local clients_n = client_count
+
+		-- model_seq is refreshed in the aggregate so the next publish
+		-- carries a current value, but it is intentionally NOT a
+		-- republish trigger. Why: publish_main_state retains
+		-- state/ui/summary, which the model subscribes to (state/#),
+		-- which bumps model_seq, which used to fire a republish, which
+		-- bumped model_seq again -- a tight self-feeding loop that
+		-- pinned the CPU and spammed retains.
+		aggregate.model_seq = model and model:seq() or 0
 
 		if aggregate.sessions ~= sessions_n then
 			aggregate.sessions = sessions_n
@@ -175,10 +183,6 @@ function M.start(conn, opts)
 		end
 		if aggregate.model_ready ~= model_ready then
 			aggregate.model_ready = model_ready
-			changed = true
-		end
-		if aggregate.model_seq ~= model_seq then
-			aggregate.model_seq = model_seq
 			changed = true
 		end
 

--- a/src/services/ui/uploads.lua
+++ b/src/services/ui/uploads.lua
@@ -112,13 +112,20 @@ function Uploads:_receive_artifact(artifact_cap, upload_id, stream, meta, deadli
 
 		-- Give get_body_chars a deadline-relative timeout. Without
 		-- one some lua-http builds return (nil, nil) on the very
-		-- first read instead of waiting for body bytes, and the
-		-- caller surfaces a useless "body_read_failed: body_read_failed".
+		-- first read instead of waiting for body bytes.
+		--
+		-- lua-http 0.4 also signals end-of-body via (nil, nil)
+		-- AFTER all bytes have been delivered, rather than via a
+		-- final empty-string read. Treat that as a clean EOF;
+		-- only (nil, err) is a real failure.
 		local chunk, rerr = stream:get_body_chars(64 * 1024, remaining)
 		if chunk == nil then
+			if rerr == nil then
+				break
+			end
 			abort_ingest()
 			return nil, errors.bad_request('body_read_failed: '
-				.. tostring(rerr or 'body_read_failed')
+				.. tostring(rerr)
 				.. ' (offset=' .. tostring(offset) .. ')')
 		end
 		if chunk == '' then

--- a/src/services/ui/uploads.lua
+++ b/src/services/ui/uploads.lua
@@ -110,10 +110,16 @@ function Uploads:_receive_artifact(artifact_cap, upload_id, stream, meta, deadli
 			return nil, terr
 		end
 
-		local chunk, rerr = stream:get_body_chars(64 * 1024)
+		-- Give get_body_chars a deadline-relative timeout. Without
+		-- one some lua-http builds return (nil, nil) on the very
+		-- first read instead of waiting for body bytes, and the
+		-- caller surfaces a useless "body_read_failed: body_read_failed".
+		local chunk, rerr = stream:get_body_chars(64 * 1024, remaining)
 		if chunk == nil then
 			abort_ingest()
-			return nil, errors.bad_request('body_read_failed: ' .. tostring(rerr or 'body_read_failed'))
+			return nil, errors.bad_request('body_read_failed: '
+				.. tostring(rerr or 'body_read_failed')
+				.. ' (offset=' .. tostring(offset) .. ')')
 		end
 		if chunk == '' then
 			break

--- a/src/services/ui/uploads.lua
+++ b/src/services/ui/uploads.lua
@@ -35,6 +35,14 @@ local function normalise_update_err(err, fallback)
 	return err
 end
 
+local function positive_integer_header(headers, name)
+	local raw = headers:get(name)
+	if raw == nil or raw == '' then return nil end
+	local n = tonumber(raw)
+	if n == nil or n <= 0 or n % 1 ~= 0 then return nil end
+	return n
+end
+
 function M.new(opts)
 	opts = opts or {}
 	assert(type(opts.require_session) == 'function', 'uploads: require_session is required')
@@ -81,6 +89,7 @@ function Uploads:_receive_artifact(artifact_cap, upload_id, stream, meta, deadli
 			build = meta.build,
 			checksum = meta.checksum,
 			upload_id = upload_id,
+			transfer_chunk_raw = meta.transfer_chunk_raw,
 		},
 		policy = 'transient_only',
 	}
@@ -188,6 +197,7 @@ function Uploads:_create_update_job(user_conn, artefact, meta, deadline)
 			uploaded = true,
 			commit_policy = 'manual',
 			require_explicit_commit = true,
+			transfer_chunk_raw = meta.transfer_chunk_raw,
 		},
 	}, timeout_s)
 
@@ -226,6 +236,7 @@ function Uploads:upload_update(session_id, stream, req_headers)
 		version = req_headers:get('x-artifact-version'),
 		build = req_headers:get('x-artifact-build'),
 		checksum = req_headers:get('x-artifact-checksum'),
+		transfer_chunk_raw = positive_integer_header(req_headers, 'x-transfer-chunk-raw'),
 	}
 	if self._allowed_components and self._allowed_components[meta.component] ~= true then
 		return nil, errors.bad_request('component_not_allowed')

--- a/src/services/update.lua
+++ b/src/services/update.lua
@@ -356,6 +356,36 @@ function M.start(conn, opts)
 
   local artifacts = artifacts_mod.new(ctx, { preflighters = type(opts.preflighters) == 'table' and opts.preflighters or nil })
   ctx.artifacts = artifacts
+
+  -- Dev-loop opt-out for the mcu component preflighter. The default
+  -- mcu preflighter calls mcu_image_v1.inspect_source, which checks
+  -- for the DCMCUIMG envelope (signed-image v1 format). Until
+  -- fabric-security ships imagev1 packing, raw sealed .bin artefacts
+  -- from pico2-a-b's abpack don't have that header and get rejected
+  -- with "bad_magic" before staging can even start. Set
+  -- DEVICECODE_DEV_SKIP_IMAGE_PREFLIGHT=1 to register a no-op
+  -- preflighter that lets the artefact through unchanged. The opt-out is
+  -- restricted to CONFIG_TARGET=mcu-dev so a leaked environment variable
+  -- cannot disable image preflight on production targets.
+  if os.getenv('DEVICECODE_DEV_SKIP_IMAGE_PREFLIGHT') == '1' then
+    local target = os.getenv('CONFIG_TARGET')
+    if target == 'mcu-dev' then
+      svc:obs_log('warn', {
+        what = 'preflighter_disabled',
+        component = 'mcu',
+        env = 'DEVICECODE_DEV_SKIP_IMAGE_PREFLIGHT',
+        target = target,
+      })
+      artifacts:set_preflighter('mcu', function(_, _, desc) return desc or {}, nil end)
+    else
+      svc:obs_log('warn', {
+        what = 'preflighter_disable_rejected',
+        component = 'mcu',
+        env = 'DEVICECODE_DEV_SKIP_IMAGE_PREFLIGHT',
+        target = target,
+      })
+    end
+  end
   ctx.artifact_open = function(...)
     return artifacts:open(...)
   end


### PR DESCRIPTION
## Summary

Brings the W4–W12 surface online on the rt-ui base for end-to-end firmware update via `fw-update-e2e`. Companion PR to devicecode-go's `fabric-update`.

- mcu-dev.json: minimal MCU-only dev config (HAL managers, fabric link with per-action `outbound_call_rules`, device + update sections, stage timeout raised to 900s for 115200-baud transfers).
- smoke.lua: hardware bring-up canary (state/self/software observe + prepare RPC + synthetic transfer).
- ui/uploads.lua: forwards `x-transfer-chunk-raw` through artifact-ingest + job metadata, treats lua-http's (nil, nil) as clean EOF, surfaces deadline-relative read timeout.
- ui/service.lua: drops model_seq from publish_main_state's change-detection (was a self-feeding republish loop pinning CPU on every retain).
- update.lua: `DEVICECODE_DEV_SKIP_IMAGE_PREFLIGHT=1` env opt-out for the mcu preflighter, gated to CONFIG_TARGET=mcu-dev. Lets raw sealed .bin artefacts pass until fabric-security ships imagev1 packing.
- device.lua: threads chunk_size from job metadata to the fabric_stage payload.
- fabric/transfer_mgr.lua: honours backward `xfer_need` by rewinding the send cursor (the receiver-driven recovery path the protocol spec assumes).
- fabric/protocol.lua: emits per-chunk xxHash32 `crc` on `xfer_chunk` frames, paired with the Go-side validator. Catches single-byte UART corruption inside the base64 data string that JSON parsing alone misses.

## Test plan

- [ ] `make test` (unit suite)
- [ ] On Tera + a flashed devicecode-go@fabric-update MCU: `fw-update-e2e -n 3` reaches `succeeded` end-to-end.
- [ ] MCU UART log shows `xfer_chunk crc mismatch` and `xfer_need on malformed` lines firing during transfer (recovery converging) without aborting.