### PR TITLE
hal: add op-first HAL drivers, managers and shared blob-transfer primitives

### DIFF
--- a/src/services/hal/drivers/artifact_store.lua
+++ b/src/services/hal/drivers/artifact_store.lua
@@ -1,0 +1,1112 @@
+---@module 'services.hal.drivers.artifact_store'
+
+local fibers    = require 'fibers'
+local op        = require 'fibers.op'
+local file      = require 'fibers.io.file'
+local exec      = require 'fibers.io.exec'
+local channel   = require 'fibers.channel'
+local pulse_mod = require 'fibers.pulse'
+local cjson     = require 'cjson.safe'
+local uuid      = require 'uuid'
+
+local checksum    = require 'shared.hash.xxhash32'
+local blob_source = require 'shared.blob_source'
+
+local M = {}
+
+---@class ArtifactStore
+---@field transient_root string
+---@field durable_root string
+---@field durable_enabled boolean
+---@field import_root string
+---@field logger table|nil
+local Store = {}
+Store.__index = Store
+
+---@class ArtifactHandle
+---@field _store ArtifactStore
+---@field _rec table
+---@field _blob_path string
+local Artifact = {}
+Artifact.__index = Artifact
+
+---@class ArtifactSink
+---@field _cmd_ch Channel
+---@field _closed Pulse
+---@field _artifact_ref string
+---@field _phase string
+---@field _terminal boolean
+---@field _artifact ArtifactHandle|nil
+---@field _last_error string|nil
+local ArtifactSink = {}
+ArtifactSink.__index = ArtifactSink
+
+----------------------------------------------------------------------
+-- Plain helpers
+----------------------------------------------------------------------
+
+local function dlog(logger, level, payload)
+	if logger and logger[level] then
+		logger[level](logger, payload)
+	end
+end
+
+local function join_path(...)
+	return table.concat({ ... }, '/')
+end
+
+local function dirname(path)
+	if path == '/' then
+		return '/'
+	end
+
+	local d = tostring(path or ''):match('^(.*)/[^/]+$')
+	if d == nil or d == '' then
+		return '.'
+	end
+	return d
+end
+
+local function deep_copy(v, seen)
+	if type(v) ~= 'table' then
+		return v
+	end
+
+	seen = seen or {}
+	if seen[v] then
+		return seen[v]
+	end
+
+	local out = {}
+	seen[v] = out
+	for k, x in pairs(v) do
+		out[deep_copy(k, seen)] = deep_copy(x, seen)
+	end
+	return out
+end
+
+local function valid_ref(ref)
+	return type(ref) == 'string'
+		and ref ~= ''
+		and ref:match('^[A-Za-z0-9_.-]+$') ~= nil
+end
+
+local function is_not_found_err(err)
+	if err == nil then
+		return false
+	end
+	local s = tostring(err):lower()
+	return s:find('no such file', 1, true) ~= nil
+		or s:find('not found', 1, true) ~= nil
+		or s:find('enoent', 1, true) ~= nil
+end
+
+local function unwrap_attempt(st, rep, ok, value_or_err)
+	if st ~= 'ok' then
+		return false, tostring(value_or_err or rep)
+	end
+	return ok, value_or_err
+end
+
+local function attempt_op(fn)
+	return fibers.run_scope_op(fn):wrap(unwrap_attempt)
+end
+
+----------------------------------------------------------------------
+-- Durability and paths
+----------------------------------------------------------------------
+
+local function choose_durability(self, policy)
+	policy = policy or 'transient_only'
+
+	if policy == 'require_durable' then
+		if not self.durable_enabled then
+			return nil, 'durable_disabled'
+		end
+		return 'durable'
+	end
+
+	if policy == 'prefer_durable' then
+		if self.durable_enabled then
+			return 'durable'
+		end
+		return 'transient'
+	end
+
+	if policy == 'transient_only' then
+		return 'transient'
+	end
+
+	return nil, 'invalid_policy'
+end
+
+local function root_for(self, durability)
+	if durability == 'durable' then
+		return self.durable_root
+	end
+	return self.transient_root
+end
+
+local function staging_root(self, durability)
+	return join_path(root_for(self, durability), '.staging')
+end
+
+local function staging_dir(self, ref, durability)
+	return join_path(staging_root(self, durability), ref)
+end
+
+local function object_dir(self, ref, durability)
+	return join_path(root_for(self, durability), ref)
+end
+
+local function data_path(dir)
+	return join_path(dir, 'blob.bin')
+end
+
+local function final_meta_path(dir)
+	return join_path(dir, 'meta.json')
+end
+
+local function partial_meta_path(dir)
+	return join_path(dir, 'meta.json.partial')
+end
+
+----------------------------------------------------------------------
+-- Filesystem / process-backed ops
+----------------------------------------------------------------------
+
+-- Keep recursive removal boxed here until the file layer grows an rmdir/remove-tree
+-- primitive. This is now used only where directory removal is genuinely required.
+local function rm_rf_op(path)
+	return exec.command('rm', '-rf', path):run_op():wrap(function (st, code, _sig, err)
+		if st == 'exited' and code == 0 then
+			return true, nil
+		end
+		if st == 'signalled' then
+			return false, 'rm_signalled'
+		end
+		return false, tostring(err or ('rm_failed:' .. tostring(code)))
+	end)
+end
+
+local function mkdir_p_op(path, perms)
+	return attempt_op(function ()
+		local ok, err = file.mkdir_p(path, perms)
+		if not ok then
+			return false, tostring(err)
+		end
+		return true, nil
+	end)
+end
+
+local function rename_path_op(src, dst)
+	return attempt_op(function ()
+		local ok, err = file.rename(src, dst)
+		if not ok then
+			return false, tostring(err)
+		end
+		return true, nil
+	end)
+end
+
+local function unlink_path_op(path, tolerate_missing)
+	return attempt_op(function ()
+		local ok, err = file.unlink(path)
+		if ok then
+			return true, nil
+		end
+		if tolerate_missing and is_not_found_err(err) then
+			return true, nil
+		end
+		return false, tostring(err)
+	end)
+end
+
+local function unlink_known_artifact_files_op(dir)
+	return attempt_op(function ()
+		local ok, err
+
+		ok, err = fibers.perform(unlink_path_op(data_path(dir), true))
+		if not ok then
+			return false, err
+		end
+
+		ok, err = fibers.perform(unlink_path_op(partial_meta_path(dir), true))
+		if not ok then
+			return false, err
+		end
+
+		ok, err = fibers.perform(unlink_path_op(final_meta_path(dir), true))
+		if not ok then
+			return false, err
+		end
+
+		return true, nil
+	end)
+end
+
+local function remove_artifact_dir_op(dir)
+	return attempt_op(function ()
+		local ok, err = fibers.perform(unlink_known_artifact_files_op(dir))
+		if not ok then
+			return false, err
+		end
+
+		local ok_rm, rm_err = fibers.perform(rm_rf_op(dir))
+		if not ok_rm then
+			return false, rm_err
+		end
+
+		return true, nil
+	end)
+end
+
+local function close_best_effort_op(stream)
+	if not stream or not stream.close_op then
+		return op.always(true, nil)
+	end
+
+	return stream:close_op():wrap(function ()
+		return true, nil
+	end)
+end
+
+local function open_stream_now(path, mode)
+	local stream, err = file.open(path, mode)
+	if not stream then
+		return nil, tostring(err)
+	end
+	return stream, nil
+end
+
+local function read_text_op(path)
+	return attempt_op(function (scope)
+		local stream, err = open_stream_now(path, 'r')
+		if not stream then
+			return false, err
+		end
+
+		scope:finally(function ()
+			op.perform_raw(close_best_effort_op(stream))
+		end)
+
+		local body, rerr = fibers.perform(stream:read_all_op())
+		if rerr ~= nil then
+			return false, tostring(rerr)
+		end
+
+		return true, body or ''
+	end)
+end
+
+local function write_atomic_text_op(path, data)
+	return attempt_op(function (scope)
+		local dir = dirname(path)
+		local ok_dir, dir_err = fibers.perform(mkdir_p_op(dir))
+		if not ok_dir then
+			return false, dir_err
+		end
+
+		local stream, err = file.tmpfile(384, dir)
+		if not stream then
+			return false, tostring(err)
+		end
+
+		scope:finally(function ()
+			op.perform_raw(close_best_effort_op(stream))
+		end)
+
+		local n, werr = fibers.perform(stream:write_op(data))
+		if n == nil then
+			return false, tostring(werr or 'write_failed')
+		end
+
+		local okf, ferr = fibers.perform(stream:flush_op())
+		if okf == nil then
+			return false, tostring(ferr or 'flush_failed')
+		end
+
+		local okr, rerr = stream:rename(path)
+		if not okr then
+			return false, tostring(rerr or 'rename_failed')
+		end
+
+		return true, nil
+	end)
+end
+
+local function read_json_op(path)
+	return read_text_op(path):wrap(function (ok, body_or_err)
+		if not ok then
+			return false, body_or_err
+		end
+
+		local obj, derr = cjson.decode(body_or_err)
+		if obj == nil then
+			return false, tostring(derr or 'decode_failed')
+		end
+
+		return true, obj
+	end)
+end
+
+local function write_json_op(path, obj)
+	local raw, err = cjson.encode(obj)
+	if not raw then
+		return op.always(false, tostring(err or 'encode_failed'))
+	end
+	return write_atomic_text_op(path, raw)
+end
+
+----------------------------------------------------------------------
+-- Metadata helpers
+----------------------------------------------------------------------
+
+local function new_ready_record(ref, durability, size, checksum_hex, meta, created_at)
+	local now = os.time()
+	return {
+		version      = 2,
+		artifact_ref = ref,
+		state        = 'ready',
+		durability   = durability,
+		size         = size,
+		checksum     = checksum_hex,
+		created_at   = created_at or now,
+		updated_at   = now,
+		meta         = deep_copy(meta or {}),
+	}
+end
+
+local function new_partial_record(session)
+	return {
+		version      = 2,
+		artifact_ref = session.artifact_ref,
+		state        = session.phase,
+		durability   = session.durability,
+		size         = session.bytes,
+		checksum     = checksum.digest_hex_state(session.checksum_state),
+		created_at   = session.created_at,
+		updated_at   = os.time(),
+		meta         = deep_copy(session.meta or {}),
+		last_error   = session.last_error,
+	}
+end
+
+local function locate_artifact_op(self, ref)
+	return attempt_op(function ()
+		for _, durability in ipairs({ 'transient', 'durable' }) do
+			local dir = object_dir(self, ref, durability)
+			local mp = final_meta_path(dir)
+			local ok, rec_or_err = fibers.perform(read_json_op(mp))
+			if ok then
+				return true, {
+					rec        = rec_or_err,
+					durability = durability,
+					dir        = dir,
+					meta_path  = mp,
+					blob_path  = data_path(dir),
+				}
+			end
+			if not is_not_found_err(rec_or_err) then
+				return false, rec_or_err
+			end
+		end
+		return false, 'not_found'
+	end)
+end
+
+----------------------------------------------------------------------
+-- Artifact ready handle
+----------------------------------------------------------------------
+
+function Artifact:ref()
+	return self._rec.artifact_ref
+end
+
+function Artifact:describe()
+	return deep_copy(self._rec)
+end
+
+function Artifact:local_path()
+	return self._blob_path
+end
+
+function Artifact:open_source_op()
+	return attempt_op(function ()
+		local stream, err = open_stream_now(self._blob_path, 'r')
+		if not stream then
+			return false, err
+		end
+		return true, blob_source.from_stream(stream)
+	end)
+end
+
+----------------------------------------------------------------------
+-- Sink session internals
+----------------------------------------------------------------------
+
+local function sink_terminal_err(phase)
+	if phase == 'committed' then
+		return 'committed'
+	end
+	if phase == 'aborted' then
+		return 'aborted'
+	end
+	if phase == 'closed' then
+		return 'closed'
+	end
+	if phase == 'sealed' then
+		return 'sealed'
+	end
+	return 'closed'
+end
+
+local function make_sink_status_snapshot(session)
+	return {
+		artifact_ref = session.artifact_ref,
+		state        = session.phase,
+		terminal     = session.terminal == true,
+		bytes        = session.bytes,
+		checksum     = checksum.digest_hex_state(session.checksum_state),
+		last_error   = session.last_error,
+	}
+end
+
+local function sink_reply(ch, ok, value, err, terminal, phase)
+	return ch:put_op({
+		ok       = ok,
+		value    = value,
+		err      = err,
+		terminal = terminal and true or false,
+		phase    = phase,
+	})
+end
+
+local function request_reply_op(ch, req, closed)
+	return attempt_op(function ()
+		local reply_ch = channel.new(1)
+		req.reply_ch = reply_ch
+
+		local which, _, close_reason = fibers.perform(fibers.named_choice{
+			sent   = ch:put_op(req),
+			closed = closed:next_op(),
+		})
+
+		if which == 'closed' then
+			return false, tostring(close_reason or 'session_closed')
+		end
+
+		local which2, a, b = fibers.perform(fibers.named_choice{
+			reply  = reply_ch:get_op(),
+			closed = closed:next_op(),
+		})
+
+		if which2 == 'closed' then
+			return false, tostring(b or 'session_closed')
+		end
+
+		local reply = a
+		if not reply then
+			return false, tostring(b or 'reply_missing')
+		end
+
+		if reply.ok then
+			return true, reply.value
+		end
+		return false, tostring(reply.err or 'request_failed')
+	end)
+end
+
+local function commit_sealed_op(session)
+	return attempt_op(function ()
+		local object_parent = root_for(session.store, session.durability)
+		local object_path = object_dir(session.store, session.artifact_ref, session.durability)
+		local meta = new_ready_record(
+			session.artifact_ref,
+			session.durability,
+			session.bytes,
+			checksum.digest_hex_state(session.checksum_state),
+			session.meta,
+			session.created_at
+		)
+
+		local ok_parent, perr = fibers.perform(mkdir_p_op(object_parent))
+		if not ok_parent then
+			return false, perr
+		end
+
+		local ok_meta, merr = fibers.perform(write_json_op(final_meta_path(session.staging_dir), meta))
+		if not ok_meta then
+			return false, merr
+		end
+
+		local ok_mv, mverr = fibers.perform(rename_path_op(session.staging_dir, object_path))
+		if not ok_mv then
+			return false, mverr
+		end
+
+		session.artifact = setmetatable({
+			_store     = session.store,
+			_rec       = meta,
+			_blob_path = data_path(object_path),
+		}, Artifact)
+		session.phase = 'committed'
+		session.terminal = true
+		return true, session.artifact
+	end)
+end
+
+local function session_append_op(session, chunk)
+	if session.phase ~= 'open' then
+		return op.always(false, sink_terminal_err(session.phase))
+	end
+	if type(chunk) ~= 'string' then
+		return op.always(false, 'chunk must be a string')
+	end
+	if session.stream == nil then
+		session.phase = 'aborted'
+		session.terminal = true
+		return op.always(false, 'closed')
+	end
+
+	return session.stream:write_op(chunk):wrap(function (n, err)
+		if n == nil then
+			session.phase = 'aborted'
+			session.terminal = true
+			session.last_error = tostring(err or 'write_failed')
+			return false, session.last_error
+		end
+		checksum.update(session.checksum_state, chunk)
+		session.bytes = session.bytes + #chunk
+		return true, nil
+	end)
+end
+
+local function session_abort_op(session, reason)
+	if session.phase == 'committed' then
+		return op.always(false, 'committed')
+	end
+	if session.phase == 'aborted' or session.phase == 'closed' then
+		session.terminal = true
+		return op.always(true, nil)
+	end
+
+	return attempt_op(function ()
+		if session.stream ~= nil then
+			local _ = fibers.perform(close_best_effort_op(session.stream))
+			session.stream = nil
+		end
+
+		local ok_rm, rm_err = fibers.perform(remove_artifact_dir_op(session.staging_dir))
+		if not ok_rm then
+			return false, rm_err
+		end
+
+		session.last_error = reason and tostring(reason) or session.last_error
+		session.phase = 'aborted'
+		session.terminal = true
+		return true, nil
+	end)
+end
+
+local function session_commit_op(session)
+	if session.phase == 'committed' then
+		return op.always(true, session.artifact)
+	end
+	if session.phase == 'aborted' or session.phase == 'closed' then
+		return op.always(false, sink_terminal_err(session.phase))
+	end
+
+	return fibers.run_scope_op(function ()
+		if session.phase == 'open' or (session.phase == 'sealed' and session.stream ~= nil) then
+			local okf, ferr = fibers.perform(session.stream:flush_op())
+			if okf == nil then
+				session.last_error = tostring(ferr or 'flush_failed')
+				session.phase = 'sealed'
+				return false, session.last_error
+			end
+
+			local okc, cerr = fibers.perform(session.stream:close_op())
+			if okc == nil then
+				session.last_error = tostring(cerr or 'close_failed')
+				session.phase = 'sealed'
+				return false, session.last_error
+			end
+
+			session.stream = nil
+			session.phase = 'sealed'
+		end
+
+		local ok_commit, art_or_err = fibers.perform(commit_sealed_op(session))
+		if not ok_commit then
+			session.last_error = tostring(art_or_err)
+			return false, session.last_error
+		end
+
+		return true, art_or_err
+	end):wrap(unwrap_attempt)
+end
+
+local function handle_session_request_op(session, req)
+	return op.guard(function ()
+		if req.verb == 'append' then
+			return session_append_op(session, req.chunk)
+		elseif req.verb == 'commit' then
+			return session_commit_op(session)
+		elseif req.verb == 'abort' then
+			return session_abort_op(session, req.reason)
+		elseif req.verb == 'close' then
+			if session.phase == 'committed' then
+				session.terminal = true
+				return op.always(true, nil)
+			end
+			return session_abort_op(session, req.reason or 'closed without commit')
+		elseif req.verb == 'status' then
+			return op.always(true, make_sink_status_snapshot(session))
+		end
+		return op.always(false, 'unsupported_sink_verb:' .. tostring(req.verb))
+	end)
+end
+
+local function sink_session_main(session)
+	local scope = assert(session.scope, 'artifact sink session missing scope')
+
+	scope:finally(function ()
+		if session.stream ~= nil then
+			op.perform_raw(close_best_effort_op(session.stream))
+			session.stream = nil
+		end
+		if session.phase ~= 'committed' then
+			op.perform_raw(remove_artifact_dir_op(session.staging_dir))
+		end
+		session.closed:close(session.phase)
+	end)
+
+	while true do
+		local which, a, b = fibers.perform(fibers.named_choice{
+			req  = session.cmd_ch:get_op(),
+			stop = scope:not_ok_op(),
+		})
+
+		if which == 'stop' then
+			if session.phase ~= 'committed' then
+				session.phase = 'aborted'
+				session.terminal = true
+			end
+			return
+		end
+
+		local req = a
+		if not req then
+			if session.phase ~= 'committed' then
+				session.phase = 'aborted'
+				session.terminal = true
+			end
+			return
+		end
+
+		local ok, value_or_err = fibers.perform(handle_session_request_op(session, req))
+		local terminal = session.terminal == true
+		local err = ok and nil or value_or_err
+		local value = ok and value_or_err or nil
+		local _ = fibers.perform(sink_reply(req.reply_ch, ok, value, err, terminal, session.phase))
+
+		if terminal then
+			return
+		end
+	end
+end
+
+----------------------------------------------------------------------
+-- Artifact sink client handle
+----------------------------------------------------------------------
+
+local function sink_status_snapshot_from_handle(self)
+	return {
+		artifact_ref = self._artifact_ref,
+		state        = self._phase,
+		terminal     = self._terminal,
+		last_error   = self._last_error,
+	}
+end
+
+local function sink_request_op(self, verb, payload)
+	return op.guard(function ()
+		if self._terminal then
+			if verb == 'status' then
+				return op.always(true, sink_status_snapshot_from_handle(self))
+			end
+			if verb == 'commit' then
+				if self._phase == 'committed' then
+					return op.always(true, self._artifact)
+				end
+				return op.always(false, sink_terminal_err(self._phase))
+			end
+			if verb == 'close' then
+				return op.always(true, nil)
+			end
+			if verb == 'abort' then
+				if self._phase == 'aborted' or self._phase == 'closed' then
+					return op.always(true, nil)
+				end
+				return op.always(false, sink_terminal_err(self._phase))
+			end
+			return op.always(false, sink_terminal_err(self._phase))
+		end
+
+		return request_reply_op(self._cmd_ch, payload, self._closed):wrap(function (ok, value_or_err)
+			if ok then
+				if verb == 'commit' and type(value_or_err) == 'table' and getmetatable(value_or_err) == Artifact then
+					self._artifact = value_or_err
+					self._phase = 'committed'
+					self._terminal = true
+				elseif verb == 'close' or verb == 'abort' then
+					self._phase = 'aborted'
+					self._terminal = true
+				elseif verb == 'status' and type(value_or_err) == 'table' then
+					self._phase = value_or_err.state or self._phase
+					self._last_error = value_or_err.last_error or self._last_error
+				end
+				return true, value_or_err
+			end
+
+			if verb == 'commit' then
+				self._phase = 'sealed'
+				self._last_error = value_or_err
+			elseif verb == 'abort' or verb == 'close' then
+				self._phase = 'aborted'
+				self._terminal = true
+				self._last_error = value_or_err
+			end
+			return false, value_or_err
+		end)
+	end)
+end
+
+function ArtifactSink:append_op(chunk)
+	return sink_request_op(self, 'append', {
+		verb  = 'append',
+		chunk = chunk,
+	})
+end
+
+function ArtifactSink:write_chunk_op(chunk)
+	return self:append_op(chunk)
+end
+
+function ArtifactSink:commit_op(opts)
+	return sink_request_op(self, 'commit', {
+		verb = 'commit',
+		opts = opts,
+	})
+end
+
+function ArtifactSink:abort_op(reason)
+	return sink_request_op(self, 'abort', {
+		verb   = 'abort',
+		reason = reason,
+	})
+end
+
+function ArtifactSink:close_op()
+	return sink_request_op(self, 'close', {
+		verb = 'close',
+	})
+end
+
+function ArtifactSink:status_op()
+	return sink_request_op(self, 'status', {
+		verb = 'status',
+	})
+end
+
+function ArtifactSink:status()
+	return sink_status_snapshot_from_handle(self)
+end
+
+----------------------------------------------------------------------
+-- Store API
+----------------------------------------------------------------------
+
+function Store:status_op()
+	return op.always(true, {
+		kind            = 'artifact_store',
+		transient_root  = self.transient_root,
+		durable_root    = self.durable_root,
+		durable_enabled = self.durable_enabled,
+		import_root     = self.import_root,
+	})
+end
+
+function Store:create_sink_op(meta, opts)
+	opts = opts or {}
+	return op.guard(function ()
+		local owner_scope = fibers.current_scope()
+		if owner_scope == nil then
+			return op.always(false, 'create_sink_op must be called from inside a fiber')
+		end
+
+		local durability, derr = choose_durability(self, opts.policy)
+		if not durability then
+			return op.always(false, derr)
+		end
+
+		return attempt_op(function (scope)
+			local ref = tostring(uuid.new())
+			local sroot = staging_root(self, durability)
+			local sdir = staging_dir(self, ref, durability)
+			local dpath = data_path(sdir)
+			local pmeta = partial_meta_path(sdir)
+			local created_at = os.time()
+			local handed_off = false
+			local stream = nil
+
+			scope:finally(function ()
+				if not handed_off then
+					if stream ~= nil then
+						op.perform_raw(close_best_effort_op(stream))
+					end
+					op.perform_raw(remove_artifact_dir_op(sdir))
+				end
+			end)
+
+			local ok_root, root_err = fibers.perform(mkdir_p_op(sroot))
+			if not ok_root then
+				return false, root_err
+			end
+
+			local ok_dir, dir_err = fibers.perform(mkdir_p_op(sdir))
+			if not ok_dir then
+				return false, dir_err
+			end
+
+			stream, dir_err = open_stream_now(dpath, 'w')
+			if not stream then
+				return false, dir_err
+			end
+
+			local session_scope, serr = owner_scope:child()
+			if not session_scope then
+				return false, tostring(serr)
+			end
+
+			local session = {
+				store             = self,
+				scope             = session_scope,
+				cmd_ch            = channel.new(8),
+				closed            = pulse_mod.new(),
+				artifact_ref      = ref,
+				durability        = durability,
+				staging_dir       = sdir,
+				data_path         = dpath,
+				partial_meta_path = pmeta,
+				stream            = stream,
+				phase             = 'open',
+				terminal          = false,
+				bytes             = 0,
+				checksum_state    = checksum.new(),
+				meta              = deep_copy(meta or {}),
+				created_at        = created_at,
+				artifact          = nil,
+				last_error        = nil,
+			}
+
+			local ok_spawn, spawn_err = session_scope:spawn(function ()
+				return sink_session_main(session)
+			end)
+			if not ok_spawn then
+				return false, tostring(spawn_err)
+			end
+
+			handed_off = true
+			stream = nil
+
+			return true, setmetatable({
+				_cmd_ch       = session.cmd_ch,
+				_closed       = session.closed,
+				_artifact_ref = ref,
+				_phase        = 'open',
+				_terminal     = false,
+				_artifact     = nil,
+				_last_error   = nil,
+			}, ArtifactSink)
+		end)
+	end)
+end
+
+function Store:open_op(ref)
+	return op.guard(function ()
+		if not valid_ref(ref) then
+			return op.always(false, 'invalid_artifact_ref')
+		end
+		return locate_artifact_op(self, ref):wrap(function (ok, located_or_err)
+			if not ok then
+				return false, located_or_err
+			end
+			local rec = located_or_err.rec
+			if rec.state ~= 'ready' then
+				return false, 'artifact_not_ready'
+			end
+			return true, setmetatable({
+				_store     = self,
+				_rec       = rec,
+				_blob_path = located_or_err.blob_path,
+			}, Artifact)
+		end)
+	end)
+end
+
+function Store:resolve_local_op(ref)
+	return op.guard(function ()
+		if not valid_ref(ref) then
+			return op.always(false, 'invalid_artifact_ref')
+		end
+		return locate_artifact_op(self, ref):wrap(function (ok, located_or_err)
+			if not ok then
+				return false, located_or_err
+			end
+			local rec = located_or_err.rec
+			if rec.state ~= 'ready' then
+				return false, 'artifact_not_ready'
+			end
+			return true, {
+				artifact_ref = rec.artifact_ref,
+				durability   = rec.durability,
+				path         = located_or_err.blob_path,
+				meta         = deep_copy(rec.meta),
+				size         = rec.size,
+				checksum     = rec.checksum,
+				state        = rec.state,
+			}
+		end)
+	end)
+end
+
+local function import_source_attempt_op(self, source, meta, opts)
+	opts = opts or {}
+	return attempt_op(function (scope)
+		local ok_sink, sink_or_err = fibers.perform(self:create_sink_op(meta, opts))
+		if not ok_sink then
+			return false, sink_or_err
+		end
+		local sink = sink_or_err
+
+		scope:finally(function ()
+			if source and source.close_op then
+				op.perform_raw(source:close_op())
+			end
+			if sink and sink.close_op then
+				op.perform_raw(sink:close_op())
+			end
+		end)
+
+		local st, rep, bytes_or_primary = fibers.perform(blob_source.copy_op(source, sink, {
+			close_source = false,
+			close_sink   = false,
+		}))
+		if st ~= 'ok' then
+			return false, tostring(bytes_or_primary or rep)
+		end
+
+		local ok_commit, art_or_err = fibers.perform(sink:commit_op())
+		if not ok_commit then
+			return false, tostring(art_or_err)
+		end
+
+		return true, art_or_err
+	end)
+end
+
+function Store:import_source_op(source, meta, opts)
+	return op.guard(function ()
+		if type(source) ~= 'table' or type(source.read_chunk_op) ~= 'function' then
+			return op.always(false, 'invalid_source')
+		end
+		return import_source_attempt_op(self, source, meta, opts)
+	end)
+end
+
+function Store:import_path_op(path, meta, opts)
+	return op.guard(function ()
+		if type(path) ~= 'string' or path == '' then
+			return op.always(false, 'invalid_path')
+		end
+
+		local resolved = path
+		if resolved:sub(1, 1) ~= '/' then
+			if resolved:find('..', 1, true) or resolved:find('\\', 1, true) then
+				return op.always(false, 'invalid_path')
+			end
+			resolved = join_path(self.import_root, resolved)
+		end
+
+		return attempt_op(function ()
+			local stream, err = open_stream_now(resolved, 'r')
+			if not stream then
+				return false, err
+			end
+			local source = blob_source.from_stream(stream)
+			return fibers.perform(import_source_attempt_op(self, source, meta, opts))
+		end)
+	end)
+end
+
+function Store:delete_op(ref)
+	return op.guard(function ()
+		if not valid_ref(ref) then
+			return op.always(false, 'invalid_artifact_ref')
+		end
+		return attempt_op(function ()
+			local ok, located_or_err = fibers.perform(locate_artifact_op(self, ref))
+			if not ok then
+				if located_or_err == 'not_found' then
+					return true, nil
+				end
+				return false, located_or_err
+			end
+			return fibers.perform(remove_artifact_dir_op(located_or_err.dir))
+		end)
+	end)
+end
+
+----------------------------------------------------------------------
+-- Constructor
+----------------------------------------------------------------------
+
+function M.new(opts, logger)
+	opts = opts or {}
+
+	local transient_root = opts.transient_root
+		or os.getenv('DEVICECODE_ARTIFACT_TRANSIENT_ROOT')
+		or '/run/devicecode/artifacts'
+
+	local durable_root = opts.durable_root
+		or os.getenv('DEVICECODE_ARTIFACT_DURABLE_ROOT')
+		or '/data/devicecode/artifacts'
+
+	local import_root = opts.import_root
+		or os.getenv('DEVICECODE_IMPORT_ARTIFACT_ROOT')
+		or os.getenv('DEVICECODE_ARTIFACT_DIR')
+		or durable_root
+		or transient_root
+
+	local durable_enabled = opts.durable_enabled
+	if durable_enabled == nil then
+		local env = os.getenv('DEVICECODE_DURABLE_ARTIFACTS')
+		durable_enabled = not (env == '0' or env == 'false' or env == 'FALSE')
+	end
+
+	return setmetatable({
+		transient_root  = transient_root,
+		durable_root    = durable_root,
+		durable_enabled = durable_enabled and true or false,
+		import_root     = import_root,
+		logger          = logger,
+	}, Store)
+end
+
+M.Store = Store
+M.Artifact = Artifact
+M.ArtifactSink = ArtifactSink
+
+return M

--- a/src/services/hal/drivers/artifact_store_provider.lua
+++ b/src/services/hal/drivers/artifact_store_provider.lua
@@ -1,0 +1,274 @@
+---@module 'services.hal.drivers.artifact_store_provider'
+
+local fibers       = require 'fibers'
+local sleep        = require 'fibers.sleep'
+local op           = require 'fibers.op'
+local channel      = require 'fibers.channel'
+
+local hal_types    = require 'services.hal.types.core'
+local cap_types    = require 'services.hal.types.capabilities'
+local cap_args     = require 'services.hal.types.capability_args'
+local control_loop = require 'services.hal.support.control_loop'
+
+local backend_mod  = require 'services.hal.drivers.artifact_store'
+
+local M = {}
+
+local CONTROL_Q_LEN         = 8
+local DEFAULT_STOP_TIMEOUT  = 5.0
+
+---@class ArtifactStoreProvider
+---@field id string
+---@field opts table
+---@field logger table|nil
+---@field scope Scope|nil
+---@field control_ch Channel
+---@field emit_ch Channel|nil
+---@field backend any
+---@field started boolean
+---@field caps_applied boolean
+local Driver = {}
+Driver.__index = Driver
+
+local function deep_copy(v, seen)
+	if type(v) ~= 'table' then
+		return v
+	end
+
+	seen = seen or {}
+	if seen[v] then
+		return seen[v]
+	end
+
+	local out = {}
+	seen[v] = out
+	for k, x in pairs(v) do
+		out[deep_copy(k, seen)] = deep_copy(x, seen)
+	end
+	return out
+end
+
+local function dlog(self, level, payload)
+	if self.logger and self.logger[level] then
+		self.logger[level](self.logger, payload)
+	end
+end
+
+local function emit_op(emit_ch, class, id, mode, key, data)
+	return op.guard(function ()
+		local payload, err = hal_types.new.Emit(class, id, mode, key, data)
+		if not payload then
+			return op.always(false, tostring(err))
+		end
+
+		return emit_ch:put_op(payload):wrap(function ()
+			return true, nil
+		end)
+	end)
+end
+
+local function methods_for(self)
+	return {
+		status = function (opts, _request)
+			if opts ~= nil and getmetatable(opts) ~= cap_args.ArtifactStoreStatusOpts then
+				return op.always(false, 'invalid status opts')
+			end
+			return self.backend:status_op()
+		end,
+
+		create_sink = function (opts, _request)
+			if type(opts) ~= 'table' or getmetatable(opts) ~= cap_args.ArtifactStoreCreateSinkOpts then
+				return op.always(false, 'invalid create_sink opts')
+			end
+			return self.backend:create_sink_op(opts.meta, {
+				policy = opts.policy,
+			})
+		end,
+
+		import_path = function (opts, _request)
+			if type(opts) ~= 'table' or getmetatable(opts) ~= cap_args.ArtifactStoreImportPathOpts then
+				return op.always(false, 'invalid import_path opts')
+			end
+			return self.backend:import_path_op(opts.path, opts.meta, {
+				policy = opts.policy,
+			})
+		end,
+
+		import_source = function (opts, _request)
+			if type(opts) ~= 'table' or getmetatable(opts) ~= cap_args.ArtifactStoreImportSourceOpts then
+				return op.always(false, 'invalid import_source opts')
+			end
+			return self.backend:import_source_op(opts.source, opts.meta, {
+				policy = opts.policy,
+			})
+		end,
+
+		open = function (opts, _request)
+			if type(opts) ~= 'table' or getmetatable(opts) ~= cap_args.ArtifactStoreOpenOpts then
+				return op.always(false, 'invalid open opts')
+			end
+			return self.backend:open_op(opts.artifact_ref)
+		end,
+
+		delete = function (opts, _request)
+			if type(opts) ~= 'table' or getmetatable(opts) ~= cap_args.ArtifactStoreDeleteOpts then
+				return op.always(false, 'invalid delete opts')
+			end
+			return self.backend:delete_op(opts.artifact_ref)
+		end,
+	}
+end
+
+local function shell_main(self)
+	assert(self.scope, 'artifact_store shell without scope')
+	assert(self.emit_ch, 'artifact_store shell without emit channel')
+
+	local ok_meta, meta_err = fibers.perform(emit_op(
+		self.emit_ch,
+		'artifact_store',
+		self.id,
+		'meta',
+		'info',
+		{
+			provider = 'hal.artifact_store',
+			version = 2,
+			transient_root = self.backend.transient_root,
+			durable_root = self.backend.durable_root,
+			durable_enabled = self.backend.durable_enabled,
+			import_root = self.backend.import_root,
+		}
+	))
+	if ok_meta ~= true then
+		error(tostring(meta_err or 'initial meta emit failed'), 0)
+	end
+
+	local ok_state, state_err = fibers.perform(emit_op(
+		self.emit_ch,
+		'artifact_store',
+		self.id,
+		'state',
+		'status',
+		{ state = 'available' }
+	))
+	if ok_state ~= true then
+		error(tostring(state_err or 'initial state emit failed'), 0)
+	end
+
+	control_loop.run_request_loop(
+		self.control_ch,
+		methods_for(self),
+		self.logger,
+		'artifact_store'
+	)
+end
+
+function Driver:capabilities_op(emit_ch)
+	return op.guard(function ()
+		if self.caps_applied then
+			return op.always(false, 'capabilities already applied')
+		end
+
+		self.emit_ch = emit_ch
+
+		local cap, err = cap_types.new.ArtifactStoreCapability(self.id, self.control_ch)
+		if not cap then
+			return op.always(false, tostring(err))
+		end
+
+		self.caps_applied = true
+		return op.always(true, { cap })
+	end)
+end
+
+function Driver:start_op(owner_scope)
+	assert(owner_scope ~= nil, 'artifact_store provider start_op: owner_scope is required')
+
+	return op.guard(function ()
+		if self.started then
+			return op.always(false, 'already started')
+		end
+		if not self.caps_applied then
+			return op.always(false, 'capabilities not applied')
+		end
+		if not self.emit_ch then
+			return op.always(false, 'missing emit channel')
+		end
+
+		local shell_scope, err = owner_scope:child()
+		if not shell_scope then
+			return op.always(false, tostring(err))
+		end
+
+		self.scope = shell_scope
+
+		local ok, serr = shell_scope:spawn(function ()
+			return shell_main(self)
+		end)
+		if not ok then
+			self.scope = nil
+			return op.always(false, tostring(serr))
+		end
+
+		self.started = true
+		return op.always(true, nil)
+	end)
+end
+
+function Driver:stop_op(timeout)
+	timeout = timeout or DEFAULT_STOP_TIMEOUT
+
+	return op.guard(function ()
+		if not self.started or not self.scope then
+			return op.always(true, nil)
+		end
+
+		local shell_scope = self.scope
+		shell_scope:cancel('artifact_store provider stopped')
+
+		return fibers.boolean_choice(
+			shell_scope:join_op():wrap(function ()
+				self.started = false
+				self.scope = nil
+				return true, nil
+			end),
+			sleep.sleep_op(timeout):wrap(function ()
+				return false, 'artifact_store provider stop timeout'
+			end)
+		):wrap(function (completed, _a, b)
+			if completed then
+				return true, nil
+			end
+			return false, b
+		end)
+	end)
+end
+
+function Driver:fault_op()
+	if self.scope and self.started then
+		return self.scope:fault_op()
+	end
+	return op.never()
+end
+
+function M.new(id, opts, logger)
+	assert(type(id) == 'string' and id ~= '', 'artifact_store_provider.new: invalid id')
+
+	local raw_opts = opts or {}
+	local injected_backend = raw_opts.backend
+	opts = deep_copy(raw_opts)
+
+	return setmetatable({
+		id           = id,
+		opts         = opts,
+		logger       = logger,
+		scope        = nil,
+		control_ch   = channel.new(CONTROL_Q_LEN),
+		emit_ch      = nil,
+		backend      = injected_backend or backend_mod.new(opts, logger),
+		started      = false,
+		caps_applied = false,
+	}, Driver)
+end
+
+M.Driver = Driver
+return M

