### PR TITLE
system + hal: refactor bus naming, remove time handling, add device register sync

### DIFF
--- a/docs/specs/system.md
+++ b/docs/specs/system.md
@@ -26,9 +26,9 @@ HAL capabilities consumed:
 
 Service topics consumed:
 
-| Topic                       | Usage                                                              |
-|-----------------------------|--------------------------------------------------------------------|
-| `{'svc', 'time', 'synced'}` | Retained bool — both fibers subscribe; sysinfo fiber uses it to gate `boot_time` computation; main fiber uses it to sync/desync alarms |
+| Topic                         | Usage                                                              |
+|-------------------------------|--------------------------------------------------------------------|
+| `{'state', 'time', 'synced'}` | Retained bool — both fibers subscribe; sysinfo fiber uses it to gate `boot_time` computation; main fiber uses it to sync/desync alarms |
 
 ## Configuration
 
@@ -103,7 +103,7 @@ Alarms are replaced wholesale on each config update: `delete_all()` followed by 
 When an alarm with `type = 'shutdown'` or `type = 'reboot'` fires:
 
 1. Compute `deadline = monotime() + 10`.
-2. Publish retained `{'+', 'control', 'shutdown'}` with `{ reason = alarm.payload.name, deadline = deadline }`.
+2. Publish retained `{'state', 'system', 'shutdown'}` with `{ reason = alarm.payload.name, deadline = deadline }`.
 3. Create an independent scope with a deadline of `deadline + 1` (one extra second beyond the broadcast deadline).
 4. Subscribe to `{'+', 'health'}` and track all services that are not yet `'disabled'`.
 5. Wait for all tracked services to reach `'disabled'` state, or until the deadline scope expires.
@@ -118,7 +118,7 @@ The shutdown scope is independent of the service scope, since the service scope 
 
 ```mermaid
 flowchart TD
-  St[Start] --> A(Subscribe to cfg/system + svc/time/synced)
+  St[Start] --> A(Subscribe to cfg/system + state/time/synced)
   A --> B{op.choice: config msg, time synced msg, alarm fires, scope cancelled}
   B -->|config msg| C(Apply config: update report_period channel, handle USB3, reload alarms)
   C --> B
@@ -139,7 +139,7 @@ flowchart TD
 
 ```mermaid
 flowchart TD
-  St[Start] --> A(Subscribe to svc/time/synced + thermal cap meta)
+  St[Start] --> A(Subscribe to state/time/synced + thermal cap meta)
   A --> B(Receive report_period from config channel)
   B --> C(Read platform retained state; publish hw_revision, fw_version, serial, board_revision metrics)
   C --> D{op.choice: sleep report_period, new report_period, time synced msg, thermal meta msg, scope cancelled}
@@ -166,6 +166,6 @@ flowchart TD
 - Platform static identity fields are read once from the retained `platform` state topic at sysinfo fiber startup. Each field is immediately published as an `obs/v1/system/metric/<name>` metric. They are not re-published on each report cycle.
 - USB3 handling: if `usb3_enabled = false` in config, call `cap/usb/usb3/rpc/disable`. If `usb3_enabled = true`, call `cap/usb/usb3/rpc/enable`. This is idempotent (calling disable when already disabled is harmless).
 - The sysinfo fiber does **not** fail if any individual `get` RPC fails — it logs a warning and skips publishing that metric.
-- The sysinfo fiber subscribes to `{'svc', 'time', 'synced'}` and maintains a local `time_synced` flag. `boot_time` (`os.time() - uptime`) is only computed and published when `time_synced = true`, ensuring the wall-clock value is correct before it enters the metrics pipeline.
+- The sysinfo fiber subscribes to `{'state', 'time', 'synced'}` and maintains a local `time_synced` flag. `boot_time` (`os.time() - uptime`) is only computed and published when `time_synced = true`, ensuring the wall-clock value is correct before it enters the metrics pipeline.
 - `finally` blocks in both fibers log the reason for shutdown.
 - Thermal zone subscription tracks whether `zone0` is present. Temperature is only read and published when `zone0` is known. No per-zone metric publications are made — a single `temperature` metric name is preserved to maintain continuity with historically collected data.

--- a/src/services/hal.lua
+++ b/src/services/hal.lua
@@ -865,6 +865,9 @@ function HalService.start(conn, opts)
 				return
 			end
 			register_device(device_event.event_type, dev_inst)