--- a/src/services/hal/drivers/control_store.lua
+++ b/src/services/hal/drivers/control_store.lua
@@ -1,0 +1,221 @@
+---@module 'services.hal.drivers.control_store'
+
+local fibers       = require 'fibers'
+local sleep        = require 'fibers.sleep'
+local op           = require 'fibers.op'
+local channel      = require 'fibers.channel'
+
+local hal_types    = require 'services.hal.types.core'
+local cap_types    = require 'services.hal.types.capabilities'
+local cap_args     = require 'services.hal.types.capability_args'
+local control_loop = require 'services.hal.support.control_loop'
+
+local provider_mod = require 'services.hal.drivers.control_store_provider'
+
+local M = {}
+
+local CONTROL_Q_LEN        = 8
+local DEFAULT_STOP_TIMEOUT = 5.0
+
+---@class ControlStoreDriver
+---@field id string
+---@field root string
+---@field scope Scope|nil
+---@field control_ch Channel
+---@field emit_ch Channel|nil
+---@field logger table|nil
+---@field provider ControlStoreProvider
+---@field started boolean
+---@field caps_applied boolean
+local Driver = {}
+Driver.__index = Driver
+
+local function dlog(self, level, payload)
+	if self.logger and self.logger[level] then
+		self.logger[level](self.logger, payload)
+	end
+end
+
+local function emit_op(emit_ch, class, id, mode, key, data)
+	return op.guard(function ()
+		local payload, err = hal_types.new.Emit(class, id, mode, key, data)
+		if not payload then
+			return op.always(false, tostring(err))
+		end
+
+		return emit_ch:put_op(payload):wrap(function ()
+			return true, nil
+		end)
+	end)
+end
+
+local function methods_for(self)
+	return {
+		status = function (opts, request)
+			return self.provider:status_op()
+		end,
+
+		get = function (opts, request)
+			if type(opts) ~= 'table' or getmetatable(opts) ~= cap_args.ControlStoreGetOpts then
+				return op.always(false, 'invalid get opts')
+			end
+			return self.provider:get_op(opts)
+		end,
+
+		put = function (opts, request)
+			if type(opts) ~= 'table' or getmetatable(opts) ~= cap_args.ControlStorePutOpts then
+				return op.always(false, 'invalid put opts')
+			end
+			return self.provider:put_op(opts)
+		end,
+
+		delete = function (opts, request)
+			if type(opts) ~= 'table' or getmetatable(opts) ~= cap_args.ControlStoreDeleteOpts then
+				return op.always(false, 'invalid delete opts')
+			end
+			return self.provider:delete_op(opts)
+		end,
+
+		list = function (opts, request)
+			if opts ~= nil and (type(opts) ~= 'table' or getmetatable(opts) ~= cap_args.ControlStoreListOpts) then
+				return op.always(false, 'invalid list opts')
+			end
+			return self.provider:list_op(opts)
+		end,
+	}
+end
+
+local function shell_main(self)
+	assert(self.scope, 'control_store shell without scope')
+	assert(self.emit_ch, 'control_store shell without emit channel')
+
+	local eok1, eerr1 = fibers.perform(emit_op(self.emit_ch, 'control_store', self.id, 'meta', 'details', {
+		root = self.root,
+		kind = 'control_store',
+	}))
+	if eok1 ~= true then
+		error(tostring(eerr1 or 'initial meta emit failed'), 0)
+	end
+
+	local eok2, eerr2 = fibers.perform(emit_op(self.emit_ch, 'control_store', self.id, 'state', 'status', {
+		state = 'available',
+	}))
+	if eok2 ~= true then
+		error(tostring(eerr2 or 'initial state emit failed'), 0)
+	end
+
+	control_loop.run_request_loop(self.control_ch, methods_for(self), self.logger, 'control_store')
+end
+
+function Driver:capabilities_op(emit_ch)
+	return op.guard(function ()
+		if self.caps_applied then
+			return op.always(false, 'capabilities already applied')
+		end
+
+		self.emit_ch = emit_ch
+
+		local cap, err = cap_types.new.ControlStoreCapability(self.id, self.control_ch)
+		if not cap then
+			return op.always(false, tostring(err))
+		end
+
+		self.caps_applied = true
+		return op.always(true, { cap })
+	end)
+end
+
+---@param owner_scope Scope
+function Driver:start_op(owner_scope)
+	assert(owner_scope ~= nil, 'control_store driver start_op: owner_scope is required')
+
+	return op.guard(function ()
+		if self.started then
+			return op.always(false, 'already started')
+		end
+		if not self.caps_applied then
+			return op.always(false, 'capabilities not applied')
+		end
+		if not self.emit_ch then
+			return op.always(false, 'missing emit channel')
+		end
+
+		local shell_scope, serr = owner_scope:child()
+		if not shell_scope then
+			return op.always(false, tostring(serr))
+		end
+
+		self.scope = shell_scope
+
+		local ok, err = shell_scope:spawn(function ()
+			return shell_main(self)
+		end)
+		if not ok then
+			self.scope = nil
+			return op.always(false, tostring(err))
+		end
+
+		self.started = true
+		return op.always(true, nil)
+	end)
+end
+
+function Driver:stop_op(timeout)
+	timeout = timeout or DEFAULT_STOP_TIMEOUT
+
+	return op.guard(function ()
+		if not self.started or not self.scope then
+			return op.always(true, nil)
+		end
+
+		local shell_scope = self.scope
+		shell_scope:cancel()
+
+		return fibers.boolean_choice(
+			shell_scope:join_op():wrap(function ()
+				self.started = false
+				self.scope   = nil
+				return true, nil
+			end),
+			sleep.sleep_op(timeout):wrap(function ()
+				return false, 'control_store driver stop timeout'
+			end)
+		):wrap(function (completed, a, b)
+			if completed then
+				return true, nil
+			end
+			return false, b
+		end)
+	end)
+end
+
+function Driver:fault_op()
+	if self.scope and self.started then
+		return self.scope:fault_op()
+	end
+	return op.never()
+end
+
+---@param id string
+---@param root string
+---@param logger table|nil
+---@return ControlStoreDriver
+function M.new(id, root, logger)
+	assert(type(id) == 'string' and id ~= '', 'control_store.new: invalid id')
+	assert(type(root) == 'string' and root ~= '', 'control_store.new: invalid root')
+
+	return setmetatable({
+		id           = id,
+		root         = root,
+		scope        = nil,
+		control_ch   = channel.new(CONTROL_Q_LEN),
+		emit_ch      = nil,
+		logger       = logger,
+		provider     = provider_mod.new(root, logger),
+		started      = false,
+		caps_applied = false,
+	}, Driver)
+end
+
+M.Driver = Driver
+return M