+			if device_event.ready_cond then
+				device_event.ready_cond:signal()
+			end
 			return
 		end
 

--- a/src/services/hal/managers/platform.lua
+++ b/src/services/hal/managers/platform.lua
@@ -10,9 +10,10 @@ local hal_types       = require "services.hal.types.core"
 ---@type any
 local platform_driver_any = platform_driver
 
-local fibers = require "fibers"
-local op     = require "fibers.op"
-local sleep  = require "fibers.sleep"
+local fibers  = require "fibers"
+local op      = require "fibers.op"
+local sleep   = require "fibers.sleep"
+local cond    = require "fibers.cond"
 
 local STOP_TIMEOUT = 5.0
 
@@ -64,17 +65,19 @@ local function manager(scope, dev_ev_ch, cap_emit_ch)
         error("Platform Manager: failed to bind capabilities: " .. tostring(cap_err))
     end
 
-    local ok, start_err = driver:start()
-    if not ok then
-        error("Platform Manager: failed to start driver: " .. tostring(start_err))
-    end
-
+    local ready_cond = cond.new()
     local device_event, ev_err = hal_types.new.DeviceEvent(
-        "added", "platform", "1", {}, capabilities)
+        "added", "platform", "1", {}, capabilities, ready_cond)
     if not device_event then
         error("Platform Manager: failed to create DeviceEvent: " .. tostring(ev_err))
     end
     dev_ev_ch:put(device_event)
+    ready_cond:wait()
+
+    local ok, start_err = driver:start()
+    if not ok then
+        error("Platform Manager: failed to start driver: " .. tostring(start_err))
+    end
 
     dlog(PlatformManager.logger, 'info', { what = 'device_registered' })
 end

--- a/src/services/hal/managers/power.lua
+++ b/src/services/hal/managers/power.lua
@@ -10,9 +10,10 @@ local hal_types    = require "services.hal.types.core"
 ---@type any
 local power_driver_any = power_driver
 
-local fibers = require "fibers"
-local op     = require "fibers.op"
-local sleep  = require "fibers.sleep"
+local fibers  = require "fibers"
+local op      = require "fibers.op"
+local sleep   = require "fibers.sleep"
+local cond    = require "fibers.cond"
 
 local STOP_TIMEOUT = 5.0
 
@@ -64,17 +65,19 @@ local function manager(scope, dev_ev_ch, cap_emit_ch)
         error("Power Manager: failed to bind capabilities: " .. tostring(cap_err))
     end
 
-    local ok, start_err = driver:start()
-    if not ok then
-        error("Power Manager: failed to start driver: " .. tostring(start_err))
-    end
-
+    local ready_cond = cond.new()
     local device_event, ev_err = hal_types.new.DeviceEvent(
-        "added", "power", "1", {}, capabilities)
+        "added", "power", "1", {}, capabilities, ready_cond)
     if not device_event then
         error("Power Manager: failed to create DeviceEvent: " .. tostring(ev_err))
     end
     dev_ev_ch:put(device_event)
+    ready_cond:wait()
+
+    local ok, start_err = driver:start()
+    if not ok then
+        error("Power Manager: failed to start driver: " .. tostring(start_err))
+    end
 
     dlog(PowerManager.logger, 'info', { what = 'device_registered' })
 end

--- a/src/services/hal/managers/sysmon.lua
+++ b/src/services/hal/managers/sysmon.lua
@@ -21,10 +21,11 @@ local memory_driver_any = memory_driver
 ---@type any
 local thermal_driver_any = thermal_driver
 
-local fibers  = require "fibers"
-local op      = require "fibers.op"
-local sleep   = require "fibers.sleep"
-local exec    = require "fibers.io.exec"
+local fibers   = require "fibers"
+local op       = require "fibers.op"
+local sleep    = require "fibers.sleep"
+local exec     = require "fibers.io.exec"
+local cond     = require "fibers.cond"
 
 local STOP_TIMEOUT = 5.0
 
@@ -102,13 +103,8 @@ local function register_driver(driver, class, id, meta, dev_ev_ch, cap_emit_ch)
         return false
     end
 
-    local ok, start_err = driver:start()
-    if not ok then
-        dlog(SysmonManager.logger, 'error', { what = 'driver_start_failed', class = class, id = id, err = start_err })
-        return false
-    end
-
-    local device_event, ev_err = hal_types.new.DeviceEvent("added", class, id, meta, capabilities)
+    local ready_cond = cond.new()
+    local device_event, ev_err = hal_types.new.DeviceEvent("added", class, id, meta, capabilities, ready_cond)
     if not device_event then
         dlog(SysmonManager.logger, 'error', {
             what = 'device_event_create_failed', class = class, id = id, err = ev_err,
@@ -116,6 +112,13 @@ local function register_driver(driver, class, id, meta, dev_ev_ch, cap_emit_ch)
         return false
     end
     dev_ev_ch:put(device_event)
+    ready_cond:wait()
+
+    local ok, start_err = driver:start()
+    if not ok then
+        dlog(SysmonManager.logger, 'error', { what = 'driver_start_failed', class = class, id = id, err = start_err })
+        return false
+    end
     return true
 end
 

--- a/src/services/hal/managers/usb.lua
+++ b/src/services/hal/managers/usb.lua
@@ -10,9 +10,10 @@ local hal_types  = require "services.hal.types.core"
 ---@type any
 local usb_driver_any = usb_driver
 
-local fibers = require "fibers"
-local op     = require "fibers.op"
-local sleep  = require "fibers.sleep"
+local fibers  = require "fibers"
+local op      = require "fibers.op"
+local sleep   = require "fibers.sleep"
+local cond    = require "fibers.cond"
 
 local STOP_TIMEOUT = 5.0
 
@@ -64,17 +65,19 @@ local function manager(scope, dev_ev_ch, cap_emit_ch)
         error("USB Manager: failed to bind capabilities: " .. tostring(cap_err))
     end
 
-    local ok, start_err = driver:start()
-    if not ok then
-        error("USB Manager: failed to start driver: " .. tostring(start_err))
-    end
-
+    local ready_cond = cond.new()
     local device_event, ev_err = hal_types.new.DeviceEvent(
-        "added", "usb", "usb3", {}, capabilities)
+        "added", "usb", "usb3", {}, capabilities, ready_cond)
     if not device_event then
         error("USB Manager: failed to create DeviceEvent: " .. tostring(ev_err))
     end
     dev_ev_ch:put(device_event)
+    ready_cond:wait()
+
+    local ok, start_err = driver:start()
+    if not ok then
+        error("USB Manager: failed to start driver: " .. tostring(start_err))
+    end
 
     dlog(UsbManager.logger, 'info', { what = 'device_registered' })
 end

--- a/src/services/hal/types/core.lua
+++ b/src/services/hal/types/core.lua
@@ -128,6 +128,7 @@ end
 ---@field id DeviceId
 ---@field meta Meta
 ---@field capabilities CapList
+---@field ready_cond Cond? Optional one-shot condition; signalled by HAL after the device is fully registered.
 local DeviceEvent = {}
 DeviceEvent.__index = DeviceEvent
 
@@ -137,9 +138,10 @@ DeviceEvent.__index = DeviceEvent
 ---@param id DeviceId
 ---@param meta Meta?
 ---@param capabilities CapList?
+---@param ready_cond Cond? Optional one-shot condition; signalled by HAL after the device is fully registered.
 ---@return DeviceEvent?
 ---@return string error
-function new.DeviceEvent(event_type, class, id, meta, capabilities)
+function new.DeviceEvent(event_type, class, id, meta, capabilities, ready_cond)
     meta = meta or {}
     capabilities = capabilities or {}
 
@@ -168,12 +170,17 @@ function new.DeviceEvent(event_type, class, id, meta, capabilities)
         end
     end
 
+    if ready_cond ~= nil and type(ready_cond.signal) ~= 'function' then
+        return nil, "invalid ready_cond"
+    end
+
     local ev = setmetatable({
-        event_type = event_type,
-        class = class,
-        id = id,
-        meta = meta,
+        event_type  = event_type,
+        class       = class,
+        id          = id,
+        meta        = meta,
         capabilities = capabilities,
+        ready_cond  = ready_cond,
     }, DeviceEvent)
 
     return ev, ""

--- a/src/services/system.lua
+++ b/src/services/system.lua
@@ -162,14 +162,6 @@ local SYSINFO_METRICS = {
         mk_opts = cap_sdk.args.new.CpuGetOpts
     },
     {
-        class = 'cpu',
-        id = '1',
-        method = 'get',
-        field = 'frequency',
-        metric_key = 'cpu_frequency',
-        mk_opts = cap_sdk.args.new.CpuGetOpts
-    },
-    {
         class = 'memory',
         id = '1',
         method = 'get',
@@ -228,7 +220,10 @@ local function sysinfo_fiber(_, svc, report_period_ch)
             local id = identity_msg.payload
             for _, metric in ipairs(PLATFORM_IDENTITY_METRICS) do
                 if id[metric.field] ~= nil then
-                    svc:obs_metric(metric.metric_key, { value = id[metric.field] })
+                    svc:obs_metric(metric.metric_key, {
+                        namespace = { 'system', metric.metric_key },
+                        value = id[metric.field]
+                    })
                 end
             end
             svc:obs_log('debug', 'sysinfo: published platform identity metrics')
@@ -293,7 +288,10 @@ local function sysinfo_fiber(_, svc, report_period_ch)
                                 err = err
                             })
                         else