--- a/src/services/hal/drivers/control_store_provider.lua
+++ b/src/services/hal/drivers/control_store_provider.lua
@@ -1,0 +1,295 @@
+---@module 'services.hal.drivers.control_store_provider'
+
+local fibers = require 'fibers'
+local op     = require 'fibers.op'
+local file   = require 'fibers.io.file'
+
+local M = {}
+
+---@class ControlStoreProvider
+---@field root string
+---@field logger table|nil
+local Provider = {}
+Provider.__index = Provider
+
+local INDEX_FILE = '.control_store_index'
+
+local function valid_key(key)
+	return type(key) == 'string'
+		and key ~= ''
+		and not key:find('[/\\]', 1)
+		and key:match('^[%w%._%-]+$') ~= nil
+end
+
+local function path_for(root, key)
+	return root .. '/' .. key
+end
+
+local function index_path(root)
+	return root .. '/' .. INDEX_FILE
+end
+
+local function split_lines(s)
+	local out = {}
+	if s == '' then
+		return out
+	end
+	for line in (s .. '\n'):gmatch('(.-)\n') do
+		if line ~= '' then
+			out[#out + 1] = line
+		end
+	end
+	return out
+end
+
+local function join_lines(xs)
+	return table.concat(xs, '\n')
+end
+
+local function sort_unique(xs)
+	local seen, out = {}, {}
+	for _, x in ipairs(xs) do
+		if not seen[x] then
+			seen[x] = true
+			out[#out + 1] = x
+		end
+	end
+	table.sort(out)
+	return out
+end
+
+local function is_not_found_err(err)
+	if err == nil then
+		return false
+	end
+	local s = tostring(err):lower()
+	return s:find('no such file', 1, true) ~= nil
+		or s:find('not found', 1, true) ~= nil
+		or s:find('enoent', 1, true) ~= nil
+end
+
+-- Box the currently synchronous file.open(...) impurity inside a single
+-- operation-owned subtree. The caller still gets a proper Op.
+local function with_open_file_op(path, mode, body_fn)
+	return fibers.run_scope_op(function (scope)
+		local f, err = file.open(path, mode)
+		if not f then
+			return false, tostring(err)
+		end
+
+		scope:finally(function ()
+			-- Best-effort close; this resource belongs to this operation attempt.
+			op.perform_raw(f:close_op())
+		end)
+
+		return body_fn(f)
+	end):wrap(function (st, rep, ok, value_or_err)
+		if st ~= 'ok' then
+			return false, tostring(value_or_err or rep)
+		end
+		return ok, value_or_err
+	end)
+end
+
+local function read_file_required_op(path)
+	return with_open_file_op(path, 'r', function (f)
+		local body, rerr = fibers.perform(f:read_all_op())
+		if rerr ~= nil then
+			return false, tostring(rerr)
+		end
+		return true, body or ''
+	end)
+end
+
+local function read_index_op(root)
+	local path = index_path(root)
+
+	return fibers.run_scope_op(function ()
+		local ok, body_or_err = fibers.perform(read_file_required_op(path))
+		if ok then
+			return true, sort_unique(split_lines(body_or_err))
+		end
+
+		if is_not_found_err(body_or_err) then
+			return true, {}
+		end
+
+		return false, body_or_err
+	end):wrap(function (st, rep, ok, value_or_err)
+		if st ~= 'ok' then
+			return false, tostring(value_or_err or rep)
+		end
+		return ok, value_or_err
+	end)
+end
+
+local function write_file_op(path, data)
+	return with_open_file_op(path, 'w', function (f)
+		local n, werr = fibers.perform(f:write_op(data))
+		if n == nil then
+			return false, tostring(werr)
+		end
+		return true, nil
+	end)
+end
+
+local function write_index_op(root, keys)
+	return write_file_op(index_path(root), join_lines(sort_unique(keys)))
+end
+
+function Provider:status_op()
+	return op.always(true, {
+		root = self.root,
+		kind = 'control_store',
+	})
+end
+
+function Provider:get_op(opts)
+	return op.guard(function ()
+		if type(opts) ~= 'table' or not valid_key(opts.key) then
+			return op.always(false, 'invalid key')
+		end
+
+		return fibers.run_scope_op(function ()
+			local ok_index, keys_or_err = fibers.perform(read_index_op(self.root))
+			if not ok_index then
+				return false, keys_or_err
+			end
+
+			local present = false
+			for _, k in ipairs(keys_or_err) do
+				if k == opts.key then
+					present = true
+					break
+				end
+			end
+			if not present then
+				return false, 'not found'
+			end
+
+			return fibers.perform(read_file_required_op(path_for(self.root, opts.key)))
+		end):wrap(function (st, rep, ok, value_or_err)
+			if st ~= 'ok' then
+				return false, tostring(value_or_err or rep)
+			end
+			return ok, value_or_err
+		end)
+	end)
+end
+
+function Provider:put_op(opts)
+	return op.guard(function ()
+		if type(opts) ~= 'table' or not valid_key(opts.key) then
+			return op.always(false, 'invalid key')
+		end
+		if type(opts.data) ~= 'string' then
+			return op.always(false, 'data must be a string')
+		end
+
+		return fibers.run_scope_op(function ()
+			local okw, werr = fibers.perform(write_file_op(path_for(self.root, opts.key), opts.data))
+			if not okw then
+				return false, werr
+			end
+
+			local ok_index, keys_or_err = fibers.perform(read_index_op(self.root))
+			if not ok_index then
+				return false, keys_or_err
+			end
+
+			keys_or_err[#keys_or_err + 1] = opts.key
+			return fibers.perform(write_index_op(self.root, keys_or_err))
+		end):wrap(function (st, rep, ok, err)
+			if st ~= 'ok' then
+				return false, tostring(err or rep)
+			end
+			return ok, err
+		end)
+	end)
+end
+
+function Provider:delete_op(opts)
+	return op.guard(function ()
+		if type(opts) ~= 'table' or not valid_key(opts.key) then
+			return op.always(false, 'invalid key')
+		end
+
+		return fibers.run_scope_op(function ()
+			local ok_index, keys_or_err = fibers.perform(read_index_op(self.root))
+			if not ok_index then
+				return false, keys_or_err
+			end
+
+			local kept, present = {}, false
+			for _, k in ipairs(keys_or_err) do
+				if k == opts.key then
+					present = true
+				else
+					kept[#kept + 1] = k
+				end
+			end
+			if not present then
+				return false, 'not found'
+			end
+
+			-- Temporary best-effort tombstone/truncate until the lower file layer
+			-- gives us an unlink_op().
+			local okw, werr = fibers.perform(write_file_op(path_for(self.root, opts.key), ''))
+			if not okw then
+				return false, werr
+			end
+
+			return fibers.perform(write_index_op(self.root, kept))
+		end):wrap(function (st, rep, ok, err)
+			if st ~= 'ok' then
+				return false, tostring(err or rep)
+			end
+			return ok, err
+		end)
+	end)
+end
+
+function Provider:list_op(opts)
+	return op.guard(function ()
+		if opts ~= nil and type(opts) ~= 'table' then
+			return op.always(false, 'invalid options')
+		end
+
+		local prefix = opts and opts.prefix or nil
+		if prefix ~= nil and type(prefix) ~= 'string' then
+			return op.always(false, 'invalid prefix')
+		end
+
+		return read_index_op(self.root):wrap(function (ok, keys_or_err)
+			if not ok then
+				return false, keys_or_err
+			end
+
+			if prefix == nil or prefix == '' then
+				return true, keys_or_err
+			end
+
+			local out = {}
+			for _, k in ipairs(keys_or_err) do
+				if k:sub(1, #prefix) == prefix then
+					out[#out + 1] = k
+				end
+			end
+			return true, out
+		end)
+	end)
+end
+
+---@param root string
+---@param logger table|nil
+---@return ControlStoreProvider
+function M.new(root, logger)
+	assert(type(root) == 'string' and root ~= '', 'control_store_provider.new: invalid root')
+	return setmetatable({
+		root   = root,
+		logger = logger,
+	}, Provider)
+end
+
+M.Provider = Provider
+return M

--- a/src/services/hal/drivers/signature_verify_openssl.lua
+++ b/src/services/hal/drivers/signature_verify_openssl.lua
@@ -1,0 +1,162 @@
+---@module 'services.hal.drivers.signature_verify_openssl'
+
+local fibers = require 'fibers'
+local op     = require 'fibers.op'
+local file   = require 'fibers.io.file'
+local exec   = require 'fibers.io.exec'
+
+local M = {}
+
+---@class SignatureVerifyOpenSSL
+---@field file any
+---@field exec any
+---@field tmpdir string
+---@field backend_name string
+local Driver = {}
+Driver.__index = Driver
+
+local function tmpfile_path(stream)
+	if stream and type(stream.filename) == 'function' then
+		return stream:filename()
+	end
+	return nil
+end
+
+local function close_best_effort_op(stream)
+	if not stream or not stream.close_op then
+		return op.always(true, nil)
+	end
+
+	return stream:close_op():wrap(function (_ok, _err)
+		-- Close here is resource hygiene rather than semantic result.
+		return true, nil
+	end)
+end
+
+local function classify_verify_failure(detail)
+	local low = tostring(detail or ''):lower()
+	return low:find('signature verification failure', 1, true) ~= nil
+		or low:find('signature verify failure', 1, true) ~= nil
+		or low:find('verification failure', 1, true) ~= nil
+end
+
+function Driver:verify_ed25519_op(pubkey_pem, message, signature)
+	return op.guard(function ()
+		if type(pubkey_pem) ~= 'string' or pubkey_pem == '' then
+			return op.always(false, 'public_key_required')
+		end
+		if type(message) ~= 'string' then
+			return op.always(false, 'message_required')
+		end
+		if type(signature) ~= 'string' or signature == '' then
+			return op.always(false, 'signature_required')
+		end
+
+		return fibers.run_scope_op(function (scope)
+			local function register_tmp(stream)
+				scope:finally(function ()
+					op.perform_raw(close_best_effort_op(stream))
+				end)
+			end
+
+			local function write_tmp_bytes(label, data)
+				-- Box the currently synchronous tmpfile creation inside one
+				-- operation-owned subtree. Callers still receive a real Op.
+				local stream, err = self.file.tmpfile(384, self.tmpdir)
+				if not stream then
+					return nil, label .. '_tmpfile_failed:' .. tostring(err)
+				end
+
+				register_tmp(stream)
+
+				local path = tmpfile_path(stream)
+				if type(path) ~= 'string' or path == '' then
+					return nil, label .. '_tmpfile_path_unavailable'
+				end
+
+				local n, werr = fibers.perform(stream:write_op(data))
+				if n == nil then
+					return nil, label .. '_write_failed:' .. tostring(werr or 'write_failed')
+				end
+
+				local fok, ferr = fibers.perform(stream:flush_op())
+				if fok == nil then
+					return nil, label .. '_flush_failed:' .. tostring(ferr or 'flush_failed')
+				end
+
+				return { stream = stream, path = path }, nil
+			end
+
+			local pubf, perr = write_tmp_bytes('pubkey', pubkey_pem)
+			if not pubf then
+				return false, perr
+			end
+
+			local msgf, merr = write_tmp_bytes('message', message)
+			if not msgf then
+				return false, merr
+			end
+
+			local sigf, serr = write_tmp_bytes('signature', signature)
+			if not sigf then
+				return false, serr
+			end
+
+			local cmd = self.exec.command(
+				'openssl',
+				'pkeyutl',
+				'-verify',
+				'-pubin',
+				'-inkey',  pubf.path,
+				'-sigfile', sigf.path,
+				'-in',      msgf.path,
+				'-rawin'
+			)
+
+			local out, st, code, sig, cerr = fibers.perform(cmd:combined_output_op())
+			local detail = tostring(cerr or out or '')
+
+			if st == 'exited' and code == 0 then
+				return true, nil
+			end
+
+			if st == 'exited' and code == 1 and classify_verify_failure(detail) then
+				return false, 'signature_verify_failed'
+			end
+
+			if st == 'signalled' then
+				return false, 'openssl_signalled:' .. tostring(sig)
+			end
+
+			if st == 'exited' then
+				if detail == '' then
+					detail = 'exit_' .. tostring(code)
+				end
+				return false, 'openssl_verify_failed:' .. detail
+			end
+
+			if detail == '' then
+				detail = tostring(st or 'unknown')
+			end
+			return false, 'openssl_verify_failed:' .. detail
+		end):wrap(function (st, rep, ok, err)
+			if st ~= 'ok' then
+				return false, tostring(err or rep)
+			end
+			return ok, err
+		end)
+	end)
+end
+
+function M.new(opts)
+	opts = opts or {}
+	return setmetatable({
+		file         = opts.file or file,
+		exec         = opts.exec or exec,
+		tmpdir       = opts.tmpdir or os.getenv('TMPDIR') or '/tmp',
+		backend_name = 'openssl-cli',
+	}, Driver)
+end
+
+M.Driver = Driver
+return M

--- a/src/services/hal/drivers/signature_verify_provider.lua
+++ b/src/services/hal/drivers/signature_verify_provider.lua
@@ -1,0 +1,375 @@
+---@module 'services.hal.drivers.signature_verify_provider'
+
+local fibers       = require 'fibers'
+local sleep        = require 'fibers.sleep'
+local op           = require 'fibers.op'
+local channel      = require 'fibers.channel'
+
+local hal_types    = require 'services.hal.types.core'
+local cap_types    = require 'services.hal.types.capabilities'
+local cap_args     = require 'services.hal.types.capability_args'
+local control_loop = require 'services.hal.support.control_loop'
+
+local backend_mod  = require 'services.hal.drivers.signature_verify_openssl'
+
+local M = {}
+
+local CONTROL_Q_LEN        = 8
+local DONE_Q_LEN           = 32
+local DEFAULT_STOP_TIMEOUT = 5.0
+local DEFAULT_MAX_IN_FLIGHT = 4
+
+---@class SignatureVerifyDone
+---@field reply_ch Channel
+---@field ok boolean
+---@field value_or_err any
+
+---@class SignatureVerifyProvider
+---@field id string
+---@field opts table
+---@field logger table|nil
+---@field scope Scope|nil
+---@field control_ch Channel
+---@field done_ch Channel
+---@field emit_ch Channel|nil
+---@field backend SignatureVerifyOpenSSL
+---@field started boolean
+---@field caps_applied boolean
+---@field in_flight integer
+---@field max_in_flight integer
+local Driver = {}
+Driver.__index = Driver
+
+local function deep_copy(v, seen)
+	if type(v) ~= 'table' then
+		return v
+	end
+
+	seen = seen or {}
+	if seen[v] then
+		return seen[v]
+	end
+
+	local out = {}
+	seen[v] = out
+	for k, x in pairs(v) do
+		out[deep_copy(k, seen)] = deep_copy(x, seen)
+	end
+	return out
+end
+
+local function dlog(self, level, payload)
+	if self.logger and self.logger[level] then
+		self.logger[level](self.logger, payload)
+	end
+end
+
+local function normalise_max_in_flight(v)
+	if v == nil then
+		return DEFAULT_MAX_IN_FLIGHT
+	end
+
+	if type(v) ~= 'number' then
+		error('signature_verify_provider.new: max_in_flight must be a number', 2)
+	end
+
+	if v ~= v or v == math.huge or v == -math.huge then
+		error('signature_verify_provider.new: max_in_flight must be finite', 2)
+	end
+
+	if v % 1 ~= 0 then
+		error('signature_verify_provider.new: max_in_flight must be an integer', 2)
+	end
+
+	if v < 1 then
+		error('signature_verify_provider.new: max_in_flight must be >= 1', 2)
+	end
+
+	return v
+end
+
+local function emit_op(emit_ch, class, id, mode, key, data)
+	return op.guard(function ()
+		local payload, err = hal_types.new.Emit(class, id, mode, key, data)
+		if not payload then
+			return op.always(false, tostring(err))
+		end
+
+		return emit_ch:put_op(payload):wrap(function ()
+			return true, nil
+		end)
+	end)
+end
+
+local function reply_now(self, reply_ch, ok, value_or_err)
+	local sent, err = fibers.perform(control_loop.reply_op(reply_ch, ok, value_or_err))
+	if not sent then
+		dlog(self, 'warn', {
+			what = 'signature_verify_reply_failed',
+			err  = tostring(err),
+		})
+	end
+end
+
+local function validate_verify_opts(opts)
+	if type(opts) ~= 'table' or getmetatable(opts) ~= cap_args.SignatureVerifyEd25519Opts then
+		return false, 'invalid verify_ed25519 opts'
+	end
+	return true, nil
+end
+
+local function spawn_verify_worker(self, request)
+	local ok_opts, opts_err = validate_verify_opts(request.opts)
+	if not ok_opts then
+		reply_now(self, request.reply_ch, false, opts_err)
+		return
+	end
+
+	if self.in_flight >= self.max_in_flight then
+		reply_now(self, request.reply_ch, false, 'busy')
+		return
+	end
+
+	local scope = assert(self.scope, 'signature_verify worker spawn without scope')
+	local opts  = request.opts
+
+	self.in_flight = self.in_flight + 1
+
+	local ok, err = scope:spawn(function ()
+		local vok, verr = fibers.perform(self.backend:verify_ed25519_op(
+			opts.pubkey_pem,
+			opts.message,
+			opts.signature
+		))
+
+		fibers.perform(self.done_ch:put_op({
+			reply_ch      = request.reply_ch,
+			ok            = vok,
+			value_or_err  = verr,
+		}))
+	end)
+
+	if not ok then
+		self.in_flight = self.in_flight - 1
+		reply_now(self, request.reply_ch, false, tostring(err))
+	end
+end
+
+local function handle_request(self, request)
+	if not request then
+		return false
+	end
+
+	if request.verb == 'verify_ed25519' then
+		spawn_verify_worker(self, request)
+		return true
+	end
+
+	reply_now(self, request.reply_ch, false, 'unsupported verb: ' .. tostring(request.verb))
+	return true
+end
+
+local function handle_done(self, done)
+	if not done then
+		return false
+	end
+
+	if self.in_flight > 0 then
+		self.in_flight = self.in_flight - 1
+	end
+
+	reply_now(self, done.reply_ch, done.ok, done.value_or_err)
+	return true
+end
+
+local function shell_main(self)
+	assert(self.scope,   'signature_verify shell without scope')
+	assert(self.emit_ch, 'signature_verify shell without emit channel')
+
+	local meta_ok, meta_err = fibers.perform(emit_op(
+		self.emit_ch,
+		'signature_verify',
+		self.id,
+		'meta',
+		'info',
+		{
+			provider      = 'hal.signature_verify',
+			backend       = self.backend.backend_name or 'openssl-cli',
+			version       = 2,
+			max_in_flight = self.max_in_flight,
+		}
+	))
+	if meta_ok ~= true then
+		error(tostring(meta_err or 'initial meta emit failed'), 0)
+	end
+
+	local st_ok, st_err = fibers.perform(emit_op(
+		self.emit_ch,
+		'signature_verify',
+		self.id,
+		'state',
+		'status',
+		{ state = 'available' }
+	))
+	if st_ok ~= true then
+		error(tostring(st_err or 'initial state emit failed'), 0)
+	end
+
+	local scope = assert(self.scope, 'signature_verify shell without scope')
+
+	while true do
+		local which, a, b = fibers.perform(fibers.named_choice{
+			req  = self.control_ch:get_op(),
+			done = self.done_ch:get_op(),
+			stop = scope:not_ok_op(),
+		})
+
+		if which == 'stop' then
+			local status, reason_or_primary = a, b
+			dlog(self, 'debug', {
+				what      = 'signature_verify_shell_stopping',
+				status    = tostring(status),
+				reason    = tostring(reason_or_primary),
+				in_flight = self.in_flight,
+			})
+			return
+		end
+
+		if which == 'done' then
+			local done = a
+			if not done then
+				return
+			end
+			handle_done(self, done)
+		elseif which == 'req' then
+			local request = a
+			if not request then
+				return
+			end
+			handle_request(self, request)
+		end
+	end
+end
+
+function Driver:capabilities_op(emit_ch)
+	return op.guard(function ()
+		if self.caps_applied then
+			return op.always(false, 'capabilities already applied')
+		end
+
+		self.emit_ch = emit_ch
+
+		local cap, err = cap_types.new.SignatureVerifyCapability(self.id, self.control_ch)
+		if not cap then
+			return op.always(false, tostring(err))
+		end
+
+		self.caps_applied = true
+		return op.always(true, { cap })
+	end)
+end
+
+---@param owner_scope Scope
+function Driver:start_op(owner_scope)
+	assert(owner_scope ~= nil, 'signature_verify provider start_op: owner_scope is required')
+
+	return op.guard(function ()
+		if self.started then
+			return op.always(false, 'already started')
+		end
+		if not self.caps_applied then
+			return op.always(false, 'capabilities not applied')
+		end
+		if not self.emit_ch then
+			return op.always(false, 'missing emit channel')
+		end
+
+		local shell_scope, err = owner_scope:child()
+		if not shell_scope then
+			return op.always(false, tostring(err))
+		end
+
+		self.scope = shell_scope
+
+		local ok, serr = shell_scope:spawn(function ()
+			return shell_main(self)
+		end)
+		if not ok then
+			self.scope = nil
+			return op.always(false, tostring(serr))
+		end
+
+		self.started = true
+		return op.always(true, nil)
+	end)
+end
+
+function Driver:stop_op(timeout)
+	timeout = timeout or DEFAULT_STOP_TIMEOUT
+
+	return op.guard(function ()
+		if not self.started or not self.scope then
+			return op.always(true, nil)
+		end
+
+		local shell_scope = self.scope
+		shell_scope:cancel('signature_verify provider stopped')
+
+		return fibers.boolean_choice(
+			shell_scope:join_op():wrap(function ()
+				self.started   = false
+				self.scope     = nil
+				self.in_flight = 0
+				return true, nil
+			end),
+			sleep.sleep_op(timeout):wrap(function ()
+				return false, 'signature_verify provider stop timeout'
+			end)
+		):wrap(function (completed, _a, b)
+			if completed then
+				return true, nil
+			end
+			return false, b
+		end)
+	end)
+end
+
+function Driver:fault_op()
+	if self.scope and self.started then
+		return self.scope:fault_op()
+	end
+	return op.never()
+end
+
+---@param id string
+---@param opts table|nil
+---@param logger table|nil
+---@return SignatureVerifyProvider
+function M.new(id, opts, logger)
+	assert(type(id) == 'string' and id ~= '', 'signature_verify_provider.new: invalid id')
+
+	local raw_opts = opts or {}
+	local injected_backend = raw_opts.backend
+
+	opts = deep_copy(raw_opts)
+
+	local max_in_flight = normalise_max_in_flight(opts.max_in_flight)
+
+	return setmetatable({
+		id            = id,
+		opts          = opts,
+		logger        = logger,
+		scope         = nil,
+		control_ch    = channel.new(CONTROL_Q_LEN),
+		done_ch       = channel.new(DONE_Q_LEN),
+		emit_ch       = nil,
+		backend       = injected_backend or backend_mod.new(opts),
+		started       = false,
+		caps_applied  = false,
+		in_flight     = 0,
+		max_in_flight = max_in_flight,
+	}, Driver)
+end
+
+M.Driver = Driver
+return M

--- a/src/services/hal/drivers/uart.lua
+++ b/src/services/hal/drivers/uart.lua
@@ -1,0 +1,593 @@
+---@module 'services.hal.drivers.uart'
+
+local fibers    = require 'fibers'
+local sleep     = require 'fibers.sleep'
+local op        = require 'fibers.op'
+local channel   = require 'fibers.channel'
+local file      = require 'fibers.io.file'
+local uuid      = require 'uuid'
+
+local hal_types = require 'services.hal.types.core'
+local cap_types = require 'services.hal.types.capabilities'
+local cap_args  = require 'services.hal.types.capability_args'
+
+local unpack = rawget(table, 'unpack') or _G.unpack
+local pack   = rawget(table, 'pack') or function (...)
+	return { n = select('#', ...), ... }
+end
+
+local M = {}
+
+local CONTROL_Q_LEN        = 8
+local INTERNAL_Q_LEN       = 8
+local DEFAULT_STOP_TIMEOUT = 5.0
+
+---@class UARTSession
+---@field lease_id string
+---@field stream Stream
+---@field internal_ch Channel
+---@field closed boolean
+local UARTSession = {}
+UARTSession.__index = UARTSession
+
+---@class UARTDriver
+---@field id string
+---@field path string
+---@field default_baud integer|nil
+---@field default_mode string|nil
+---@field scope Scope|nil
+---@field control_ch Channel
+---@field internal_ch Channel
+---@field emit_ch Channel|nil
+---@field logger table|nil
+---@field started boolean
+---@field caps_applied boolean
+---@field active_session UARTSession|nil
+---@field active_lease_id string|nil
+local Driver = {}
+Driver.__index = Driver
+
+local function dlog(self, level, payload)
+    if self.logger and self.logger[level] then
+        self.logger[level](self.logger, payload)
+    end
+end
+
+local function emit_op(emit_ch, class, id, mode, key, data)
+    return op.guard(function ()
+        local payload, err = hal_types.new.Emit(class, id, mode, key, data)
+        if not payload then
+            return op.always(false, tostring(err))
+        end
+
+        return emit_ch:put_op(payload):wrap(function ()
+            return true, nil
+        end)
+    end)
+end
+
+local function status_payload(self)
+    return {
+        state         = 'available',
+        available     = true,
+        open          = self.active_session ~= nil,
+        lease_id      = self.active_lease_id,
+        path          = self.path,
+        baud          = self.default_baud,
+        mode          = self.default_mode,
+        config_source = 'devicetree',
+    }
+end
+
+local function meta_payload(self)
+    return {
+        kind          = 'uart',
+        path          = self.path,
+        baud          = self.default_baud,
+        mode          = self.default_mode,
+        config_source = 'devicetree',
+    }
+end
+
+local function reply_request_op(reply_ch, ok, value_or_err)
+    return op.guard(function ()
+        local reply, err = hal_types.new.Reply(ok, value_or_err)
+        if not reply then
+            return op.always(false, 'invalid reply: ' .. tostring(err))
+        end
+
+        return reply_ch:put_op(reply):wrap(function (sent, send_err)
+            if sent == true then
+                return true, nil
+            end
+            if sent == nil then
+                return false, tostring(send_err or 'reply channel closed')
+            end
+            return false, tostring(send_err or 'reply delivery failed')
+        end)
+    end)
+end
+
+local function new_session(lease_id, stream, internal_ch)
+    return setmetatable({
+        lease_id    = lease_id,
+        stream      = stream,
+        internal_ch = internal_ch,
+        closed      = false,
+    }, UARTSession)
+end
+
+function UARTSession:read_some_op(max)
+    return op.guard(function ()
+        if self.closed then
+            return op.always(nil, 'uart session closed')
+        end
+        return self.stream:read_some_op(max)
+    end)
+end
+
+function UARTSession:read_exactly_op(n)
+    return op.guard(function ()
+        if self.closed then
+            return op.always(nil, 'uart session closed')
+        end
+        return self.stream:read_exactly_op(n)
+    end)
+end
+
+function UARTSession:read_line_op(opts)
+    return op.guard(function ()
+        if self.closed then
+            return op.always(nil, 'uart session closed')
+        end
+        return self.stream:read_line_op(opts)
+    end)
+end
+
+function UARTSession:read_all_op()
+    return op.guard(function ()
+        if self.closed then
+            return op.always('', 'uart session closed')
+        end
+        return self.stream:read_all_op()
+    end)
+end
+
+function UARTSession:write_op(...)
+    local parts = { ... }
+    return op.guard(function ()
+        if self.closed then
+            return op.always(nil, 'uart session closed')
+        end
+        return self.stream:write_op(unpack(parts))
+    end)
+end
+
+function UARTSession:flush_op()
+    return op.guard(function ()
+        if self.closed then
+            return op.always(nil, 'uart session closed')
+        end
+        return self.stream:flush_op()
+    end)
+end
+
+-- Close the underlying stream and best-effort notify the driver shell.
+-- If notification fails because the shell is already stopping, close still
+-- succeeds; the session is closed regardless.
+function UARTSession:close_op()
+    return fibers.run_scope_op(function ()
+        if self.closed then
+            return true, nil
+        end
+
+        local ok, err = fibers.perform(self.stream:close_op())
+        if ok == nil then
+            return false, tostring(err)
+        end
+
+        self.closed = true
+
+        local sent, send_err = fibers.perform(self.internal_ch:put_op({
+            kind     = 'session_closed',
+            lease_id = self.lease_id,
+        }))
+
+        -- Explicit best-effort semantics: close wins even if shell notification
+        -- cannot be delivered because the driver is already shutting down.
+        if sent ~= true then
+            return true, nil
+        end
+
+        return true, nil
+    end):wrap(function (st, rep, ok, err)
+        if st ~= 'ok' then
+            return false, tostring(err or rep)
+        end
+        return ok, err
+    end)
+end
+
+local function open_stream_op(path)
+    return fibers.run_scope_op(function ()
+        -- Box the currently synchronous file.open(...) impurity inside one
+        -- operation-owned subtree. Surface remains op-native.
+        local stream, err = file.open(path, 'r+')
+        if not stream then
+            return false, tostring(err)
+        end
+        return true, stream
+    end):wrap(function (st, rep, ok, value_or_err)
+        if st ~= 'ok' then
+            return false, tostring(value_or_err or rep)
+        end
+        return ok, value_or_err
+    end)
+end
+
+local function open_session_op(self)
+    return fibers.run_scope_op(function ()
+        local ok, stream_or_err = fibers.perform(open_stream_op(self.path))
+        if not ok then
+            return false, stream_or_err
+        end
+
+        local lease_id = uuid.new()
+        local session = new_session(lease_id, stream_or_err, self.internal_ch)
+
+        local reply, rerr = hal_types.new.UARTOpenReply(
+            lease_id,
+            session,
+            self.path,
+            self.default_baud,
+            self.default_mode
+        )
+        if not reply then
+            local _ = fibers.perform(stream_or_err:close_op())
+            _ = _
+            return false, tostring(rerr)
+        end
+
+        return true, reply
+    end):wrap(function (st, rep, ok, value_or_err)
+        if st ~= 'ok' then
+            return false, tostring(value_or_err or rep)
+        end
+        return ok, value_or_err
+    end)
+end
+
+local function publish_status_op(self)
+    return emit_op(self.emit_ch, 'uart', self.id, 'state', 'status', status_payload(self))
+end
+
+local function publish_event_op(self, event_name, data)
+    return emit_op(self.emit_ch, 'uart', self.id, 'event', event_name, data)
+end
+
+local function close_active_session_op(self, emit_closed_event)
+    return fibers.run_scope_op(function ()
+        local session = self.active_session
+        local lease_id = self.active_lease_id
+
+        if not session then
+            return true, nil
+        end
+
+        if not session.closed then
+            local ok, err = fibers.perform(session.stream:close_op())
+            if ok == nil then
+                return false, tostring(err)
+            end
+            session.closed = true
+        end
+
+        self.active_session  = nil
+        self.active_lease_id = nil
+
+        local ok_status, status_err = fibers.perform(publish_status_op(self))
+        if not ok_status then
+            return false, tostring(status_err)
+        end
+
+        if emit_closed_event then
+            local ok_event, event_err = fibers.perform(publish_event_op(self, 'closed', {
+                lease_id = lease_id,
+                path     = self.path,
+            }))
+            if not ok_event then
+                return false, tostring(event_err)
+            end
+        end
+
+        return true, nil
+    end):wrap(function (st, rep, ok, err)
+        if st ~= 'ok' then
+            return false, tostring(err or rep)
+        end
+        return ok, err
+    end)
+end
+
+local function methods_for(self)
+    return {
+        status = function (_opts, _request)
+            return op.always(true, status_payload(self))
+        end,
+
+        open = function (opts, _request)
+            if opts ~= nil and (type(opts) ~= 'table' or getmetatable(opts) ~= cap_args.UARTOpenOpts) then
+                return op.always(false, 'invalid open opts')
+            end
+
+            if self.active_session ~= nil then
+                return op.always(false, 'busy')
+            end
+
+            return fibers.run_scope_op(function ()
+                local ok, reply_or_err = fibers.perform(open_session_op(self))
+                if not ok then
+                    return false, reply_or_err
+                end
+
+                self.active_session  = reply_or_err.session
+                self.active_lease_id = reply_or_err.lease_id
+
+                local ok_status, status_err = fibers.perform(publish_status_op(self))
+                if not ok_status then
+                    return false, tostring(status_err)
+                end
+
+                local ok_event, event_err = fibers.perform(publish_event_op(self, 'opened', {
+                    lease_id = reply_or_err.lease_id,
+                    path     = self.path,
+                }))
+                if not ok_event then
+                    return false, tostring(event_err)
+                end
+
+                return true, reply_or_err
+            end):wrap(function (st, rep, ok, value_or_err)
+                if st ~= 'ok' then
+                    return false, tostring(value_or_err or rep)
+                end
+                return ok, value_or_err
+            end)
+        end,
+    }
+end
+
+local function handle_internal_event_op(self, ev)
+    return op.guard(function ()
+        if type(ev) ~= 'table' then
+            return op.always(true, nil)
+        end
+
+        if ev.kind ~= 'session_closed' then
+            return op.always(true, nil)
+        end
+
+        if self.active_lease_id ~= ev.lease_id then
+            return op.always(true, nil)
+        end
+
+        return close_active_session_op(self, true)
+    end)
+end
+
+local function handle_request_op(self, request)
+    return fibers.run_scope_op(function ()
+        local methods = methods_for(self)
+        local fn = methods[request.verb]
+
+        local ok, value_or_err
+        if type(fn) ~= 'function' then
+            ok = false
+            value_or_err = 'unsupported verb: ' .. tostring(request.verb)
+        else
+            ok, value_or_err = fibers.perform(fn(request.opts, request))
+        end
+
+        local replied, reply_err =
+            fibers.perform(reply_request_op(request.reply_ch, ok, value_or_err))
+
+        if not replied then
+            return false, tostring(reply_err)
+        end
+
+        return true, nil
+    end):wrap(function (st, rep, ok, err)
+        if st ~= 'ok' then
+            return false, tostring(err or rep)
+        end
+        return ok, err
+    end)
+end
+
+local function shell_main(self)
+    assert(self.scope, 'uart shell without scope')
+    assert(self.emit_ch, 'uart shell without emit channel')
+
+    local ok_meta, meta_err =
+        fibers.perform(emit_op(self.emit_ch, 'uart', self.id, 'meta', 'details', meta_payload(self)))
+    if ok_meta ~= true then
+        error(tostring(meta_err or 'initial uart meta emit failed'), 0)
+    end
+
+    local ok_status, status_err = fibers.perform(publish_status_op(self))
+    if ok_status ~= true then
+        error(tostring(status_err or 'initial uart status emit failed'), 0)
+    end
+
+    while true do
+        local which, a, b = fibers.perform(fibers.named_choice{
+            req  = self.control_ch:get_op(),
+            evt  = self.internal_ch:get_op(),
+            stop = self.scope:not_ok_op(),
+        })
+
+        if which == 'stop' then
+            local ok_close, close_err = fibers.perform(close_active_session_op(self, false))
+            if not ok_close then
+                dlog(self, 'warn', {
+                    what = 'uart_close_on_stop_failed',
+                    err  = tostring(close_err),
+                })
+            end
+            return
+        end
+
+        if which == 'evt' then
+            local ok_evt, evt_err = fibers.perform(handle_internal_event_op(self, a))
+            if not ok_evt then
+                error(tostring(evt_err), 0)
+            end
+        end
+
+        if which == 'req' then
+            local request, req_err = a, b
+            if not request then
+                return
+            end
+
+            local ok_req, req_err2 = fibers.perform(handle_request_op(self, request))
+            if not ok_req then
+                dlog(self, 'warn', {
+                    what = 'uart_request_failed',
+                    err  = tostring(req_err2),
+                })
+            end
+        end
+    end
+end
+
+function Driver:capabilities_op(emit_ch)
+    return op.guard(function ()
+        if self.caps_applied then
+            return op.always(false, 'capabilities already applied')
+        end
+
+        self.emit_ch = emit_ch
+
+        local cap, err = cap_types.new.UARTCapability(self.id, self.control_ch)
+        if not cap then
+            return op.always(false, tostring(err))
+        end
+
+        self.caps_applied = true
+        return op.always(true, { cap })
+    end)
+end
+
+---@param owner_scope Scope
+function Driver:start_op(owner_scope)
+    assert(owner_scope ~= nil, 'uart driver start_op: owner_scope is required')
+
+    return op.guard(function ()
+        if self.started then
+            return op.always(false, 'already started')
+        end
+        if not self.caps_applied then
+            return op.always(false, 'capabilities not applied')
+        end
+        if not self.emit_ch then
+            return op.always(false, 'missing emit channel')
+        end
+
+        local shell_scope, serr = owner_scope:child()
+        if not shell_scope then
+            return op.always(false, tostring(serr))
+        end
+
+        self.scope = shell_scope
+
+        local ok, err = shell_scope:spawn(function ()
+            return shell_main(self)
+        end)
+        if not ok then
+            self.scope = nil
+            return op.always(false, tostring(err))
+        end
+
+        self.started = true
+        return op.always(true, nil)
+    end)
+end
+
+function Driver:stop_op(timeout)
+    timeout = timeout or DEFAULT_STOP_TIMEOUT
+
+    return op.guard(function ()
+        if not self.started or not self.scope then
+            return op.always(true, nil)
+        end
+
+        local shell_scope = self.scope
+        local session = self.active_session
+
+        shell_scope:cancel()
+
+        return fibers.boolean_choice(
+            shell_scope:join_op():wrap(function ()
+                -- Make the post-stop contract explicit: any previously returned
+                -- session wrapper is no longer usable, even if the shell stop
+                -- path did not get to mark it in time.
+                if session then
+                    session.closed = true
+                end
+
+                self.started         = false
+                self.scope           = nil
+                self.active_session  = nil
+                self.active_lease_id = nil
+                return true, nil
+            end),
+            sleep.sleep_op(timeout):wrap(function ()
+                return false, 'uart driver stop timeout'
+            end)
+        ):wrap(function (completed, _a, b)
+            if completed then
+                return true, nil
+            end
+            return false, b
+        end)
+    end)
+end
+
+function Driver:fault_op()
+    if self.scope and self.started then
+        return self.scope:fault_op()
+    end
+    return op.never()
+end
+
+---@param id string
+---@param path string
+---@param baud integer|nil
+---@param mode string|nil
+---@param logger table|nil
+---@return UARTDriver
+function M.new(id, path, baud, mode, logger)
+    assert(type(id) == 'string' and id ~= '', 'uart.new: invalid id')
+    assert(type(path) == 'string' and path ~= '', 'uart.new: invalid path')
+
+    return setmetatable({
+        id              = id,
+        path            = path,
+        default_baud    = baud,
+        default_mode    = mode,
+        scope           = nil,
+        control_ch      = channel.new(CONTROL_Q_LEN),
+        internal_ch     = channel.new(INTERNAL_Q_LEN),
+        emit_ch         = nil,
+        logger          = logger,
+        started         = false,
+        caps_applied    = false,
+        active_session  = nil,
+        active_lease_id = nil,
+    }, Driver)
+end
+
+M.Driver = Driver
+M.UARTSession = UARTSession
+return M

--- a/src/services/hal/managers/artifact_store.lua
+++ b/src/services/hal/managers/artifact_store.lua
@@ -1,0 +1,434 @@
+---@module 'services.hal.managers.artifact_store'
+
+local fibers     = require 'fibers'
+local op         = require 'fibers.op'
+local sleep      = require 'fibers.sleep'
+local channel    = require 'fibers.channel'
+
+local hal_types  = require 'services.hal.types.core'
+local driver_mod = require 'services.hal.drivers.artifact_store_provider'
+
+local M = {
+	__op_only = true,
+}
+
+local STOP_TIMEOUT = 5.0
+
+---@class ArtifactStoreManagerState
+---@field started boolean
+---@field scope Scope|nil
+---@field logger table|nil
+---@field dev_ev_ch Channel|nil
+---@field cap_emit_ch Channel|nil
+---@field cfg_ch Channel
+---@field drivers table<string, any>
+local S = {
+	started     = false,
+	scope       = nil,
+	logger      = nil,
+	dev_ev_ch   = nil,
+	cap_emit_ch = nil,
+	cfg_ch      = channel.new(8),
+	drivers     = {},
+}
+
+local function dlog(logger, level, payload)
+	if logger and logger[level] then
+		logger[level](logger, payload)
+	end
+end
+
+local function child_logger(id)
+	if S.logger and S.logger.child then
+		return S.logger:child({
+			component = 'driver',
+			driver    = 'artifact_store',
+			id        = id,
+		})
+	end
+	return S.logger
+end
+
+local function validate_config(cfg)
+	cfg = cfg or {}
+
+	if type(cfg) ~= 'table' then
+		return false, 'artifact_store config must be a table'
+	end
+
+	local specs = cfg.stores
+	if specs == nil and cfg[1] == nil then
+		specs = { { id = 'main' } }
+	elseif specs == nil then
+		specs = cfg
+	end
+
+	if type(specs) ~= 'table' then
+		return false, 'artifact_store.stores must be a table'
+	end
+
+	local seen = {}
+	for i, rec in ipairs(specs) do
+		if type(rec) ~= 'table' then
+			return false, ('artifact_store.stores[%d] must be a table'):format(i)
+		end
+
+		local id = rec.id or rec.name or 'main'
+		if type(id) ~= 'string' or id == '' then
+			return false, ('artifact_store.stores[%d].id must be a non-empty string'):format(i)
+		end
+
+		if seen[id] then
+			return false, 'duplicate artifact_store provider id: ' .. id
+		end
+		seen[id] = true
+	end
+
+	return true, nil
+end
+
+local function normalise_config(cfg)
+	local specs = cfg.stores
+	if specs == nil and cfg[1] == nil then
+		specs = { { id = 'main' } }
+	elseif specs == nil then
+		specs = cfg
+	end
+
+	local out = {}
+	for i = 1, #specs do
+		local rec = specs[i]
+		local id = rec.id or rec.name or 'main'
+		local opts = {}
+		for k, v in pairs(rec) do
+			if k ~= 'id' and k ~= 'name' then
+				opts[k] = v
+			end
+		end
+		out[id] = { id = id, opts = opts }
+	end
+	return out
+end
+
+local function deep_equal(a, b, seen)
+	if a == b then
+		return true
+	end
+
+	local ta, tb = type(a), type(b)
+	if ta ~= tb then
+		return false
+	end
+
+	if ta ~= 'table' then
+		return false
+	end
+
+	seen = seen or {}
+	if seen[a] and seen[a] == b then
+		return true
+	end
+	seen[a] = b
+
+	for k, va in pairs(a) do
+		if not deep_equal(va, b[k], seen) then
+			return false
+		end
+	end
+
+	for k in pairs(b) do
+		if a[k] == nil then
+			return false
+		end
+	end
+
+	return true
+end
+
+local function driver_matches_spec(driver, spec)
+	if not driver or not spec then
+		return false
+	end
+
+	return deep_equal(driver.opts or {}, spec.opts or {})
+end
+
+local function emit_device_added_op(driver, caps)
+	return op.guard(function ()
+		local ev, err = hal_types.new.DeviceEvent(
+			'added',
+			'artifact_store',
+			driver.id,
+			{ provider = 'hal.artifact_store' },
+			caps
+		)
+		if not ev then
+			return op.always(false, tostring(err))
+		end
+
+		return S.dev_ev_ch:put_op(ev):wrap(function ()
+			return true, nil
+		end)
+	end)
+end
+
+local function emit_device_removed_op(driver)
+	return op.guard(function ()
+		local ev, err = hal_types.new.DeviceEvent(
+			'removed',
+			'artifact_store',
+			driver.id,
+			{ provider = 'hal.artifact_store' },
+			{}
+		)
+		if not ev then
+			return op.always(false, tostring(err))
+		end
+
+		return S.dev_ev_ch:put_op(ev):wrap(function ()
+			return true, nil
+		end)
+	end)
+end
+
+local function start_driver_op(id, opts)
+	return fibers.run_scope_op(function ()
+		local driver = driver_mod.new(id, opts, child_logger(id))
+
+		local ok_caps, caps_or_err = fibers.perform(driver:capabilities_op(S.cap_emit_ch))
+		if not ok_caps then
+			return false, tostring(caps_or_err)
+		end
+		local caps = caps_or_err
+
+		local started = false
+		local handed_off = false
+
+		local function cleanup_started_driver()
+			if started and not handed_off then
+				op.perform_raw(driver:stop_op())
+			end
+		end
+
+		fibers.current_scope():finally(function ()
+			cleanup_started_driver()
+		end)
+
+		local ok_start, start_err =
+			fibers.perform(driver:start_op(assert(S.scope, 'artifact_store manager scope missing')))
+		if not ok_start then
+			return false, tostring(start_err)
+		end
+		started = true
+
+		local ok_emit, emit_err = fibers.perform(emit_device_added_op(driver, caps))
+		if not ok_emit then
+			return false, tostring(emit_err)
+		end
+
+		S.drivers[id] = driver
+		handed_off = true
+		return true, nil
+	end):wrap(function (st, rep, ok, err)
+		if st ~= 'ok' then
+			return false, tostring(err or rep)
+		end
+		return ok, err
+	end)
+end
+
+local function stop_driver_op(id, driver)
+	return fibers.run_scope_op(function ()
+		local ok_emit, emit_err = fibers.perform(emit_device_removed_op(driver))
+		if not ok_emit then
+			return false, tostring(emit_err)
+		end
+
+		local ok_stop, stop_err = fibers.perform(driver:stop_op())
+		if not ok_stop then
+			return false, tostring(stop_err)
+		end
+
+		S.drivers[id] = nil
+		return true, nil
+	end):wrap(function (st, rep, ok, err)
+		if st ~= 'ok' then
+			return false, tostring(err or rep)
+		end
+		return ok, err
+	end)
+end
+
+local function reconcile_op(cfg)
+	return fibers.run_scope_op(function ()
+		local desired = normalise_config(cfg)
+
+		for id, driver in pairs(S.drivers) do
+			local spec = desired[id]
+			local should_remove =
+				(spec == nil)
+				or (not driver_matches_spec(driver, spec))
+
+			if should_remove then
+				local ok_stop, stop_err = fibers.perform(stop_driver_op(id, driver))
+				if not ok_stop then
+					return false, stop_err
+				end
+			end
+		end
+
+		for id, spec in pairs(desired) do
+			if not S.drivers[id] then
+				local ok_start, start_err = fibers.perform(start_driver_op(id, spec.opts))
+				if not ok_start then
+					return false, start_err
+				end
+			end
+		end
+
+		return true, nil
+	end):wrap(function (st, rep, ok, err)
+		if st ~= 'ok' then
+			return false, tostring(err or rep)
+		end
+		return ok, err
+	end)
+end
+
+local function shell_loop()
+	local scope = assert(S.scope, 'artifact_store shell without scope')
+
+	while true do
+		local which, a, b = fibers.perform(fibers.named_choice{
+			cfg  = S.cfg_ch:get_op(),
+			stop = scope:not_ok_op(),
+		})
+
+		if which == 'stop' then
+			local status, reason_or_primary = a, b
+			dlog(S.logger, 'debug', {
+				what   = 'artifact_store_shell_stopping',
+				status = tostring(status),
+				reason = tostring(reason_or_primary),
+			})
+			return
+		end
+
+		local req = a
+		if not req then
+			return
+		end
+
+		local ok, err = fibers.perform(reconcile_op(req.config))
+		fibers.perform(req.reply_ch:put_op({
+			ok  = ok,
+			err = err,
+		}))
+	end
+end
+
+function M.start_op(logger, dev_ev_ch, cap_emit_ch)
+	local owner_scope = fibers.current_scope()
+	assert(owner_scope ~= nil, 'artifact_store.start_op must be called from inside a fiber')
+
+	return op.guard(function ()
+		if S.started then
+			return op.always(false, 'already started')
+		end
+
+		local scope, err = owner_scope:child()
+		if not scope then
+			return op.always(false, tostring(err))
+		end
+
+		S.scope       = scope
+		S.logger      = logger
+		S.dev_ev_ch   = dev_ev_ch
+		S.cap_emit_ch = cap_emit_ch
+
+		local ok, serr = scope:spawn(shell_loop)
+		if not ok then
+			S.scope       = nil
+			S.logger      = nil
+			S.dev_ev_ch   = nil
+			S.cap_emit_ch = nil
+			return op.always(false, tostring(serr))
+		end
+
+		S.started = true
+		return op.always(true, nil)
+	end)
+end
+
+function M.apply_config_op(cfg)
+	return fibers.run_scope_op(function ()
+		local ok, err = validate_config(cfg)
+		if not ok then
+			return false, err
+		end
+		if not S.started then
+			return false, 'artifact_store manager not started'
+		end
+
+		local reply_ch = channel.new(1)
+
+		fibers.perform(S.cfg_ch:put_op({
+			config   = cfg,
+			reply_ch = reply_ch,
+		}))
+
+		local reply, recv_err = fibers.perform(reply_ch:get_op())
+		if not reply then
+			return false, tostring(recv_err or 'config reply missing')
+		end
+
+		return reply.ok, reply.err
+	end):wrap(function (st, rep, ok, err)
+		if st ~= 'ok' then
+			return false, tostring(err or rep)
+		end
+		return ok, err
+	end)
+end
+
+function M.stop_op(timeout)
+	timeout = timeout or STOP_TIMEOUT
+
+	return op.guard(function ()
+		if not S.started or not S.scope then
+			return op.always(true, nil)
+		end
+
+		local scope = S.scope
+		scope:cancel('artifact_store manager stopped')
+
+		return fibers.boolean_choice(
+			scope:join_op():wrap(function ()
+				S.started     = false
+				S.scope       = nil
+				S.logger      = nil
+				S.dev_ev_ch   = nil
+				S.cap_emit_ch = nil
+				S.drivers     = {}
+				return true, nil
+			end),
+			sleep.sleep_op(timeout):wrap(function ()
+				return false, 'artifact_store manager stop timeout'
+			end)
+		):wrap(function (completed, _a, b)
+			if completed then
+				return true, nil
+			end
+			return false, b
+		end)
+	end)
+end
+
+function M.fault_op()
+	if S.scope and S.started then
+		return S.scope:fault_op()
+	end
+	return op.never()
+end
+
+return M

--- a/src/services/hal/managers/control_store.lua
+++ b/src/services/hal/managers/control_store.lua
@@ -1,0 +1,324 @@
+---@module 'services.hal.managers.control_store'
+
+local fibers    = require 'fibers'
+local op        = require 'fibers.op'
+local sleep     = require 'fibers.sleep'
+local channel   = require 'fibers.channel'
+
+local hal_types  = require 'services.hal.types.core'
+local driver_mod = require 'services.hal.drivers.control_store'
+
+local M = {
+    __op_only = true,
+}
+
+local STOP_TIMEOUT = 5.0
+
+---@class ControlStoreManagerState
+---@field started boolean
+---@field scope Scope|nil
+---@field logger table|nil
+---@field dev_ev_ch Channel|nil
+---@field cap_emit_ch Channel|nil
+---@field cfg_ch Channel
+---@field drivers table<string, ControlStoreDriver>
+local S = {
+    started     = false,
+    scope       = nil,
+    logger      = nil,
+    dev_ev_ch   = nil,
+    cap_emit_ch = nil,
+    cfg_ch      = channel.new(8),
+    drivers     = {},
+}
+
+local function validate_config(namespaces)
+    if type(namespaces) ~= 'table' then
+        return false, 'config must be a list'
+    end
+    for _, ns in ipairs(namespaces) do
+        if type(ns) ~= 'table' then
+            return false, 'each namespace must be a table'
+        end
+        if type(ns.name) ~= 'string' or ns.name == '' then
+            return false, 'namespace.name must be a non-empty string'
+        end
+        if type(ns.root) ~= 'string' or ns.root == '' then
+            return false, 'namespace.root must be a non-empty string'
+        end
+    end
+    return true, nil
+end
+
+local function emit_device_added_op(driver, caps)
+    return op.guard(function ()
+        local ev, err = hal_types.new.DeviceEvent(
+            'added',
+            'control_store',
+            driver.id,
+            { root = driver.root, source = 'control_store_manager' },
+            caps
+        )
+        if not ev then
+            return op.always(false, tostring(err))
+        end
+        return S.dev_ev_ch:put_op(ev):wrap(function ()
+            return true, nil
+        end)
+    end)
+end
+
+local function emit_device_removed_op(driver)
+    return op.guard(function ()
+        local ev, err = hal_types.new.DeviceEvent(
+            'removed',
+            'control_store',
+            driver.id,
+            {},
+            {}
+        )
+        if not ev then
+            return op.always(false, tostring(err))
+        end
+        return S.dev_ev_ch:put_op(ev):wrap(function ()
+            return true, nil
+        end)
+    end)
+end
+
+local function start_driver_op(name, root)
+    return fibers.run_scope_op(function ()
+        local driver = driver_mod.new(name, root, S.logger)
+
+        local ok_caps, caps_or_err = fibers.perform(driver:capabilities_op(S.cap_emit_ch))
+        if not ok_caps then
+        return false, tostring(caps_or_err)
+        end
+        local caps = caps_or_err
+
+        local started = false
+        local handed_off = false
+
+        local function cleanup_started_driver()
+        if started and not handed_off then
+            -- Best-effort rollback; this resource belongs to this start attempt
+            op.perform_raw(driver:stop_op())
+        end
+        end
+
+        -- If anything below errors, rollback the started driver.
+        fibers.current_scope():finally(function ()
+        cleanup_started_driver()
+        end)
+
+        local ok_start, start_err =
+        fibers.perform(driver:start_op(assert(S.scope, 'control_store manager scope missing')))
+        if not ok_start then
+        return false, tostring(start_err)
+        end
+        started = true
+
+        local ok_emit, emit_err = fibers.perform(emit_device_added_op(driver, caps))
+        if not ok_emit then
+        return false, tostring(emit_err)
+        end
+
+        S.drivers[name] = driver
+        handed_off = true
+        return true, nil
+    end):wrap(function (st, rep, ok, err)
+        if st ~= 'ok' then
+        return false, tostring(err or rep)
+        end
+        return ok, err
+    end)
+end
+
+local function stop_driver_op(name, driver)
+    return fibers.run_scope_op(function ()
+        local ok_emit, emit_err = fibers.perform(emit_device_removed_op(driver))
+        if not ok_emit then
+            return false, tostring(emit_err)
+        end
+
+        local ok_stop, stop_err = fibers.perform(driver:stop_op())
+        if not ok_stop then
+            return false, tostring(stop_err)
+        end
+
+        S.drivers[name] = nil
+        return true, nil
+    end):wrap(function (st, rep, ok, err)
+        if st ~= 'ok' then
+            return false, tostring(err or rep)
+        end
+        return ok, err
+    end)
+end
+
+local function reconcile_op(namespaces)
+    return fibers.run_scope_op(function ()
+        local desired = {}
+        for _, ns in ipairs(namespaces) do
+            desired[ns.name] = ns.root
+        end
+
+        for name, driver in pairs(S.drivers) do
+            local want_root = desired[name]
+            if want_root == nil or want_root ~= driver.root then
+                local ok_stop, stop_err = fibers.perform(stop_driver_op(name, driver))
+                if not ok_stop then
+                    return false, stop_err
+                end
+            end
+        end
+
+        for name, root in pairs(desired) do
+            if not S.drivers[name] then
+                local ok_start, start_err = fibers.perform(start_driver_op(name, root))
+                if not ok_start then
+                    return false, start_err
+                end
+            end
+        end
+
+        return true, nil
+    end):wrap(function (st, rep, ok, err)
+        if st ~= 'ok' then
+            return false, tostring(err or rep)
+        end
+        return ok, err
+    end)
+end
+
+local function shell_loop()
+    local scope = assert(S.scope, 'control_store shell without scope')
+
+    while true do
+        local which, a, b = fibers.perform(fibers.named_choice{
+            cfg  = S.cfg_ch:get_op(),
+            stop = scope:not_ok_op(),
+        })
+
+        if which == 'stop' then
+            return
+        end
+
+        local req, recv_err = a, b
+        if not req then
+            return
+        end
+
+        local ok, err = fibers.perform(reconcile_op(req.config))
+        fibers.perform(req.reply_ch:put_op({ ok = ok, err = err }))
+    end
+end
+
+function M.start_op(logger, dev_ev_ch, cap_emit_ch)
+    -- Capture the owning long-lived HAL scope now, not at perform time.
+    -- This op may be passed around before being performed; the driver shell must
+    -- still be parented to the manager/service scope that initiated startup.
+    local owner_scope = fibers.current_scope()
+    assert(owner_scope ~= nil, 'control_store.start_op must be called from inside a fiber')
+
+    return op.guard(function ()
+        if S.started then
+            return op.always(false, 'already started')
+        end
+
+        local scope, err = owner_scope:child()
+        if not scope then
+            return op.always(false, tostring(err))
+        end
+
+        S.scope       = scope
+        S.logger      = logger
+        S.dev_ev_ch   = dev_ev_ch
+        S.cap_emit_ch = cap_emit_ch
+
+        local ok, serr = scope:spawn(shell_loop)
+        if not ok then
+            S.scope       = nil
+            S.logger      = nil
+            S.dev_ev_ch   = nil
+            S.cap_emit_ch = nil
+            return op.always(false, tostring(serr))
+        end
+
+        S.started = true
+        return op.always(true, nil)
+    end)
+end
+
+function M.apply_config_op(namespaces)
+    return fibers.run_scope_op(function ()
+        local ok, err = validate_config(namespaces)
+        if not ok then
+            return false, err
+        end
+        if not S.started then
+            return false, 'control_store manager not started'
+        end
+
+        local reply_ch = channel.new(1)
+
+        fibers.perform(S.cfg_ch:put_op({
+            config   = namespaces,
+            reply_ch = reply_ch,
+        }))
+
+        local reply, recv_err = fibers.perform(reply_ch:get_op())
+        if not reply then
+            return false, tostring(recv_err or 'config reply missing')
+        end
+
+        return reply.ok, reply.err
+    end):wrap(function (st, rep, ok, err)
+        if st ~= 'ok' then
+            return false, tostring(err or rep)
+        end
+        return ok, err
+    end)
+end
+
+function M.stop_op(timeout)
+    timeout = timeout or STOP_TIMEOUT
+
+    return op.guard(function ()
+        if not S.started or not S.scope then
+            return op.always(true, nil)
+        end
+
+        local scope = S.scope
+        scope:cancel()
+
+        return fibers.boolean_choice(
+            scope:join_op():wrap(function ()
+                S.started     = false
+                S.scope       = nil
+                S.logger      = nil
+                S.dev_ev_ch   = nil
+                S.cap_emit_ch = nil
+                S.drivers     = {}
+                return true, nil
+            end),
+            sleep.sleep_op(timeout):wrap(function ()
+                return false, 'control_store manager stop timeout'
+            end)
+        ):wrap(function (completed, a, b)
+            if completed then
+                return true, nil
+            end
+            return false, b
+        end)
+    end)
+end
+
+function M.fault_op()
+    if S.scope and S.started then
+        return S.scope:fault_op()
+    end
+    return op.never()
+end
+
+return M

--- a/src/services/hal/managers/signature_verify.lua
+++ b/src/services/hal/managers/signature_verify.lua
@@ -1,0 +1,438 @@
+---@module 'services.hal.managers.signature_verify'
+
+local fibers     = require 'fibers'
+local op         = require 'fibers.op'
+local sleep      = require 'fibers.sleep'
+local channel    = require 'fibers.channel'
+
+local hal_types  = require 'services.hal.types.core'
+local driver_mod = require 'services.hal.drivers.signature_verify_provider'
+
+local M = {
+	__op_only = true,
+}
+
+local STOP_TIMEOUT = 5.0
+
+---@class SignatureVerifyManagerState
+---@field started boolean
+---@field scope Scope|nil
+---@field logger table|nil
+---@field dev_ev_ch Channel|nil
+---@field cap_emit_ch Channel|nil
+---@field cfg_ch Channel
+---@field drivers table<string, SignatureVerifyProvider>
+local S = {
+	started     = false,
+	scope       = nil,
+	logger      = nil,
+	dev_ev_ch   = nil,
+	cap_emit_ch = nil,
+	cfg_ch      = channel.new(8),
+	drivers     = {},
+}
+
+local function dlog(logger, level, payload)
+	if logger and logger[level] then
+		logger[level](logger, payload)
+	end
+end
+
+local function child_logger(id)
+	if S.logger and S.logger.child then
+		return S.logger:child({
+			component = 'driver',
+			driver    = 'signature_verify',
+			id        = id,
+		})
+	end
+	return S.logger
+end
+
+local function validate_config(cfg)
+	cfg = cfg or {}
+
+	if type(cfg) ~= 'table' then
+		return false, 'signature_verify config must be a table'
+	end
+
+	local specs = cfg.providers
+	if specs == nil and cfg[1] == nil then
+		specs = { { id = 'main' } }
+	elseif specs == nil then
+		specs = cfg
+	end
+
+	if type(specs) ~= 'table' then
+		return false, 'signature_verify.providers must be a table'
+	end
+
+	local seen = {}
+	for i, rec in ipairs(specs) do
+		if type(rec) ~= 'table' then
+			return false, ('signature_verify.providers[%d] must be a table'):format(i)
+		end
+
+		local id = rec.id or rec.name or 'main'
+		if type(id) ~= 'string' or id == '' then
+			return false, ('signature_verify.providers[%d].id must be a non-empty string'):format(i)
+		end
+
+		if seen[id] then
+			return false, 'duplicate signature_verify provider id: ' .. id
+		end
+		seen[id] = true
+	end
+
+	return true, nil
+end
+
+local function normalise_config(cfg)
+	local specs = cfg.providers
+	if specs == nil and cfg[1] == nil then
+		specs = { { id = 'main' } }
+	elseif specs == nil then
+		specs = cfg
+	end
+
+	local out = {}
+	for i = 1, #specs do
+		local rec = specs[i]
+		local id = rec.id or rec.name or 'main'
+		local opts = {}
+		for k, v in pairs(rec) do
+			if k ~= 'id' and k ~= 'name' then
+				opts[k] = v
+			end
+		end
+		out[id] = { id = id, opts = opts }
+	end
+	return out
+end
+
+local function deep_equal(a, b, seen)
+	if a == b then
+		return true
+	end
+
+	local ta, tb = type(a), type(b)
+	if ta ~= tb then
+		return false
+	end
+
+	if ta ~= 'table' then
+		return false
+	end
+
+	seen = seen or {}
+	if seen[a] and seen[a] == b then
+		return true
+	end
+	seen[a] = b
+
+	for k, va in pairs(a) do
+		if not deep_equal(va, b[k], seen) then
+			return false
+		end
+	end
+
+	for k in pairs(b) do
+		if a[k] == nil then
+			return false
+		end
+	end
+
+	return true
+end
+
+local function driver_matches_spec(driver, spec)
+	if not driver or not spec then
+		return false
+	end
+
+	return deep_equal(driver.opts or {}, spec.opts or {})
+end
+
+local function emit_device_added_op(driver, caps)
+	return op.guard(function ()
+		local ev, err = hal_types.new.DeviceEvent(
+			'added',
+			'signature_verify',
+			driver.id,
+			{ provider = 'hal.signature_verify' },
+			caps
+		)
+		if not ev then
+			return op.always(false, tostring(err))
+		end
+
+		return S.dev_ev_ch:put_op(ev):wrap(function ()
+			return true, nil
+		end)
+	end)
+end
+
+local function emit_device_removed_op(driver)
+	return op.guard(function ()
+		local ev, err = hal_types.new.DeviceEvent(
+			'removed',
+			'signature_verify',
+			driver.id,
+			{ provider = 'hal.signature_verify' },
+			{}
+		)
+		if not ev then
+			return op.always(false, tostring(err))
+		end
+
+		return S.dev_ev_ch:put_op(ev):wrap(function ()
+			return true, nil
+		end)
+	end)
+end
+
+local function start_driver_op(id, opts)
+	return fibers.run_scope_op(function ()
+		local driver = driver_mod.new(id, opts, child_logger(id))
+
+		local ok_caps, caps_or_err = fibers.perform(driver:capabilities_op(S.cap_emit_ch))
+		if not ok_caps then
+			return false, tostring(caps_or_err)
+		end
+		local caps = caps_or_err
+
+		local started = false
+		local handed_off = false
+
+		local function cleanup_started_driver()
+			if started and not handed_off then
+				op.perform_raw(driver:stop_op())
+			end
+		end
+
+		fibers.current_scope():finally(function ()
+			cleanup_started_driver()
+		end)
+
+		local ok_start, start_err =
+			fibers.perform(driver:start_op(assert(S.scope, 'signature_verify manager scope missing')))
+		if not ok_start then
+			return false, tostring(start_err)
+		end
+		started = true
+
+		local ok_emit, emit_err = fibers.perform(emit_device_added_op(driver, caps))
+		if not ok_emit then
+			return false, tostring(emit_err)
+		end
+
+		S.drivers[id] = driver
+		handed_off = true
+		return true, nil
+	end):wrap(function (st, rep, ok, err)
+		if st ~= 'ok' then
+			return false, tostring(err or rep)
+		end
+		return ok, err
+	end)
+end
+
+local function stop_driver_op(id, driver)
+	return fibers.run_scope_op(function ()
+		local ok_emit, emit_err = fibers.perform(emit_device_removed_op(driver))
+		if not ok_emit then
+			return false, tostring(emit_err)
+		end
+
+		local ok_stop, stop_err = fibers.perform(driver:stop_op())
+		if not ok_stop then
+			return false, tostring(stop_err)
+		end
+
+		S.drivers[id] = nil
+		return true, nil
+	end):wrap(function (st, rep, ok, err)
+		if st ~= 'ok' then
+			return false, tostring(err or rep)
+		end
+		return ok, err
+	end)
+end
+
+local function reconcile_op(cfg)
+	return fibers.run_scope_op(function ()
+		local desired = normalise_config(cfg)
+
+		-- First stop providers that disappeared, or whose config changed.
+		for id, driver in pairs(S.drivers) do
+			local spec = desired[id]
+
+			local should_remove =
+				(spec == nil)
+				or (not driver_matches_spec(driver, spec))
+
+			if should_remove then
+				local ok_stop, stop_err = fibers.perform(stop_driver_op(id, driver))
+				if not ok_stop then
+					return false, stop_err
+				end
+			end
+		end
+
+		-- Then start any desired providers that are now absent.
+		-- This covers both genuinely new providers and ones we just restarted.
+		for id, spec in pairs(desired) do
+			if not S.drivers[id] then
+				local ok_start, start_err = fibers.perform(start_driver_op(id, spec.opts))
+				if not ok_start then
+					return false, start_err
+				end
+			end
+		end
+
+		return true, nil
+	end):wrap(function (st, rep, ok, err)
+		if st ~= 'ok' then
+			return false, tostring(err or rep)
+		end
+		return ok, err
+	end)
+end
+
+local function shell_loop()
+	local scope = assert(S.scope, 'signature_verify shell without scope')
+
+	while true do
+		local which, a, b = fibers.perform(fibers.named_choice{
+			cfg  = S.cfg_ch:get_op(),
+			stop = scope:not_ok_op(),
+		})
+
+		if which == 'stop' then
+			local status, reason_or_primary = a, b
+			dlog(S.logger, 'debug', {
+				what   = 'signature_verify_shell_stopping',
+				status = tostring(status),
+				reason = tostring(reason_or_primary),
+			})
+			return
+		end
+
+		local req = a
+		if not req then
+			return
+		end
+
+		local ok, err = fibers.perform(reconcile_op(req.config))
+		fibers.perform(req.reply_ch:put_op({
+			ok  = ok,
+			err = err,
+		}))
+	end
+end
+
+function M.start_op(logger, dev_ev_ch, cap_emit_ch)
+	local owner_scope = fibers.current_scope()
+	assert(owner_scope ~= nil, 'signature_verify.start_op must be called from inside a fiber')
+
+	return op.guard(function ()
+		if S.started then
+			return op.always(false, 'already started')
+		end
+
+		local scope, err = owner_scope:child()
+		if not scope then
+			return op.always(false, tostring(err))
+		end
+
+		S.scope       = scope
+		S.logger      = logger
+		S.dev_ev_ch   = dev_ev_ch
+		S.cap_emit_ch = cap_emit_ch
+
+		local ok, serr = scope:spawn(shell_loop)
+		if not ok then
+			S.scope       = nil
+			S.logger      = nil
+			S.dev_ev_ch   = nil
+			S.cap_emit_ch = nil
+			return op.always(false, tostring(serr))
+		end
+
+		S.started = true
+		return op.always(true, nil)
+	end)
+end
+
+function M.apply_config_op(cfg)
+	return fibers.run_scope_op(function ()
+		local ok, err = validate_config(cfg)
+		if not ok then
+			return false, err
+		end
+		if not S.started then
+			return false, 'signature_verify manager not started'
+		end
+
+		local reply_ch = channel.new(1)
+
+		fibers.perform(S.cfg_ch:put_op({
+			config   = cfg,
+			reply_ch = reply_ch,
+		}))
+
+		local reply, recv_err = fibers.perform(reply_ch:get_op())
+		if not reply then
+			return false, tostring(recv_err or 'config reply missing')
+		end
+
+		return reply.ok, reply.err
+	end):wrap(function (st, rep, ok, err)
+		if st ~= 'ok' then
+			return false, tostring(err or rep)
+		end
+		return ok, err
+	end)
+end
+
+function M.stop_op(timeout)
+	timeout = timeout or STOP_TIMEOUT
+
+	return op.guard(function ()
+		if not S.started or not S.scope then
+			return op.always(true, nil)
+		end
+
+		local scope = S.scope
+		scope:cancel('signature_verify manager stopped')
+
+		return fibers.boolean_choice(
+			scope:join_op():wrap(function ()
+				S.started     = false
+				S.scope       = nil
+				S.logger      = nil
+				S.dev_ev_ch   = nil
+				S.cap_emit_ch = nil
+				S.drivers     = {}
+				return true, nil
+			end),
+			sleep.sleep_op(timeout):wrap(function ()
+				return false, 'signature_verify manager stop timeout'
+			end)
+		):wrap(function (completed, _a, b)
+			if completed then
+				return true, nil
+			end
+			return false, b
+		end)
+	end)
+end
+
+function M.fault_op()
+	if S.scope and S.started then
+		return S.scope:fault_op()
+	end
+	return op.never()
+end
+
+return M

--- a/src/services/hal/managers/uart.lua
+++ b/src/services/hal/managers/uart.lua
@@ -1,0 +1,352 @@
+---@module 'services.hal.managers.uart'
+
+local fibers     = require 'fibers'
+local op         = require 'fibers.op'
+local sleep      = require 'fibers.sleep'
+local channel    = require 'fibers.channel'
+
+local hal_types  = require 'services.hal.types.core'
+local driver_mod = require 'services.hal.drivers.uart'
+
+local M = {
+    __op_only = true,
+}
+
+local STOP_TIMEOUT = 5.0
+
+---@class UARTManagerState
+---@field started boolean
+---@field scope Scope|nil
+---@field logger table|nil
+---@field dev_ev_ch Channel|nil
+---@field cap_emit_ch Channel|nil
+---@field cfg_ch Channel
+---@field drivers table<string, UARTDriver>
+local S = {
+    started     = false,
+    scope       = nil,
+    logger      = nil,
+    dev_ev_ch   = nil,
+    cap_emit_ch = nil,
+    cfg_ch      = channel.new(8),
+    drivers     = {},
+}
+
+local function valid_mode(mode)
+    return mode == nil
+        or mode == '8N1'
+        or mode == '7E1'
+        or mode == '8O1'
+end
+
+local function validate_config(entries)
+    if type(entries) ~= 'table' then
+        return false, 'config must be a list'
+    end
+
+    for _, entry in ipairs(entries) do
+        if type(entry) ~= 'table' then
+            return false, 'each uart entry must be a table'
+        end
+        if type(entry.id) ~= 'string' or entry.id == '' then
+            return false, 'uart entry id must be a non-empty string'
+        end
+        if type(entry.path) ~= 'string' or entry.path == '' then
+            return false, 'uart entry path must be a non-empty string'
+        end
+        if entry.baud ~= nil and (type(entry.baud) ~= 'number' or entry.baud <= 0 or entry.baud % 1 ~= 0) then
+            return false, 'uart entry baud must be a positive integer'
+        end
+        if not valid_mode(entry.mode) then
+            return false, 'uart entry mode is invalid'
+        end
+    end
+
+    return true, nil
+end
+
+local function emit_device_added_op(driver, caps)
+    return op.guard(function ()
+        local ev, err = hal_types.new.DeviceEvent(
+            'added',
+            'uart',
+            driver.id,
+            {
+                path   = driver.path,
+                baud   = driver.default_baud,
+                mode   = driver.default_mode,
+                source = 'uart_manager',
+            },
+            caps
+        )
+        if not ev then
+            return op.always(false, tostring(err))
+        end
+        return S.dev_ev_ch:put_op(ev):wrap(function ()
+            return true, nil
+        end)
+    end)
+end
+
+local function emit_device_removed_op(driver)
+    return op.guard(function ()
+        local ev, err = hal_types.new.DeviceEvent(
+            'removed',
+            'uart',
+            driver.id,
+            {},
+            {}
+        )
+        if not ev then
+            return op.always(false, tostring(err))
+        end
+        return S.dev_ev_ch:put_op(ev):wrap(function ()
+            return true, nil
+        end)
+    end)
+end
+
+local function same_driver_config(driver, entry)
+    return driver.path == entry.path
+        and driver.default_baud == entry.baud
+        and driver.default_mode == entry.mode
+end
+
+local function start_driver_op(entry)
+    return fibers.run_scope_op(function ()
+        local driver = driver_mod.new(
+            entry.id,
+            entry.path,
+            entry.baud,
+            entry.mode,
+            S.logger
+        )
+
+        local ok_caps, caps_or_err = fibers.perform(driver:capabilities_op(S.cap_emit_ch))
+        if not ok_caps then
+            return false, tostring(caps_or_err)
+        end
+        local caps = caps_or_err
+
+        local started = false
+        local handed_off = false
+
+        local function cleanup_started_driver()
+            if started and not handed_off then
+                op.perform_raw(driver:stop_op())
+            end
+        end
+
+        fibers.current_scope():finally(function ()
+            cleanup_started_driver()
+        end)
+
+        local ok_start, start_err =
+            fibers.perform(driver:start_op(assert(S.scope, 'uart manager scope missing')))
+        if not ok_start then
+            return false, tostring(start_err)
+        end
+        started = true
+
+        local ok_emit, emit_err = fibers.perform(emit_device_added_op(driver, caps))
+        if not ok_emit then
+            return false, tostring(emit_err)
+        end
+
+        S.drivers[entry.id] = driver
+        handed_off = true
+        return true, nil
+    end):wrap(function (st, rep, ok, err)
+        if st ~= 'ok' then
+            return false, tostring(err or rep)
+        end
+        return ok, err
+    end)
+end
+
+local function stop_driver_op(id, driver)
+    return fibers.run_scope_op(function ()
+        local ok_emit, emit_err = fibers.perform(emit_device_removed_op(driver))
+        if not ok_emit then
+            return false, tostring(emit_err)
+        end
+
+        local ok_stop, stop_err = fibers.perform(driver:stop_op())
+        if not ok_stop then
+            return false, tostring(stop_err)
+        end
+
+        S.drivers[id] = nil
+        return true, nil
+    end):wrap(function (st, rep, ok, err)
+        if st ~= 'ok' then
+            return false, tostring(err or rep)
+        end
+        return ok, err
+    end)
+end
+
+local function reconcile_op(entries)
+    return fibers.run_scope_op(function ()
+        local desired = {}
+        for _, entry in ipairs(entries) do
+            desired[entry.id] = entry
+        end
+
+        for id, driver in pairs(S.drivers) do
+            local want = desired[id]
+            if want == nil or not same_driver_config(driver, want) then
+                local ok_stop, stop_err = fibers.perform(stop_driver_op(id, driver))
+                if not ok_stop then
+                    return false, stop_err
+                end
+            end
+        end
+
+        for id, entry in pairs(desired) do
+            if not S.drivers[id] then
+                local ok_start, start_err = fibers.perform(start_driver_op(entry))
+                if not ok_start then
+                    return false, start_err
+                end
+            end
+        end
+
+        return true, nil
+    end):wrap(function (st, rep, ok, err)
+        if st ~= 'ok' then
+            return false, tostring(err or rep)
+        end
+        return ok, err
+    end)
+end
+
+local function shell_loop()
+    local scope = assert(S.scope, 'uart shell without scope')
+
+    while true do
+        local which, a, b = fibers.perform(fibers.named_choice{
+            cfg  = S.cfg_ch:get_op(),
+            stop = scope:not_ok_op(),
+        })
+
+        if which == 'stop' then
+            return
+        end
+
+        local req, recv_err = a, b
+        if not req then
+            return
+        end
+
+        local ok, err = fibers.perform(reconcile_op(req.config))
+        local _ = fibers.perform(req.reply_ch:put_op({ ok = ok, err = err }))
+        _ = _
+    end
+end
+
+function M.start_op(logger, dev_ev_ch, cap_emit_ch)
+    local owner_scope = fibers.current_scope()
+    assert(owner_scope ~= nil, 'uart.start_op must be called from inside a fiber')
+
+    return op.guard(function ()
+        if S.started then
+            return op.always(false, 'already started')
+        end
+
+        local scope, err = owner_scope:child()
+        if not scope then
+            return op.always(false, tostring(err))
+        end
+
+        S.scope       = scope
+        S.logger      = logger
+        S.dev_ev_ch   = dev_ev_ch
+        S.cap_emit_ch = cap_emit_ch
+
+        local ok, serr = scope:spawn(shell_loop)
+        if not ok then
+            S.scope       = nil
+            S.logger      = nil
+            S.dev_ev_ch   = nil
+            S.cap_emit_ch = nil
+            return op.always(false, tostring(serr))
+        end
+
+        S.started = true
+        return op.always(true, nil)
+    end)
+end
+
+function M.apply_config_op(entries)
+    return fibers.run_scope_op(function ()
+        local ok, err = validate_config(entries)
+        if not ok then
+            return false, err
+        end
+        if not S.started then
+            return false, 'uart manager not started'
+        end
+
+        local reply_ch = channel.new(1)
+
+        fibers.perform(S.cfg_ch:put_op({
+            config   = entries,
+            reply_ch = reply_ch,
+        }))
+
+        local reply, recv_err = fibers.perform(reply_ch:get_op())
+        if not reply then
+            return false, tostring(recv_err or 'config reply missing')
+        end
+
+        return reply.ok, reply.err
+    end):wrap(function (st, rep, ok, err)
+        if st ~= 'ok' then
+            return false, tostring(err or rep)
+        end
+        return ok, err
+    end)
+end
+
+function M.stop_op(timeout)
+    timeout = timeout or STOP_TIMEOUT
+
+    return op.guard(function ()
+        if not S.started or not S.scope then
+            return op.always(true, nil)
+        end
+
+        local scope = S.scope
+        scope:cancel()
+
+        return fibers.boolean_choice(
+            scope:join_op():wrap(function ()
+                S.started     = false
+                S.scope       = nil
+                S.logger      = nil
+                S.dev_ev_ch   = nil
+                S.cap_emit_ch = nil
+                S.drivers     = {}
+                return true, nil
+            end),
+            sleep.sleep_op(timeout):wrap(function ()
+                return false, 'uart manager stop timeout'
+            end)
+        ):wrap(function (completed, _a, b)
+            if completed then
+                return true, nil
+            end
+            return false, b
+        end)
+    end)
+end
+
+function M.fault_op()
+    if S.scope and S.started then
+        return S.scope:fault_op()
+    end
+    return op.never()
+end
+
+return M

--- a/src/services/hal/support/control_loop.lua
+++ b/src/services/hal/support/control_loop.lua
@@ -1,0 +1,146 @@
+local fibers    = require 'fibers'
+local op        = require 'fibers.op'
+local scope_mod = require 'fibers.scope'
+
+local hal_types = require 'services.hal.types.core'
+
+local perform = fibers.perform
+
+local M = {}
+
+local function dlog(logger, level, payload)
+	if logger and logger[level] then
+		logger[level](logger, payload)
+	end
+end
+
+---@param ev any
+---@param verb string
+---@return Op
+local function assert_op_result(ev, verb)
+	if type(ev) ~= 'table' or getmetatable(ev) ~= op.Op then
+		error(
+			('control method %q must return an Op, got %s (%s)'):format(
+				tostring(verb),
+				type(ev),
+				tostring(ev)
+			),
+			3
+		)
+	end
+	return ev
+end
+
+--- Evaluate a control request against an op-returning method table.
+---
+--- Contract:
+---   methods[verb](opts, request) -> Op
+---
+--- The returned Op must resolve to:
+---   ok:boolean, value_or_err:any
+---
+---@param methods table<string, fun(opts:any, request:ControlRequest): Op>
+---@param request ControlRequest
+---@return Op
+function M.evaluate_request_op(methods, request)
+	return op.guard(function ()
+		local fn = methods[request.verb]
+		if type(fn) ~= 'function' then
+			return op.always(false, 'unsupported verb: ' .. tostring(request.verb))
+		end
+
+		return assert_op_result(fn(request.opts, request), tostring(request.verb))
+	end)
+end
+
+--- Reply to a control request via its reply channel.
+---
+--- Returns:
+---   true, nil           on successful delivery
+---   false, reason       on validation/delivery failure
+---
+---@param reply_ch Channel
+---@param ok boolean
+---@param value_or_err any
+---@return Op
+function M.reply_op(reply_ch, ok, value_or_err)
+	return op.guard(function ()
+		local reply, err = hal_types.new.Reply(ok, value_or_err)
+		if not reply then
+			return op.always(false, 'invalid reply: ' .. tostring(err))
+		end
+
+		return reply_ch:put_op(reply):wrap(function (sent, send_err)
+			if sent == true then
+				return true, nil
+			end
+			if sent == nil then
+				return false, tostring(send_err or 'reply channel closed')
+			end
+			return false, tostring(send_err or 'reply delivery failed')
+		end)
+	end)
+end
+
+--- Canonical shell loop for HAL request/reply control channels.
+---
+--- This is intentionally the semantic boundary where blocking policy is visible:
+---   * wait for the next request or scope shutdown/failure
+---   * perform exactly one request Op
+---   * perform exactly one reply Op
+---
+--- Request handlers must return Ops and must not hide blocking behind
+--- immediate helper methods.
+---
+---@param ch Channel
+---@param methods table<string, fun(opts:any, request:ControlRequest): Op>
+---@param logger table|nil
+---@param what string|nil
+function M.run_request_loop(ch, methods, logger, what)
+	local scope = scope_mod.current()
+
+	scope:finally(function ()
+		dlog(logger, 'debug', {
+			what = tostring(what or 'control_loop') .. '_exiting',
+		})
+	end)
+
+	while true do
+		local which, a, b = perform(fibers.named_choice{
+			request = ch:get_op(),
+			stop    = scope:not_ok_op(),
+		})
+
+		if which == 'stop' then
+			local status, reason_or_primary = a, b
+			dlog(logger, 'debug', {
+				what   = tostring(what or 'control_loop') .. '_stopping',
+				status = tostring(status),
+				reason = tostring(reason_or_primary),
+			})
+			return
+		end
+
+		local request, req_err = a, b
+		if not request then
+			dlog(logger, 'debug', {
+				what = tostring(what or 'control_loop') .. '_closed',
+				err  = tostring(req_err or 'control channel closed'),
+			})
+			return
+		end
+
+		local ok, value_or_err = perform(M.evaluate_request_op(methods, request))
+
+		local replied, reply_err = perform(M.reply_op(request.reply_ch, ok, value_or_err))
+		if not replied then
+			dlog(logger, 'warn', {
+				what = tostring(what or 'control_loop') .. '_reply_failed',
+				verb = tostring(request.verb),
+				err  = tostring(reply_err),
+			})
+		end
+	end
+end
+
+return M

--- a/src/services/hal/templates/driver_template.lua
+++ b/src/services/hal/templates/driver_template.lua
@@ -6,6 +6,8 @@ local op = require "fibers.op"
 local channel = require "fibers.channel"
 local sleep = require "fibers.sleep"
 
+local safe = require "coxpcall"
+
 ---@class TemplateDriver
 ---@field id string
 ---@field scope Scope
@@ -99,7 +101,7 @@ function TemplateDriver:control_manager()
         if not valid then
             ok, reason, code = false, validation_err, 1
         else
-            local call_ok, fn_ok, fn_reason, fn_code = pcall(fn, self, request.opts)
+            local call_ok, fn_ok, fn_reason, fn_code = safe.pcall(fn, self, request.opts)
             if not call_ok then
                 ok, reason, code = false, tostring(fn_ok), 1
             else

--- a/src/services/hal/types/capabilities.lua
+++ b/src/services/hal/types/capabilities.lua
@@ -207,7 +207,8 @@ end
 ---@return string error
 function new.UARTCapability(id, control_ch)
     local offerings = {
-        'open', 'close', 'write'
+        'status',
+        'open',
     }
     return new.Capability('uart', id, control_ch, offerings)
 end
@@ -283,6 +284,46 @@ function new.ControlError(reason, code)
         code = code,
     }, ControlError)
     return control_error
+end
+
+---@param id CapabilityId
+---@param control_ch Channel
+---@return Capability?
+---@return string error
+function new.ControlStoreCapability(id, control_ch)
+	local offerings = {
+		'get',
+		'put',
+		'delete',
+		'list',
+		'status',
+	}
+	return new.Capability('control_store', id, control_ch, offerings)
+end
+
+---@param id CapabilityId
+---@param control_ch Channel
+---@return Capability?
+---@return string error
+function new.SignatureVerifyCapability(id, control_ch)
+	return new.Capability('signature_verify', id, control_ch, {
+		'verify_ed25519',
+	})
+end
+
+---@param id CapabilityId
+---@param control_ch Channel
+---@return Capability?
+---@return string error
+function new.ArtifactStoreCapability(id, control_ch)
+	return new.Capability('artifact_store', id, control_ch, {
+		'create_sink',
+		'import_path',
+		'import_source',
+		'open',
+		'delete',
+		'status',
+	})
 end
 
 return {

--- a/src/services/hal/types/capability_args.lua
+++ b/src/services/hal/types/capability_args.lua
@@ -126,29 +126,33 @@ function new.FilesystemWriteOpts(filename, data)
     }, FilesystemWriteOpts), ""
 end
 
+----------------------------------------------------------------------
+-- UART
+----------------------------------------------------------------------
+
 ---@class UARTOpenOpts
----@field read boolean
----@field write boolean
 local UARTOpenOpts = {}
 UARTOpenOpts.__index = UARTOpenOpts
 
----Create a new UARTOpenOpts.
----At least one of read or write must be true.
----@param read boolean
----@param write boolean
----@return UARTOpenOpts?
----@return string error
-function new.UARTOpenOpts(read, write)
-    if type(read) ~= 'boolean' or type(write) ~= 'boolean' then
-        return nil, "read and write must be booleans"
+---@param opts table|nil
+---@return UARTOpenOpts?|nil
+---@return string
+function new.UARTOpenOpts(opts)
+    if opts ~= nil and type(opts) ~= 'table' then
+        return nil, 'invalid uart open opts'
     end
-    if not read and not write then
-        return nil, "at least one of read or write must be true"
+
+    opts = opts or {}
+
+    -- Deliberately empty for now.
+    -- On current OpenWrt targets UART line settings are assumed to come from
+    -- platform/devicetree configuration. Runtime termios configuration can be
+    -- added later without changing the capability surface.
+    for k in pairs(opts) do
+        return nil, 'unsupported uart open option: ' .. tostring(k)
     end
-    return setmetatable({
-        read  = read,
-        write = write,
-    }, UARTOpenOpts), ""
+
+    return setmetatable({}, UARTOpenOpts), ''
 end
 
 ---@class UARTWriteOpts
@@ -264,6 +268,285 @@ function new.PowerActionOpts(delay)
     return setmetatable({ delay = delay }, PowerActionOpts), ""
 end
 
+---@class ControlStoreGetOpts
+---@field key string
+local ControlStoreGetOpts = {}
+ControlStoreGetOpts.__index = ControlStoreGetOpts
+
+---@class ControlStorePutOpts
+---@field key string
+---@field data string
+local ControlStorePutOpts = {}
+ControlStorePutOpts.__index = ControlStorePutOpts
+
+---@class ControlStoreDeleteOpts
+---@field key string
+local ControlStoreDeleteOpts = {}
+ControlStoreDeleteOpts.__index = ControlStoreDeleteOpts
+
+---@class ControlStoreListOpts
+---@field prefix string|nil
+local ControlStoreListOpts = {}
+ControlStoreListOpts.__index = ControlStoreListOpts
+
+local function valid_store_key(key)
+	return type(key) == 'string'
+		and key ~= ''
+		and not key:find('[/\\]', 1)
+		and key:match('^[%w%._%-]+$') ~= nil
+end
+
+---@param key string
+---@return ControlStoreGetOpts?|nil
+---@return string
+function new.ControlStoreGetOpts(key)
+	if not valid_store_key(key) then
+		return nil, 'invalid key'
+	end
+	return setmetatable({ key = key }, ControlStoreGetOpts), ''
+end
+
+---@param key string
+---@param data string
+---@return ControlStorePutOpts?|nil
+---@return string
+function new.ControlStorePutOpts(key, data)
+	if not valid_store_key(key) then
+		return nil, 'invalid key'
+	end
+	if type(data) ~= 'string' then
+		return nil, 'data must be a string'
+	end
+	return setmetatable({ key = key, data = data }, ControlStorePutOpts), ''
+end
+
+---@param key string
+---@return ControlStoreDeleteOpts?|nil
+---@return string
+function new.ControlStoreDeleteOpts(key)
+	if not valid_store_key(key) then
+		return nil, 'invalid key'
+	end
+	return setmetatable({ key = key }, ControlStoreDeleteOpts), ''
+end
+
+---@param prefix string|nil
+---@return ControlStoreListOpts?|nil
+---@return string
+function new.ControlStoreListOpts(prefix)
+	if prefix ~= nil and type(prefix) ~= 'string' then
+		return nil, 'invalid prefix'
+	end
+	return setmetatable({ prefix = prefix }, ControlStoreListOpts), ''
+end
+
+---@class SignatureVerifyEd25519Opts
+---@field pubkey_pem string
+---@field message string
+---@field signature string
+local SignatureVerifyEd25519Opts = {}
+SignatureVerifyEd25519Opts.__index = SignatureVerifyEd25519Opts
+
+---@param pubkey_pem string
+---@param message string
+---@param signature string
+---@return SignatureVerifyEd25519Opts?
+---@return string
+function new.SignatureVerifyEd25519Opts(pubkey_pem, message, signature)
+	if type(pubkey_pem) ~= 'string' or pubkey_pem == '' then
+		return nil, 'invalid pubkey_pem'
+	end
+	if type(message) ~= 'string' then
+		return nil, 'invalid message'
+	end
+	if type(signature) ~= 'string' or signature == '' then
+		return nil, 'invalid signature'
+	end
+
+	return setmetatable({
+		pubkey_pem = pubkey_pem,
+		message    = message,
+		signature  = signature,
+	}, SignatureVerifyEd25519Opts), ''
+end
+
+----------------------------------------------------------------------
+-- Artifact store
+----------------------------------------------------------------------
+
+---@class ArtifactStoreCreateSinkOpts
+---@field meta table
+---@field policy string|nil
+local ArtifactStoreCreateSinkOpts = {}
+ArtifactStoreCreateSinkOpts.__index = ArtifactStoreCreateSinkOpts
+
+---@class ArtifactStoreImportPathOpts
+---@field path string
+---@field meta table
+---@field policy string|nil
+local ArtifactStoreImportPathOpts = {}
+ArtifactStoreImportPathOpts.__index = ArtifactStoreImportPathOpts
+
+---@class ArtifactStoreImportSourceOpts
+---@field source any
+---@field meta table
+---@field policy string|nil
+local ArtifactStoreImportSourceOpts = {}
+ArtifactStoreImportSourceOpts.__index = ArtifactStoreImportSourceOpts
+
+---@class ArtifactStoreOpenOpts
+---@field artifact_ref string
+local ArtifactStoreOpenOpts = {}
+ArtifactStoreOpenOpts.__index = ArtifactStoreOpenOpts
+
+---@class ArtifactStoreDeleteOpts
+---@field artifact_ref string
+local ArtifactStoreDeleteOpts = {}
+ArtifactStoreDeleteOpts.__index = ArtifactStoreDeleteOpts
+
+---@class ArtifactStoreStatusOpts
+local ArtifactStoreStatusOpts = {}
+ArtifactStoreStatusOpts.__index = ArtifactStoreStatusOpts
+
+local function valid_artifact_ref(ref)
+	return type(ref) == 'string' and ref ~= '' and ref:match('^[A-Za-z0-9_.-]+$') ~= nil
+end
+
+local function valid_artifact_policy(policy)
+	return policy == nil
+		or policy == 'transient_only'
+		or policy == 'prefer_durable'
+		or policy == 'require_durable'
+end
+
+local function valid_blob_source(source)
+	return type(source) == 'table'
+		and type(source.read_chunk_op) == 'function'
+end
+
+---@param meta table|nil
+---@param policy string|nil
+---@return ArtifactStoreCreateSinkOpts?|nil
+---@return string
+function new.ArtifactStoreCreateSinkOpts(meta, policy)
+	if meta ~= nil and type(meta) ~= 'table' then
+		return nil, 'invalid meta'
+	end
+	if not valid_artifact_policy(policy) then
+		return nil, 'invalid policy'
+	end
+
+	return setmetatable({
+		meta   = meta or {},
+		policy = policy,
+	}, ArtifactStoreCreateSinkOpts), ''
+end
+
+---@param path string
+---@param meta table|nil
+---@param policy string|nil
+---@return ArtifactStoreImportPathOpts?|nil
+---@return string
+function new.ArtifactStoreImportPathOpts(path, meta, policy)
+	if type(path) ~= 'string' or path == '' then
+		return nil, 'invalid path'
+	end
+	if meta ~= nil and type(meta) ~= 'table' then
+		return nil, 'invalid meta'
+	end
+	if not valid_artifact_policy(policy) then
+		return nil, 'invalid policy'
+	end
+
+	return setmetatable({
+		path   = path,
+		meta   = meta or {},
+		policy = policy,
+	}, ArtifactStoreImportPathOpts), ''
+end
+
+---@param source any
+---@param meta table|nil
+---@param policy string|nil
+---@return ArtifactStoreImportSourceOpts?|nil
+---@return string
+function new.ArtifactStoreImportSourceOpts(source, meta, policy)
+	if not valid_blob_source(source) then
+		return nil, 'invalid source'
+	end
+	if meta ~= nil and type(meta) ~= 'table' then
+		return nil, 'invalid meta'
+	end
+	if not valid_artifact_policy(policy) then
+		return nil, 'invalid policy'
+	end
+
+	return setmetatable({
+		source = source,
+		meta   = meta or {},
+		policy = policy,
+	}, ArtifactStoreImportSourceOpts), ''
+end
+
+---@param artifact_ref string
+---@return ArtifactStoreOpenOpts?|nil
+---@return string
+function new.ArtifactStoreOpenOpts(artifact_ref)
+	if not valid_artifact_ref(artifact_ref) then
+		return nil, 'invalid artifact_ref'
+	end
+	return setmetatable({
+		artifact_ref = artifact_ref,
+	}, ArtifactStoreOpenOpts), ''
+end
+
+---@param artifact_ref string
+---@return ArtifactStoreDeleteOpts?|nil
+---@return string
+function new.ArtifactStoreDeleteOpts(artifact_ref)
+	if not valid_artifact_ref(artifact_ref) then
+		return nil, 'invalid artifact_ref'
+	end
+	return setmetatable({
+		artifact_ref = artifact_ref,
+	}, ArtifactStoreDeleteOpts), ''
+end
+
+---@return ArtifactStoreStatusOpts
+---@return string
+function new.ArtifactStoreStatusOpts()
+	return setmetatable({}, ArtifactStoreStatusOpts), ''
+end
+
+----------------------------------------------------------------------
+-- UART
+----------------------------------------------------------------------
+
+---@class UARTOpenOpts
+local UARTOpenOpts = {}
+UARTOpenOpts.__index = UARTOpenOpts
+
+---@param opts table|nil
+---@return UARTOpenOpts?|nil
+---@return string
+function new.UARTOpenOpts(opts)
+    if opts ~= nil and type(opts) ~= 'table' then
+        return nil, 'invalid uart open opts'
+    end
+
+    opts = opts or {}
+
+    -- Deliberately empty for now.
+    -- On current OpenWrt targets UART line settings are assumed to come from
+    -- platform/devicetree configuration. Runtime termios configuration can be
+    -- added later without changing the capability surface.
+    for k in pairs(opts) do
+        return nil, 'unsupported uart open option: ' .. tostring(k)
+    end
+
+    return setmetatable({}, UARTOpenOpts), ''
+end
+
 return {
     ModemGetOpts = ModemGetOpts,
     ModemConnectOpts = ModemConnectOpts,
@@ -276,5 +559,16 @@ return {
     ThermalGetOpts = ThermalGetOpts,
     PlatformGetOpts = PlatformGetOpts,
     PowerActionOpts = PowerActionOpts,
+    ControlStoreGetOpts = ControlStoreGetOpts,
+    ControlStorePutOpts = ControlStorePutOpts,
+    ControlStoreDeleteOpts = ControlStoreDeleteOpts,
+    ControlStoreListOpts = ControlStoreListOpts,
+    SignatureVerifyEd25519Opts = SignatureVerifyEd25519Opts,
+    ArtifactStoreCreateSinkOpts = ArtifactStoreCreateSinkOpts,
+    ArtifactStoreImportPathOpts = ArtifactStoreImportPathOpts,
+    ArtifactStoreImportSourceOpts = ArtifactStoreImportSourceOpts,
+    ArtifactStoreOpenOpts = ArtifactStoreOpenOpts,
+    ArtifactStoreDeleteOpts = ArtifactStoreDeleteOpts,
+    ArtifactStoreStatusOpts = ArtifactStoreStatusOpts,
     new = new,
 }

--- a/src/services/hal/types/core.lua
+++ b/src/services/hal/types/core.lua
@@ -235,11 +235,58 @@ end
 ---@field stop fun(): string error
 ---@field apply_config fun(config: table): boolean ok, string error
 
+----------------------------------------------------------------------
+-- UART open reply
+----------------------------------------------------------------------
+
+---@class UARTOpenReply
+---@field lease_id string
+---@field session any
+---@field path string
+---@field baud integer|nil
+---@field mode string|nil
+local UARTOpenReply = {}
+UARTOpenReply.__index = UARTOpenReply
+
+---@param lease_id string
+---@param session any
+---@param path string
+---@param baud integer|nil
+---@param mode string|nil
+---@return UARTOpenReply?|nil
+---@return string
+function new.UARTOpenReply(lease_id, session, path, baud, mode)
+    if type(lease_id) ~= 'string' or lease_id == '' then
+        return nil, 'invalid lease_id'
+    end
+    if session == nil then
+        return nil, 'missing session'
+    end
+    if type(path) ~= 'string' or path == '' then
+        return nil, 'invalid path'
+    end
+    if baud ~= nil and (type(baud) ~= 'number' or baud <= 0 or baud % 1 ~= 0) then
+        return nil, 'invalid baud'
+    end
+    if mode ~= nil and type(mode) ~= 'string' then
+        return nil, 'invalid mode'
+    end
+
+    return setmetatable({
+        lease_id = lease_id,
+        session  = session,
+        path     = path,
+        baud     = baud,
+        mode     = mode,
+    }, UARTOpenReply), ''
+end
+
 return {
     ControlRequest = ControlRequest,
     Reply = Reply,
     Emit = Emit,
     DeviceEvent = DeviceEvent,
     Device = Device,
+    UARTOpenReply = UARTOpenReply,
     new = new,
 }

--- a/src/shared/blob_source.lua
+++ b/src/shared/blob_source.lua
@@ -1,0 +1,210 @@
+---@module 'shared.blob_source'
+
+local fibers = require 'fibers'
+local op     = require 'fibers.op'
+
+---@class BlobSource
+local BlobSource = {}
+BlobSource.__index = BlobSource
+
+---@class BlobSink
+local BlobSink = {}
+BlobSink.__index = BlobSink
+
+----------------------------------------------------------------------
+-- String source
+----------------------------------------------------------------------
+
+---@class StringSource : BlobSource
+---@field _data string
+---@field _off integer
+local StringSource = setmetatable({}, { __index = BlobSource })
+StringSource.__index = StringSource
+
+---@param max_bytes integer|nil
+---@return Op  -- (chunk:string|nil, err:string|nil)
+function StringSource:read_chunk_op(max_bytes)
+	return op.guard(function ()
+		if self._off >= #self._data then
+			return op.always(nil, nil) -- EOF
+		end
+
+		local n = max_bytes or (#self._data - self._off)
+		if type(n) ~= 'number' or n <= 0 then
+			return op.always(nil, 'invalid max_bytes')
+		end
+
+		local chunk = self._data:sub(self._off + 1, self._off + n)
+		self._off = self._off + #chunk
+		return op.always(chunk, nil)
+	end)
+end
+
+function StringSource:close_op()
+	return op.always(true, nil)
+end
+
+----------------------------------------------------------------------
+-- Stream source
+----------------------------------------------------------------------
+
+---@class StreamSource : BlobSource
+---@field _stream Stream
+local StreamSource = setmetatable({}, { __index = BlobSource })
+StreamSource.__index = StreamSource
+
+---@param max_bytes integer|nil
+---@return Op  -- (chunk:string|nil, err:string|nil)
+function StreamSource:read_chunk_op(max_bytes)
+	local n = max_bytes or 65536
+	return self._stream:read_some_op(n):wrap(function (chunk, err)
+		return chunk, err
+	end)
+end
+
+function StreamSource:close_op()
+	return self._stream:close_op()
+end
+
+----------------------------------------------------------------------
+-- Memory sink
+----------------------------------------------------------------------
+
+---@class MemorySink : BlobSink
+---@field _parts string[]
+local MemorySink = setmetatable({}, { __index = BlobSink })
+MemorySink.__index = MemorySink
+
+---@param chunk string
+---@return Op  -- (ok:boolean|nil, err:string|nil)
+function MemorySink:write_chunk_op(chunk)
+	return op.guard(function ()
+		if type(chunk) ~= 'string' then
+			return op.always(nil, 'chunk must be a string')
+		end
+		self._parts[#self._parts + 1] = chunk
+		return op.always(true, nil)
+	end)
+end
+
+function MemorySink:close_op()
+	return op.always(true, nil)
+end
+
+function MemorySink:result()
+	return table.concat(self._parts)
+end
+
+----------------------------------------------------------------------
+-- Stream sink
+----------------------------------------------------------------------
+
+---@class StreamSink : BlobSink
+---@field _stream Stream
+local StreamSink = setmetatable({}, { __index = BlobSink })
+StreamSink.__index = StreamSink
+
+---@param chunk string
+---@return Op  -- (ok:boolean|nil, err:string|nil)
+function StreamSink:write_chunk_op(chunk)
+	return self._stream:write_op(chunk):wrap(function (n, err)
+		if n == nil then
+			return nil, err
+		end
+		return true, nil
+	end)
+end
+
+function StreamSink:close_op()
+	return self._stream:close_op()
+end
+
+----------------------------------------------------------------------
+-- Structured copy
+----------------------------------------------------------------------
+
+---@param source BlobSource
+---@param sink BlobSink
+---@param opts? { chunk_size?: integer, close_source?: boolean, close_sink?: boolean }
+---@return Op -- yields st, rep, bytes_or_primary via run_scope_op
+local function copy_op(source, sink, opts)
+	opts = opts or {}
+	local chunk_size   = opts.chunk_size or 65536
+	local close_source = opts.close_source ~= false
+	local close_sink   = opts.close_sink ~= false
+
+	return fibers.run_scope_op(function (scope)
+		local bytes = 0
+
+		scope:finally(function ()
+			if close_source and source and source.close_op then
+				op.perform_raw(source:close_op())
+			end
+			if close_sink and sink and sink.close_op then
+				op.perform_raw(sink:close_op())
+			end
+		end)
+
+		while true do
+			local chunk, rerr = fibers.perform(source:read_chunk_op(chunk_size))
+			if rerr ~= nil then
+				error(rerr, 0)
+			end
+			if chunk == nil then
+				return bytes
+			end
+
+			local ok, werr = fibers.perform(sink:write_chunk_op(chunk))
+			if ok == nil then
+				error(werr or 'write failed', 0)
+			end
+
+			bytes = bytes + #chunk
+		end
+	end)
+end
+
+----------------------------------------------------------------------
+-- Constructors
+----------------------------------------------------------------------
+
+local M = {}
+
+---@param data string
+---@return BlobSource
+function M.from_string(data)
+	assert(type(data) == 'string', 'from_string: data must be string')
+	return setmetatable({
+		_data = data,
+		_off  = 0,
+	}, StringSource)
+end
+
+---@param stream Stream
+---@return BlobSource
+function M.from_stream(stream)
+	return setmetatable({
+		_stream = stream,
+	}, StreamSource)
+end
+
+---@return BlobSink
+function M.to_memory()
+	return setmetatable({
+		_parts = {},
+	}, MemorySink)
+end
+
+---@param stream Stream
+---@return BlobSink
+function M.to_stream(stream)
+	return setmetatable({
+		_stream = stream,
+	}, StreamSink)
+end
+
+M.copy_op = copy_op
+M.BlobSource = BlobSource
+M.BlobSink   = BlobSink
+
+return M

--- a/src/shared/hash/xxhash32.lua
+++ b/src/shared/hash/xxhash32.lua
@@ -1,0 +1,190 @@
+-- shared/hash/xxhash32.lua
+--
+-- Small, dependency-free xxHash32 helpers.
+--
+-- This provides a deterministic non-cryptographic integrity checksum for
+-- transfer protocol use and tests without pulling in an external dependency.
+-- It is not a security primitive.
+
+local ok_bit32, bit32_mod = pcall(require, 'bit32')
+local ok_bit, bit_mod = pcall(require, 'bit')
+
+local bitops = ok_bit32 and bit32_mod or bit_mod
+assert(bitops, 'shared.hash.xxhash32 requires bit32 or bit')
+
+local band   = assert(bitops.band,   'bit library missing band')
+local bor    = assert(bitops.bor,    'bit library missing bor')
+local bxor   = assert(bitops.bxor,   'bit library missing bxor')
+local lshift = assert(bitops.lshift, 'bit library missing lshift')
+local rshift = assert(bitops.rshift, 'bit library missing rshift')
+
+local rol
+if bitops.lrotate then
+	rol = bitops.lrotate
+elseif bitops.rol then
+	rol = bitops.rol
+else
+	rol = function (x, n)
+		n = n % 32
+		return band(bor(lshift(x, n), rshift(x, 32 - n)), 0xffffffff)
+	end
+end
+
+local M = {}
+
+local P1 = 0x9E3779B1
+local P2 = 0x85EBCA77
+local P3 = 0xC2B2AE3D
+local P4 = 0x27D4EB2F
+local P5 = 0x165667B1
+
+local TWO32 = 4294967296
+
+local function u32(n)
+	return band(n, 0xffffffff)
+end
+
+local function hex8(n)
+	n = u32(n)
+	if n < 0 then
+		n = n + TWO32
+	end
+	return ('%08x'):format(n)
+end
+
+local function mul32(a, b)
+	a = u32(a)
+	b = u32(b)
+
+	local a_lo = band(a, 0xffff)
+	local a_hi = band(rshift(a, 16), 0xffff)
+	local b_lo = band(b, 0xffff)
+	local b_hi = band(rshift(b, 16), 0xffff)
+
+	local lo  = a_lo * b_lo
+	local mid = a_hi * b_lo + a_lo * b_hi
+
+	return u32(lo + lshift(band(mid, 0xffff), 16))
+end
+
+local function read_u32_le(s, i)
+	local b1, b2, b3, b4 = s:byte(i, i + 3)
+	return bor(
+		b1 or 0,
+		lshift(b2 or 0, 8),
+		lshift(b3 or 0, 16),
+		lshift(b4 or 0, 24)
+	)
+end
+
+local function round_lane(acc, lane)
+	acc = u32(acc + mul32(lane, P2))
+	acc = rol(acc, 13)
+	acc = mul32(acc, P1)
+	return acc
+end
+
+local function avalanche(h)
+	h = bxor(h, rshift(h, 15))
+	h = mul32(h, P2)
+	h = bxor(h, rshift(h, 13))
+	h = mul32(h, P3)
+	h = bxor(h, rshift(h, 16))
+	return u32(h)
+end
+
+function M.new(seed)
+	seed = u32(seed or 0)
+	return {
+		seed = seed,
+		total_len = 0,
+		mem = '',
+		v1 = u32(seed + P1 + P2),
+		v2 = u32(seed + P2),
+		v3 = seed,
+		v4 = u32(seed - P1),
+		large = false,
+	}
+end
+
+function M.update(state, s)
+	assert(type(state) == 'table', 'checksum.update expects state')
+	assert(type(s) == 'string', 'checksum.update expects string')
+	if s == '' then
+		return state
+	end
+
+	state.total_len = state.total_len + #s
+	local buf = state.mem .. s
+	local idx = 1
+	local n = #buf
+
+	if n >= 16 then
+		state.large = true
+		while idx + 15 <= n do
+			state.v1 = round_lane(state.v1, read_u32_le(buf, idx)); idx = idx + 4
+			state.v2 = round_lane(state.v2, read_u32_le(buf, idx)); idx = idx + 4
+			state.v3 = round_lane(state.v3, read_u32_le(buf, idx)); idx = idx + 4
+			state.v4 = round_lane(state.v4, read_u32_le(buf, idx)); idx = idx + 4
+		end
+	end
+
+	state.mem = buf:sub(idx)
+	return state
+end
+
+function M.digest(state)
+	assert(type(state) == 'table', 'checksum.digest expects state')
+
+	local h
+	if state.large then
+		h = u32(
+			rol(state.v1, 1) +
+			rol(state.v2, 7) +
+			rol(state.v3, 12) +
+			rol(state.v4, 18)
+		)
+	else
+		h = u32(state.seed + P5)
+	end
+
+	h = u32(h + state.total_len)
+
+	local i = 1
+	local n = #state.mem
+
+	while i + 3 <= n do
+		h = u32(h + mul32(read_u32_le(state.mem, i), P3))
+		h = mul32(rol(h, 17), P4)
+		i = i + 4
+	end
+
+	while i <= n do
+		h = u32(h + mul32(state.mem:byte(i) or 0, P5))
+		h = mul32(rol(h, 11), P1)
+		i = i + 1
+	end
+
+	return avalanche(h)
+end
+
+function M.digest_hex_state(state)
+	return hex8(M.digest(state))
+end
+
+function M.xxhash32(s, seed)
+	assert(type(s) == 'string', 'checksum.xxhash32 expects string')
+	local st = M.new(seed)
+	M.update(st, s)
+	return M.digest(st)
+end
+
+function M.digest_hex(s)
+	return hex8(M.xxhash32(s))
+end
+
+function M.verify_hex(s, expected)
+	return M.digest_hex(s) == tostring(expected)
+end
+
+return M

--- a/tests/integration/devhost/hal_uart_spec.lua
+++ b/tests/integration/devhost/hal_uart_spec.lua
@@ -1,0 +1,306 @@
+local fibers    = require 'fibers'
+local channel   = require 'fibers.channel'
+local sleep     = require 'fibers.sleep'
+local op        = require 'fibers.op'
+
+local hal_types = require 'services.hal.types.core'
+local cap_args  = require 'services.hal.types.capability_args'
+
+local runfibers = require 'tests.support.run_fibers'
+local pty       = require 'tests.support.pty'
+local safe      = require 'coxpcall'
+
+local perform = fibers.perform
+local T = {}
+
+local function fresh_manager()
+	package.loaded['services.hal.managers.uart'] = nil
+	package.loaded['services.hal.drivers.uart'] = nil
+	return require('services.hal.managers.uart')
+end
+
+local function dummy_logger()
+	local logger = {}
+	for _, k in ipairs({ 'debug', 'info', 'warn', 'error' }) do
+		logger[k] = function() end
+	end
+	function logger:child()
+		return self
+	end
+	return logger
+end
+
+local function wait_channel_get(ch, timeout_s, what)
+	local which, a, b = perform(op.named_choice({
+		item = ch:get_op(),
+		timeout = sleep.sleep_op(timeout_s or 1.0):wrap(function()
+			return true
+		end),
+	}))
+
+	if which == 'timeout' then
+		error(('timed out waiting for %s'):format(what or 'channel item'), 0)
+	end
+
+	if a == nil then
+		error(('channel closed while waiting for %s: %s'):format(what or 'channel item', tostring(b)), 0)
+	end
+
+	return a
+end
+
+local function wait_device_event(dev_ev_ch, event_type, class, id, timeout_s)
+	local deadline = fibers.now() + (timeout_s or 1.0)
+
+	while fibers.now() < deadline do
+		local ev = wait_channel_get(dev_ev_ch, deadline - fibers.now(), 'device event')
+		if ev.event_type == event_type and ev.class == class and ev.id == id then
+			return ev
+		end
+	end
+
+	error(('timed out waiting for device event %s %s/%s'):format(
+		tostring(event_type), tostring(class), tostring(id)
+	), 0)
+end
+
+local function call_control(cap, verb, opts)
+	local reply_ch = channel.new(1)
+	local req, err = hal_types.new.ControlRequest(verb, opts or {}, reply_ch)
+	assert(req, tostring(err))
+
+	-- channel:put_op() returns no values on success
+	perform(cap.control_ch:put_op(req))
+
+	local reply = wait_channel_get(reply_ch, 1.0, 'control reply')
+	assert(type(reply) == 'table', 'control reply must be a table')
+	assert(type(reply.ok) == 'boolean', 'control reply ok must be boolean')
+
+	return reply
+end
+
+local function open_uart_session(cap)
+	local open_opts, err = cap_args.new.UARTOpenOpts()
+	assert(open_opts, tostring(err))
+
+	local reply = call_control(cap, 'open', open_opts)
+	assert(reply.ok == true, tostring(reply.reason))
+	assert(type(reply.reason) == 'table')
+	assert(type(reply.reason.session) == 'table')
+	return reply.reason.session, reply.reason
+end
+
+local function start_manager(scope)
+	local uart_mgr = fresh_manager()
+
+	local dev_ev_ch   = channel.new(16)
+	local cap_emit_ch = channel.new(32)
+
+	local ok, err = perform(uart_mgr.start_op(dummy_logger(), dev_ev_ch, cap_emit_ch))
+	assert(ok == true, tostring(err))
+
+	scope:finally(function()
+		safe.pcall(function()
+			perform(uart_mgr.stop_op())
+		end)
+	end)
+
+	return uart_mgr, dev_ev_ch, cap_emit_ch
+end
+
+function T.devhost_uart_open_returns_wrapped_session_and_allows_reopen()
+	runfibers.run(function(scope)
+		local uart_mgr, dev_ev_ch = start_manager(scope)
+		local port = pty.open(scope)
+
+		local ok_cfg, err_cfg = perform(uart_mgr.apply_config_op({
+			{
+				id   = 'uart0',
+				path = port.slave_name,
+				baud = 115200,
+				mode = '8N1',
+			},
+		}))
+		assert(ok_cfg == true, tostring(err_cfg))
+
+		local added = wait_device_event(dev_ev_ch, 'added', 'uart', 'uart0', 1.5)
+		assert(type(added.capabilities) == 'table' and #added.capabilities == 1)
+		local cap = added.capabilities[1]
+		assert(cap.class == 'uart')
+		assert(cap.id == 'uart0')
+
+		local session1 = open_uart_session(cap)
+		local ok_w1, err_w1 = port:write('abc')
+		assert(ok_w1 == true, tostring(err_w1))
+
+		local got1, rerr1 = perform(session1:read_some_op(3))
+		assert(got1 ~= nil, tostring(rerr1))
+		assert(got1 == 'abc', ('expected "abc", got %q'):format(tostring(got1)))
+
+		local n1, swerr1 = perform(session1:write_op('xyz'))
+		assert(n1 ~= nil, tostring(swerr1))
+		local got2 = port:expect_some(3, 1.0, 'read from PTY master')
+		assert(got2 == 'xyz', ('expected "xyz", got %q'):format(tostring(got2)))
+
+		local ok_c1, cerr1 = perform(session1:close_op())
+		assert(ok_c1 ~= nil, tostring(cerr1))
+
+		local session2 = open_uart_session(cap)
+		local n2, swerr2 = perform(session2:write_op('q'))
+		assert(n2 ~= nil, tostring(swerr2))
+		local got3 = port:expect_some(1, 1.0, 'read from reopened UART session')
+		assert(got3 == 'q', ('expected "q", got %q'):format(tostring(got3)))
+
+		local ok_c2, cerr2 = perform(session2:close_op())
+		assert(ok_c2 ~= nil, tostring(cerr2))
+	end, { timeout = 4.0 })
+end
+
+function T.devhost_uart_reconfigures_when_the_port_changes()
+	runfibers.run(function(scope)
+		local uart_mgr, dev_ev_ch = start_manager(scope)
+		local port1 = pty.open(scope)
+		local port2 = pty.open(scope)
+
+		local ok1, err1 = perform(uart_mgr.apply_config_op({
+			{
+				id   = 'uart0',
+				path = port1.slave_name,
+				baud = 115200,
+				mode = '8N1',
+			},
+		}))
+		assert(ok1 == true, tostring(err1))
+
+		local added1 = wait_device_event(dev_ev_ch, 'added', 'uart', 'uart0', 1.5)
+		local cap1 = added1.capabilities[1]
+		local session1 = open_uart_session(cap1)
+
+		local n1, errw1 = perform(session1:write_op('first'))
+		assert(n1 ~= nil, tostring(errw1))
+		local got1 = port1:expect_some(5, 1.0, 'read from first PTY master')
+		assert(got1 == 'first', ('expected "first", got %q'):format(tostring(got1)))
+
+		local okc1, cerr1 = perform(session1:close_op())
+		assert(okc1 ~= nil, tostring(cerr1))
+
+		local ok2, err2 = perform(uart_mgr.apply_config_op({
+			{
+				id   = 'uart0',
+				path = port2.slave_name,
+				baud = 115200,
+				mode = '8N1',
+			},
+		}))
+		assert(ok2 == true, tostring(err2))
+
+		local removed = wait_device_event(dev_ev_ch, 'removed', 'uart', 'uart0', 1.5)
+		assert(removed ~= nil)
+		local added2 = wait_device_event(dev_ev_ch, 'added', 'uart', 'uart0', 1.5)
+		local cap2 = added2.capabilities[1]
+
+		local session2 = open_uart_session(cap2)
+		local n2, errw2 = perform(session2:write_op('second'))
+		assert(n2 ~= nil, tostring(errw2))
+		local got2 = port2:expect_some(6, 1.0, 'read from second PTY master')
+		assert(got2 == 'second', ('expected "second", got %q'):format(tostring(got2)))
+
+		local okc2, cerr2 = perform(session2:close_op())
+		assert(okc2 ~= nil, tostring(cerr2))
+	end, { timeout = 4.0 })
+end
+
+
+function T.reconfigure_poisons_old_session_wrapper()
+	runfibers.run(function(scope)
+		local uart_mgr, dev_ev_ch = start_manager(scope)
+		local port1 = pty.open(scope)
+		local port2 = pty.open(scope)
+
+		local ok1, err1 = perform(uart_mgr.apply_config_op({
+			{
+				id   = 'uart0',
+				path = port1.slave_name,
+				baud = 115200,
+				mode = '8N1',
+			},
+		}))
+		assert(ok1 == true, tostring(err1))
+
+		local added1 = wait_device_event(dev_ev_ch, 'added', 'uart', 'uart0', 1.5)
+		local cap1 = added1.capabilities[1]
+		local session1 = open_uart_session(cap1)
+
+		local n1, errw1 = perform(session1:write_op('old'))
+		assert(n1 ~= nil, tostring(errw1))
+		local got1 = port1:expect_some(3, 1.0, 'read from old PTY master')
+		assert(got1 == 'old', ('expected "old", got %q'):format(tostring(got1)))
+
+		local ok2, err2 = perform(uart_mgr.apply_config_op({
+			{
+				id   = 'uart0',
+				path = port2.slave_name,
+				baud = 115200,
+				mode = '8N1',
+			},
+		}))
+		assert(ok2 == true, tostring(err2))
+
+		wait_device_event(dev_ev_ch, 'removed', 'uart', 'uart0', 1.5)
+		local added2 = wait_device_event(dev_ev_ch, 'added', 'uart', 'uart0', 1.5)
+		local cap2 = added2.capabilities[1]
+
+		local old_n, old_werr = perform(session1:write_op('x'))
+		assert(old_n == nil)
+		assert(old_werr ~= nil)
+		local old_chunk, old_rerr = perform(session1:read_some_op(1))
+		assert(old_chunk == nil)
+		assert(old_rerr ~= nil)
+
+		local session2 = open_uart_session(cap2)
+		local n2, errw2 = perform(session2:write_op('new'))
+		assert(n2 ~= nil, tostring(errw2))
+		local got2 = port2:expect_some(3, 1.0, 'read from new PTY master')
+		assert(got2 == 'new', ('expected "new", got %q'):format(tostring(got2)))
+
+		local okc2, cerr2 = perform(session2:close_op())
+		assert(okc2 ~= nil, tostring(cerr2))
+	end, { timeout = 4.0 })
+end
+
+function T.pending_read_loses_to_timeout_cleanly()
+	runfibers.run(function(scope)
+		local uart_mgr, dev_ev_ch = start_manager(scope)
+		local port = pty.open(scope)
+
+		local ok_cfg, err_cfg = perform(uart_mgr.apply_config_op({
+			{
+				id   = 'uart0',
+				path = port.slave_name,
+				baud = 115200,
+				mode = '8N1',
+			},
+		}))
+		assert(ok_cfg == true, tostring(err_cfg))
+
+		local added = wait_device_event(dev_ev_ch, 'added', 'uart', 'uart0', 1.5)
+		local cap = added.capabilities[1]
+		local session = open_uart_session(cap)
+
+		local which = perform(fibers.named_choice{
+			data = session:read_some_op(16):wrap(function(chunk, err)
+				return 'data', chunk, err
+			end),
+			timeout = sleep.sleep_op(0.05):wrap(function()
+				return 'timeout'
+			end),
+		})
+
+		assert(which == 'timeout')
+
+		local ok_c, cerr = perform(session:close_op())
+		assert(ok_c ~= nil, tostring(cerr))
+	end, { timeout = 3.0 })
+end
+
+return T

--- a/tests/run.lua
+++ b/tests/run.lua
@@ -31,8 +31,20 @@ local files = {
 	'unit.hal.cap_sdk_spec',
 	'unit.hal.hal_compat_spec',
 	'unit.hal.service_raw_host_spec',
+	'unit.hal.control_store_provider_spec',
+	'unit.hal.control_store_manager_spec',
+	"unit.hal.signature_verify_manager_spec",
+	"unit.hal.signature_verify_provider_spec",
+	"unit.hal.signature_verify_openssl_spec",
+	"unit.hal.artifact_store_driver_spec",
+	"unit.hal.artifact_store_provider_spec",
+	"unit.hal.artifact_store_manager_spec",
+	"unit.hal.uart_driver_spec",
+	"unit.hal.uart_manager_spec",
+	'unit.shared.blob_source_spec',
 	'integration.devhost.main_failure_spec',
 	'integration.devhost.config_recovery_spec',
+	"integration.devhost.hal_uart_spec",
 }
 
 local function monotonic_now()

--- a/tests/support/pty.lua
+++ b/tests/support/pty.lua
@@ -1,0 +1,250 @@
+-- tests/support/pty.lua
+
+local posix  = require 'posix'
+local file   = require 'fibers.io.file'
+local exec   = require 'fibers.io.exec'
+local fibers = require 'fibers'
+local sleep  = require 'fibers.sleep'
+local op     = require 'fibers.op'
+local safe   = require 'coxpcall'
+
+local perform = fibers.perform
+local M = {}
+
+local function close_fd(fd)
+	local fn = posix.close
+	if type(fn) ~= 'function' then
+		local ok, unistd = pcall(require, 'posix.unistd')
+		if ok and type(unistd.close) == 'function' then
+			fn = unistd.close
+		end
+	end
+	if type(fn) == 'function' and fd ~= nil then
+		pcall(function() fn(fd) end)
+	end
+end
+
+local function close_stream_best_effort(stream)
+	if not (stream and stream.close_op) then
+		return true, nil
+	end
+
+	local ok, a, b = safe.pcall(function()
+		return perform(stream:close_op())
+	end)
+	if not ok then
+		return nil, tostring(a)
+	end
+	return a, b
+end
+
+local function wait_read_some(stream, max_n, timeout_s)
+	local which, a, b = perform(op.named_choice({
+		data = stream:read_some_op(max_n),
+		timeout = sleep.sleep_op(timeout_s or 1.0):wrap(function()
+			return true
+		end),
+	}))
+
+	if which == 'timeout' then
+		return nil, 'timeout'
+	end
+
+	return a, b
+end
+
+local function write_all(stream, data)
+	local off = 1
+	while off <= #data do
+		local n, err = perform(stream:write_op(data:sub(off)))
+		if n == nil then
+			return nil, err
+		end
+		off = off + n
+	end
+	return true, nil
+end
+
+local function read_exact(stream, nbytes, timeout_s)
+	local deadline = fibers.now() + (timeout_s or 1.0)
+	local parts = {}
+	local got = 0
+
+	while got < nbytes do
+		local remain = deadline - fibers.now()
+		if remain <= 0 then
+			return nil, 'timeout'
+		end
+
+		local chunk, err = wait_read_some(stream, nbytes - got, remain)
+		if chunk == nil then
+			return nil, err
+		end
+
+		parts[#parts + 1] = chunk
+		got = got + #chunk
+	end
+
+	return table.concat(parts), nil
+end
+
+local function stty_raw_noecho(path)
+	local cmd = exec.command('stty', '-F', tostring(path), 'raw', '-echo')
+	local out, st, code, sig, err = perform(cmd:combined_output_op())
+
+	if st == 'exited' and code == 0 then
+		return true, nil
+	end
+
+	local detail = err or out or ('status=' .. tostring(st))
+	if st == 'exited' then
+		detail = tostring(detail) .. ' (exit ' .. tostring(code) .. ')'
+	elseif st == 'signalled' then
+		detail = tostring(detail) .. ' (signal ' .. tostring(sig) .. ')'
+	end
+	return nil, detail
+end
+
+---@class TestPTY
+---@field master Stream
+---@field slave_name string
+---@field _anchor_fd integer|nil
+local PTY = {}
+PTY.__index = PTY
+
+function PTY:write(data)
+	local ok, err = write_all(self.master, data)
+	if ok ~= true then
+		return nil, err
+	end
+	return true, nil
+end
+
+function PTY:read_some(max_n, timeout_s)
+	return wait_read_some(self.master, max_n, timeout_s)
+end
+
+function PTY:expect_some(max_n, timeout_s, label)
+	local data, err = self:read_some(max_n, timeout_s)
+	if data == nil then
+		error(('%s timed out: %s'):format(label or 'PTY read', tostring(err)), 0)
+	end
+	return data
+end
+
+function PTY:expect_exact(nbytes, timeout_s, label)
+	local data, err = read_exact(self.master, nbytes, timeout_s)
+	if data == nil then
+		error(('%s timed out: %s'):format(label or 'PTY read exact', tostring(err)), 0)
+	end
+	return data
+end
+
+function PTY:expect_no_data(timeout_s, label)
+	local data, _err = self:read_some(4096, timeout_s or 0.10)
+	if data ~= nil then
+		error(('%s unexpectedly received data: %q'):format(label or 'PTY read', tostring(data)), 0)
+	end
+	return true
+end
+
+function PTY:close()
+	if self.master then
+		close_stream_best_effort(self.master)
+		self.master = nil
+	end
+
+	if self._anchor_fd ~= nil then
+		close_fd(self._anchor_fd)
+		self._anchor_fd = nil
+	end
+
+	return true
+end
+
+---@param scope Scope|nil
+---@return TestPTY
+function M.open(scope)
+	local master_fd, slave_fd, slave_name, err = posix.openpty()
+	if not master_fd then
+		error('openpty failed: ' .. tostring(slave_fd or err), 0)
+	end
+
+	-- Put the slave side into raw/noecho mode up front so code under test
+	-- that opens slave_name directly sees predictable byte-stream behaviour.
+	local ok_raw, err_raw = stty_raw_noecho(slave_name)
+	if ok_raw ~= true then
+		close_fd(master_fd)
+		close_fd(slave_fd)
+		error('failed to configure PTY slave raw mode: ' .. tostring(err_raw), 0)
+	end
+
+	local master = file.fdopen(master_fd, 'r+', 'pty-master:' .. tostring(slave_name))
+	master:setvbuf('no')
+
+	local rec = setmetatable({
+		master     = master,
+		slave_name = slave_name,
+		_anchor_fd = slave_fd,
+	}, PTY)
+
+	if scope and scope.finally then
+		scope:finally(function()
+			rec:close()
+		end)
+	end
+
+	return rec
+end
+
+function M.open_slave_stream(path, opts)
+	opts = opts or {}
+
+	if opts.raw ~= false then
+		local ok, err = stty_raw_noecho(path)
+		if ok ~= true then
+			return nil, 'stty failed: ' .. tostring(err)
+		end
+	end
+
+	local s, err = file.open(path, 'r+')
+	if not s then
+		return nil, err
+	end
+
+	pcall(function()
+		if s.setvbuf then s:setvbuf('no') end
+	end)
+
+	return s, nil
+end
+
+function M.read_some(stream, max_n, timeout_s)
+	return wait_read_some(stream, max_n, timeout_s)
+end
+
+function M.expect_some(stream, max_n, timeout_s, label)
+	local data, err = wait_read_some(stream, max_n, timeout_s)
+	if data == nil then
+		error(('%s timed out: %s'):format(label or 'stream read', tostring(err)), 0)
+	end
+	return data
+end
+
+function M.expect_exact(stream, nbytes, timeout_s, label)
+	local data, err = read_exact(stream, nbytes, timeout_s)
+	if data == nil then
+		error(('%s timed out: %s'):format(label or 'stream read exact', tostring(err)), 0)
+	end
+	return data
+end
+
+function M.expect_no_data(stream, timeout_s, label)
+	local data, _err = wait_read_some(stream, 4096, timeout_s or 0.10)
+	if data ~= nil then
+		error(('%s unexpectedly received data: %q'):format(label or 'stream read', tostring(data)), 0)
+	end
+	return true
+end
+
+return M

--- a/tests/unit/hal/artifact_store_driver_spec.lua
+++ b/tests/unit/hal/artifact_store_driver_spec.lua
@@ -1,0 +1,244 @@
+local fibers      = require 'fibers'
+local runfibers   = require 'tests.support.run_fibers'
+local blob_source = require 'shared.blob_source'
+
+local store_mod   = require 'services.hal.drivers.artifact_store'
+
+local T = {}
+
+local function mk_tmpdir(tag)
+	local path = ('/tmp/dc-lua-%s-%d-%06d'):format(tag, os.time(), math.random(0, 999999))
+	local ok = os.execute(('mkdir -p %q'):format(path))
+	assert(ok == true or ok == 0, 'failed to create temp dir: ' .. path)
+	return path
+end
+
+local function rm_rf(path)
+	os.execute(('rm -rf %q'):format(path))
+end
+
+function T.artifact_store_imports_source_opens_and_deletes_transient_artifact()
+	local base = mk_tmpdir('as-driver-roundtrip')
+	local transient_root = base .. '/transient'
+	local durable_root = base .. '/durable'
+
+	runfibers.run(function()
+		local store = store_mod.new({
+			transient_root = transient_root,
+			durable_root = durable_root,
+			durable_enabled = false,
+		}, nil)
+
+		local ok_import, artifact = fibers.perform(store:import_source_op(
+			blob_source.from_string('hello'),
+			{ kind = 'update', target = 'mcu' },
+			{ policy = 'transient_only' }
+		))
+		assert(ok_import == true, tostring(artifact))
+
+		local rec = artifact:describe()
+		assert(rec.durability == 'transient')
+		assert(rec.state == 'ready')
+		assert(rec.size == 5)
+		assert(type(rec.checksum) == 'string')
+		assert(#rec.checksum == 8)
+
+		local ok_open_src, src = fibers.perform(artifact:open_source_op())
+		assert(ok_open_src == true, tostring(src))
+
+		local chunk, err = fibers.perform(src:read_chunk_op(99))
+		assert(err == nil)
+		assert(chunk == 'hello')
+
+		local eof, eof_err = fibers.perform(src:read_chunk_op(99))
+		assert(eof == nil)
+		assert(eof_err == nil)
+
+		local ok_resolve, resolved = fibers.perform(store:resolve_local_op(artifact:ref()))
+		assert(ok_resolve == true, tostring(resolved))
+		assert(type(resolved.path) == 'string')
+
+		local ok_delete, err_delete = fibers.perform(store:delete_op(artifact:ref()))
+		assert(ok_delete == true, tostring(err_delete))
+
+		local ok_open, open_err = fibers.perform(store:open_op(artifact:ref()))
+		assert(ok_open == false)
+		assert(open_err == 'not_found')
+	end)
+
+	rm_rf(base)
+end
+
+function T.artifact_store_honours_durability_policy()
+	local base = mk_tmpdir('as-driver-policy')
+	local transient_root = base .. '/transient'
+	local durable_root = base .. '/durable'
+
+	runfibers.run(function()
+		local store = store_mod.new({
+			transient_root = transient_root,
+			durable_root = durable_root,
+			durable_enabled = false,
+		}, nil)
+
+		local ok_art, art_or_err = fibers.perform(store:import_source_op(
+			blob_source.from_string('a'),
+			{ kind = 'update' },
+			{ policy = 'prefer_durable' }
+		))
+		assert(ok_art == true, tostring(art_or_err))
+		assert(art_or_err:describe().durability == 'transient')
+
+		local ok_sink, sink_or_err = fibers.perform(store:create_sink_op(
+			{ kind = 'update' },
+			{ policy = 'require_durable' }
+		))
+		assert(ok_sink == false)
+		assert(sink_or_err == 'durable_disabled')
+
+		local store2 = store_mod.new({
+			transient_root = transient_root,
+			durable_root = durable_root,
+			durable_enabled = true,
+		}, nil)
+
+		local ok_art2, art2_or_err = fibers.perform(store2:import_source_op(
+			blob_source.from_string('b'),
+			{ kind = 'update' },
+			{ policy = 'require_durable' }
+		))
+		assert(ok_art2 == true, tostring(art2_or_err))
+		assert(art2_or_err:describe().durability == 'durable')
+	end)
+
+	rm_rf(base)
+end
+
+function T.artifact_store_imports_path_and_reports_status()
+	local base = mk_tmpdir('as-driver-path')
+	local transient_root = base .. '/transient'
+	local durable_root = base .. '/durable'
+	local import_root = base .. '/incoming'
+
+	os.execute(('mkdir -p %q'):format(import_root))
+
+	local f = assert(io.open(import_root .. '/fw.bin', 'wb'))
+	assert(f:write('firmware-bytes'))
+	assert(f:close())
+
+	runfibers.run(function()
+		local store = store_mod.new({
+			transient_root = transient_root,
+			durable_root = durable_root,
+			import_root = import_root,
+			durable_enabled = false,
+		}, nil)
+
+		local ok_import, artifact = fibers.perform(store:import_path_op('fw.bin', {
+			kind = 'firmware',
+			target = 'cm5',
+		}, {
+			policy = 'prefer_durable',
+		}))
+		assert(ok_import == true, tostring(artifact))
+
+		local rec = artifact:describe()
+		assert(rec.durability == 'transient')
+		assert(rec.state == 'ready')
+
+		local ok_status, status = fibers.perform(store:status_op())
+		assert(ok_status == true, tostring(status))
+		assert(status.kind == 'artifact_store')
+		assert(status.transient_root == transient_root)
+		assert(status.durable_root == durable_root)
+		assert(status.durable_enabled == false)
+		assert(status.import_root == import_root)
+	end)
+
+	rm_rf(base)
+end
+
+function T.artifact_sink_close_aborts_open_session_and_cleans_up_partial_artifact()
+	local base = mk_tmpdir('as-driver-close-abort')
+	local transient_root = base .. '/transient'
+	local durable_root = base .. '/durable'
+
+	runfibers.run(function()
+		local store = store_mod.new({
+			transient_root = transient_root,
+			durable_root = durable_root,
+			durable_enabled = false,
+		}, nil)
+
+		local ok_sink, sink_or_err = fibers.perform(store:create_sink_op(
+			{ kind = 'update', target = 'mcu' },
+			{ policy = 'transient_only' }
+		))
+		assert(ok_sink == true, tostring(sink_or_err))
+		local sink = sink_or_err
+
+		local ref = sink:status().artifact_ref
+
+		local ok_write, write_err = fibers.perform(sink:write_chunk_op('partial-data'))
+		assert(ok_write == true, tostring(write_err))
+
+		local ok_close, close_err = fibers.perform(sink:close_op())
+		assert(ok_close == true, tostring(close_err))
+
+		local snapshot = sink:status()
+		assert(snapshot.terminal == true)
+		assert(snapshot.state == 'aborted')
+
+		local ok_open, open_err = fibers.perform(store:open_op(ref))
+		assert(ok_open == false)
+		assert(open_err == 'not_found')
+
+		local ok_resolve, resolve_err = fibers.perform(store:resolve_local_op(ref))
+		assert(ok_resolve == false)
+		assert(resolve_err == 'not_found')
+	end)
+
+	rm_rf(base)
+end
+
+function T.artifact_sink_commit_is_idempotent_for_same_session()
+	local base = mk_tmpdir('as-driver-idempotent-commit')
+	local transient_root = base .. '/transient'
+	local durable_root = base .. '/durable'
+
+	runfibers.run(function()
+		local store = store_mod.new({
+			transient_root = transient_root,
+			durable_root = durable_root,
+			durable_enabled = false,
+		}, nil)
+
+		local ok_sink, sink_or_err = fibers.perform(store:create_sink_op(
+			{ kind = 'update', target = 'mcu' },
+			{ policy = 'transient_only' }
+		))
+		assert(ok_sink == true, tostring(sink_or_err))
+		local sink = sink_or_err
+
+		local ok_write, write_err = fibers.perform(sink:write_chunk_op('payload'))
+		assert(ok_write == true, tostring(write_err))
+
+		local ok_commit1, art1_or_err = fibers.perform(sink:commit_op())
+		assert(ok_commit1 == true, tostring(art1_or_err))
+		local art1 = art1_or_err
+
+		local ok_commit2, art2_or_err = fibers.perform(sink:commit_op())
+		assert(ok_commit2 == true, tostring(art2_or_err))
+		local art2 = art2_or_err
+
+		assert(art1:ref() == art2:ref())
+		assert(art1:describe().checksum == art2:describe().checksum)
+
+		local ok_open, art_or_err = fibers.perform(store:open_op(art1:ref()))
+		assert(ok_open == true, tostring(art_or_err))
+	end)
+
+	rm_rf(base)
+end
+
+return T

--- a/tests/unit/hal/artifact_store_manager_spec.lua
+++ b/tests/unit/hal/artifact_store_manager_spec.lua
@@ -1,0 +1,235 @@
+local fibers    = require 'fibers'
+local sleep     = require 'fibers.sleep'
+local channel   = require 'fibers.channel'
+
+local runfibers = require 'tests.support.run_fibers'
+
+local T = {}
+
+local function fresh_manager()
+	package.loaded['services.hal.managers.artifact_store'] = nil
+	return require 'services.hal.managers.artifact_store'
+end
+
+local function recv_or_fail(ch)
+	local v, err = fibers.perform(ch:get_op())
+	assert(v, tostring(err))
+	return v
+end
+
+local function mk_tmpdir(tag)
+	local path = ('/tmp/dc-lua-%s-%d-%06d'):format(tag, os.time(), math.random(0, 999999))
+	local ok = os.execute(('mkdir -p %q'):format(path))
+	assert(ok == true or ok == 0, 'failed to create temp dir: ' .. path)
+	return path
+end
+
+local function rm_rf(path)
+	os.execute(('rm -rf %q'):format(path))
+end
+
+function T.apply_config_fails_when_not_started()
+	local M = fresh_manager()
+
+	runfibers.run(function()
+		local ok, err = fibers.perform(M.apply_config_op({
+			stores = {
+				{ id = 'main', transient_root = '/tmp/a', durable_root = '/tmp/b', durable_enabled = false },
+			},
+		}))
+		assert(ok == false)
+		assert(tostring(err):match('not started'))
+	end)
+end
+
+function T.start_apply_config_and_stop_round_trip()
+	local M = fresh_manager()
+	local base = mk_tmpdir('as-manager-start')
+	local transient_root = base .. '/transient'
+	local durable_root = base .. '/durable'
+
+	runfibers.run(function()
+		local dev_ev_ch = channel.new(8)
+		local cap_emit_ch = channel.new(8)
+
+		local ok_start, err_start = fibers.perform(M.start_op(nil, dev_ev_ch, cap_emit_ch))
+		assert(ok_start == true, tostring(err_start))
+
+		local ok_cfg, err_cfg = fibers.perform(M.apply_config_op({
+			stores = {
+				{
+					id = 'main',
+					transient_root = transient_root,
+					durable_root = durable_root,
+					durable_enabled = false,
+				},
+			},
+		}))
+		assert(ok_cfg == true, tostring(err_cfg))
+
+		local ev = recv_or_fail(dev_ev_ch)
+		assert(ev.event_type == 'added')
+		assert(ev.class == 'artifact_store')
+		assert(ev.id == 'main')
+		assert(#ev.capabilities == 1)
+		assert(ev.capabilities[1].class == 'artifact_store')
+		assert(ev.capabilities[1].offerings.create_sink == true)
+
+		local e1 = recv_or_fail(cap_emit_ch)
+		local e2 = recv_or_fail(cap_emit_ch)
+
+		local by_mode = {
+			[e1.mode] = e1,
+			[e2.mode] = e2,
+		}
+
+		assert(by_mode.meta ~= nil)
+		assert(by_mode.state ~= nil)
+		assert(by_mode.meta.class == 'artifact_store')
+		assert(by_mode.meta.id == 'main')
+		assert(by_mode.meta.data.transient_root == transient_root)
+		assert(by_mode.meta.data.durable_root == durable_root)
+		assert(by_mode.state.data.state == 'available')
+
+		local ok_stop, err_stop = fibers.perform(M.stop_op())
+		assert(ok_stop == true, tostring(err_stop))
+	end)
+
+	rm_rf(base)
+end
+
+function T.reapply_same_config_is_idempotent()
+	local M = fresh_manager()
+	local base = mk_tmpdir('as-manager-same')
+	local transient_root = base .. '/transient'
+	local durable_root = base .. '/durable'
+
+	runfibers.run(function()
+		local dev_ev_ch = channel.new(8)
+		local cap_emit_ch = channel.new(8)
+
+		local ok_start, err_start = fibers.perform(M.start_op(nil, dev_ev_ch, cap_emit_ch))
+		assert(ok_start == true, tostring(err_start))
+
+		local cfg = {
+			stores = {
+				{
+					id = 'main',
+					transient_root = transient_root,
+					durable_root = durable_root,
+					durable_enabled = false,
+				},
+			},
+		}
+
+		local ok1, err1 = fibers.perform(M.apply_config_op(cfg))
+		assert(ok1 == true, tostring(err1))
+		local added = recv_or_fail(dev_ev_ch)
+		assert(added.event_type == 'added')
+
+		local ok2, err2 = fibers.perform(M.apply_config_op(cfg))
+		assert(ok2 == true, tostring(err2))
+
+		local which = fibers.perform(require('fibers').named_choice{
+			msg = dev_ev_ch:get_op():wrap(function(v) return 'msg', v end),
+			timeout = sleep.sleep_op(0.05):wrap(function() return 'timeout' end),
+		})
+		assert(which == 'timeout', 'reapplying same config should not emit new device events')
+
+		local ok_stop, err_stop = fibers.perform(M.stop_op())
+		assert(ok_stop == true, tostring(err_stop))
+	end)
+
+	rm_rf(base)
+end
+
+function T.config_change_removes_then_adds_provider()
+	local M = fresh_manager()
+	local base = mk_tmpdir('as-manager-change')
+	local transient_root_a = base .. '/transient-a'
+	local transient_root_b = base .. '/transient-b'
+	local durable_root = base .. '/durable'
+
+	runfibers.run(function()
+		local dev_ev_ch = channel.new(8)
+		local cap_emit_ch = channel.new(8)
+
+		local ok_start, err_start = fibers.perform(M.start_op(nil, dev_ev_ch, cap_emit_ch))
+		assert(ok_start == true, tostring(err_start))
+
+		local ok1, err1 = fibers.perform(M.apply_config_op({
+			stores = {
+				{
+					id = 'main',
+					transient_root = transient_root_a,
+					durable_root = durable_root,
+					durable_enabled = false,
+				},
+			},
+		}))
+		assert(ok1 == true, tostring(err1))
+		local first = recv_or_fail(dev_ev_ch)
+		assert(first.event_type == 'added')
+
+		local ok2, err2 = fibers.perform(M.apply_config_op({
+			stores = {
+				{
+					id = 'main',
+					transient_root = transient_root_b,
+					durable_root = durable_root,
+					durable_enabled = false,
+				},
+			},
+		}))
+		assert(ok2 == true, tostring(err2))
+
+		local ev_a = recv_or_fail(dev_ev_ch)
+		local ev_b = recv_or_fail(dev_ev_ch)
+		assert(ev_a.event_type == 'removed')
+		assert(ev_b.event_type == 'added')
+		assert(ev_b.id == 'main')
+
+		local ok_stop, err_stop = fibers.perform(M.stop_op())
+		assert(ok_stop == true, tostring(err_stop))
+	end)
+
+	rm_rf(base)
+end
+
+function T.invalid_config_is_rejected()
+	local M = fresh_manager()
+
+	runfibers.run(function()
+		local dev_ev_ch = channel.new(8)
+		local cap_emit_ch = channel.new(8)
+
+		local ok_start, err_start = fibers.perform(M.start_op(nil, dev_ev_ch, cap_emit_ch))
+		assert(ok_start == true, tostring(err_start))
+
+		local ok_cfg, err_cfg = fibers.perform(M.apply_config_op({
+			stores = 'nope',
+		}))
+		assert(ok_cfg == false)
+		assert(tostring(err_cfg):match('stores must be a table'))
+
+		local ok_stop, err_stop = fibers.perform(M.stop_op())
+		assert(ok_stop == true, tostring(err_stop))
+	end)
+end
+
+function T.stop_op_before_start_is_ok_and_fault_op_is_inert()
+	local M = fresh_manager()
+
+	runfibers.run(function()
+		local ok_stop, err_stop = fibers.perform(M.stop_op())
+		assert(ok_stop == true, tostring(err_stop))
+
+		local which = fibers.perform(require('fibers').named_choice{
+			fault = M.fault_op():wrap(function(...) return 'fault', ... end),
+			timeout = sleep.sleep_op(0.05):wrap(function() return 'timeout' end),
+		})
+		assert(which == 'timeout')
+	end)
+end
+
+return T

--- a/tests/unit/hal/artifact_store_provider_spec.lua
+++ b/tests/unit/hal/artifact_store_provider_spec.lua
@@ -1,0 +1,336 @@
+local fibers      = require 'fibers'
+local channel     = require 'fibers.channel'
+
+local runfibers   = require 'tests.support.run_fibers'
+local core_types  = require 'services.hal.types.core'
+local cap_args    = require 'services.hal.types.capability_args'
+local blob_source = require 'shared.blob_source'
+
+local provider_mod = require 'services.hal.drivers.artifact_store_provider'
+
+local T = {}
+
+local function mk_tmpdir(tag)
+	local path = ('/tmp/dc-lua-%s-%d-%06d'):format(tag, os.time(), math.random(0, 999999))
+	local ok = os.execute(('mkdir -p %q'):format(path))
+	assert(ok == true or ok == 0, 'failed to create temp dir: ' .. path)
+	return path
+end
+
+local function rm_rf(path)
+	os.execute(('rm -rf %q'):format(path))
+end
+
+local function recv_or_fail(ch)
+	local v, err = fibers.perform(ch:get_op())
+	assert(v, tostring(err))
+	return v
+end
+
+local function request(driver, verb, opts)
+	local reply_ch = channel.new(1)
+	local req, err = core_types.new.ControlRequest(verb, opts or {}, reply_ch)
+	assert(req, tostring(err))
+
+	local sent, send_err = fibers.perform(driver.control_ch:put_op(req))
+	assert(sent ~= false, tostring(send_err))
+
+	local reply, recv_err = fibers.perform(reply_ch:get_op())
+	assert(reply, tostring(recv_err))
+	return reply
+end
+
+function T.capabilities_op_returns_artifact_store_capability()
+	local base = mk_tmpdir('as-provider-cap')
+	local transient_root = base .. '/transient'
+	local durable_root = base .. '/durable'
+	local emit_ch = channel.new(8)
+
+	runfibers.run(function()
+		local driver = provider_mod.new('main', {
+			transient_root = transient_root,
+			durable_root = durable_root,
+			durable_enabled = false,
+		}, nil)
+
+		local ok, caps_or_err = fibers.perform(driver:capabilities_op(emit_ch))
+		assert(ok == true, tostring(caps_or_err))
+		assert(type(caps_or_err) == 'table')
+		assert(#caps_or_err == 1)
+
+		local cap = caps_or_err[1]
+		assert(cap.class == 'artifact_store')
+		assert(cap.id == 'main')
+		assert(cap.offerings.create_sink == true)
+		assert(cap.offerings.import_path == true)
+		assert(cap.offerings.import_source == true)
+		assert(cap.offerings.open == true)
+		assert(cap.offerings.delete == true)
+		assert(cap.offerings.status == true)
+	end)
+
+	rm_rf(base)
+end
+
+function T.start_op_emits_initial_meta_and_available_state()
+	local base = mk_tmpdir('as-provider-start')
+	local transient_root = base .. '/transient'
+	local durable_root = base .. '/durable'
+	local emit_ch = channel.new(8)
+
+	runfibers.run(function(scope)
+		local driver = provider_mod.new('main', {
+			transient_root = transient_root,
+			durable_root = durable_root,
+			durable_enabled = false,
+		}, nil)
+
+		local ok_caps, caps_err = fibers.perform(driver:capabilities_op(emit_ch))
+		assert(ok_caps == true, tostring(caps_err))
+
+		local ok_start, start_err = fibers.perform(driver:start_op(scope))
+		assert(ok_start == true, tostring(start_err))
+
+		local e1 = recv_or_fail(emit_ch)
+		local e2 = recv_or_fail(emit_ch)
+
+		local by_mode = {
+			[e1.mode] = e1,
+			[e2.mode] = e2,
+		}
+
+		assert(by_mode.meta ~= nil)
+		assert(by_mode.state ~= nil)
+
+		assert(by_mode.meta.class == 'artifact_store')
+		assert(by_mode.meta.id == 'main')
+		assert(by_mode.meta.key == 'info')
+		assert(by_mode.meta.data.transient_root == transient_root)
+		assert(by_mode.meta.data.durable_root == durable_root)
+		assert(by_mode.meta.data.durable_enabled == false)
+
+		assert(by_mode.state.key == 'status')
+		assert(by_mode.state.data.state == 'available')
+
+		local ok_stop, stop_err = fibers.perform(driver:stop_op())
+		assert(ok_stop == true, tostring(stop_err))
+	end)
+
+	rm_rf(base)
+end
+
+function T.create_sink_commit_open_and_delete_round_trip()
+	local base = mk_tmpdir('as-provider-roundtrip')
+	local transient_root = base .. '/transient'
+	local durable_root = base .. '/durable'
+	local emit_ch = channel.new(8)
+
+	runfibers.run(function(scope)
+		local driver = provider_mod.new('main', {
+			transient_root = transient_root,
+			durable_root = durable_root,
+			durable_enabled = false,
+		}, nil)
+
+		local ok_caps, caps_err = fibers.perform(driver:capabilities_op(emit_ch))
+		assert(ok_caps == true, tostring(caps_err))
+
+		local ok_start, start_err = fibers.perform(driver:start_op(scope))
+		assert(ok_start == true, tostring(start_err))
+
+		local create_opts = assert(cap_args.new.ArtifactStoreCreateSinkOpts(
+			{ kind = 'update', target = 'mcu' },
+			'transient_only'
+		))
+		local create_reply = request(driver, 'create_sink', create_opts)
+		assert(create_reply.ok == true)
+
+		local sink = create_reply.reason
+		local ok_write, write_err = fibers.perform(sink:write_chunk_op('hello'))
+		assert(ok_write == true, tostring(write_err))
+
+		local ok_commit, art_or_err = fibers.perform(sink:commit_op())
+		assert(ok_commit == true, tostring(art_or_err))
+		local artifact = art_or_err
+
+		local open_opts = assert(cap_args.new.ArtifactStoreOpenOpts(artifact:ref()))
+		local open_reply = request(driver, 'open', open_opts)
+		assert(open_reply.ok == true)
+
+		local opened = open_reply.reason
+		local ok_src, src_or_err = fibers.perform(opened:open_source_op())
+		assert(ok_src == true, tostring(src_or_err))
+
+		local chunk, err = fibers.perform(src_or_err:read_chunk_op(99))
+		assert(err == nil)
+		assert(chunk == 'hello')
+
+		local del_opts = assert(cap_args.new.ArtifactStoreDeleteOpts(artifact:ref()))
+		local del_reply = request(driver, 'delete', del_opts)
+		assert(del_reply.ok == true)
+
+		local status_reply = request(driver, 'status', assert(cap_args.new.ArtifactStoreStatusOpts()))
+		assert(status_reply.ok == true)
+		assert(status_reply.reason.kind == 'artifact_store')
+
+		local ok_stop, stop_err = fibers.perform(driver:stop_op())
+		assert(ok_stop == true, tostring(stop_err))
+	end)
+
+	rm_rf(base)
+end
+
+function T.import_source_request_round_trips_success()
+	local base = mk_tmpdir('as-provider-import-source')
+	local transient_root = base .. '/transient'
+	local durable_root = base .. '/durable'
+	local emit_ch = channel.new(8)
+
+	runfibers.run(function(scope)
+		local driver = provider_mod.new('main', {
+			transient_root = transient_root,
+			durable_root = durable_root,
+			durable_enabled = false,
+		}, nil)
+
+		local ok_caps, caps_err = fibers.perform(driver:capabilities_op(emit_ch))
+		assert(ok_caps == true, tostring(caps_err))
+
+		local ok_start, start_err = fibers.perform(driver:start_op(scope))
+		assert(ok_start == true, tostring(start_err))
+
+		local import_opts = assert(cap_args.new.ArtifactStoreImportSourceOpts(
+			blob_source.from_string('firmware'),
+			{ kind = 'firmware', target = 'cm5' },
+			'transient_only'
+		))
+
+		local reply = request(driver, 'import_source', import_opts)
+		assert(reply.ok == true)
+
+		local artifact = reply.reason
+		local rec = artifact:describe()
+		assert(rec.state == 'ready')
+		assert(rec.size == 8)
+
+		local ok_stop, stop_err = fibers.perform(driver:stop_op())
+		assert(ok_stop == true, tostring(stop_err))
+	end)
+
+	rm_rf(base)
+end
+
+function T.stop_op_before_start_is_ok_and_fault_op_is_inert()
+	local base = mk_tmpdir('as-provider-stop')
+	local transient_root = base .. '/transient'
+	local durable_root = base .. '/durable'
+
+	runfibers.run(function()
+		local driver = provider_mod.new('main', {
+			transient_root = transient_root,
+			durable_root = durable_root,
+			durable_enabled = false,
+		}, nil)
+
+		local ok_stop, stop_err = fibers.perform(driver:stop_op())
+		assert(ok_stop == true, tostring(stop_err))
+
+		local which = fibers.perform(require('fibers').named_choice{
+			fault = driver:fault_op():wrap(function(...) return 'fault', ... end),
+			timeout = require('fibers.sleep').sleep_op(0.05):wrap(function() return 'timeout' end),
+		})
+		assert(which == 'timeout')
+	end)
+
+	rm_rf(base)
+end
+
+function T.create_sink_close_aborts_partial_artifact()
+	local base = mk_tmpdir('as-provider-close')
+	local transient_root = base .. '/transient'
+	local durable_root = base .. '/durable'
+	local emit_ch = channel.new(8)
+
+	runfibers.run(function(scope)
+		local driver = provider_mod.new('main', {
+			transient_root = transient_root,
+			durable_root = durable_root,
+			durable_enabled = false,
+		}, nil)
+
+		local ok_caps, caps_err = fibers.perform(driver:capabilities_op(emit_ch))
+		assert(ok_caps == true, tostring(caps_err))
+
+		local ok_start, start_err = fibers.perform(driver:start_op(scope))
+		assert(ok_start == true, tostring(start_err))
+
+		local create_opts = assert(cap_args.new.ArtifactStoreCreateSinkOpts(
+			{ kind = 'update', target = 'mcu' },
+			'transient_only'
+		))
+
+		local create_reply = request(driver, 'create_sink', create_opts)
+		assert(create_reply.ok == true)
+		local sink = create_reply.reason
+
+		local ref = sink:status().artifact_ref
+
+		local ok_write, write_err = fibers.perform(sink:write_chunk_op('partial'))
+		assert(ok_write == true, tostring(write_err))
+
+		local ok_close, close_err = fibers.perform(sink:close_op())
+		assert(ok_close == true, tostring(close_err))
+
+		local open_opts = assert(cap_args.new.ArtifactStoreOpenOpts(ref))
+		local open_reply = request(driver, 'open', open_opts)
+		assert(open_reply.ok == false)
+		assert(open_reply.reason == 'not_found')
+
+		local ok_stop, stop_err = fibers.perform(driver:stop_op())
+		assert(ok_stop == true, tostring(stop_err))
+	end)
+
+	rm_rf(base)
+end
+
+function T.commit_is_idempotent_for_same_provider_sink_session()
+	local base = mk_tmpdir('as-provider-idempotent')
+	local transient_root = base .. '/transient'
+	local durable_root = base .. '/durable'
+	local emit_ch = channel.new(8)
+
+	runfibers.run(function(scope)
+		local driver = provider_mod.new('main', {
+			transient_root = transient_root,
+			durable_root = durable_root,
+			durable_enabled = false,
+		}, nil)
+
+		local ok_caps, caps_err = fibers.perform(driver:capabilities_op(emit_ch))
+		assert(ok_caps == true, tostring(caps_err))
+
+		local ok_start, start_err = fibers.perform(driver:start_op(scope))
+		assert(ok_start == true, tostring(start_err))
+
+		local create_opts = assert(cap_args.new.ArtifactStoreCreateSinkOpts({ kind = 'update' }, 'transient_only'))
+		local create_reply = request(driver, 'create_sink', create_opts)
+		assert(create_reply.ok == true)
+		local sink = create_reply.reason
+
+		local ok_write, write_err = fibers.perform(sink:write_chunk_op('abc'))
+		assert(ok_write == true, tostring(write_err))
+
+		local ok1, art1 = fibers.perform(sink:commit_op())
+		assert(ok1 == true, tostring(art1))
+		local ok2, art2 = fibers.perform(sink:commit_op())
+		assert(ok2 == true, tostring(art2))
+		assert(art1:ref() == art2:ref())
+
+		local ok_stop, stop_err = fibers.perform(driver:stop_op())
+		assert(ok_stop == true, tostring(stop_err))
+	end)
+
+	rm_rf(base)
+end
+
+return T

--- a/tests/unit/hal/control_loop_spec.lua
+++ b/tests/unit/hal/control_loop_spec.lua
@@ -1,0 +1,104 @@
+local fibers       = require 'fibers'
+local op           = require 'fibers.op'
+local channel      = require 'fibers.channel'
+local runfibers    = require 'tests.support.run_fibers'
+local control_loop = require 'services.hal.support.control_loop'
+local types        = require 'services.hal.types.core'
+
+local T = {}
+
+function T.evaluate_request_op_rejects_unknown_verbs()
+    runfibers.run(function()
+        local req = assert(types.new.ControlRequest('missing', {}, channel.new()))
+        local ok, err = fibers.perform(control_loop.evaluate_request_op({}, req))
+        assert(ok == false)
+        assert(tostring(err):match('unsupported verb'))
+    end)
+end
+
+function T.evaluate_request_op_requires_op_handlers()
+    runfibers.run(function()
+        local req = assert(types.new.ControlRequest('bad', {}, channel.new()))
+        local ok, err = pcall(function()
+            fibers.perform(control_loop.evaluate_request_op({
+                bad = function() return true, 'nope' end,
+            }, req))
+        end)
+        assert(ok == false)
+        assert(tostring(err):match('must return an Op'))
+    end)
+end
+
+function T.run_request_loop_handles_requests_and_replies()
+    runfibers.run(function(scope)
+        local ch = channel.new()
+
+        local ok_spawn, err = scope:spawn(function()
+            control_loop.run_request_loop(ch, {
+                echo = function(opts)
+                    return op.always(true, { echoed = opts.value })
+                end,
+            }, nil, 'test_loop')
+        end)
+        assert(ok_spawn, tostring(err))
+
+        local reply_ch = channel.new()
+        local req = assert(types.new.ControlRequest('echo', { value = 42 }, reply_ch))
+
+        local sent, send_err = fibers.perform(ch:put_op(req))
+        assert(sent ~= false, tostring(send_err))
+
+        local reply, reply_err = fibers.perform(reply_ch:get_op())
+        assert(reply, tostring(reply_err))
+        assert(reply.ok == true)
+        assert(type(reply.reason) == 'table')
+        assert(reply.reason.echoed == 42)
+    end)
+end
+
+function T.run_request_loop_returns_error_reply_for_unsupported_verbs()
+    runfibers.run(function(scope)
+        local ch = channel.new()
+
+        local ok_spawn, err = scope:spawn(function()
+            control_loop.run_request_loop(ch, {}, nil, 'test_loop')
+        end)
+        assert(ok_spawn, tostring(err))
+
+        local reply_ch = channel.new()
+        local req = assert(types.new.ControlRequest('nope', {}, reply_ch))
+
+        local sent, send_err = fibers.perform(ch:put_op(req))
+        assert(sent ~= false, tostring(send_err))
+
+        local reply = fibers.perform(reply_ch:get_op())
+        assert(reply ~= nil)
+        assert(reply.ok == false)
+        assert(tostring(reply.reason):match('unsupported verb'))
+    end)
+end
+
+function T.run_request_loop_exits_when_scope_is_cancelled()
+    runfibers.run(function(scope)
+        local loop_scope, cerr = scope:child()
+        assert(loop_scope, tostring(cerr))
+
+        local ch = channel.new()
+
+        local ok_spawn, err = loop_scope:spawn(function()
+            control_loop.run_request_loop(ch, {
+                echo = function(opts)
+                    return op.always(true, opts)
+                end,
+            }, nil, 'test_loop')
+        end)
+        assert(ok_spawn, tostring(err))
+
+        loop_scope:cancel('stop test')
+
+        local st, rep, primary = fibers.perform(loop_scope:join_op())
+        assert(st == 'cancelled', tostring(primary))
+    end)
+end
+
+return T

--- a/tests/unit/hal/control_store_manager_spec.lua
+++ b/tests/unit/hal/control_store_manager_spec.lua
@@ -1,0 +1,196 @@
+local fibers     = require 'fibers'
+local channel    = require 'fibers.channel'
+local runfibers  = require 'tests.support.run_fibers'
+
+local T = {}
+
+local function mk_tmpdir(tag)
+  local path = ('/tmp/dc-lua-%s-%d-%06d'):format(tag, os.time(), math.random(0, 999999))
+  local ok = os.execute(('mkdir -p %q'):format(path))
+  assert(ok == true or ok == 0, 'failed to create temp dir: ' .. path)
+  return path
+end
+
+local function rm_rf(path)
+  os.execute(('rm -rf %q'):format(path))
+end
+
+local function fresh_manager()
+  package.loaded['services.hal.managers.control_store'] = nil
+  package.loaded['services.hal.drivers.control_store'] = nil
+  package.loaded['services.hal.drivers.control_store_provider'] = nil
+  return require('services.hal.managers.control_store')
+end
+
+local function recv_or_fail(ch)
+  local v, err = fibers.perform(ch:get_op())
+  assert(v ~= nil, tostring(err))
+  return v
+end
+
+function T.start_apply_config_and_stop_round_trip()
+  local root = mk_tmpdir('csm-roundtrip')
+  local M = fresh_manager()
+
+  runfibers.run(function(scope)
+    local dev_ev_ch = channel.new(8)
+    local cap_emit_ch = channel.new(8)
+
+    local ok_start, err_start = fibers.perform(M.start_op(nil, dev_ev_ch, cap_emit_ch))
+    assert(ok_start == true, tostring(err_start))
+
+    local ok_cfg, err_cfg = fibers.perform(M.apply_config_op({
+      { name = 'main', root = root },
+    }))
+    assert(ok_cfg == true, tostring(err_cfg))
+
+    local ev = recv_or_fail(dev_ev_ch)
+    assert(ev.event_type == 'added')
+    assert(ev.class == 'control_store')
+    assert(ev.id == 'main')
+    assert(type(ev.capabilities) == 'table' and #ev.capabilities == 1)
+
+    local ok_stop, err_stop = fibers.perform(M.stop_op())
+    assert(ok_stop == true, tostring(err_stop))
+  end)
+
+  rm_rf(root)
+end
+
+function T.apply_config_fails_when_not_started()
+  local root = mk_tmpdir('csm-not-started')
+  local M = fresh_manager()
+
+  runfibers.run(function()
+    local ok, err = fibers.perform(M.apply_config_op({
+      { name = 'main', root = root },
+    }))
+    assert(ok == false)
+    assert(tostring(err):match('not started'))
+  end)
+
+  rm_rf(root)
+end
+
+function T.cap_emit_channel_receives_initial_meta_and_state()
+  local root = mk_tmpdir('csm-emit')
+  local M = fresh_manager()
+
+  runfibers.run(function()
+    local dev_ev_ch = channel.new(8)
+    local cap_emit_ch = channel.new(8)
+
+    local ok_start, err_start = fibers.perform(M.start_op(nil, dev_ev_ch, cap_emit_ch))
+    assert(ok_start == true, tostring(err_start))
+
+    local ok_cfg, err_cfg = fibers.perform(M.apply_config_op({
+      { name = 'main', root = root },
+    }))
+    assert(ok_cfg == true, tostring(err_cfg))
+
+    local e1 = recv_or_fail(cap_emit_ch)
+    local e2 = recv_or_fail(cap_emit_ch)
+
+    local by_mode = {
+      [e1.mode] = e1,
+      [e2.mode] = e2,
+    }
+
+    assert(by_mode.meta ~= nil)
+    assert(by_mode.state ~= nil)
+    assert(by_mode.meta.class == 'control_store')
+    assert(by_mode.meta.id == 'main')
+    assert(by_mode.meta.key == 'details')
+    assert(by_mode.meta.data.root == root)
+    assert(by_mode.state.key == 'status')
+    assert(by_mode.state.data.state == 'available')
+
+    local ok_stop, err_stop = fibers.perform(M.stop_op())
+    assert(ok_stop == true, tostring(err_stop))
+  end)
+
+  rm_rf(root)
+end
+
+function T.reapply_same_config_is_idempotent()
+  local root = mk_tmpdir('csm-idempotent')
+  local M = fresh_manager()
+
+  runfibers.run(function()
+    local dev_ev_ch = channel.new(8)
+    local cap_emit_ch = channel.new(8)
+
+    local ok_start = fibers.perform(M.start_op(nil, dev_ev_ch, cap_emit_ch))
+    assert(ok_start == true)
+
+    local ok1, err1 = fibers.perform(M.apply_config_op({ { name = 'main', root = root } }))
+    assert(ok1 == true, tostring(err1))
+    local added = recv_or_fail(dev_ev_ch)
+    assert(added.event_type == 'added')
+
+    local ok2, err2 = fibers.perform(M.apply_config_op({ { name = 'main', root = root } }))
+    assert(ok2 == true, tostring(err2))
+
+    local which = fibers.perform(require('fibers').named_choice{
+      msg = dev_ev_ch:get_op():wrap(function(v) return 'msg', v end),
+      timeout = require('fibers.sleep').sleep_op(0.05):wrap(function() return 'timeout' end),
+    })
+    assert(which == 'timeout', 'reapplying same config should not emit new device events')
+
+    local ok_stop, err_stop = fibers.perform(M.stop_op())
+    assert(ok_stop == true, tostring(err_stop))
+  end)
+
+  rm_rf(root)
+end
+
+function T.reconcile_root_change_emits_removed_then_added()
+  local root1 = mk_tmpdir('csm-root1')
+  local root2 = mk_tmpdir('csm-root2')
+  local M = fresh_manager()
+
+  runfibers.run(function()
+    local dev_ev_ch = channel.new(8)
+    local cap_emit_ch = channel.new(8)
+
+    local ok_start, err_start = fibers.perform(M.start_op(nil, dev_ev_ch, cap_emit_ch))
+    assert(ok_start == true, tostring(err_start))
+
+    local ok1, err1 = fibers.perform(M.apply_config_op({ { name = 'main', root = root1 } }))
+    assert(ok1 == true, tostring(err1))
+    local first = recv_or_fail(dev_ev_ch)
+    assert(first.event_type == 'added')
+
+    local ok2, err2 = fibers.perform(M.apply_config_op({ { name = 'main', root = root2 } }))
+    assert(ok2 == true, tostring(err2))
+
+    local ev_a = recv_or_fail(dev_ev_ch)
+    local ev_b = recv_or_fail(dev_ev_ch)
+    assert(ev_a.event_type == 'removed')
+    assert(ev_b.event_type == 'added')
+    assert(ev_b.id == 'main')
+
+    local ok_stop, err_stop = fibers.perform(M.stop_op())
+    assert(ok_stop == true, tostring(err_stop))
+  end)
+
+  rm_rf(root1)
+  rm_rf(root2)
+end
+
+function T.stop_op_before_start_is_ok_and_fault_op_is_inert()
+  local M = fresh_manager()
+
+  runfibers.run(function()
+    local ok_stop, err_stop = fibers.perform(M.stop_op())
+    assert(ok_stop == true, tostring(err_stop))
+
+    local which = fibers.perform(fibers.named_choice{
+      fault = M.fault_op():wrap(function(...) return 'fault', ... end),
+      timeout = require('fibers.sleep').sleep_op(0.05):wrap(function() return 'timeout' end),
+    })
+    assert(which == 'timeout')
+  end)
+end
+
+return T

--- a/tests/unit/hal/control_store_provider_spec.lua
+++ b/tests/unit/hal/control_store_provider_spec.lua
@@ -1,0 +1,171 @@
+local runfibers = require 'tests.support.run_fibers'
+local cap_args  = require 'services.hal.types.capability_args'
+
+local T = {}
+
+local function mk_tmpdir(tag)
+  local path = ('/tmp/dc-lua-%s-%d-%06d'):format(tag, os.time(), math.random(0, 999999))
+  local ok = os.execute(('mkdir -p %q'):format(path))
+  assert(ok == true or ok == 0, 'failed to create temp dir: ' .. path)
+  return path
+end
+
+local function rm_rf(path)
+  os.execute(('rm -rf %q'):format(path))
+end
+
+local function read_file(path)
+  local f, err = io.open(path, 'rb')
+  if not f then return nil, err end
+  local data = f:read('*a')
+  f:close()
+  return data
+end
+
+local function fresh_provider(root)
+  package.loaded['services.hal.drivers.control_store_provider'] = nil
+  return require('services.hal.drivers.control_store_provider').new(root, nil)
+end
+
+function T.status_op_reports_root_and_kind()
+  local root = mk_tmpdir('csp-status')
+  local provider = fresh_provider(root)
+
+  runfibers.run(function()
+    local ok, payload = require('fibers').perform(provider:status_op())
+    assert(ok == true)
+    assert(type(payload) == 'table')
+    assert(payload.root == root)
+    assert(payload.kind == 'control_store')
+  end)
+
+  rm_rf(root)
+end
+
+function T.put_get_and_list_round_trip()
+  local root = mk_tmpdir('csp-roundtrip')
+  local provider = fresh_provider(root)
+
+  runfibers.run(function()
+    local fibers = require 'fibers'
+
+    local put_opts = assert(cap_args.new.ControlStorePutOpts('alpha', 'hello'))
+    local ok_put, err_put = fibers.perform(provider:put_op(put_opts))
+    assert(ok_put == true, tostring(err_put))
+
+    local get_opts = assert(cap_args.new.ControlStoreGetOpts('alpha'))
+    local ok_get, value = fibers.perform(provider:get_op(get_opts))
+    assert(ok_get == true, tostring(value))
+    assert(value == 'hello')
+
+    local ok_list, keys = fibers.perform(provider:list_op())
+    assert(ok_list == true, tostring(keys))
+    assert(#keys == 1)
+    assert(keys[1] == 'alpha')
+  end)
+
+  rm_rf(root)
+end
+
+function T.list_op_filters_by_prefix_and_is_sorted_unique()
+  local root = mk_tmpdir('csp-prefix')
+  local provider = fresh_provider(root)
+
+  runfibers.run(function()
+    local fibers = require 'fibers'
+
+    for _, pair in ipairs({
+      { 'a.one', '1' },
+      { 'a.two', '2' },
+      { 'b.one', '3' },
+    }) do
+      local ok, err = fibers.perform(provider:put_op(assert(cap_args.new.ControlStorePutOpts(pair[1], pair[2]))))
+      assert(ok == true, tostring(err))
+    end
+
+    local ok, keys = fibers.perform(provider:list_op(assert(cap_args.new.ControlStoreListOpts('a.'))))
+    assert(ok == true, tostring(keys))
+    assert(#keys == 2)
+    assert(keys[1] == 'a.one')
+    assert(keys[2] == 'a.two')
+  end)
+
+  rm_rf(root)
+end
+
+function T.get_op_rejects_invalid_key()
+  local root = mk_tmpdir('csp-invalid-get')
+  local provider = fresh_provider(root)
+
+  runfibers.run(function()
+    local fibers = require 'fibers'
+    local ok, err = fibers.perform(provider:get_op({ key = '../bad' }))
+    assert(ok == false)
+    assert(tostring(err):match('invalid key'))
+  end)
+
+  rm_rf(root)
+end
+
+function T.put_op_rejects_invalid_data()
+  local root = mk_tmpdir('csp-invalid-put')
+  local provider = fresh_provider(root)
+
+  runfibers.run(function()
+    local fibers = require 'fibers'
+    local ok, err = fibers.perform(provider:put_op({ key = 'alpha', data = 123 }))
+    assert(ok == false)
+    assert(tostring(err):match('data must be a string'))
+  end)
+
+  rm_rf(root)
+end
+
+function T.get_op_returns_not_found_for_missing_key()
+  local root = mk_tmpdir('csp-missing')
+  local provider = fresh_provider(root)
+
+  runfibers.run(function()
+    local fibers = require 'fibers'
+    local ok, err = fibers.perform(provider:get_op(assert(cap_args.new.ControlStoreGetOpts('missing'))))
+    assert(ok == false)
+    assert(tostring(err):match('not found'))
+  end)
+
+  rm_rf(root)
+end
+
+function T.delete_op_removes_key_from_index_and_truncates_file()
+  local root = mk_tmpdir('csp-delete')
+  local provider = fresh_provider(root)
+  local key_path = root .. '/alpha'
+  local index_path = root .. '/.control_store_index'
+
+  runfibers.run(function()
+    local fibers = require 'fibers'
+
+    local ok_put, err_put = fibers.perform(provider:put_op(assert(cap_args.new.ControlStorePutOpts('alpha', 'payload'))))
+    assert(ok_put == true, tostring(err_put))
+
+    local ok_del, err_del = fibers.perform(provider:delete_op(assert(cap_args.new.ControlStoreDeleteOpts('alpha'))))
+    assert(ok_del == true, tostring(err_del))
+
+    local ok_get, err_get = fibers.perform(provider:get_op(assert(cap_args.new.ControlStoreGetOpts('alpha'))))
+    assert(ok_get == false)
+    assert(tostring(err_get):match('not found'))
+
+    local ok_list, keys = fibers.perform(provider:list_op())
+    assert(ok_list == true, tostring(keys))
+    assert(#keys == 0)
+  end)
+
+  local data = assert(read_file(key_path))
+  assert(data == '', 'delete currently truncates underlying file')
+
+  local index_data = assert(read_file(index_path))
+  assert(index_data == '', 'index should no longer contain deleted key')
+
+  rm_rf(root)
+end
+
+return T

--- a/tests/unit/hal/signature_verify_manager_spec.lua
+++ b/tests/unit/hal/signature_verify_manager_spec.lua
@@ -1,0 +1,218 @@
+local fibers     = require 'fibers'
+local sleep      = require 'fibers.sleep'
+local channel    = require 'fibers.channel'
+
+local runfibers  = require 'tests.support.run_fibers'
+
+local T = {}
+
+local function fresh_manager()
+	package.loaded['services.hal.managers.signature_verify'] = nil
+	return require 'services.hal.managers.signature_verify'
+end
+
+local function recv_or_fail(ch)
+	local v, err = fibers.perform(ch:get_op())
+	assert(v, tostring(err))
+	return v
+end
+
+local function fake_backend(name, ok, value_or_err)
+	return {
+		backend_name = name or 'fake-manager-backend',
+
+		verify_ed25519_op = function()
+			return require('fibers').always(ok, value_or_err)
+		end,
+	}
+end
+
+function T.apply_config_fails_when_not_started()
+	local M = fresh_manager()
+
+	runfibers.run(function()
+		local ok, err = fibers.perform(M.apply_config_op({
+			providers = {
+				{ id = 'main', backend = fake_backend('fake-a', true, nil) },
+			},
+		}))
+		assert(ok == false)
+		assert(tostring(err):match('not started'))
+	end)
+end
+
+function T.start_apply_config_and_stop_round_trip()
+	local M = fresh_manager()
+
+	runfibers.run(function()
+		local dev_ev_ch = channel.new(8)
+		local cap_emit_ch = channel.new(8)
+
+		local ok_start, err_start = fibers.perform(M.start_op(nil, dev_ev_ch, cap_emit_ch))
+		assert(ok_start == true, tostring(err_start))
+
+		local ok_cfg, err_cfg = fibers.perform(M.apply_config_op({
+			providers = {
+				{
+					id = 'main',
+					backend = fake_backend('fake-sig-manager', true, { verified = true }),
+					max_in_flight = 2,
+				},
+			},
+		}))
+		assert(ok_cfg == true, tostring(err_cfg))
+
+		local ev = recv_or_fail(dev_ev_ch)
+		assert(ev.event_type == 'added')
+		assert(ev.class == 'signature_verify')
+		assert(ev.id == 'main')
+		assert(#ev.capabilities == 1)
+		assert(ev.capabilities[1].class == 'signature_verify')
+		assert(ev.capabilities[1].offerings.verify_ed25519 == true)
+
+		local e1 = recv_or_fail(cap_emit_ch)
+		local e2 = recv_or_fail(cap_emit_ch)
+
+		local by_mode = {
+			[e1.mode] = e1,
+			[e2.mode] = e2,
+		}
+
+		assert(by_mode.meta ~= nil)
+		assert(by_mode.state ~= nil)
+		assert(by_mode.meta.class == 'signature_verify')
+		assert(by_mode.meta.id == 'main')
+		assert(by_mode.meta.key == 'info')
+		assert(by_mode.meta.data.backend == 'fake-sig-manager')
+		assert(by_mode.meta.data.max_in_flight == 2)
+		assert(by_mode.state.key == 'status')
+		assert(by_mode.state.data.state == 'available')
+
+		local ok_stop, err_stop = fibers.perform(M.stop_op())
+		assert(ok_stop == true, tostring(err_stop))
+	end)
+end
+
+function T.reapply_same_config_is_idempotent()
+	local M = fresh_manager()
+	local backend = fake_backend('same-backend', true, nil)
+
+	runfibers.run(function()
+		local dev_ev_ch = channel.new(8)
+		local cap_emit_ch = channel.new(8)
+
+		local ok_start, err_start = fibers.perform(M.start_op(nil, dev_ev_ch, cap_emit_ch))
+		assert(ok_start == true, tostring(err_start))
+
+		local cfg = {
+			providers = {
+				{
+					id = 'main',
+					backend = backend,
+					max_in_flight = 1,
+				},
+			},
+		}
+
+		local ok1, err1 = fibers.perform(M.apply_config_op(cfg))
+		assert(ok1 == true, tostring(err1))
+		local added = recv_or_fail(dev_ev_ch)
+		assert(added.event_type == 'added')
+
+		local ok2, err2 = fibers.perform(M.apply_config_op(cfg))
+		assert(ok2 == true, tostring(err2))
+
+		local which = fibers.perform(require('fibers').named_choice{
+			msg = dev_ev_ch:get_op():wrap(function(v) return 'msg', v end),
+			timeout = sleep.sleep_op(0.05):wrap(function() return 'timeout' end),
+		})
+		assert(which == 'timeout', 'reapplying same config should not emit new device events')
+
+		local ok_stop, err_stop = fibers.perform(M.stop_op())
+		assert(ok_stop == true, tostring(err_stop))
+	end)
+end
+
+function T.config_change_removes_then_adds_provider()
+	local M = fresh_manager()
+	local backend = fake_backend('change-backend', true, nil)
+
+	runfibers.run(function()
+		local dev_ev_ch = channel.new(8)
+		local cap_emit_ch = channel.new(8)
+
+		local ok_start, err_start = fibers.perform(M.start_op(nil, dev_ev_ch, cap_emit_ch))
+		assert(ok_start == true, tostring(err_start))
+
+		local ok1, err1 = fibers.perform(M.apply_config_op({
+			providers = {
+				{
+					id = 'main',
+					backend = backend,
+					max_in_flight = 1,
+				},
+			},
+		}))
+		assert(ok1 == true, tostring(err1))
+		local first = recv_or_fail(dev_ev_ch)
+		assert(first.event_type == 'added')
+
+		local ok2, err2 = fibers.perform(M.apply_config_op({
+			providers = {
+				{
+					id = 'main',
+					backend = backend,
+					max_in_flight = 2,
+				},
+			},
+		}))
+		assert(ok2 == true, tostring(err2))
+
+		local ev_a = recv_or_fail(dev_ev_ch)
+		local ev_b = recv_or_fail(dev_ev_ch)
+		assert(ev_a.event_type == 'removed')
+		assert(ev_b.event_type == 'added')
+		assert(ev_b.id == 'main')
+
+		local ok_stop, err_stop = fibers.perform(M.stop_op())
+		assert(ok_stop == true, tostring(err_stop))
+	end)
+end
+
+function T.invalid_config_is_rejected()
+	local M = fresh_manager()
+
+	runfibers.run(function()
+		local dev_ev_ch = channel.new(8)
+		local cap_emit_ch = channel.new(8)
+
+		local ok_start, err_start = fibers.perform(M.start_op(nil, dev_ev_ch, cap_emit_ch))
+		assert(ok_start == true, tostring(err_start))
+
+		local ok_cfg, err_cfg = fibers.perform(M.apply_config_op({
+			providers = 'nope',
+		}))
+		assert(ok_cfg == false)
+		assert(tostring(err_cfg):match('providers must be a table'))
+
+		local ok_stop, err_stop = fibers.perform(M.stop_op())
+		assert(ok_stop == true, tostring(err_stop))
+	end)
+end
+
+function T.stop_op_before_start_is_ok_and_fault_op_is_inert()
+	local M = fresh_manager()
+
+	runfibers.run(function()
+		local ok_stop, err_stop = fibers.perform(M.stop_op())
+		assert(ok_stop == true, tostring(err_stop))
+
+		local which = fibers.perform(require('fibers').named_choice{
+			fault = M.fault_op():wrap(function(...) return 'fault', ... end),
+			timeout = sleep.sleep_op(0.05):wrap(function() return 'timeout' end),
+		})
+		assert(which == 'timeout')
+	end)
+end
+
+return T

--- a/tests/unit/hal/signature_verify_openssl_spec.lua
+++ b/tests/unit/hal/signature_verify_openssl_spec.lua
@@ -1,0 +1,226 @@
+local fibers    = require 'fibers'
+local op        = require 'fibers.op'
+local runfibers = require 'tests.support.run_fibers'
+
+local backend_mod = require 'services.hal.drivers.signature_verify_openssl'
+
+local T = {}
+
+local function make_stream(path, cfg)
+	cfg = cfg or {}
+	cfg.writes = cfg.writes or {}
+	cfg.closed = 0
+
+	local stream = {}
+
+	function stream:filename()
+		return path
+	end
+
+	function stream:write_op(data)
+		if cfg.write_err then
+			return op.always(nil, cfg.write_err)
+		end
+		cfg.writes[#cfg.writes + 1] = data
+		return op.always(#data, nil)
+	end
+
+	function stream:flush_op()
+		if cfg.flush_err then
+			return op.always(nil, cfg.flush_err)
+		end
+		return op.always(true, nil)
+	end
+
+	function stream:close_op()
+		cfg.closed = cfg.closed + 1
+		return op.always(true, nil)
+	end
+
+	return stream, cfg
+end
+
+local function make_fake_file(tmp_specs)
+	local i = 0
+
+	return {
+		tmpfile = function(_perms, _tmpdir)
+			i = i + 1
+			local spec = tmp_specs[i]
+			if not spec then
+				return nil, 'unexpected tmpfile request #' .. tostring(i)
+			end
+			if spec.err then
+				return nil, spec.err
+			end
+
+			local stream, state = make_stream('/tmp/sv-' .. tostring(i), spec)
+			spec._state = state
+			return stream
+		end,
+	}
+end
+
+local function make_fake_exec(result, capture)
+	capture = capture or {}
+
+	return {
+		command = function(...)
+			capture.argv = { ... }
+
+			return {
+				combined_output_op = function()
+					return op.always(
+						result.out,
+						result.st,
+						result.code,
+						result.sig,
+						result.err
+					)
+				end,
+			}
+		end,
+	}
+end
+
+function T.verify_ed25519_rejects_invalid_inputs_before_touching_file_or_exec()
+	runfibers.run(function()
+		local calls = { tmpfile = 0, command = 0 }
+
+		local driver = backend_mod.new({
+			file = {
+				tmpfile = function()
+					calls.tmpfile = calls.tmpfile + 1
+					return nil, 'should not be called'
+				end,
+			},
+			exec = {
+				command = function()
+					calls.command = calls.command + 1
+					return {
+						combined_output_op = function()
+							return op.always('', 'exited', 0, nil, nil)
+						end,
+					}
+				end,
+			},
+			tmpdir = '/tmp',
+		})
+
+		local ok, err = fibers.perform(driver:verify_ed25519_op('', 'msg', 'sig'))
+		assert(ok == false)
+		assert(err == 'public_key_required')
+		assert(calls.tmpfile == 0)
+		assert(calls.command == 0)
+	end)
+end
+
+function T.verify_ed25519_success_writes_all_inputs_and_invokes_openssl()
+	runfibers.run(function()
+		local specs = {
+			{},
+			{},
+			{},
+		}
+		local capture = {}
+
+		local driver = backend_mod.new({
+			file = make_fake_file(specs),
+			exec = make_fake_exec({
+				out  = 'Signature Verified Successfully\n',
+				st   = 'exited',
+				code = 0,
+				sig  = nil,
+				err  = nil,
+			}, capture),
+			tmpdir = '/tmp',
+		})
+
+		local ok, err = fibers.perform(driver:verify_ed25519_op(
+			'PUBKEY',
+			'MESSAGE',
+			'SIGNATURE'
+		))
+
+		assert(ok == true)
+		assert(err == nil)
+
+		assert(specs[1]._state.writes[1] == 'PUBKEY')
+		assert(specs[2]._state.writes[1] == 'MESSAGE')
+		assert(specs[3]._state.writes[1] == 'SIGNATURE')
+
+		assert(specs[1]._state.closed == 1)
+		assert(specs[2]._state.closed == 1)
+		assert(specs[3]._state.closed == 1)
+
+		assert(capture.argv[1] == 'openssl')
+		assert(capture.argv[2] == 'pkeyutl')
+		assert(capture.argv[3] == '-verify')
+		assert(capture.argv[4] == '-pubin')
+		assert(capture.argv[5] == '-inkey')
+		assert(capture.argv[6] == '/tmp/sv-1')
+		assert(capture.argv[7] == '-sigfile')
+		assert(capture.argv[8] == '/tmp/sv-3')
+		assert(capture.argv[9] == '-in')
+		assert(capture.argv[10] == '/tmp/sv-2')
+		assert(capture.argv[11] == '-rawin')
+	end)
+end
+
+function T.verify_ed25519_classifies_bad_signature()
+	runfibers.run(function()
+		local driver = backend_mod.new({
+			file = make_fake_file({ {}, {}, {} }),
+			exec = make_fake_exec({
+				out  = 'Signature Verification Failure\n',
+				st   = 'exited',
+				code = 1,
+				sig  = nil,
+				err  = nil,
+			}),
+			tmpdir = '/tmp',
+		})
+
+		local ok, err = fibers.perform(driver:verify_ed25519_op(
+			'PUBKEY',
+			'MESSAGE',
+			'SIGNATURE'
+		))
+
+		assert(ok == false)
+		assert(err == 'signature_verify_failed')
+	end)
+end
+
+function T.verify_ed25519_surfaces_write_failure_with_labelled_error()
+	runfibers.run(function()
+		local specs = {
+			{},
+			{ write_err = 'diskfull' },
+			{},
+		}
+
+		local driver = backend_mod.new({
+			file = make_fake_file(specs),
+			exec = make_fake_exec({
+				out  = '',
+				st   = 'exited',
+				code = 0,
+				sig  = nil,
+				err  = nil,
+			}),
+			tmpdir = '/tmp',
+		})
+
+		local ok, err = fibers.perform(driver:verify_ed25519_op(
+			'PUBKEY',
+			'MESSAGE',
+			'SIGNATURE'
+		))
+
+		assert(ok == false)
+		assert(err == 'message_write_failed:diskfull')
+	end)
+end
+
+return T

--- a/tests/unit/hal/signature_verify_provider_spec.lua
+++ b/tests/unit/hal/signature_verify_provider_spec.lua
@@ -1,0 +1,244 @@
+local fibers     = require 'fibers'
+local op         = require 'fibers.op'
+local sleep      = require 'fibers.sleep'
+local channel    = require 'fibers.channel'
+
+local runfibers  = require 'tests.support.run_fibers'
+local core_types = require 'services.hal.types.core'
+local cap_args   = require 'services.hal.types.capability_args'
+
+local provider_mod = require 'services.hal.drivers.signature_verify_provider'
+
+local T = {}
+
+local function recv_or_fail(ch)
+	local v, err = fibers.perform(ch:get_op())
+	assert(v, tostring(err))
+	return v
+end
+
+local function fake_backend(result_ok, result_value, extra)
+	extra = extra or {}
+
+	return {
+		backend_name = extra.backend_name or 'fake-backend',
+
+		verify_ed25519_op = function(_self, pubkey_pem, message, signature)
+			if extra.observe then
+				extra.observe[#extra.observe + 1] = {
+					pubkey_pem = pubkey_pem,
+					message    = message,
+					signature  = signature,
+				}
+			end
+			return op.always(result_ok, result_value)
+		end,
+	}
+end
+
+local function request(driver, verb, opts)
+	local reply_ch = channel.new(1)
+	local req, err = core_types.new.ControlRequest(verb, opts or {}, reply_ch)
+	assert(req, tostring(err))
+
+	local sent, send_err = fibers.perform(driver.control_ch:put_op(req))
+	assert(sent ~= false, tostring(send_err))
+
+	local reply, recv_err = fibers.perform(reply_ch:get_op())
+	assert(reply, tostring(recv_err))
+	return reply
+end
+
+function T.capabilities_op_returns_signature_verify_capability()
+	runfibers.run(function()
+		local emit_ch = channel.new(8)
+		local driver = provider_mod.new('main', {
+			backend = fake_backend(true, nil),
+		}, nil)
+
+		local ok, caps_or_err = fibers.perform(driver:capabilities_op(emit_ch))
+		assert(ok == true, tostring(caps_or_err))
+		assert(type(caps_or_err) == 'table')
+		assert(#caps_or_err == 1)
+
+		local cap = caps_or_err[1]
+		assert(cap.class == 'signature_verify')
+		assert(cap.id == 'main')
+		assert(cap.offerings.verify_ed25519 == true)
+	end)
+end
+
+function T.start_op_emits_initial_meta_and_available_state()
+	runfibers.run(function(scope)
+		local emit_ch = channel.new(8)
+		local driver = provider_mod.new('main', {
+			backend = fake_backend(true, nil, { backend_name = 'fake-sig' }),
+			max_in_flight = 2,
+		}, nil)
+
+		local ok_caps, caps_err = fibers.perform(driver:capabilities_op(emit_ch))
+		assert(ok_caps == true, tostring(caps_err))
+
+		local ok_start, start_err = fibers.perform(driver:start_op(scope))
+		assert(ok_start == true, tostring(start_err))
+
+		local e1 = recv_or_fail(emit_ch)
+		local e2 = recv_or_fail(emit_ch)
+
+		local by_mode = {
+			[e1.mode] = e1,
+			[e2.mode] = e2,
+		}
+
+		assert(by_mode.meta ~= nil)
+		assert(by_mode.state ~= nil)
+
+		assert(by_mode.meta.class == 'signature_verify')
+		assert(by_mode.meta.id == 'main')
+		assert(by_mode.meta.key == 'info')
+		assert(by_mode.meta.data.backend == 'fake-sig')
+		assert(by_mode.meta.data.max_in_flight == 2)
+
+		assert(by_mode.state.key == 'status')
+		assert(by_mode.state.data.state == 'available')
+
+		local ok_stop, stop_err = fibers.perform(driver:stop_op())
+		assert(ok_stop == true, tostring(stop_err))
+	end)
+end
+
+function T.verify_ed25519_request_round_trips_success()
+	runfibers.run(function(scope)
+		local seen = {}
+		local emit_ch = channel.new(8)
+		local driver = provider_mod.new('main', {
+			backend = fake_backend(true, { verified = true }, { observe = seen }),
+		}, nil)
+
+		local ok_caps, caps_err = fibers.perform(driver:capabilities_op(emit_ch))
+		assert(ok_caps == true, tostring(caps_err))
+
+		local ok_start, start_err = fibers.perform(driver:start_op(scope))
+		assert(ok_start == true, tostring(start_err))
+
+		local opts, opts_err = cap_args.new.SignatureVerifyEd25519Opts(
+			'PUBKEY',
+			'MESSAGE',
+			'SIGNATURE'
+		)
+		assert(opts, tostring(opts_err))
+
+		local reply = request(driver, 'verify_ed25519', opts)
+		assert(reply.ok == true)
+		assert(type(reply.reason) == 'table')
+		assert(reply.reason.verified == true)
+
+		assert(#seen == 1)
+		assert(seen[1].pubkey_pem == 'PUBKEY')
+		assert(seen[1].message == 'MESSAGE')
+		assert(seen[1].signature == 'SIGNATURE')
+
+		local ok_stop, stop_err = fibers.perform(driver:stop_op())
+		assert(ok_stop == true, tostring(stop_err))
+	end)
+end
+
+function T.busy_is_returned_when_max_in_flight_reached()
+	runfibers.run(function(scope)
+		local gate = channel.new(1)
+
+		local backend = {
+			backend_name = 'gated',
+
+			verify_ed25519_op = function()
+				return gate:get_op():wrap(function(token)
+					return true, token
+				end)
+			end,
+		}
+
+		local emit_ch = channel.new(8)
+		local driver = provider_mod.new('main', {
+			backend = backend,
+			max_in_flight = 1,
+		}, nil)
+
+		local ok_caps, caps_err = fibers.perform(driver:capabilities_op(emit_ch))
+		assert(ok_caps == true, tostring(caps_err))
+
+		local ok_start, start_err = fibers.perform(driver:start_op(scope))
+		assert(ok_start == true, tostring(start_err))
+
+		local opts, opts_err = cap_args.new.SignatureVerifyEd25519Opts(
+			'PUBKEY',
+			'MESSAGE',
+			'SIGNATURE'
+		)
+		assert(opts, tostring(opts_err))
+
+		local first_reply_ch = channel.new(1)
+		local req1, req1_err = core_types.new.ControlRequest('verify_ed25519', opts, first_reply_ch)
+		assert(req1, tostring(req1_err))
+
+		local sent1, send1_err = fibers.perform(driver.control_ch:put_op(req1))
+		assert(sent1 ~= false, tostring(send1_err))
+
+		fibers.perform(sleep.sleep_op(0.01))
+
+		local reply2 = request(driver, 'verify_ed25519', opts)
+		assert(reply2.ok == false)
+		assert(reply2.reason == 'busy')
+
+		local gate_sent, gate_err = fibers.perform(gate:put_op('done'))
+		assert(gate_sent ~= false, tostring(gate_err))
+
+		local reply1, recv1_err = fibers.perform(first_reply_ch:get_op())
+		assert(reply1, tostring(recv1_err))
+		assert(reply1.ok == true)
+		assert(reply1.reason == 'done')
+
+		local ok_stop, stop_err = fibers.perform(driver:stop_op())
+		assert(ok_stop == true, tostring(stop_err))
+	end)
+end
+
+function T.unsupported_verb_returns_negative_reply()
+	runfibers.run(function(scope)
+		local emit_ch = channel.new(8)
+		local driver = provider_mod.new('main', {
+			backend = fake_backend(true, nil),
+		}, nil)
+
+		local ok_caps, caps_err = fibers.perform(driver:capabilities_op(emit_ch))
+		assert(ok_caps == true, tostring(caps_err))
+
+		local ok_start, start_err = fibers.perform(driver:start_op(scope))
+		assert(ok_start == true, tostring(start_err))
+
+		local reply = request(driver, 'nope', {})
+		assert(reply.ok == false)
+		assert(tostring(reply.reason):match('unsupported verb'))
+
+		local ok_stop, stop_err = fibers.perform(driver:stop_op())
+		assert(ok_stop == true, tostring(stop_err))
+	end)
+end
+
+function T.stop_op_before_start_is_ok_and_fault_op_is_inert()
+	runfibers.run(function()
+		local driver = provider_mod.new('main', {
+			backend = fake_backend(true, nil),
+		}, nil)
+
+		local ok_stop, stop_err = fibers.perform(driver:stop_op())
+		assert(ok_stop == true, tostring(stop_err))
+
+		local which = fibers.perform(fibers.named_choice{
+			fault   = driver:fault_op():wrap(function(...) return 'fault', ... end),
+			timeout = sleep.sleep_op(0.05):wrap(function() return 'timeout' end),
+		})
+		assert(which == 'timeout')
+	end)
+end
+
+return T

--- a/tests/unit/hal/uart_driver_spec.lua
+++ b/tests/unit/hal/uart_driver_spec.lua
@@ -1,0 +1,420 @@
+local fibers      = require 'fibers'
+local channel     = require 'fibers.channel'
+local sleep       = require 'fibers.sleep'
+
+local runfibers   = require 'tests.support.run_fibers'
+local pty         = require 'tests.support.pty'
+
+local core_types  = require 'services.hal.types.core'
+local cap_args    = require 'services.hal.types.capability_args'
+
+local T = {}
+
+local function fresh_driver()
+	package.loaded['services.hal.drivers.uart'] = nil
+	return require('services.hal.drivers.uart')
+end
+
+local function recv_or_fail(ch)
+	local v, err = fibers.perform(ch:get_op())
+	assert(v ~= nil, tostring(err))
+	return v
+end
+
+local function wait_emit(cap_emit_ch, class, id, mode, key, timeout_s)
+	local deadline = fibers.now() + (timeout_s or 1.0)
+
+	while fibers.now() < deadline do
+		local remain = deadline - fibers.now()
+		local which, a = fibers.perform(fibers.named_choice{
+			item = cap_emit_ch:get_op(),
+			timeout = sleep.sleep_op(remain):wrap(function()
+				return 'timeout'
+			end),
+		})
+
+		if which == 'timeout' then
+			break
+		end
+
+		local ev = a
+		if ev and ev.class == class and ev.id == id and ev.mode == mode and ev.key == key then
+			return ev
+		end
+	end
+
+	error(('timed out waiting for %s/%s %s %s'):format(
+		tostring(class), tostring(id), tostring(mode), tostring(key)
+	), 0)
+end
+
+local function call_control_op(control_ch, verb, opts)
+	return fibers.run_scope_op(function()
+		local reply_ch = channel.new(1)
+
+		local req, err = core_types.new.ControlRequest(verb, opts or {}, reply_ch)
+		assert(req, tostring(err))
+
+		-- channel:put_op() returns no values on success; success is "no error raised"
+		fibers.perform(control_ch:put_op(req))
+
+		local reply, recv_err = fibers.perform(reply_ch:get_op())
+		if not reply then
+			return false, tostring(recv_err or 'missing reply')
+		end
+
+		assert(type(reply) == 'table', 'control reply must be a table')
+		assert(type(reply.ok) == 'boolean', 'control reply ok must be boolean')
+
+		if reply.ok then
+			return true, reply.reason
+		end
+
+		return false, reply.reason
+	end):wrap(function(st, rep, ok, value_or_err)
+		if st ~= 'ok' then
+			return false, tostring(value_or_err or rep)
+		end
+		return ok, value_or_err
+	end)
+end
+
+local function drain_initial_emits(cap_emit_ch, id)
+	local e1 = recv_or_fail(cap_emit_ch)
+	local e2 = recv_or_fail(cap_emit_ch)
+
+	local by_mode = {
+		[e1.mode] = e1,
+		[e2.mode] = e2,
+	}
+
+	assert(by_mode.meta ~= nil)
+	assert(by_mode.state ~= nil)
+	assert(by_mode.meta.class == 'uart')
+	assert(by_mode.meta.id == id)
+	assert(by_mode.meta.key == 'details')
+	assert(by_mode.state.class == 'uart')
+	assert(by_mode.state.id == id)
+	assert(by_mode.state.key == 'status')
+
+	return by_mode
+end
+
+function T.capabilities_op_returns_one_uart_capability()
+	local uart = fresh_driver()
+
+	runfibers.run(function()
+		local emit_ch = channel.new(8)
+		local d = uart.new('mcu', '/dev/null', 115200, '8N1', nil)
+
+		local ok, caps_or_err = fibers.perform(d:capabilities_op(emit_ch))
+		assert(ok == true, tostring(caps_or_err))
+		assert(type(caps_or_err) == 'table' and #caps_or_err == 1)
+
+		local cap = caps_or_err[1]
+		assert(cap.class == 'uart')
+		assert(cap.id == 'mcu')
+		assert(cap.offerings.open == true)
+		assert(cap.offerings.status == true)
+		assert(cap.offerings.close == nil)
+		assert(cap.offerings.write == nil)
+	end)
+end
+
+function T.start_op_emits_initial_meta_and_status()
+	local uart = fresh_driver()
+
+	runfibers.run(function(scope)
+		local port = pty.open(scope)
+		local emit_ch = channel.new(8)
+
+		local d = uart.new('mcu', port.slave_name, 115200, '8N1', nil)
+		local ok_caps, caps_or_err = fibers.perform(d:capabilities_op(emit_ch))
+		assert(ok_caps == true, tostring(caps_or_err))
+
+		local ok_start, err_start = fibers.perform(d:start_op(scope))
+		assert(ok_start == true, tostring(err_start))
+
+		local initial = drain_initial_emits(emit_ch, 'mcu')
+		assert(initial.meta.data.path == port.slave_name)
+		assert(initial.meta.data.kind == 'uart')
+		assert(initial.state.data.open == false)
+		assert(initial.state.data.available == true)
+
+		local ok_stop, err_stop = fibers.perform(d:stop_op())
+		assert(ok_stop == true, tostring(err_stop))
+	end)
+end
+
+function T.status_reports_open_false_before_any_session_exists()
+	local uart = fresh_driver()
+
+	runfibers.run(function(scope)
+		local port = pty.open(scope)
+		local emit_ch = channel.new(8)
+
+		local d = uart.new('mcu', port.slave_name, 115200, '8N1', nil)
+		local ok_caps, caps_or_err = fibers.perform(d:capabilities_op(emit_ch))
+		assert(ok_caps == true, tostring(caps_or_err))
+
+		local ok_start, err_start = fibers.perform(d:start_op(scope))
+		assert(ok_start == true, tostring(err_start))
+
+		drain_initial_emits(emit_ch, 'mcu')
+
+		local ok, status = fibers.perform(call_control_op(d.control_ch, 'status', {}))
+		assert(ok == true, tostring(status))
+		assert(type(status) == 'table')
+		assert(status.open == false)
+		assert(status.available == true)
+		assert(status.path == port.slave_name)
+
+		local ok_stop, err_stop = fibers.perform(d:stop_op())
+		assert(ok_stop == true, tostring(err_stop))
+	end)
+end
+
+function T.open_returns_uart_open_reply_with_wrapped_session()
+	local uart = fresh_driver()
+
+	runfibers.run(function(scope)
+		local port = pty.open(scope)
+		local emit_ch = channel.new(16)
+
+		local d = uart.new('mcu', port.slave_name, 115200, '8N1', nil)
+
+		local ok_caps, caps_or_err = fibers.perform(d:capabilities_op(emit_ch))
+		assert(ok_caps == true, tostring(caps_or_err))
+
+		local ok_start, err_start = fibers.perform(d:start_op(scope))
+		assert(ok_start == true, tostring(err_start))
+
+		drain_initial_emits(emit_ch, 'mcu')
+
+		local opts, opts_err = cap_args.new.UARTOpenOpts()
+		assert(opts, tostring(opts_err))
+
+		local ok, reply = fibers.perform(call_control_op(d.control_ch, 'open', opts))
+		assert(ok == true, tostring(reply))
+		assert(type(reply) == 'table')
+		assert(type(reply.lease_id) == 'string' and reply.lease_id ~= '')
+		assert(reply.path == port.slave_name)
+		assert(type(reply.session) == 'table')
+		assert(type(reply.session.read_some_op) == 'function')
+		assert(type(reply.session.read_exactly_op) == 'function')
+		assert(type(reply.session.read_line_op) == 'function')
+		assert(type(reply.session.read_all_op) == 'function')
+		assert(type(reply.session.write_op) == 'function')
+		assert(type(reply.session.flush_op) == 'function')
+		assert(type(reply.session.close_op) == 'function')
+
+		local st = wait_emit(emit_ch, 'uart', 'mcu', 'state', 'status', 1.0)
+		assert(st.data.open == true)
+		assert(st.data.lease_id == reply.lease_id)
+
+		local ev = wait_emit(emit_ch, 'uart', 'mcu', 'event', 'opened', 1.0)
+		assert(ev.data.lease_id == reply.lease_id)
+
+		local ok_close, err_close = fibers.perform(reply.session:close_op())
+		assert(ok_close == true, tostring(err_close))
+
+		local st2 = wait_emit(emit_ch, 'uart', 'mcu', 'state', 'status', 1.0)
+		assert(st2.data.open == false)
+		assert(st2.data.lease_id == nil)
+
+		local ev2 = wait_emit(emit_ch, 'uart', 'mcu', 'event', 'closed', 1.0)
+		assert(ev2.data.lease_id == reply.lease_id)
+
+		local ok_stop, err_stop = fibers.perform(d:stop_op())
+		assert(ok_stop == true, tostring(err_stop))
+	end)
+end
+
+function T.second_open_while_active_returns_busy()
+	local uart = fresh_driver()
+
+	runfibers.run(function(scope)
+		local port = pty.open(scope)
+		local emit_ch = channel.new(16)
+
+		local d = uart.new('mcu', port.slave_name, 115200, '8N1', nil)
+
+		local ok_caps, caps_or_err = fibers.perform(d:capabilities_op(emit_ch))
+		assert(ok_caps == true, tostring(caps_or_err))
+
+		local ok_start, err_start = fibers.perform(d:start_op(scope))
+		assert(ok_start == true, tostring(err_start))
+
+		drain_initial_emits(emit_ch, 'mcu')
+
+		local opts = assert(cap_args.new.UARTOpenOpts())
+		local ok1, reply1 = fibers.perform(call_control_op(d.control_ch, 'open', opts))
+		assert(ok1 == true, tostring(reply1))
+		wait_emit(emit_ch, 'uart', 'mcu', 'state', 'status', 1.0)
+		wait_emit(emit_ch, 'uart', 'mcu', 'event', 'opened', 1.0)
+
+		local ok2, err2 = fibers.perform(call_control_op(d.control_ch, 'open', opts))
+		assert(ok2 == false)
+		assert(type(err2) == 'string')
+		assert(err2:match('busy'))
+
+		local ok_close, err_close = fibers.perform(reply1.session:close_op())
+		assert(ok_close == true, tostring(err_close))
+		wait_emit(emit_ch, 'uart', 'mcu', 'state', 'status', 1.0)
+		wait_emit(emit_ch, 'uart', 'mcu', 'event', 'closed', 1.0)
+
+		local ok_stop, err_stop = fibers.perform(d:stop_op())
+		assert(ok_stop == true, tostring(err_stop))
+	end)
+end
+
+function T.stop_op_closes_active_session_best_effort()
+	local uart = fresh_driver()
+
+	runfibers.run(function(scope)
+		local port = pty.open(scope)
+		local emit_ch = channel.new(16)
+
+		local d = uart.new('mcu', port.slave_name, 115200, '8N1', nil)
+
+		local ok_caps, caps_or_err = fibers.perform(d:capabilities_op(emit_ch))
+		assert(ok_caps == true, tostring(caps_or_err))
+
+		local ok_start, err_start = fibers.perform(d:start_op(scope))
+		assert(ok_start == true, tostring(err_start))
+
+		drain_initial_emits(emit_ch, 'mcu')
+
+		local opts = assert(cap_args.new.UARTOpenOpts())
+		local ok, reply = fibers.perform(call_control_op(d.control_ch, 'open', opts))
+		assert(ok == true, tostring(reply))
+		wait_emit(emit_ch, 'uart', 'mcu', 'state', 'status', 1.0)
+		wait_emit(emit_ch, 'uart', 'mcu', 'event', 'opened', 1.0)
+
+		local ok_stop, err_stop = fibers.perform(d:stop_op())
+		assert(ok_stop == true, tostring(err_stop))
+
+		local n, werr = fibers.perform(reply.session:write_op('x'))
+		assert(n == nil)
+		assert(werr ~= nil)
+	end)
+end
+
+
+function T.read_ops_fail_after_stop()
+	local uart = fresh_driver()
+
+	runfibers.run(function(scope)
+		local port = pty.open(scope)
+		local emit_ch = channel.new(16)
+
+		local d = uart.new('mcu', port.slave_name, 115200, '8N1', nil)
+
+		local ok_caps, caps_or_err = fibers.perform(d:capabilities_op(emit_ch))
+		assert(ok_caps == true, tostring(caps_or_err))
+
+		local ok_start, err_start = fibers.perform(d:start_op(scope))
+		assert(ok_start == true, tostring(err_start))
+
+		drain_initial_emits(emit_ch, 'mcu')
+
+		local opts = assert(cap_args.new.UARTOpenOpts())
+		local ok, reply = fibers.perform(call_control_op(d.control_ch, 'open', opts))
+		assert(ok == true, tostring(reply))
+		wait_emit(emit_ch, 'uart', 'mcu', 'state', 'status', 1.0)
+		wait_emit(emit_ch, 'uart', 'mcu', 'event', 'opened', 1.0)
+
+		local ok_stop, err_stop = fibers.perform(d:stop_op())
+		assert(ok_stop == true, tostring(err_stop))
+
+		local chunk, rerr = fibers.perform(reply.session:read_some_op(1))
+		assert(chunk == nil)
+		assert(rerr ~= nil)
+
+		local n, werr = fibers.perform(reply.session:write_op('x'))
+		assert(n == nil)
+		assert(werr ~= nil)
+	end)
+end
+
+function T.concurrent_open_allows_exactly_one_winner()
+	local uart = fresh_driver()
+
+	runfibers.run(function(scope)
+		local port = pty.open(scope)
+		local emit_ch = channel.new(16)
+		local results_ch = channel.new(2)
+
+		local d = uart.new('mcu', port.slave_name, 115200, '8N1', nil)
+		local ok_caps, caps_or_err = fibers.perform(d:capabilities_op(emit_ch))
+		assert(ok_caps == true, tostring(caps_or_err))
+		local ok_start, err_start = fibers.perform(d:start_op(scope))
+		assert(ok_start == true, tostring(err_start))
+		drain_initial_emits(emit_ch, 'mcu')
+
+		local opts = assert(cap_args.new.UARTOpenOpts())
+		local function contender(name)
+			local ok, value = fibers.perform(call_control_op(d.control_ch, 'open', opts))
+			fibers.perform(results_ch:put_op({ name = name, ok = ok, value = value }))
+		end
+
+		local s1, e1 = scope:spawn(function() contender('a') end)
+		assert(s1 == true, tostring(e1))
+		local s2, e2 = scope:spawn(function() contender('b') end)
+		assert(s2 == true, tostring(e2))
+
+		local r1 = recv_or_fail(results_ch)
+		local r2 = recv_or_fail(results_ch)
+		local results = { r1, r2 }
+		local winners, losers = {}, {}
+		for _, r in ipairs(results) do
+			if r.ok then winners[#winners + 1] = r else losers[#losers + 1] = r end
+		end
+		assert(#winners == 1)
+		assert(#losers == 1)
+		assert(type(losers[1].value) == 'string' and losers[1].value:match('busy'))
+
+		local st = wait_emit(emit_ch, 'uart', 'mcu', 'state', 'status', 1.0)
+		assert(st.data.open == true)
+		assert(st.data.lease_id == winners[1].value.lease_id)
+		local ev = wait_emit(emit_ch, 'uart', 'mcu', 'event', 'opened', 1.0)
+		assert(ev.data.lease_id == winners[1].value.lease_id)
+
+		local ok_close, err_close = fibers.perform(winners[1].value.session:close_op())
+		assert(ok_close == true, tostring(err_close))
+		wait_emit(emit_ch, 'uart', 'mcu', 'state', 'status', 1.0)
+		wait_emit(emit_ch, 'uart', 'mcu', 'event', 'closed', 1.0)
+
+		local ok_stop, err_stop = fibers.perform(d:stop_op())
+		assert(ok_stop == true, tostring(err_stop))
+	end)
+end
+
+function T.open_rejects_invalid_opts()
+	local uart = fresh_driver()
+
+	runfibers.run(function(scope)
+		local port = pty.open(scope)
+		local emit_ch = channel.new(8)
+
+		local d = uart.new('mcu', port.slave_name, 115200, '8N1', nil)
+
+		local ok_caps, caps_or_err = fibers.perform(d:capabilities_op(emit_ch))
+		assert(ok_caps == true, tostring(caps_or_err))
+
+		local ok_start, err_start = fibers.perform(d:start_op(scope))
+		assert(ok_start == true, tostring(err_start))
+
+		drain_initial_emits(emit_ch, 'mcu')
+
+		local ok, err = fibers.perform(call_control_op(d.control_ch, 'open', { bogus = true }))
+		assert(ok == false)
+		assert(type(err) == 'string')
+		assert(err:match('invalid open opts') or err:match('unsupported'))
+
+		local ok_stop, err_stop = fibers.perform(d:stop_op())
+		assert(ok_stop == true, tostring(err_stop))
+	end)
+end
+
+return T

--- a/tests/unit/hal/uart_manager_spec.lua
+++ b/tests/unit/hal/uart_manager_spec.lua
@@ -1,0 +1,186 @@
+local fibers     = require 'fibers'
+local channel    = require 'fibers.channel'
+
+local runfibers  = require 'tests.support.run_fibers'
+local pty        = require 'tests.support.pty'
+
+local T = {}
+
+local function fresh_manager()
+	package.loaded['services.hal.managers.uart'] = nil
+	package.loaded['services.hal.drivers.uart'] = nil
+	return require('services.hal.managers.uart')
+end
+
+local function recv_or_fail(ch)
+	local v, err = fibers.perform(ch:get_op())
+	assert(v ~= nil, tostring(err))
+	return v
+end
+
+function T.start_op_and_stop_op_round_trip()
+	local M = fresh_manager()
+
+	runfibers.run(function()
+		local dev_ev_ch = channel.new(8)
+		local cap_emit_ch = channel.new(8)
+
+		local ok_start, err_start = fibers.perform(M.start_op(nil, dev_ev_ch, cap_emit_ch))
+		assert(ok_start == true, tostring(err_start))
+
+		local ok_stop, err_stop = fibers.perform(M.stop_op())
+		assert(ok_stop == true, tostring(err_stop))
+	end)
+end
+
+function T.apply_config_op_before_start_fails()
+	local M = fresh_manager()
+
+	runfibers.run(function()
+		local ok, err = fibers.perform(M.apply_config_op({
+			{ id = 'mcu', path = '/dev/ttyS0', baud = 115200, mode = '8N1' },
+		}))
+		assert(ok == false)
+		assert(tostring(err):match('not started'))
+	end)
+end
+
+function T.apply_config_op_adds_uart_driver_and_emits_added_event()
+	local M = fresh_manager()
+
+	runfibers.run(function(scope)
+		local port = pty.open(scope)
+		local dev_ev_ch = channel.new(8)
+		local cap_emit_ch = channel.new(16)
+
+		local ok_start, err_start = fibers.perform(M.start_op(nil, dev_ev_ch, cap_emit_ch))
+		assert(ok_start == true, tostring(err_start))
+
+		local ok_cfg, err_cfg = fibers.perform(M.apply_config_op({
+			{ id = 'mcu', path = port.slave_name, baud = 115200, mode = '8N1' },
+		}))
+		assert(ok_cfg == true, tostring(err_cfg))
+
+		local ev = recv_or_fail(dev_ev_ch)
+		assert(ev.event_type == 'added')
+		assert(ev.class == 'uart')
+		assert(ev.id == 'mcu')
+		assert(type(ev.capabilities) == 'table' and #ev.capabilities == 1)
+		assert(ev.capabilities[1].class == 'uart')
+		assert(ev.meta.path == port.slave_name)
+
+		local ok_stop, err_stop = fibers.perform(M.stop_op())
+		assert(ok_stop == true, tostring(err_stop))
+	end)
+end
+
+function T.reapply_same_config_is_idempotent()
+	local M = fresh_manager()
+
+	runfibers.run(function(scope)
+		local port = pty.open(scope)
+		local dev_ev_ch = channel.new(8)
+		local cap_emit_ch = channel.new(16)
+
+		assert(fibers.perform(M.start_op(nil, dev_ev_ch, cap_emit_ch)) == true)
+
+		local cfg = {
+			{ id = 'mcu', path = port.slave_name, baud = 115200, mode = '8N1' },
+		}
+
+		local ok1, err1 = fibers.perform(M.apply_config_op(cfg))
+		assert(ok1 == true, tostring(err1))
+		local added = recv_or_fail(dev_ev_ch)
+		assert(added.event_type == 'added')
+
+		local ok2, err2 = fibers.perform(M.apply_config_op(cfg))
+		assert(ok2 == true, tostring(err2))
+
+		local which = fibers.perform(require('fibers').named_choice{
+			msg = dev_ev_ch:get_op():wrap(function(v) return 'msg', v end),
+			timeout = require('fibers.sleep').sleep_op(0.05):wrap(function() return 'timeout' end),
+		})
+		assert(which == 'timeout')
+
+		local ok_stop, err_stop = fibers.perform(M.stop_op())
+		assert(ok_stop == true, tostring(err_stop))
+	end)
+end
+
+function T.changing_path_causes_removed_then_added()
+	local M = fresh_manager()
+
+	runfibers.run(function(scope)
+		local port1 = pty.open(scope)
+		local port2 = pty.open(scope)
+		local dev_ev_ch = channel.new(16)
+		local cap_emit_ch = channel.new(16)
+
+		assert(fibers.perform(M.start_op(nil, dev_ev_ch, cap_emit_ch)) == true)
+
+		local ok1, err1 = fibers.perform(M.apply_config_op({
+			{ id = 'mcu', path = port1.slave_name, baud = 115200, mode = '8N1' },
+		}))
+		assert(ok1 == true, tostring(err1))
+		assert(recv_or_fail(dev_ev_ch).event_type == 'added')
+
+		local ok2, err2 = fibers.perform(M.apply_config_op({
+			{ id = 'mcu', path = port2.slave_name, baud = 115200, mode = '8N1' },
+		}))
+		assert(ok2 == true, tostring(err2))
+
+		local ev1 = recv_or_fail(dev_ev_ch)
+		local ev2 = recv_or_fail(dev_ev_ch)
+		assert(ev1.event_type == 'removed')
+		assert(ev2.event_type == 'added')
+		assert(ev2.id == 'mcu')
+
+		local ok_stop, err_stop = fibers.perform(M.stop_op())
+		assert(ok_stop == true, tostring(err_stop))
+	end)
+end
+
+function T.changing_baud_or_mode_causes_removed_then_added()
+	local M = fresh_manager()
+
+	runfibers.run(function(scope)
+		local port = pty.open(scope)
+		local dev_ev_ch = channel.new(16)
+		local cap_emit_ch = channel.new(16)
+
+		assert(fibers.perform(M.start_op(nil, dev_ev_ch, cap_emit_ch)) == true)
+
+		local ok1, err1 = fibers.perform(M.apply_config_op({
+			{ id = 'mcu', path = port.slave_name, baud = 115200, mode = '8N1' },
+		}))
+		assert(ok1 == true, tostring(err1))
+		assert(recv_or_fail(dev_ev_ch).event_type == 'added')
+
+		local ok2, err2 = fibers.perform(M.apply_config_op({
+			{ id = 'mcu', path = port.slave_name, baud = 9600, mode = '8N1' },
+		}))
+		assert(ok2 == true, tostring(err2))
+
+		local ev1 = recv_or_fail(dev_ev_ch)
+		local ev2 = recv_or_fail(dev_ev_ch)
+		assert(ev1.event_type == 'removed')
+		assert(ev2.event_type == 'added')
+
+		local ok_stop, err_stop = fibers.perform(M.stop_op())
+		assert(ok_stop == true, tostring(err_stop))
+	end)
+end
+
+function T.fault_op_is_inert_before_start()
+	local M = fresh_manager()
+
+	runfibers.run(function()
+		local which = fibers.perform(fibers.named_choice{
+			fault = M.fault_op():wrap(function(...) return 'fault', ... end),
+			timeout = require('fibers.sleep').sleep_op(0.05):wrap(function() return 'timeout' end),
+		})
+		assert(which == 'timeout')
+	end)
+end
+
+return T

--- a/tests/unit/shared/blob_source_spec.lua
+++ b/tests/unit/shared/blob_source_spec.lua
@@ -1,0 +1,166 @@
+local fibers      = require 'fibers'
+local sleep       = require 'fibers.sleep'
+local op          = require 'fibers.op'
+local runfibers   = require 'tests.support.run_fibers'
+local blob_source = require 'shared.blob_source'
+
+local T = {}
+
+function T.string_source_reads_chunks_and_reaches_eof()
+  runfibers.run(function()
+    local src = blob_source.from_string('abcdef')
+
+    local c1, e1 = fibers.perform(src:read_chunk_op(2))
+    assert(c1 == 'ab' and e1 == nil)
+
+    local c2, e2 = fibers.perform(src:read_chunk_op(3))
+    assert(c2 == 'cde' and e2 == nil)
+
+    local c3, e3 = fibers.perform(src:read_chunk_op(3))
+    assert(c3 == 'f' and e3 == nil)
+
+    local c4, e4 = fibers.perform(src:read_chunk_op(3))
+    assert(c4 == nil and e4 == nil)
+  end)
+end
+
+function T.string_source_rejects_invalid_max_bytes()
+  runfibers.run(function()
+    local src = blob_source.from_string('abc')
+    local chunk, err = fibers.perform(src:read_chunk_op(0))
+    assert(chunk == nil)
+    assert(tostring(err):match('invalid max_bytes'))
+  end)
+end
+
+function T.memory_sink_accumulates_written_chunks()
+  runfibers.run(function()
+    local sink = blob_source.to_memory()
+    local ok1, err1 = fibers.perform(sink:write_chunk_op('ab'))
+    local ok2, err2 = fibers.perform(sink:write_chunk_op('cd'))
+    assert(ok1 == true and err1 == nil)
+    assert(ok2 == true and err2 == nil)
+    assert(sink:result() == 'abcd')
+  end)
+end
+
+function T.copy_op_copies_string_source_to_memory_sink()
+  runfibers.run(function()
+    local src = blob_source.from_string('hello world')
+    local sink = blob_source.to_memory()
+
+    local st, rep, bytes = fibers.perform(blob_source.copy_op(src, sink, { chunk_size = 4 }))
+    assert(st == 'ok', tostring(bytes or rep))
+    assert(bytes == 11)
+    assert(sink:result() == 'hello world')
+  end)
+end
+
+function T.copy_op_does_not_close_when_disabled()
+  runfibers.run(function()
+    local src_closed = 0
+    local sink_closed = 0
+    local src = {
+      remaining = true,
+      read_chunk_op = function(self, n)
+        return op.guard(function()
+          if self.remaining then
+            self.remaining = false
+            return op.always('xy', nil)
+          end
+          return op.always(nil, nil)
+        end)
+      end,
+      close_op = function()
+        return op.guard(function()
+          src_closed = src_closed + 1
+          return op.always(true, nil)
+        end)
+      end,
+    }
+    local sink = {
+      chunks = {},
+      write_chunk_op = function(self, chunk)
+        return op.guard(function()
+          self.chunks[#self.chunks + 1] = chunk
+          return op.always(true, nil)
+        end)
+      end,
+      close_op = function()
+        return op.guard(function()
+          sink_closed = sink_closed + 1
+          return op.always(true, nil)
+        end)
+      end,
+    }
+
+    local st, rep, bytes = fibers.perform(blob_source.copy_op(src, sink, {
+      close_source = false,
+      close_sink = false,
+    }))
+    assert(st == 'ok', tostring(bytes or rep))
+    assert(bytes == 2)
+    assert(src_closed == 0)
+    assert(sink_closed == 0)
+  end)
+end
+
+function T.copy_op_closes_on_timeout_losing_arm()
+  runfibers.run(function()
+    local src_closed = 0
+    local sink_closed = 0
+    local src = {
+      read_chunk_op = function()
+        return sleep.sleep_op(0.2):wrap(function() return 'late', nil end)
+      end,
+      close_op = function()
+        return op.guard(function()
+          src_closed = src_closed + 1
+          return op.always(true, nil)
+        end)
+      end,
+    }
+    local sink = {
+      write_chunk_op = function(self, chunk)
+        return op.always(true, nil)
+      end,
+      close_op = function()
+        return op.guard(function()
+          sink_closed = sink_closed + 1
+          return op.always(true, nil)
+        end)
+      end,
+    }
+
+    local which = fibers.perform(fibers.named_choice{
+      copy = blob_source.copy_op(src, sink):wrap(function(...) return 'copy', ... end),
+      timeout = sleep.sleep_op(0.02):wrap(function() return 'timeout' end),
+    })
+    assert(which == 'timeout')
+
+    fibers.perform(sleep.sleep_op(0.02))
+
+    assert(src_closed == 1)
+    assert(sink_closed == 1)
+  end)
+end
+
+function T.copy_op_fails_when_sink_write_fails()
+  runfibers.run(function()
+    local src = blob_source.from_string('boom')
+    local sink = {
+      write_chunk_op = function(self, chunk)
+        return op.always(nil, 'sink failed')
+      end,
+      close_op = function()
+        return op.always(true, nil)
+      end,
+    }
+
+    local st, rep, primary = fibers.perform(blob_source.copy_op(src, sink))
+    assert(st == 'failed')
+    assert(tostring(primary):match('sink failed'))
+  end)
+end
+
+return T


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

* [x] 🍕 Feature
* [x] 🧑‍💻 Code Refactor
* [x] ✅ Test

## Description

Builds out the next substantive HAL slice on top of the richer service-base / capability work by adding op-first drivers, managers and shared transfer primitives for control store, artefact store, signature verification and UART, together with a reusable control-loop pattern and expanded type/test coverage.

Changes include:

* adds a shared `blob_source` abstraction for op-first source/sink handling and structured copy operations
* introduces a reusable HAL `support/control_loop.lua` for request/reply control shells where methods are required to return `Op`s
* adds op-first control-store support:

  * `drivers/control_store_provider.lua`
  * `drivers/control_store.lua`
  * `managers/control_store.lua`
* adds op-only artefact-store support:

  * `drivers/artifact_store_provider.lua`
  * `drivers/artifact_store.lua`
  * `managers/artifact_store.lua`
* adds op-only signature verification support:

  * `drivers/signature_verify_provider.lua`
  * `drivers/signature_verify_openssl.lua`
  * `managers/signature_verify.lua`
* adds op-only UART driver and manager support:

  * `drivers/uart.lua`
  * `managers/uart.lua`
  * PTY-backed devhost/integration support for exercising the UART path
* extends HAL types and templates to cover the new managers/capabilities and align the driver template with the newer op-oriented control style
* adds shared hashing support used by the new HAL functionality
* broadens the test suite substantially with unit coverage for:

  * shared blob sources
  * control loop behaviour
  * control-store provider/manager
  * artefact-store provider/driver/manager
  * signature-verify provider/OpenSSL/manager
  * UART driver/manager
* adds devhost/integration coverage for the UART path and updates the test runner/support scaffolding for the larger HAL surface

## Related Issues, Tickets & Documents

None listed.

## Screenshots/Recordings

N/A

## Manual test

* [x] 👍 yes

## Manual test description

Ran test suite 10x on PUC Lua and LuaJIT 110/110 passes

## Added tests?

* [x] 👍 yes

## Added to documentation?

* [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?

No post-deployment tasks identified.