-                            svc:obs_metric(m.metric_key, { value = value })
+                            svc:obs_metric(m.metric_key, {
+                                namespace = { 'system', m.metric_key },
+                                value = value
+                            })
                         end
                     end
                 end
@@ -309,7 +307,10 @@ local function sysinfo_fiber(_, svc, report_period_ch)
                     if uptime == nil or uptime_err ~= "" then
                         svc:obs_log('warn', { what = 'uptime_get_failed', err = uptime_err })
                     else
-                        svc:obs_metric('boot_time', { value = os.time() - math.floor(uptime) })
+                        svc:obs_metric('boot_time', {
+                            namespace = { 'system', 'boot_time' },
+                            value = os.time() - math.floor(uptime)
+                        })
                     end
                 end
             end

--- a/src/services/system.lua
+++ b/src/services/system.lua
@@ -28,20 +28,14 @@ local SCHEMA_TARGET = "devicecode.config/system/1"
 ---@return Topic
 local function t_cfg(name) return { 'cfg', name } end
 
----@param key string
 ---@return Topic
-local function t_obs_metric(key)
-    return { 'obs', 'v1', 'system', 'metric', key }
+local function t_state_time_synced()
+    return { 'state', 'time', 'synced' }
 end
 
 ---@return Topic
-local function t_svc_time_synced()
-    return { 'svc', 'time', 'synced' }
-end
-
----@return Topic
-local function t_shutdown_control()
-    return { 'svc', 'system', 'shutdown' }
+local function t_state_system_shutdown()
+    return { 'state', 'system', 'shutdown' }
 end
 
 -- ── config validation ──────────────────────────────
@@ -146,18 +140,6 @@ local function get_cap_ref(refs, class, id)
     return refs[cap_ref_key(class, id)]
 end
 
--- ── publish helpers ───────────────────────────────
-
----@param conn Connection
----@param key string
----@param value number|string
----@param namespace? string
-local function publish_metric(conn, key, value, namespace)
-    local payload = { value = value }
-    if namespace then payload.namespace = namespace end
-    conn:retain(t_obs_metric(key), payload)
-end
-
 -- ── sysinfo fiber ────────────────────────────────
 
 -- Temperature from zone0 (preserved metric name for historical continuity).
@@ -246,7 +228,7 @@ local function sysinfo_fiber(_, svc, report_period_ch)
             local id = identity_msg.payload
             for _, metric in ipairs(PLATFORM_IDENTITY_METRICS) do
                 if id[metric.field] ~= nil then
-                    publish_metric(conn, metric.metric_key, id[metric.field])
+                    svc:obs_metric(metric.metric_key, { value = id[metric.field] })
                 end
             end
             svc:obs_log('debug', 'sysinfo: published platform identity metrics')
@@ -256,7 +238,7 @@ local function sysinfo_fiber(_, svc, report_period_ch)
     end
 
     -- Subscribe to time sync.
-    local time_sub = conn:subscribe(t_svc_time_synced())
+    local time_sub = conn:subscribe(t_state_time_synced())
 
     local time_synced = false
 
@@ -311,7 +293,7 @@ local function sysinfo_fiber(_, svc, report_period_ch)
                                 err = err
                             })
                         else
-                            publish_metric(conn, m.metric_key, value)
+                            svc:obs_metric(m.metric_key, { value = value })
                         end
                     end
                 end
@@ -327,7 +309,7 @@ local function sysinfo_fiber(_, svc, report_period_ch)
                     if uptime == nil or uptime_err ~= "" then
                         svc:obs_log('warn', { what = 'uptime_get_failed', err = uptime_err })
                     else
-                        publish_metric(conn, 'boot_time', os.time() - math.floor(uptime))
+                        svc:obs_metric('boot_time', { value = os.time() - math.floor(uptime) })
                     end
                 end
             end
@@ -358,7 +340,7 @@ local function handle_alarm(svc, power_cap, alarm)
     end
 
     -- Broadcast shutdown signal so all services can clean up within the deadline.
-    conn:retain(t_shutdown_control(), {
+    conn:retain(t_state_system_shutdown(), {
         reason   = alarm_name,
         deadline = fibers.now() + SHUTDOWN_GRACE,
     })
@@ -390,7 +372,6 @@ local function system_main(svc, report_period_ch)
     parent_scope:finally(function()
         local _, primary = parent_scope:status()
         svc:obs_log('debug', { what = 'main_stopped', reason = tostring(primary or 'ok') })
-        svc:status('stopped', { reason = tostring(primary or 'ok') })
     end)
 
     -- Acquire platform cap to read hw_revision from identity state.
@@ -423,7 +404,7 @@ local function system_main(svc, report_period_ch)
 
     local alarm_mgr = alarms.AlarmManager.new()
     local cfg_sub   = conn:subscribe(t_cfg(svc.name))
-    local time_sub  = conn:subscribe(t_svc_time_synced())
+    local time_sub  = conn:subscribe(t_state_time_synced())
 
     while true do
         local choices = {
@@ -502,7 +483,8 @@ function SystemService.start(conn, opts)
 
     svc:obs_state('boot', { at = svc:wall(), ts = svc:now(), state = 'entered' })
     svc:obs_log('info', 'service start() entered')
-    svc:status('starting')
+    svc:announce({})
+    svc:starting()
     svc:spawn_heartbeat(heartbeat_s, 'tick')
 
     -- Channel carries report_period from System Main → System Sysinfo.
@@ -511,14 +493,14 @@ function SystemService.start(conn, opts)
 
     fibers.current_scope():finally(function()
         local _, primary = fibers.current_scope():status()
-        svc:status('stopped', { reason = tostring(primary or 'ok') })
+        svc:lifecycle('stopped', { ready = false, reason = tostring(primary or 'ok') })
         svc:obs_log('info', 'service stopped')
     end)
 
     -- Spawn Sysinfo first so it is ready to receive from report_period_ch.
     fibers.current_scope():spawn(sysinfo_fiber, svc, report_period_ch)
 
-    svc:status('running')
+    svc:running()
     svc:obs_log('info', 'service running')
 
     -- Run System Main in the calling fiber.

--- a/src/services/system/alarms.lua
+++ b/src/services/system/alarms.lua
@@ -11,21 +11,6 @@ local REPEAT_TYPES = {
     DAILY = "daily",
 }
 
-local time_source_ready = false
-
-local function ensure_time_source()
-    if time_source_ready then
-        return
-    end
-
-    local ok, err = pcall(falarm.set_time_source, os.time)
-    if not ok and not tostring(err):match("set_time_source may only be called once") then
-        error(err)
-    end
-
-    time_source_ready = true
-end
-
 ---@class AlarmTriggerTime
 ---@field hour integer
 ---@field min integer
@@ -63,7 +48,6 @@ end
 ---@param repeat_type string
 ---@return Alarm
 local function build_wait_alarm(trigger_time, repeat_type)
-    ensure_time_source()
     return falarm.new {
         next_time = function(last, now)
             return next_local_trigger(trigger_time, repeat_type, last, now)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [x] 📝 Documentation Update
- [ ] 🎨 Style
- [x] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description
There were three outstanding problems in system and system related components during merge testing:

- Using the old time endpoints for listening to sync events
- The alarm manager was trying to setup the alarm handling - a time service responsibility
- Metrics were not providing a namespace and as such being published as obs/v1/system/metric/<key>
- HAL components were emitting important info during the start method of the driver which was being lost due to the device not being officially registered, there is now an optional cond that can be signaled to indicate device registration

## Manual test
<!-- Have you manually tested this code and confirmed it is working? -->
- [x] 👍 yes
- [ ] 🙅 no

## Manual test description
Create a branch from system-bus-naming and merged the following branches into it:
- time-migration
- metrics-migration

Change the config.json file such that the publish protocol for each metrics is "log" and run the code. You should see the metrics logged with the proper key and values, you should see a time sync event and boot_time metric.

## Added tests?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?
- [x] 📜 system.md
- [ ] 🙅 no documentation needed

