### PR TITLE
ui: adds ui service + tests

### DIFF
--- a/docs/specs/ui.md
+++ b/docs/specs/ui.md
@@ -1,0 +1,155 @@
+# UI service guide
+
+## Purpose
+
+UI owns operator-facing application semantics.
+
+It is responsible for:
+
+```text
+static UI route policy
+read-model queries
+server-sent events
+local sessions
+authentication policy
+firmware upload policy
+update/artifact manager handoff
+UI summary publication
+```
+
+UI does not own HTTP transport. It consumes the HTTP service.
+
+## Lifetime shape
+
+```mermaid
+flowchart TD
+  UiScope["ui service scope"] --> Coordinator["coordinator"]
+  UiScope --> ReadModel["read-model component"]
+  UiScope --> Sessions["session store"]
+  UiScope --> Listener["HTTP listener consumer"]
+  UiScope --> Publisher["UI publisher"]
+
+  Listener --> HttpCap["cap/http/main/rpc/listen"]
+  Listener --> RequestScopes["HTTP request scopes"]
+
+  RequestScopes --> Static["static response"]
+  RequestScopes --> SSE["SSE stream"]
+  RequestScopes --> Upload["firmware upload"]
+  RequestScopes --> Query["read-model query"]
+  RequestScopes --> SessionOps["login/session/logout"]
+
+  Upload --> Ingest["cap/artifact-ingest/main"]
+  Upload --> Update["cap/update-manager/main"]
+
+  ReadModel --> State["retained service state watches"]
+  Publisher --> UiState["state/ui/..."]
+```
+
+A request scope owns one accepted HTTP context after listener handoff.
+
+## Public surfaces
+
+UI should publish:
+
+```text
+svc/ui/status
+svc/ui/meta
+cfg/ui
+
+state/ui/summary
+state/ui/read-model
+state/ui/sessions
+```
+
+The UI service may publish narrow UI-domain retained state. It must not become the naming boundary for workflows owned by Update or Artifact Ingest.
+
+Firmware upload should call:
+
+```text
+cap/artifact-ingest/main/rpc/create
+cap/artifact-ingest/main/rpc/append
+cap/artifact-ingest/main/rpc/commit
+cap/artifact-ingest/main/rpc/abort
+
+cap/update-manager/main/rpc/create-job
+cap/update-manager/main/rpc/start-job
+```
+
+UI must not expose upload workflows as `cmd/ui/...` or `cmd/update/...`.
+
+## HTTP request ownership
+
+```mermaid
+sequenceDiagram
+  participant HTTP as HTTP service
+  participant UI as UI listener component
+  participant Req as UI request scope
+  participant Ctx as HttpContext
+
+  HTTP-->>UI: accepted context handle
+  UI->>Req: start request scope
+  Req->>Ctx: install termination ownership
+  Req->>Ctx: read request op
+  Req->>Req: route request
+  Req->>Ctx: write response ops
+  Req->>Ctx: terminate on cancellation/finaliser
+```
+
+The UI coordinator should not perform HTTP I/O. Request scopes may perform HTTP reads and writes.
+
+## Read model
+
+The read model is observable state, not a worker that performs application policy.
+
+It should provide:
+
+```text
+snapshot
+query
+watch
+changed_op
+terminate
+```
+
+Read-model updates should be non-yielding. Expensive work belongs in request scopes or workers.
+
+## Upload ownership
+
+Upload owns:
+
+```text
+accepted HTTP context
+request body streaming
+artifact ingest session until commit or abort
+timeout policy
+update job creation/start request
+```
+
+On cancellation or append failure:
+
+```text
+abort uncommitted ingest
+terminate owned body/context resources
+resolve request once
+```
+
+After successful commit:
+
+```text
+do not abort committed artifact
+create update job through cap/update-manager
+start update job if policy requires it
+```
+
+## Reviewer checklist
+
+```text
+UI does not require cqueues, lua-http or HTTP transport modules.
+UI obtains HTTP through services.http.sdk.
+Request scopes own HTTP I/O.
+Upload uses cap/artifact-ingest and cap/update-manager.
+UI does not publish workflow records owned by Update.
+UI state stays narrow under state/ui/...
+Session changes are observable through the store/model, not callback sinks.
+Finalisers terminate contexts and unresolved requests immediately.
+```

--- a/src/services/ui.lua
+++ b/src/services/ui.lua
@@ -1,0 +1,41 @@
+-- services/ui.lua
+--
+-- Public UI service assembly entry point. Semantic owners live under
+-- services.ui.*; this file is deliberately thin.
+
+local M = {
+	service = require 'services.ui.service',
+	topics = require 'services.ui.topics',
+	errors = require 'services.ui.errors',
+	config = require 'services.ui.config',
+	sessions = require 'services.ui.sessions',
+	auth = require 'services.ui.auth',
+	read_model = require 'services.ui.read_model',
+	read_model_store = require 'services.ui.read_model_store',
+	read_model_watches = require 'services.ui.read_model_watches',
+	queries = require 'services.ui.queries',
+	user_operation = require 'services.ui.user_operation',
+	http = {
+		listener = require 'services.ui.http.listener',
+		request = require 'services.ui.http.request',
+		routes = require 'services.ui.http.routes',
+		response = require 'services.ui.http.response',
+		static = require 'services.ui.http.static',
+		sse = require 'services.ui.http.sse',
+	},
+	update = {
+		client = require 'services.ui.update.client',
+		upload = require 'services.ui.update.upload',
+		artifact_ingest = require 'services.ui.update.artifact_ingest',
+	},
+}
+
+function M.start(conn, opts)
+	return M.service.start(conn, opts)
+end
+
+function M.run(scope, params)
+	return M.service.run(scope, params)
+end
+
+return M

--- a/src/services/ui/architecture.md
+++ b/src/services/ui/architecture.md
@@ -1,0 +1,135 @@
+# UI architecture note
+
+UI is a consumer of the system HTTP capability, not an HTTP transport owner.
+
+## Purpose
+
+The UI service owns application semantics:
+
+```text
+static UI route policy
+server-sent events over read-model watches
+firmware upload policy and update-service handoff
+authentication and local sessions
+read-only projections over retained service state
+UI status and summary publication
+```
+
+The HTTP service owns:
+
+```text
+cqueues driver
+lua-http backend
+HTTP listener construction
+HTTP context command loops
+WebSocket transport capability for future consumers
+immediate transport termination
+```
+
+UI depends on `services.http.sdk` and public HTTP handles. No UI module should
+require cqueues, raw lua-http, or `services.http.transport`.
+
+## Lifetime shape
+
+```text
+ui service scope
+  service coordinator
+  read-model component
+  HTTP listener consumer component
+    HttpListener local handle from cap/http/main
+    HTTP request scopes
+      static response scopes
+      SSE response scopes
+      firmware upload scopes
+```
+
+A request scope owns one accepted `HttpContext` after listener handoff. It
+installs immediate termination before any cancellable wait. Graceful response
+work is done in the request scope; finalisers terminate immediately.
+
+## HTTP consumption
+
+UI obtains an HTTP listener using the HTTP SDK:
+
+```lua
+local ref = require('services.http').sdk.new_ref(conn, 'main')
+local reply = fibers.perform(ref:listen_op({ host = '127.0.0.1', port = 8080 }))
+local listener = reply.listener
+```
+
+The listener component accepts `HttpContext` handles and starts request scopes.
+The UI service coordinator never performs HTTP I/O.
+
+## First-cut routes
+
+```text
+GET  /...                    static files
+GET  /events                 server-sent events from the UI read model
+POST /api/update/upload      MCU firmware upload to the update/artifact boundary
+GET  /api/state/...          read-model queries
+POST /api/login              login
+GET  /api/session            session snapshot
+POST/DELETE /api/session     logout
+POST /api/call/...           authenticated command forwarding
+```
+
+## Boundaries
+
+```text
+services/ui/http/listener.lua
+  consumes cap/http/main and owns request admission
+
+services/ui/http/request.lua
+  owns one request lifetime and routes work
+
+services/ui/http/response.lua
+  owns one response state machine
+
+services/ui/http/static.lua
+  owns static file response work
+
+services/ui/http/sse.lua
+  owns SSE streaming over local read-model watches
+
+services/ui/update/upload.lua
+  owns upload body streaming and ingest handoff
+```
+
+## Rules
+
+```text
+UI service code does not use perform_raw.
+UI service code does not require cqueues or lua-http.
+UI service code does not require services.http.transport.
+The service coordinator blocks only at its control point.
+Request scopes may perform HTTP read/write Ops.
+Finalisers use terminate(reason) only; graceful closure belongs in close_op().
+Response ownership is explicit.
+Upload ownership transfer is explicit.
+```
+
+## Event-port listener boundary
+
+The UI service treats its HTTP listener as a component/source rather than a
+callback target.
+
+```text
+UI service coordinator
+  owns listener_generation
+  owns active request counts
+  owns summary publication
+
+UI HTTP listener component
+  accepts contexts from cap/http
+  starts request scopes
+  emits request lifecycle events through devicecode.support.service_events
+```
+
+Listener lifecycle events carry `listener_id` and `generation`. The coordinator
+ignores stale request events from a replaced listener. The listener module keeps a
+raw `done_tx` path only as an isolated compatibility seam for older unit tests;
+service wiring uses `events_port`.
+
+Command forwarding is expressed through `user_operation.run_op` and
+`conn:call_op`, so the request scope owns the wait and command specs no longer
+hide a blocking `conn:call` behind an ordinary function.

--- a/src/services/ui/auth.lua
+++ b/src/services/ui/auth.lua
@@ -1,0 +1,60 @@
+-- services/ui/auth.lua
+--
+-- Authentication/verifier boundary. The default verifier is deliberately local
+-- and immediate; callers that need blocking authentication should wrap it as a
+-- scoped operation outside this module.
+
+local M = {}
+local Verifier = {}
+Verifier.__index = Verifier
+
+function M.new(opts)
+	opts = opts or {}
+	if opts.verify ~= nil and type(opts.verify) ~= 'function' then
+		error('auth.new: verify must be a function', 2)
+	end
+	return setmetatable({
+		_verify = opts.verify,
+		_users = opts.users or {},
+	}, Verifier)
+end
+
+function Verifier:verify(credentials)
+	credentials = credentials or {}
+	if self._verify then
+		return self._verify(credentials)
+	end
+
+	local username = credentials.username or credentials.user
+	local password = credentials.password
+	local rec = username and self._users[username] or nil
+	if rec == nil then
+		return nil, 'unauthenticated'
+	end
+	if type(rec) == 'table' then
+		if rec.password ~= nil and rec.password ~= password then
+			return nil, 'unauthenticated'
+		end
+		return rec.principal or username, nil
+	end
+	if rec ~= password then
+		return nil, 'unauthenticated'
+	end
+	return username, nil
+end
+
+function M.verify(verifier, credentials)
+	if verifier == nil then
+		return nil, 'auth verifier unavailable'
+	end
+	if type(verifier) == 'function' then
+		return verifier(credentials)
+	end
+	if type(verifier) == 'table' and type(verifier.verify) == 'function' then
+		return verifier:verify(credentials)
+	end
+	return nil, 'invalid auth verifier'
+end
+
+M.Verifier = Verifier
+return M

--- a/src/services/ui/config.lua
+++ b/src/services/ui/config.lua
@@ -1,0 +1,273 @@
+-- services/ui/config.lua
+--
+-- Pure UI configuration normaliser.
+
+local M = {}
+
+M.SCHEMA = 'devicecode.config/ui/1'
+
+local DEFAULTS = {
+	enabled = true,
+	http = {
+		enabled = true,
+		cap_id = 'main',
+		host = '0.0.0.0',
+		port = 8080,
+	},
+	static = {
+		root = 'www',
+		index = 'index.html',
+		chunk_size = 16384,
+	},
+	sse = {
+		enabled = true,
+		queue_len = 32,
+		replay = true,
+	},
+	uploads = {
+		enabled = true,
+		max_bytes = 64 * 1024 * 1024,
+	},
+	sessions = {
+		prune_interval = 60,
+	},
+}
+
+local ROOT_KEYS = {
+	schema = true,
+	enabled = true,
+	http = true,
+	static = true,
+	sse = true,
+	uploads = true,
+	sessions = true,
+}
+
+local HTTP_KEYS = {
+	enabled = true,
+	cap = true,
+	cap_id = true,
+	id = true,
+	host = true,
+	port = true,
+	path = true,
+	tls = true,
+	max_accept_queue = true,
+	max_active_requests = true,
+}
+
+local STATIC_KEYS = { root = true, index = true, chunk_size = true }
+local SSE_KEYS = { enabled = true, queue_len = true, max_replay = true, replay = true, pattern = true }
+local UPLOAD_KEYS = { enabled = true, max_bytes = true }
+local SESSION_KEYS = { prune_interval = true }
+
+local function fail(msg) return nil, msg end
+
+local function copy_plain(v)
+	if type(v) ~= 'table' then return v end
+	local out = {}
+	for k, subv in pairs(v) do out[k] = copy_plain(subv) end
+	return out
+end
+
+local function allowed(t, keys, path)
+	for k in pairs(t or {}) do
+		if not keys[k] then return nil, path .. ' has unknown field: ' .. tostring(k) end
+	end
+	return true, nil
+end
+
+local function table_or_empty(v, path)
+	if v == nil then return {}, nil end
+	if type(v) ~= 'table' then return nil, path .. ' must be a table' end
+	return v, nil
+end
+
+local function bool_or_nil(v, path)
+	if v == nil then return nil, nil end
+	if type(v) ~= 'boolean' then return nil, path .. ' must be boolean' end
+	return v, nil
+end
+
+local function non_empty_string_or_nil(v, path)
+	if v == nil then return nil, nil end
+	if type(v) ~= 'string' or v == '' then return nil, path .. ' must be a non-empty string' end
+	return v, nil
+end
+
+local function non_negative_int_or_nil(v, path)
+	if v == nil then return nil, nil end
+	if type(v) ~= 'number' or v < 0 or v % 1 ~= 0 then return nil, path .. ' must be a non-negative integer' end
+	return v, nil
+end
+
+local function positive_number_or_false_or_nil(v, path)
+	if v == nil then return nil, nil end
+	if v == false then return false, nil end
+	if type(v) ~= 'number' or v <= 0 then return nil, path .. ' must be > 0 or false' end
+	return v, nil
+end
+
+local function normalise_http(raw)
+	local err
+	raw, err = table_or_empty(raw, 'http')
+	if not raw then return nil, err end
+	local ok
+	ok, err = allowed(raw, HTTP_KEYS, 'http')
+	if not ok then return nil, err end
+
+	local out = copy_plain(DEFAULTS.http)
+	local v
+
+	v, err = bool_or_nil(raw.enabled, 'http.enabled')
+	if err then return nil, err end
+	if v ~= nil then out.enabled = v end
+
+	v, err = non_empty_string_or_nil(raw.cap_id or raw.cap or raw.id, 'http.cap_id')
+	if err then return nil, err end
+	if v ~= nil then out.cap_id = v end
+
+	v, err = non_empty_string_or_nil(raw.host, 'http.host')
+	if err then return nil, err end
+	if v ~= nil then out.host = v end
+
+	v, err = non_negative_int_or_nil(raw.port, 'http.port')
+	if err then return nil, err end
+	if v ~= nil then out.port = v end
+
+	v, err = non_empty_string_or_nil(raw.path, 'http.path')
+	if err then return nil, err end
+	if v ~= nil then out.path = v end
+
+	v, err = bool_or_nil(raw.tls, 'http.tls')
+	if err then return nil, err end
+	if v ~= nil then out.tls = v end
+
+	v, err = non_negative_int_or_nil(raw.max_accept_queue, 'http.max_accept_queue')
+	if err then return nil, err end
+	if v ~= nil then out.max_accept_queue = v end
+
+	v, err = non_negative_int_or_nil(raw.max_active_requests, 'http.max_active_requests')
+	if err then return nil, err end
+	if v ~= nil then out.max_active_requests = v end
+
+	return out, nil
+end
+
+local function normalise_static(raw)
+	local err
+	raw, err = table_or_empty(raw, 'static')
+	if not raw then return nil, err end
+	local ok
+	ok, err = allowed(raw, STATIC_KEYS, 'static')
+	if not ok then return nil, err end
+
+	local out = copy_plain(DEFAULTS.static)
+	local v
+	v, err = non_empty_string_or_nil(raw.root, 'static.root')
+	if err then return nil, err end
+	if v ~= nil then out.root = v end
+	v, err = non_empty_string_or_nil(raw.index, 'static.index')
+	if err then return nil, err end
+	if v ~= nil then out.index = v end
+	v, err = non_negative_int_or_nil(raw.chunk_size, 'static.chunk_size')
+	if err then return nil, err end
+	if v ~= nil then out.chunk_size = v end
+	return out, nil
+end
+
+local function normalise_sse(raw)
+	local err
+	raw, err = table_or_empty(raw, 'sse')
+	if not raw then return nil, err end
+	local ok
+	ok, err = allowed(raw, SSE_KEYS, 'sse')
+	if not ok then return nil, err end
+
+	local out = copy_plain(DEFAULTS.sse)
+	local v
+	v, err = bool_or_nil(raw.enabled, 'sse.enabled')
+	if err then return nil, err end
+	if v ~= nil then out.enabled = v end
+	v, err = non_negative_int_or_nil(raw.queue_len, 'sse.queue_len')
+	if err then return nil, err end
+	if v ~= nil then out.queue_len = v end
+	v, err = non_negative_int_or_nil(raw.max_replay, 'sse.max_replay')
+	if err then return nil, err end
+	if v ~= nil then out.max_replay = v end
+	v, err = bool_or_nil(raw.replay, 'sse.replay')
+	if err then return nil, err end
+	if v ~= nil then out.replay = v end
+	if raw.pattern ~= nil then
+		if type(raw.pattern) ~= 'table' then return nil, 'sse.pattern must be a table' end
+		out.pattern = copy_plain(raw.pattern)
+	end
+	return out, nil
+end
+
+local function normalise_uploads(raw)
+	local err
+	raw, err = table_or_empty(raw, 'uploads')
+	if not raw then return nil, err end
+	local ok
+	ok, err = allowed(raw, UPLOAD_KEYS, 'uploads')
+	if not ok then return nil, err end
+	local out = copy_plain(DEFAULTS.uploads)
+	local v
+	v, err = bool_or_nil(raw.enabled, 'uploads.enabled')
+	if err then return nil, err end
+	if v ~= nil then out.enabled = v end
+	v, err = non_negative_int_or_nil(raw.max_bytes, 'uploads.max_bytes')
+	if err then return nil, err end
+	if v ~= nil then out.max_bytes = v end
+	return out, nil
+end
+
+local function normalise_sessions(raw)
+	local err
+	raw, err = table_or_empty(raw, 'sessions')
+	if not raw then return nil, err end
+	local ok
+	ok, err = allowed(raw, SESSION_KEYS, 'sessions')
+	if not ok then return nil, err end
+	local out = copy_plain(DEFAULTS.sessions)
+	local v
+	v, err = positive_number_or_false_or_nil(raw.prune_interval, 'sessions.prune_interval')
+	if err then return nil, err end
+	if v ~= nil then out.prune_interval = v end
+	return out, nil
+end
+
+function M.normalise(raw)
+	if raw == nil then raw = {} end
+	if type(raw) ~= 'table' then return fail('ui config must be a table') end
+	local ok, err = allowed(raw, ROOT_KEYS, 'ui config')
+	if not ok then return nil, err end
+	if raw.schema ~= nil and raw.schema ~= M.SCHEMA then
+		return nil, 'ui config schema must be ' .. M.SCHEMA
+	end
+
+	local enabled
+	enabled, err = bool_or_nil(raw.enabled, 'enabled')
+	if err then return nil, err end
+
+	local http; http, err = normalise_http(raw.http); if not http then return nil, err end
+	local static; static, err = normalise_static(raw.static); if not static then return nil, err end
+	local sse; sse, err = normalise_sse(raw.sse); if not sse then return nil, err end
+	local uploads; uploads, err = normalise_uploads(raw.uploads); if not uploads then return nil, err end
+	local sessions; sessions, err = normalise_sessions(raw.sessions); if not sessions then return nil, err end
+
+	return {
+		schema = M.SCHEMA,
+		enabled = enabled ~= false,
+		http = http,
+		static = static,
+		sse = sse,
+		uploads = uploads,
+		sessions = sessions,
+	}, nil
+end
+
+
+M.DEFAULTS = DEFAULTS
+return M

--- a/src/services/ui/errors.lua
+++ b/src/services/ui/errors.lua
@@ -1,0 +1,63 @@
+-- services/ui/errors.lua
+--
+-- Boundary error vocabulary and simple HTTP mapping helpers.
+
+local M = {}
+
+M.codes = {
+	bad_request      = { http = 400, message = 'bad_request' },
+	unauthenticated  = { http = 401, message = 'unauthenticated' },
+	forbidden        = { http = 403, message = 'forbidden' },
+	not_found        = { http = 404, message = 'not_found' },
+	timeout          = { http = 504, message = 'timeout' },
+	conflict         = { http = 409, message = 'conflict' },
+	closed           = { http = 499, message = 'closed' },
+	internal         = { http = 500, message = 'internal_error' },
+	upstream_failed  = { http = 502, message = 'upstream_failed' },
+}
+
+local function norm_key(err)
+	if type(err) == 'table' then
+		return err.code or err.kind or err.error or 'internal'
+	end
+	local s = tostring(err or 'internal')
+	if M.codes[s] then return s end
+	if s:find('timeout', 1, true) then return 'timeout' end
+	if s:find('unauth', 1, true) then return 'unauthenticated' end
+	if s:find('forbidden', 1, true) or s:find('permission', 1, true) then return 'forbidden' end
+	if s:find('not_found', 1, true) or s:find('no_route', 1, true) then return 'not_found' end
+	if s:find('closed', 1, true) or s:find('cancelled', 1, true) then return 'closed' end
+	return 'internal'
+end
+
+function M.normalise(err)
+	local key = norm_key(err)
+	local spec = M.codes[key] or M.codes.internal
+	local detail
+	if type(err) == 'table' then
+		detail = err.detail or err.reason or err.primary
+	else
+		detail = err
+	end
+	return {
+		code    = key,
+		status  = spec.http,
+		message = spec.message,
+		detail  = detail and tostring(detail) or nil,
+	}
+end
+
+function M.http_status(err)
+	return M.normalise(err).status
+end
+
+function M.http_body(err)
+	local e = M.normalise(err)
+	return {
+		error   = e.message,
+		code    = e.code,
+		detail  = e.detail,
+	}
+end
+
+return M

--- a/src/services/ui/http/listener.lua
+++ b/src/services/ui/http/listener.lua
@@ -1,0 +1,245 @@
+-- services/ui/http/listener.lua
+--
+-- UI HTTP listener consumer.
+--
+-- UI does not own the HTTP backend.  It obtains an HttpListener local handle
+-- from the HTTP capability service, accepts HttpContext handles, and transfers
+-- each accepted context into a request scope before any request work runs.
+
+local fibers      = require 'fibers'
+local queue       = require 'devicecode.support.queue'
+local resource    = require 'devicecode.support.resource'
+local scoped_work = require 'devicecode.support.scoped_work'
+local http_sdk    = require 'services.http'.sdk
+
+local M = {}
+
+local function emit(opts, ev)
+	local port = opts and opts.events_port
+	if port and type(port.emit_required) == 'function' then
+		local ok, err = port:emit_required(ev, 'ui_http_listener_report_failed')
+		if ok ~= true then error(err or 'ui_http_listener_report_failed', 3) end
+		return true, nil
+	end
+
+	-- Compatibility seam for older isolated listener tests. UI service code passes
+	-- an event port, not a raw mailbox callback/sink.
+	local done_tx = opts and opts.done_tx
+	if done_tx then
+		queue.assert_admit_required(done_tx, ev, 'http_listener_report_failed', 3)
+	end
+	return true, nil
+end
+
+local function terminate(obj, reason)
+	if obj == nil then return true, nil end
+	if type(obj) ~= 'table' then return nil, 'resource has no terminate method' end
+	if type(obj.terminate) == 'function' then return obj:terminate(reason) end
+	return nil, 'resource has no terminate method'
+end
+
+local function terminate_checked(obj, reason, label)
+	local ok, err = terminate(obj, reason)
+	if ok ~= true then error((label or 'resource termination failed') .. ': ' .. tostring(err), 2) end
+	return true
+end
+
+local function max_active_from(opts)
+	local n = opts.max_active_requests
+	if n == nil then return nil end
+	if type(n) ~= 'number' or n < 0 or n % 1 ~= 0 then
+		error('http.listener.run: max_active_requests must be a non-negative integer', 3)
+	end
+	return n
+end
+
+local function default_run_request(scope, ctx, opts)
+	local request_mod = require 'services.ui.http.request'
+	return request_mod.run(scope, ctx, opts)
+end
+
+local function request_id_of(ctx, next_id)
+	if type(ctx) == 'table' then
+		if type(ctx.id) == 'function' then
+			local ok, id = pcall(function () return ctx:id() end)
+			if ok and id ~= nil then return id end
+		end
+		if ctx.id ~= nil then return ctx.id end
+	end
+	return next_id
+end
+
+local function reject_overloaded(ctx, opts)
+	local reason = opts.overload_reason or 'http_request_backpressure'
+	if type(opts.reject_overloaded_request_now) == 'function' then
+		return opts.reject_overloaded_request_now(ctx, reason, opts)
+	end
+	return terminate(ctx, reason)
+end
+
+local function install_request_owner(request_scope, accepted_owner)
+	local request_owner
+	local ctx, err = accepted_owner:handoff(function (value)
+		request_owner = resource.owned(value, {
+			label = 'HTTP request context termination',
+			terminate = function (v, reason)
+				return terminate(v, reason)
+			end,
+		})
+		request_scope:finally(function (_, status, primary)
+			request_owner:terminate_checked(primary or status or 'terminated', 'HTTP request context termination')
+		end)
+		return true, nil
+	end)
+	if ctx == nil then return nil, err end
+
+	return {
+		ctx = ctx,
+		owner = request_owner,
+		cancel_owned_now = function (reason)
+			if request_owner and request_owner:is_owned() then
+				return request_owner:terminate(reason or 'request_cancelled')
+			end
+			return terminate(ctx, reason or 'request_cancelled')
+		end,
+	}, nil
+end
+
+local function obtain_listener_op(opts)
+	if opts.listener or opts.server then
+		return fibers.always(opts.listener or opts.server, nil)
+	end
+
+	if type(opts.obtain_listener_op) == 'function' then
+		return opts.obtain_listener_op(opts)
+	end
+
+	local conn = opts.conn
+	if conn == nil then return fibers.always(nil, 'http.listener.run: conn required') end
+
+	local cap_id = opts.http_cap_id or opts.cap_id or 'main'
+	local listen_args = opts.listen or {}
+	if type(listen_args) ~= 'table' then return fibers.always(nil, 'http.listener.run: listen opts must be a table') end
+	local ref = http_sdk.new_ref(conn, cap_id)
+	return ref:listen_op(listen_args, opts.call_opts):wrap(function (reply, err)
+		if reply == nil then return nil, err or 'http_listen_failed' end
+		return reply.listener, nil
+	end)
+end
+
+function M.run(scope, opts)
+	opts = opts or {}
+
+	local run_request = opts.run_request or default_run_request
+	if type(run_request) ~= 'function' then
+		error('http.listener.run: run_request must be a function', 2)
+	end
+
+	local listener = opts.listener or opts.server
+
+	-- A supplied listener is already being handed into this scope.  Install the
+	-- terminating finaliser before any scope-aware perform so an immediate
+	-- cancellation during start-up cannot leak the handle.  For SDK-created
+	-- listeners the same finaliser is installed first and becomes active as soon
+	-- as listener is assigned.
+	scope:finally(function (_, status, primary)
+		if listener ~= nil then
+			terminate_checked(listener, primary or status or 'http_listener_closed', 'HTTP listener termination')
+		end
+	end)
+
+	if listener == nil then
+		local listen_err
+		listener, listen_err = fibers.perform(obtain_listener_op(opts))
+		if listener == nil then error(listen_err or 'http.listener.run: listener unavailable', 0) end
+	end
+
+	if type(listener.accept_op) ~= 'function' then
+		error('http.listener.run: listener must expose accept_op', 2)
+	end
+
+	local active = 0
+	local next_id = 0
+	local max_active = max_active_from(opts)
+
+	while true do
+		local ctx, err = fibers.perform(listener:accept_op())
+		if ctx == nil then error(err or 'http accept failed', 0) end
+
+		next_id = next_id + 1
+		local request_id = request_id_of(ctx, next_id)
+
+		if max_active ~= nil and active >= max_active then
+			local ok, rerr = reject_overloaded(ctx, opts)
+			emit(opts, {
+				kind = 'http_request_rejected',
+				request_id = request_id,
+				reason = opts.overload_reason or 'http_request_backpressure',
+				active_requests = active,
+				max_active_requests = max_active,
+				cleanup_ok = ok == true,
+				cleanup_err = rerr,
+			})
+			if ok ~= true then error(rerr or 'http overloaded request cleanup failed', 0) end
+		else
+			local accepted_owner = resource.owned(ctx, {
+				label = 'accepted HTTP context cleanup',
+				terminate = function (value, reason)
+					return terminate(value, reason)
+				end,
+			})
+			active = active + 1
+			emit(opts, {
+				kind = 'http_request_started',
+				request_id = request_id,
+				active_requests = active,
+			})
+
+			local handle, start_err = scoped_work.start({
+				lifetime_scope = scope,
+				reaper_scope = scope,
+				report_scope = scope,
+				identity = {
+					kind = 'http_request_done',
+					request_id = request_id,
+				},
+				setup = function (request_scope)
+					return install_request_owner(request_scope, accepted_owner)
+				end,
+				run = function (request_scope, setup)
+					return run_request(request_scope, setup.ctx, opts)
+				end,
+				report = function (ev)
+					active = math.max(0, active - 1)
+					ev.active_requests = active
+					return emit(opts, ev)
+				end,
+			})
+
+			if not handle then
+				active = math.max(0, active - 1)
+				if accepted_owner:is_owned() then
+					accepted_owner:terminate_checked(start_err or 'http_request_start_failed', 'HTTP request start-failure cleanup')
+				end
+				emit(opts, {
+					kind = 'http_request_done',
+					request_id = request_id,
+					status = 'failed',
+					primary = start_err,
+					active_requests = active,
+				})
+			end
+		end
+	end
+end
+
+M._test = {
+	emit = emit,
+	max_active_from = max_active_from,
+	reject_overloaded = reject_overloaded,
+	install_request_owner = install_request_owner,
+	obtain_listener_op = obtain_listener_op,
+	terminate = terminate,
+}
+
+return M

--- a/src/services/ui/http/request.lua
+++ b/src/services/ui/http/request.lua
@@ -1,0 +1,199 @@
+-- services/ui/http/request.lua
+--
+-- One HTTP request lifetime.
+
+local fibers        = require 'fibers'
+local response_mod  = require 'services.ui.http.response'
+local routes        = require 'services.ui.http.routes'
+local static        = require 'services.ui.http.static'
+local sse           = require 'services.ui.http.sse'
+local queries       = require 'services.ui.queries'
+local auth          = require 'services.ui.auth'
+local user_operation = require 'services.ui.user_operation'
+local upload        = require 'services.ui.update.upload'
+local resource      = require 'devicecode.support.resource'
+
+local ok_http_headers, http_headers = pcall(require, 'services.http.headers')
+if not ok_http_headers then http_headers = nil end
+
+local M = {}
+
+local function header_one(headers, name)
+	if not headers then return nil end
+	if http_headers and type(http_headers.get_one) == 'function' then
+		local v = http_headers.get_one(headers, name)
+		if v ~= nil then return v end
+	end
+	if type(headers.get) == 'function' then
+		local ok, v = pcall(function () return headers:get(string.lower(name)) end)
+		if ok and v ~= nil then return v end
+	end
+	if type(headers) == 'table' then
+		return headers[name] or headers[string.lower(name)] or headers[string.upper(name)]
+	end
+	return nil
+end
+
+local function ensure_request_metadata(ctx)
+	if type(ctx) ~= 'table' then return ctx end
+	if ctx.method ~= nil and (ctx.path ~= nil or ctx.uri ~= nil) then return ctx end
+	if type(ctx.method) == 'function' and type(ctx.path) == 'function' then return ctx end
+	if type(ctx.get_headers_op) ~= 'function' then return ctx end
+
+	local h, err = fibers.perform(ctx:get_headers_op())
+	if not h then error(err or 'request headers unavailable', 0) end
+	ctx.headers = ctx.headers or h
+	ctx.method = ctx.method or header_one(h, ':method') or header_one(h, 'method') or 'GET'
+	ctx.path = ctx.path or ctx.uri or header_one(h, ':path') or '/'
+	return ctx
+end
+
+
+local function ctx_header(ctx, name)
+	return ctx and header_one(ctx.headers, name)
+end
+
+
+local function perform_response(ev)
+	-- HTTP response writes may yield through the transport bridge.  They are
+	-- performed only inside the HTTP request scope, where that wait is visible.
+	local ok, err = fibers.perform(ev)
+	if ok ~= true then
+		error(err or 'response write failed', 0)
+	end
+	return true
+end
+
+local function body_table(ctx)
+	if type(ctx.body) == 'table' then return ctx.body end
+	if type(ctx.json) == 'table' then return ctx.json end
+	return {}
+end
+
+local function session_id_from(ctx)
+	return ctx.session_id
+		or (ctx.cookies and (ctx.cookies.sid or ctx.cookies.session or ctx.cookies.ui_session))
+		or ctx_header(ctx, 'x-session-id')
+end
+
+local function principal_from(ctx, deps)
+	local sid = session_id_from(ctx)
+	if sid and deps.sessions then
+		local sess = deps.sessions:get(sid)
+		if sess then return sess.principal, sess end
+	end
+	return nil, nil
+end
+
+local function handle_read(owner, route, deps)
+	local model = assert(deps.model, 'HTTP read requires model')
+	local snap = model:snapshot()
+	local result
+	if route.query == 'all' then
+		result = queries.all(snap)
+	elseif route.query == 'services' then
+		result = queries.services_snapshot(snap)
+	elseif route.query == 'fabric' then
+		result = queries.fabric_status(snap)
+	elseif route.query == 'topic' then
+		result = queries.topic(snap, route.topic)
+	else
+		result = queries.all(snap)
+	end
+	perform_response(owner:reply_json_op(200, result))
+	return { status = 'ok', route = 'read' }
+end
+
+local function handle_login(owner, ctx, deps)
+	local principal, err = auth.verify(deps.auth, body_table(ctx))
+	if not principal then
+		perform_response(owner:reply_error_op(401, err or 'unauthenticated'))
+		return { status = 'unauthenticated' }
+	end
+	local sess = assert(deps.sessions, 'login requires sessions'):create(principal, {
+		data = { user_agent = ctx_header(ctx, 'user-agent') },
+	})
+	perform_response(owner:reply_json_op(200, { session = sess }))
+	return { status = 'ok', session_id = sess.id }
+end
+
+local function handle_logout(owner, ctx, deps)
+	local sid = session_id_from(ctx)
+	if sid and deps.sessions then deps.sessions:delete(sid) end
+	perform_response(owner:reply_json_op(200, { ok = true }))
+	return { status = 'ok' }
+end
+
+local function handle_session_get(owner, ctx, deps)
+	local sid = session_id_from(ctx)
+	local sess = sid and deps.sessions and deps.sessions:get(sid) or nil
+	if not sess then
+		perform_response(owner:reply_error_op(401, 'unauthenticated'))
+		return { status = 'unauthenticated' }
+	end
+	perform_response(owner:reply_json_op(200, { session = sess }))
+	return { status = 'ok' }
+end
+
+local function handle_command(scope, owner, ctx, route, deps)
+	local principal = principal_from(ctx, deps)
+	if principal == nil then
+		perform_response(owner:reply_error_op(401, 'unauthenticated'))
+		return { status = 'unauthenticated' }
+	end
+	local st, _rep, result_or_primary = fibers.perform(user_operation.run_op {
+		principal = principal,
+		connect = deps.connect,
+		bus = deps.bus,
+		timeout = deps.command_timeout or 5.0,
+		run_op = function (_, conn)
+			return conn:call_op(route.topic, body_table(ctx), { timeout = deps.command_timeout or 5.0 })
+				:wrap(function (value, call_err)
+					if value == nil then return nil, call_err or 'upstream_failed' end
+					return { value = value }, nil
+				end)
+		end,
+	})
+	if st ~= 'ok' then
+		perform_response(owner:reply_error_op(nil, result_or_primary))
+		return { status = 'failed', err = result_or_primary }
+	end
+	local result = result_or_primary
+	perform_response(owner:reply_json_op(200, result))
+	return { status = 'ok' }
+end
+
+function M.run(scope, ctx, deps)
+	deps = deps or {}
+	local owner = response_mod.new(ctx, { encode = deps.encode_json })
+
+	scope:finally(function (_, status, primary)
+		resource.terminate_checked(owner, primary or status or 'request_closed', 'HTTP response termination')
+	end)
+
+	ensure_request_metadata(ctx)
+	local route = routes.decode(ctx)
+
+	if route.kind == 'read' then
+		return handle_read(owner, route, deps)
+	elseif route.kind == 'login' then
+		return handle_login(owner, ctx, deps)
+	elseif route.kind == 'logout' then
+		return handle_logout(owner, ctx, deps)
+	elseif route.kind == 'session_get' then
+		return handle_session_get(owner, ctx, deps)
+	elseif route.kind == 'command' then
+		return handle_command(scope, owner, ctx, route, deps)
+	elseif route.kind == 'upload' then
+		return upload.run(scope, owner, ctx, deps.update or deps)
+	elseif route.kind == 'sse' then
+		return sse.run(scope, owner, route, deps)
+	elseif route.kind == 'static' then
+		return static.run(scope, owner, route, deps)
+	else
+		perform_response(owner:reply_error_op(404, 'not_found'))
+		return { status = 'not_found' }
+	end
+end
+
+return M

--- a/src/services/ui/http/response.lua
+++ b/src/services/ui/http/response.lua
@@ -1,0 +1,324 @@
+-- services/ui/http/response.lua
+--
+-- Response owner for one HTTP request.
+--
+-- The response owner is the only UI object that writes an HTTP response.  It
+-- owns the response state machine and exposes Op-returning write methods for
+-- request-owned scopes.  Finalisers must use terminate(reason) only; they
+-- never write bytes.
+
+local fibers = require 'fibers'
+local op     = require 'fibers.op'
+local errors = require 'services.ui.errors'
+local tablex = require 'shared.table'
+
+local ok_http_headers, http_headers = pcall(require, 'services.http.headers')
+if not ok_http_headers then http_headers = nil end
+
+local M = {}
+local Response = {}
+Response.__index = Response
+
+local TERMINAL = {
+	replied = true,
+	ended = true,
+	abandoned = true,
+}
+
+local shallow_copy = tablex.shallow_copy
+
+local function normalise_write_result(ok, err, fallback)
+	if ok == false or ok == nil then
+		return nil, err or fallback or 'response write failed'
+	end
+	return true, nil
+end
+
+local function terminate_ctx(ctx, reason)
+	if not ctx then return true, nil end
+	local fn = ctx.terminate or ctx.abandon_now
+	if type(fn) ~= 'function' then return nil, 'response context has no terminate' end
+	local ok, err = fn(ctx, reason)
+	if ok == false or ok == nil then return nil, err or 'response context termination failed' end
+	return true, nil
+end
+
+local function is_http_service_context(ctx)
+	return type(ctx) == 'table' and (type(ctx._raw_context) == 'function' or type(ctx.registry_id) == 'function')
+end
+
+local function response_headers(status, fields)
+	if http_headers and type(http_headers.status) == 'function' then
+		return http_headers.status(status, fields or {})
+	end
+	local out = shallow_copy(fields)
+	out[':status'] = tostring(status or 200)
+	return out, nil
+end
+
+local function call_write_headers_op(ctx, fn, status, headers, opts)
+	if is_http_service_context(ctx) then
+		local h, herr = response_headers(status, headers)
+		if not h then return fibers.always(nil, herr or 'response headers construction failed') end
+		return fn(ctx, h, not not (opts and opts.end_stream))
+	end
+	return fn(ctx, status, headers, opts)
+end
+
+local function call_write_chunk_op(ctx, fn, chunk, opts)
+	if is_http_service_context(ctx) then
+		return fn(ctx, chunk or '', not not (opts and opts.end_stream))
+	end
+	return fn(ctx, chunk or '', opts)
+end
+
+local function ensure_method(self, name)
+	if not (self._ctx and type(self._ctx[name]) == 'function') then
+		return nil, 'response context has no ' .. name
+	end
+	return self._ctx[name]
+end
+
+local function mark_abandoned(self, reason)
+	if TERMINAL[self._state] then return false, 'response already resolved' end
+	self._state = 'abandoned'
+	self._abandoned = reason or 'abandoned'
+	return true, nil
+end
+
+local function new_start_token(self)
+	local response_ref = self
+	local token = { active = true }
+
+	function token:release()
+		if not self.active then return false end
+		self.active = false
+		if response_ref._start_token == token then
+			response_ref._start_token = nil
+		end
+		return true
+	end
+
+	return token
+end
+
+local function acquire_start_token_op(self)
+	local function try()
+		if self._start_token ~= nil then
+			return true, nil, 'response already starting'
+		end
+		if self._state ~= 'unresolved' then
+			return true, nil, 'response already started'
+		end
+
+		-- Do not mutate response state during readiness probing.  The token is
+		-- committed by the primitive wrap only after this arm has won.
+		return true, new_start_token(self), nil
+	end
+
+	local function block()
+		error('response start token op should never block', 0)
+	end
+
+	local function wrap(token, err)
+		if not token then return nil, err end
+		if self._start_token ~= nil then
+			return nil, 'response already starting'
+		end
+		if self._state ~= 'unresolved' then
+			return nil, 'response already started'
+		end
+		self._start_token = token
+		return token, nil
+	end
+
+	return op.new_primitive(wrap, try, block)
+end
+
+function M.new(ctx, opts)
+	opts = opts or {}
+	return setmetatable({
+		_ctx = ctx or {},
+		_state = 'unresolved',
+		_status = nil,
+		_abandoned = nil,
+		_start_token = nil,
+		_encode = opts.encode,
+	}, Response)
+end
+
+function Response:state()
+	return self._state
+end
+
+function Response:done()
+	return TERMINAL[self._state] or false
+end
+
+function Response:write_headers_op(status, headers, opts)
+	status = status or 200
+	headers = shallow_copy(headers)
+	opts = opts or {}
+
+	return fibers.run_scope_op(function (scope)
+		local fn, missing = ensure_method(self, 'write_headers_op')
+		if not fn then return { ok = nil, err = missing } end
+
+		local token, token_err = fibers.perform(acquire_start_token_op(self))
+		if not token then return { ok = nil, err = token_err } end
+
+		local finished = false
+		scope:finally(function ()
+			if not finished then
+				token:release()
+				mark_abandoned(self, 'response_headers_aborted')
+				terminate_ctx(self._ctx, 'response_headers_aborted')
+			end
+		end)
+
+		local ok, err = fibers.perform(call_write_headers_op(self._ctx, fn, status, headers, {
+			end_stream = not not opts.end_stream,
+			timeout = opts.timeout,
+		}))
+
+		finished = true
+		token:release()
+
+		local write_ok, write_err = normalise_write_result(ok, err, 'response headers write failed')
+		if write_ok ~= true then
+			self._state = 'abandoned'
+			self._abandoned = write_err
+			return { ok = nil, err = write_err }
+		end
+
+		self._status = status
+		self._state = opts.end_stream and 'ended' or 'headers_sent'
+		return { ok = true }
+	end):wrap(function (st, _rep, result_or_primary)
+		if st ~= 'ok' then
+			return nil, result_or_primary or st
+		end
+		local result = result_or_primary or {}
+		return result.ok, result.err
+	end)
+end
+
+function Response:write_chunk_op(chunk, opts)
+	opts = opts or {}
+
+	return fibers.guard(function ()
+		if self._state ~= 'headers_sent' then
+			return fibers.always(nil, 'response stream is not open')
+		end
+
+		local fn, missing = ensure_method(self, 'write_chunk_op')
+		if not fn then return fibers.always(nil, missing) end
+
+		local finished = false
+		return call_write_chunk_op(self._ctx, fn, chunk or '', {
+			end_stream = not not opts.end_stream,
+			timeout = opts.timeout,
+		}):wrap(function (ok, err)
+			finished = true
+			local write_ok, write_err = normalise_write_result(ok, err, 'response chunk write failed')
+			if write_ok ~= true then
+				self._state = 'abandoned'
+				self._abandoned = write_err
+				return nil, write_err
+			end
+			if opts.end_stream then self._state = 'ended' end
+			return true, nil
+		end):on_abort(function ()
+			if not finished then
+				mark_abandoned(self, 'response_chunk_aborted')
+				terminate_ctx(self._ctx, 'response_chunk_aborted')
+			end
+		end)
+	end)
+end
+
+function Response:end_stream_op(opts)
+	opts = opts or {}
+	opts.end_stream = true
+	return self:write_chunk_op('', opts)
+end
+
+function Response:reply_op(status, body, headers, opts)
+	status = status or 200
+	body = body or ''
+	headers = shallow_copy(headers)
+	opts = opts or {}
+
+	return fibers.guard(function ()
+		if self._state ~= 'unresolved' then
+			return fibers.always(nil, 'response already resolved')
+		end
+
+		local no_body = body == '' or body == nil or not not opts.no_body
+		return fibers.run_scope_op(function ()
+			local ok, err = fibers.perform(self:write_headers_op(status, headers, {
+				end_stream = no_body,
+				timeout = opts.timeout,
+			}))
+			if ok ~= true then error(err or 'response headers write failed', 0) end
+
+			if not no_body then
+				ok, err = fibers.perform(self:write_chunk_op(body, {
+					end_stream = true,
+					timeout = opts.timeout,
+				}))
+				if ok ~= true then error(err or 'response chunk write failed', 0) end
+			end
+
+			self._state = 'replied'
+			return { ok = true }
+		end):on_abort(function ()
+			if not TERMINAL[self._state] then
+				mark_abandoned(self, 'response_aborted')
+				terminate_ctx(self._ctx, 'response_aborted')
+			end
+		end):wrap(function (st, _rep, result_or_primary)
+			if st ~= 'ok' then
+				if not TERMINAL[self._state] then
+					mark_abandoned(self, result_or_primary or st)
+					terminate_ctx(self._ctx, result_or_primary or st)
+				end
+				return nil, result_or_primary or st
+			end
+			return result_or_primary and result_or_primary.ok == true, nil
+		end)
+	end)
+end
+
+function Response:reply_json_op(status, body, headers, opts)
+	headers = shallow_copy(headers)
+	headers['content-type'] = headers['content-type'] or 'application/json'
+	local payload = body
+	if self._encode then payload = self._encode(body) end
+	return self:reply_op(status, payload, headers, opts)
+end
+
+function Response:reply_error_op(status, err)
+	local e = err
+	if type(status) ~= 'number' then
+		e = err or status
+		status = errors.http_status(e)
+	elseif e == nil then
+		e = status
+	end
+	return self:reply_json_op(status, errors.http_body(e))
+end
+
+function Response:abandon_now(reason)
+	local ok, err = mark_abandoned(self, reason or 'abandoned')
+	if ok ~= true then return ok, err end
+	return terminate_ctx(self._ctx, self._abandoned)
+end
+
+function Response:terminate(reason)
+	if TERMINAL[self._state] then return true, nil end
+	return self:abandon_now(reason or 'response_terminated')
+end
+
+M.Response = Response
+return M

--- a/src/services/ui/http/routes.lua
+++ b/src/services/ui/http/routes.lua
@@ -1,0 +1,87 @@
+-- services/ui/http/routes.lua
+--
+-- Pure route decoding for UI HTTP requests.
+
+local M = {}
+
+local function split_path(path)
+	path = tostring(path or '/')
+	local out = {}
+	for part in path:gmatch('[^/]+') do
+		out[#out + 1] = part
+	end
+	return out
+end
+
+local function method_of(ctx)
+	if ctx and type(ctx.method) == 'function' then
+		local ok, v = pcall(function () return ctx:method() end)
+		if ok and v ~= nil then return string.upper(tostring(v)) end
+	end
+	return string.upper(tostring((ctx and (ctx.method or ctx.verb)) or 'GET'))
+end
+
+local function path_of(ctx)
+	if ctx and type(ctx.path) == 'function' then
+		local ok, v = pcall(function () return ctx:path() end)
+		if ok and v ~= nil then return v end
+	end
+	return (ctx and (ctx.path or ctx.uri)) or '/'
+end
+
+function M.decode(ctx)
+	local method = method_of(ctx)
+	local parts = split_path(path_of(ctx))
+
+	if #parts == 0 then
+		return { kind = 'static', path = '/index.html' }
+	end
+
+	if parts[1] == 'events' and method == 'GET' then
+		return { kind = 'sse', pattern = { '#' } }
+	end
+
+	if parts[1] ~= 'api' then
+		return { kind = 'static', path = '/' .. table.concat(parts, '/') }
+	end
+
+	if parts[2] == 'login' and method == 'POST' then
+		return { kind = 'login' }
+	end
+
+	if parts[2] == 'session' then
+		if method == 'GET' then return { kind = 'session_get' } end
+		if method == 'DELETE' or method == 'POST' then return { kind = 'logout' } end
+	end
+
+	if parts[2] == 'state' and method == 'GET' then
+		local topic = {}
+		for i = 3, #parts do topic[#topic + 1] = parts[i] end
+		if #topic == 0 then
+			return { kind = 'read', query = 'all' }
+		end
+		return { kind = 'read', query = 'topic', topic = topic }
+	end
+
+	if parts[2] == 'services' and method == 'GET' then
+		return { kind = 'read', query = 'services' }
+	end
+
+	if parts[2] == 'fabric' and method == 'GET' then
+		return { kind = 'read', query = 'fabric' }
+	end
+
+	if parts[2] == 'update' and parts[3] == 'upload' and method == 'POST' then
+		return { kind = 'upload' }
+	end
+
+	if parts[2] == 'call' and method == 'POST' then
+		local topic = {}
+		for i = 3, #parts do topic[#topic + 1] = parts[i] end
+		return { kind = 'command', topic = topic }
+	end
+
+	return { kind = 'not_found' }
+end
+
+return M

--- a/src/services/ui/http/sse.lua
+++ b/src/services/ui/http/sse.lua
@@ -1,0 +1,115 @@
+-- services/ui/http/sse.lua
+--
+-- Server-sent-event response owner for UI read-model watches.
+--
+-- SSE is request-owned streaming HTTP work.  It observes the local UI read-model
+-- watch owner and writes framed events through the response owner.  It does not
+-- subscribe to retained bus state directly and it does not know about the HTTP
+-- backend implementation.
+
+local fibers   = require 'fibers'
+local resource = require 'devicecode.support.resource'
+
+local M = {}
+
+local function default_encode(v)
+	local tv = type(v)
+	if tv == 'nil' then return 'null' end
+	if tv == 'boolean' or tv == 'number' then return tostring(v) end
+	if tv == 'string' then return string.format('%q', v) end
+	if tv == 'table' then
+		local parts = {}
+		local is_array = true
+		local n = 0
+		for k in pairs(v) do
+			if type(k) ~= 'number' or k < 1 or k % 1 ~= 0 then is_array = false end
+			if type(k) == 'number' and k > n then n = k end
+		end
+		if is_array then
+			for i = 1, n do parts[#parts + 1] = default_encode(v[i]) end
+			return '[' .. table.concat(parts, ',') .. ']'
+		end
+		for k, vv in pairs(v) do parts[#parts + 1] = default_encode(tostring(k)) .. ':' .. default_encode(vv) end
+		return '{' .. table.concat(parts, ',') .. '}'
+	end
+	return default_encode(tostring(v))
+end
+
+local function perform_required(ev, label)
+	local ok, err = fibers.perform(ev)
+	if ok ~= true then error(err or label or 'sse write failed', 0) end
+	return true
+end
+
+local function topic_to_string(topic)
+	local parts = {}
+	for i = 1, #(topic or {}) do parts[i] = tostring(topic[i]) end
+	return table.concat(parts, '/')
+end
+
+local function frame_event(ev, encode)
+	local name = (ev and ev.op) or (ev and ev.kind) or 'message'
+	local data = encode(ev or {})
+	local id = ev and ev.topic and topic_to_string(ev.topic) or nil
+	local out = {}
+	if id and id ~= '' then out[#out + 1] = 'id: ' .. id .. '\n' end
+	out[#out + 1] = 'event: ' .. tostring(name) .. '\n'
+	data = tostring(data)
+	if data == '' then
+		out[#out + 1] = 'data: \n'
+	else
+		local start = 1
+		while start <= #data do
+			local nl = data:find('\n', start, true)
+			local line
+			if nl then
+				line = data:sub(start, nl - 1)
+				start = nl + 1
+			else
+				line = data:sub(start)
+				start = #data + 1
+			end
+			out[#out + 1] = 'data: ' .. line .. '\n'
+		end
+	end
+	out[#out + 1] = '\n'
+	return table.concat(out)
+end
+
+function M.run(scope, owner, route, opts)
+	opts = opts or {}
+	local watch_owner = assert(opts.watch_owner, 'SSE requires watch_owner')
+	local encode = opts.encode_json or opts.encode or default_encode
+	local pattern = route.pattern or opts.sse_pattern or (opts.sse and opts.sse.pattern) or { '#' }
+	local watch, err = watch_owner:watch_open(pattern, {
+		replay = opts.sse_replay ~= false,
+		queue_len = opts.sse_queue_len or (opts.sse and opts.sse.queue_len) or 32,
+		max_replay = opts.sse_max_replay or (opts.sse and opts.sse.max_replay),
+	})
+	if not watch then
+		perform_required(owner:reply_error_op(503, err or 'watch_open_failed'), 'SSE watch-open error response failed')
+		return { status = 'failed', err = err or 'watch_open_failed' }
+	end
+
+	local watch_res = resource.owned(watch, { label = 'SSE watch cleanup' })
+	scope:finally(function (_, status, primary)
+		watch_res:terminate_checked(primary or status or 'sse_closed', 'SSE watch cleanup')
+	end)
+
+	perform_required(owner:write_headers_op(200, {
+		['content-type'] = 'text/event-stream',
+		['cache-control'] = 'no-cache',
+		['connection'] = 'keep-alive',
+	}), 'SSE headers write failed')
+
+	while true do
+		local ev, rerr = fibers.perform(watch:recv_op())
+		if ev == nil then
+			return { status = 'closed', err = rerr }
+		end
+		perform_required(owner:write_chunk_op(frame_event(ev, encode)), 'SSE event write failed')
+	end
+end
+
+M.frame_event = frame_event
+return M

--- a/src/services/ui/http/static.lua
+++ b/src/services/ui/http/static.lua
@@ -1,0 +1,82 @@
+-- services/ui/http/static.lua
+--
+-- Static file response worker for one HTTP request scope.  Static responses are
+-- streamed through the response owner; this module never writes transport bytes
+-- directly.
+
+local fibers  = require 'fibers'
+local file_io = require 'fibers.io.file'
+local resource = require 'devicecode.support.resource'
+
+local M = {}
+
+local TYPES = {
+	['.html'] = 'text/html',
+	['.css']  = 'text/css',
+	['.js']   = 'application/javascript',
+	['.json'] = 'application/json',
+	['.png']  = 'image/png',
+	['.svg']  = 'image/svg+xml',
+	['.txt']  = 'text/plain',
+}
+
+local function content_type(path)
+	local ext = tostring(path or ''):match('(%.[^.]+)$')
+	return (ext and TYPES[ext]) or 'application/octet-stream'
+end
+
+local function clean_path(root, path)
+	path = tostring(path or '/index.html')
+	path = path:gsub('%.%.+', '')
+	if path == '/' then path = '/index.html' end
+	return (root or '.') .. path
+end
+
+local function perform_required(op, label)
+	local ok, err = fibers.perform(op)
+	if ok ~= true then error(err or label or 'response write failed', 0) end
+	return true
+end
+
+function M.run(scope, owner, route, opts)
+	opts = opts or {}
+	local filename = clean_path(opts.root or opts.static_root or '.', route.path)
+	local f, err = file_io.open(filename, 'r')
+	if not f then
+		perform_required(owner:reply_error_op(404, 'not_found'), 'static not found response failed')
+		return { status = 'not_found', path = route.path, err = err }
+	end
+
+	local file_owner = resource.owned(f, {
+		label = 'static file cleanup',
+		terminate = function (file)
+			if file and type(file.close) == 'function' then return file:close() end
+			return true, nil
+		end,
+	})
+	scope:finally(function (_, status, primary)
+		file_owner:terminate_checked(primary or status or 'request_closed', 'static file cleanup')
+	end)
+
+	perform_required(owner:write_headers_op(200, { ['content-type'] = content_type(filename) }), 'static headers write failed')
+
+	local bytes = 0
+	local chunk_size = opts.static_chunk_size or opts.chunk_size or 16384
+	while true do
+		local chunk, rerr = fibers.perform(f:read_some_op(chunk_size))
+		if rerr ~= nil then
+			owner:abandon_now(rerr)
+			error(rerr, 0)
+		end
+		if chunk == nil then break end
+		bytes = bytes + #chunk
+		perform_required(owner:write_chunk_op(chunk), 'static chunk write failed')
+	end
+
+	perform_required(owner:end_stream_op(), 'static end write failed')
+	file_owner:terminate_checked('done', 'static file cleanup')
+	f = nil
+	return { status = 'ok', path = route.path, bytes = bytes }
+end
+
+return M

--- a/src/services/ui/queries.lua
+++ b/src/services/ui/queries.lua
@@ -1,0 +1,96 @@
+-- services/ui/queries.lua
+--
+-- Pure read-only projections over read-model snapshots.
+
+local topics = require 'services.ui.topics'
+local tablex = require 'shared.table'
+local topicx = require 'shared.topic'
+
+local M = {}
+
+local copy_value = tablex.deep_copy
+
+local topic_has_prefix = topicx.starts_with
+
+local function sorted_items(snapshot, pred)
+	local out = {}
+	for _, msg in pairs((snapshot and snapshot.items) or {}) do
+		if not pred or pred(msg) then
+			out[#out + 1] = copy_value(msg)
+		end
+	end
+	table.sort(out, function(a, b)
+		return topics.topic_key(a.topic) < topics.topic_key(b.topic)
+	end)
+	return out
+end
+
+function M.all(snapshot)
+	return {
+		version = snapshot and snapshot.version or 0,
+		items = sorted_items(snapshot),
+	}
+end
+
+function M.topic(snapshot, topic)
+	local key = topics.topic_key(topic)
+	local item = snapshot and snapshot.items and snapshot.items[key]
+	return item and copy_value(item) or nil
+end
+
+function M.pattern(snapshot, pattern, matcher)
+	if matcher then
+		return sorted_items(snapshot, function(msg) return matcher(pattern, msg.topic) end)
+	end
+	return sorted_items(snapshot, function(msg)
+		return topic_has_prefix(msg.topic, pattern)
+	end)
+end
+
+function M.services_snapshot(snapshot)
+	return {
+		version = snapshot and snapshot.version or 0,
+		services = sorted_items(snapshot, function(msg)
+			return topic_has_prefix(msg.topic, { 'svc' })
+		end),
+	}
+end
+
+function M.fabric_status(snapshot)
+	return {
+		version = snapshot and snapshot.version or 0,
+		status = sorted_items(snapshot, function(msg)
+			return topic_has_prefix(msg.topic, { 'state', 'fabric' })
+				or topic_has_prefix(msg.topic, { 'svc', 'fabric' })
+		end),
+	}
+end
+
+function M.update_jobs_snapshot(snapshot)
+	return {
+		version = snapshot and snapshot.version or 0,
+		jobs = sorted_items(snapshot, function(msg)
+			return topic_has_prefix(msg.topic, { 'state', 'workflow', 'update-job' })
+				or topic_has_prefix(msg.topic, { 'state', 'update' })
+		end),
+	}
+end
+
+function M.summary(snapshot, sessions_count, extra)
+	local items = snapshot and snapshot.items or {}
+	local services = 0
+	for _, msg in pairs(items) do
+		if topic_has_prefix(msg.topic, { 'svc' }) then services = services + 1 end
+	end
+	local out = {
+		version = snapshot and snapshot.version or 0,
+		services = services,
+		sessions = sessions_count or 0,
+		closed = snapshot and snapshot.closed or false,
+		reason = snapshot and snapshot.reason or nil,
+	}
+	for k, v in pairs(extra or {}) do out[k] = v end
+	return out
+end
+
+return M

--- a/src/services/ui/read_model.lua
+++ b/src/services/ui/read_model.lua
@@ -1,0 +1,103 @@
+-- services/ui/read_model.lua
+--
+-- Read-model component assembly.
+--
+-- Fabric-grade split:
+--   * read_model_store.lua   : pure retained-state projection/model
+--   * read_model_watches.lua : local watch owner and fanout boundary
+--
+-- This module wires retained bus feeds into the store/watch owner. It remains as
+-- the public read-model entry point for UI callers.
+
+local fibers      = require 'fibers'
+local bus_cleanup = require 'devicecode.support.bus_cleanup'
+local store_mod   = require 'services.ui.read_model_store'
+local watches_mod = require 'services.ui.read_model_watches'
+local topics      = require 'services.ui.topics'
+
+local M = {}
+
+local function start_feed_owner(scope, target, conn, pattern, opts)
+	local watch, err = bus_cleanup.watch_retained(conn, pattern, {
+		replay = true,
+		queue_len = opts.feed_queue_len or 64,
+		full = opts.feed_full or 'reject_newest',
+	})
+	if not watch then
+		return nil, err or 'watch_retained failed'
+	end
+
+	scope:finally(function ()
+		bus_cleanup.unwatch_retained(conn, watch)
+	end)
+
+	local ok, spawn_err = fibers.spawn(function ()
+		while true do
+			local ev, recv_err = fibers.perform(watch:recv_op())
+			if ev == nil then
+				error(recv_err or 'read model retained feed closed', 0)
+			end
+			local changed, _msg, _op_name, ingest_err = target:ingest(ev)
+			if changed == nil then
+				error(ingest_err or 'read model ingest failed', 0)
+			end
+		end
+	end)
+	if not ok then
+		bus_cleanup.unwatch_retained(conn, watch)
+		return nil, spawn_err
+	end
+
+	return true, nil
+end
+
+--- Create a pure retained-state projection store.
+function M.new(opts)
+	return store_mod.new(opts)
+end
+
+--- Create a local watch owner for an existing store.
+function M.new_watches(store, opts)
+	return watches_mod.new(store, opts)
+end
+
+--- Start retained-feed owners inside an already-created read-model scope.
+---
+--- opts.model is the pure projection store.
+--- opts.watch_owner is the local watch fanout owner.
+---
+--- Returns the store and watch owner immediately; feed owners run as child
+--- fibres in the same scope.
+function M.start(scope, conn, opts)
+	opts = opts or {}
+	local store = opts.model or M.new(opts)
+	local watch_owner = opts.watch_owner
+	if watch_owner == nil then
+		watch_owner = M.new_watches(store, opts)
+	end
+
+	scope:finally(function (_, status, primary)
+		local reason = primary or status or 'read_model_closed'
+		watch_owner:terminate(reason)
+		store:terminate(reason)
+	end)
+
+	if conn ~= nil then
+		local patterns = opts.patterns or topics.default_retained_patterns()
+		for _, pattern in ipairs(patterns) do
+			local ok, err = start_feed_owner(scope, watch_owner, conn, pattern, opts)
+			if not ok then error(err or 'read_model feed start failed', 2) end
+		end
+	end
+
+	return store, watch_owner
+end
+
+M.store = store_mod
+M.watches = watches_mod
+M.Store = store_mod.Store
+M.WatchOwner = watches_mod.WatchOwner
+M.Watch = watches_mod.Watch
+M.match_topic = store_mod.match_topic
+
+return M

--- a/src/services/ui/read_model_store.lua
+++ b/src/services/ui/read_model_store.lua
@@ -1,0 +1,381 @@
+-- services/ui/read_model_store.lua
+--
+-- Pure retained-state projection store for UI.
+--
+-- Contract:
+--   * stores retained messages by literal topic key
+--   * snapshot(), items(), get(), and query() return copies
+--   * set/delete/ingest are immediate and non-yielding
+--   * changed_op(seen) returns a versioned snapshot, or a close reason
+--   * terminate(reason) wakes observers
+--   * no queue, mailbox, bus, publish, or service calls live here
+
+local op     = require 'fibers.op'
+local cond   = require 'fibers.cond'
+local topics = require 'services.ui.topics'
+local tablex = require 'shared.table'
+local topicx = require 'shared.topic'
+
+local M = {}
+
+local Store = {}
+Store.__index = Store
+
+local copy_value = tablex.deep_copy
+local deep_equal = tablex.deep_equal
+local topic_copy = topicx.copy
+
+local function copy_msg(msg)
+	if not msg then return nil end
+	return {
+		topic   = topic_copy(msg.topic),
+		payload = copy_value(msg.payload),
+		origin  = copy_value(msg.origin),
+	}
+end
+
+local function token_matches(pattern_tok, topic_tok, s_wild, m_wild)
+	if pattern_tok == s_wild then return true end
+	if pattern_tok == m_wild then return true end
+	return pattern_tok == topic_tok
+end
+
+local function match_topic(pattern, topic, s_wild, m_wild)
+	pattern = pattern or {}
+	topic = topic or {}
+	local pi, ti = 1, 1
+	while pi <= #pattern do
+		local p = pattern[pi]
+		if p == m_wild then
+			return true
+		end
+		if ti > #topic then return false end
+		if not token_matches(p, topic[ti], s_wild, m_wild) then
+			return false
+		end
+		pi = pi + 1
+		ti = ti + 1
+	end
+	return ti > #topic
+end
+
+local function index_token_key(tok)
+	local ty = type(tok)
+	return ty .. ':' .. tostring(tok)
+end
+
+local function first_literal_token(pattern, s_wild, m_wild)
+	local tok = pattern and pattern[1] or nil
+	if tok == nil or tok == s_wild or tok == m_wild then return nil end
+	return tok
+end
+
+local function sorted_msgs_from_keys(self, keys, pattern)
+	local out = {}
+	for _, key in ipairs(keys) do
+		local msg = self._items[key]
+		if msg and match_topic(pattern, msg.topic, self._s_wild, self._m_wild) then
+			out[#out + 1] = copy_msg(msg)
+		end
+	end
+	table.sort(out, function(a, b)
+		return topics.topic_key(a.topic) < topics.topic_key(b.topic)
+	end)
+	return out
+end
+
+local function assert_topic(topic, name, level)
+	if type(topic) ~= 'table' then
+		error((name or 'topic') .. ' must be a table', (level or 1) + 1)
+	end
+end
+
+local function assert_seen(seen, level)
+	if type(seen) ~= 'number' or seen < 0 or seen % 1 ~= 0 then
+		error('read_model_store.changed_op: seen must be a non-negative integer', (level or 1) + 1)
+	end
+end
+
+function Store:version()
+	return self._version
+end
+
+function Store:is_closed()
+	return self._closed
+end
+
+function Store:why()
+	return self._close_reason
+end
+
+function Store:_bump()
+	self._version = self._version + 1
+	self._changed:signal()
+	self._changed = cond.new()
+	return self._version
+end
+
+function Store:_index_add(key, topic)
+	local first = topic and topic[1]
+	if first == nil then return end
+	local ikey = index_token_key(first)
+	local bucket = self._index_first[ikey]
+	if not bucket then
+		bucket = {}
+		self._index_first[ikey] = bucket
+	end
+	bucket[key] = true
+end
+
+function Store:_index_remove(key, topic)
+	local first = topic and topic[1]
+	if first == nil then return end
+	local ikey = index_token_key(first)
+	local bucket = self._index_first[ikey]
+	if not bucket then return end
+	bucket[key] = nil
+	if next(bucket) == nil then self._index_first[ikey] = nil end
+end
+
+function Store:_candidate_keys(pattern)
+	local literal = first_literal_token(pattern, self._s_wild, self._m_wild)
+	local out = {}
+	if literal ~= nil then
+		local bucket = self._index_first[index_token_key(literal)] or {}
+		for key in pairs(bucket) do out[#out + 1] = key end
+	else
+		for key in pairs(self._items) do out[#out + 1] = key end
+	end
+	table.sort(out)
+	return out
+end
+
+--- Set a retained item.
+---
+--- Return shapes:
+---   true, msg, version   changed
+---   false, msg, version  unchanged
+---   nil, reason          closed
+function Store:set(topic, payload, origin)
+	assert_topic(topic, 'read_model_store:set topic', 2)
+	if self._closed then return nil, tostring(self._close_reason or 'closed') end
+
+	local key = topics.topic_key(topic)
+	local old = self._items[key]
+	local msg = {
+		topic = topic_copy(topic),
+		payload = copy_value(payload),
+		origin = copy_value(origin),
+	}
+
+	local same = false
+	if old and topics.topic_key(old.topic) == key then
+		same = deep_equal(old.payload, msg.payload) and deep_equal(old.origin, msg.origin)
+	end
+
+	if old then self:_index_remove(key, old.topic) end
+	self._items[key] = msg
+	self:_index_add(key, msg.topic)
+	if same then
+		return false, copy_msg(msg), self._version
+	end
+
+	local version = self:_bump()
+	return true, copy_msg(msg), version
+end
+
+--- Delete a retained item.
+---
+--- Return shapes:
+---   true, msg, version   changed
+---   false, nil, version  unchanged / absent
+---   nil, reason          closed
+function Store:delete(topic, origin)
+	assert_topic(topic, 'read_model_store:delete topic', 2)
+	if self._closed then return nil, tostring(self._close_reason or 'closed') end
+
+	local key = topics.topic_key(topic)
+	local old = self._items[key]
+	if old == nil then return false, nil, self._version end
+
+	self._items[key] = nil
+	self:_index_remove(key, old.topic)
+	local msg = {
+		topic = topic_copy(topic),
+		payload = nil,
+		origin = copy_value(origin),
+	}
+	local version = self:_bump()
+	return true, copy_msg(msg), version
+end
+
+--- Ingest a retained lifecycle event.
+---
+--- Return shapes:
+---   changed, msg, op_name, version_or_reason
+---   nil, nil, nil, reason     invalid/closed
+function Store:ingest(ev)
+	if self._closed then return nil, nil, nil, tostring(self._close_reason or 'closed') end
+	if type(ev) ~= 'table' then return nil, nil, nil, 'invalid retained event' end
+
+	if ev.op == 'retain' then
+		local changed, msg, version_or_reason = self:set(ev.topic, ev.payload, ev.origin)
+		if changed == nil then return nil, nil, nil, msg end
+		return changed, msg, 'set', version_or_reason
+	elseif ev.op == 'unretain' then
+		local changed, msg, version_or_reason = self:delete(ev.topic, ev.origin)
+		if changed == nil then return nil, nil, nil, msg end
+		return changed, msg, 'delete', version_or_reason
+	elseif ev.op == 'replay_done' then
+		return false, nil, 'replay_done', self._version
+	elseif ev.topic ~= nil and ev.payload ~= nil then
+		local changed, msg, version_or_reason = self:set(ev.topic, ev.payload, ev.origin)
+		if changed == nil then return nil, nil, nil, msg end
+		return changed, msg, 'set', version_or_reason
+	end
+
+	return nil, nil, nil, 'unknown retained event'
+end
+
+function Store:snapshot()
+	local out = {}
+	for key, msg in pairs(self._items) do
+		out[key] = copy_msg(msg)
+	end
+	return {
+		version = self._version,
+		items = out,
+		closed = self._closed,
+		reason = self._close_reason,
+	}
+end
+
+function Store:items()
+	local out = {}
+	for _, msg in pairs(self._items) do out[#out + 1] = copy_msg(msg) end
+	table.sort(out, function(a, b)
+		return topics.topic_key(a.topic) < topics.topic_key(b.topic)
+	end)
+	return out
+end
+
+function Store:get(topic)
+	assert_topic(topic, 'read_model_store:get topic', 2)
+	return copy_msg(self._items[topics.topic_key(topic)])
+end
+
+function Store:query(pattern)
+	return sorted_msgs_from_keys(self, self:_candidate_keys(pattern), pattern)
+end
+
+local function each_candidate_key_unsorted(self, pattern, fn)
+	local literal = first_literal_token(pattern, self._s_wild, self._m_wild)
+	if literal ~= nil then
+		local bucket = self._index_first[index_token_key(literal)] or {}
+		for key in pairs(bucket) do
+			if fn(key) == false then return false end
+		end
+		return true
+	end
+
+	for key in pairs(self._items) do
+		if fn(key) == false then return false end
+	end
+	return true
+end
+
+function Store:query_limited(pattern, limit)
+	if limit ~= false and limit ~= nil then
+		if type(limit) ~= 'number' or limit < 0 or limit % 1 ~= 0 then
+			error('read_model_store:query_limited limit must be a non-negative integer, nil, or false', 2)
+		end
+	end
+
+	if limit == false or limit == nil then
+		return self:query(pattern), nil
+	end
+
+	local out = {}
+	local exceeded = false
+	-- Work is bounded by the first limit + 1 matching retained entries.  We do
+	-- not materialise or sort a broader replay before reporting overflow.
+	each_candidate_key_unsorted(self, pattern, function (key)
+		local msg = self._items[key]
+		if msg and match_topic(pattern, msg.topic, self._s_wild, self._m_wild) then
+			if #out >= limit then
+				exceeded = true
+				return false
+			end
+			out[#out + 1] = copy_msg(msg)
+		end
+		return true
+	end)
+
+	if exceeded then
+		return nil, 'query_limit_exceeded'
+	end
+
+	table.sort(out, function(a, b)
+		return topics.topic_key(a.topic) < topics.topic_key(b.topic)
+	end)
+	return out, nil
+end
+
+--- Wait until version > seen, or until closed.
+---
+--- Return shapes:
+---   changed: version, snapshot, nil
+---   closed : nil, nil, reason
+function Store:changed_op(seen)
+	assert_seen(seen, 2)
+
+	return op.guard(function ()
+		if self._closed then
+			return op.always(nil, nil, tostring(self._close_reason or 'closed'))
+		end
+		if self._version > seen then
+			return op.always(self._version, self:snapshot(), nil)
+		end
+		local c = self._changed
+		return c:wait_op():wrap(function ()
+			if self._closed then
+				return nil, nil, tostring(self._close_reason or 'closed')
+			end
+			return self._version, self:snapshot(), nil
+		end)
+	end)
+end
+
+function Store:terminate(reason)
+	if self._closed then return true end
+	self._closed = true
+	self._close_reason = reason or 'closed'
+	self:_bump()
+	return true
+end
+
+function M.new(opts)
+	opts = opts or {}
+	return setmetatable({
+		_items = {},
+		_index_first = {}, -- first-token index used to bound watch replay candidate scans
+		_version = 0,
+		_changed = cond.new(),
+		_closed = false,
+		_close_reason = nil,
+		_s_wild = opts.s_wild or '+',
+		_m_wild = opts.m_wild or '#',
+	}, Store)
+end
+
+M.Store = Store
+M.copy_value = copy_value
+M.topic_copy = topic_copy
+M.copy_msg = copy_msg
+M.match_topic = match_topic
+M._test = {
+	candidate_count = function (store, pattern) return #store:_candidate_keys(pattern) end,
+	index_token_key = index_token_key,
+}
+
+return M

--- a/src/services/ui/read_model_watches.lua
+++ b/src/services/ui/read_model_watches.lua
@@ -1,0 +1,218 @@
+-- services/ui/read_model_watches.lua
+--
+-- Local UI read-model watch owner and fanout boundary.
+--
+-- This module deliberately owns bounded watch queues and replay/fanout policy.
+-- The projection store remains pure in read_model_store.lua.
+-- Replay is bounded by default. Callers may set max_replay/watch_max_replay
+-- explicitly; max_replay=false opts out deliberately for tests/special cases.
+
+local fibers  = require 'fibers'
+local mailbox = require 'fibers.mailbox'
+local queue   = require 'devicecode.support.queue'
+local store_mod = require 'services.ui.read_model_store'
+
+local M = {}
+
+local DEFAULT_MAX_REPLAY = 32
+
+
+local function resolve_max_replay(opts)
+	if opts.max_replay ~= nil then return opts.max_replay end
+	if opts.watch_max_replay ~= nil then return opts.watch_max_replay end
+	if opts.replay_limit ~= nil then return opts.replay_limit end
+	return DEFAULT_MAX_REPLAY
+end
+
+local WatchOwner = {}
+WatchOwner.__index = WatchOwner
+
+local Watch = {}
+Watch.__index = Watch
+
+local function copy_value(v)
+	return store_mod.copy_value(v)
+end
+
+local function topic_copy(topic)
+	return store_mod.topic_copy(topic)
+end
+
+local function msg_event(op_name, msg)
+	return {
+		kind    = 'read_model_event',
+		op      = op_name,
+		topic   = msg and topic_copy(msg.topic) or nil,
+		payload = msg and copy_value(msg.payload) or nil,
+		origin  = msg and copy_value(msg.origin) or nil,
+	}
+end
+
+local function terminate_watch(watch, reason)
+	if watch._closed then return true end
+	watch._closed = true
+	watch._reason = reason or 'closed'
+	if watch._tx then watch._tx:close(watch._reason) end
+	if watch._owner then
+		watch._owner._watches[watch] = nil
+	end
+	watch._owner = nil
+	return true
+end
+
+local function terminate_all(owner, reason)
+	local pending = {}
+	for watch in pairs(owner._watches) do pending[#pending + 1] = watch end
+	for _, watch in ipairs(pending) do terminate_watch(watch, reason) end
+end
+
+function WatchOwner:store()
+	return self._store
+end
+
+function WatchOwner:watch_count()
+	local n = 0
+	for _ in pairs(self._watches) do n = n + 1 end
+	return n
+end
+
+function WatchOwner:notify(op_name, msg)
+	if self._closed then return nil, tostring(self._reason or 'closed') end
+	if not msg or type(msg.topic) ~= 'table' then return false, 'no_topic' end
+
+	local targets = {}
+	for watch in pairs(self._watches) do
+		if store_mod.match_topic(watch._pattern, msg.topic, self._s_wild, self._m_wild) then
+			targets[#targets + 1] = watch
+		end
+	end
+
+	local ev = msg_event(op_name, msg)
+	for _, watch in ipairs(targets) do
+		if watch._owner == self and not watch._closed then
+			local ok = queue.try_admit_now(watch._tx, copy_value(ev))
+			if ok ~= true then
+				terminate_watch(watch, 'watch_overflow')
+			end
+		end
+	end
+	return true, nil
+end
+
+function WatchOwner:set(topic, payload, origin)
+	local changed, msg, version_or_reason = self._store:set(topic, payload, origin)
+	if changed == true then self:notify('set', msg) end
+	return changed, msg, version_or_reason
+end
+
+function WatchOwner:delete(topic, origin)
+	local changed, msg, version_or_reason = self._store:delete(topic, origin)
+	if changed == true then self:notify('delete', msg) end
+	return changed, msg, version_or_reason
+end
+
+function WatchOwner:ingest(ev)
+	local changed, msg, op_name, version_or_reason = self._store:ingest(ev)
+	if changed == true and (op_name == 'set' or op_name == 'delete') then
+		self:notify(op_name, msg)
+	end
+	return changed, msg, op_name, version_or_reason
+end
+
+function WatchOwner:watch_open(pattern, opts)
+	opts = opts or {}
+	if self._closed then return nil, tostring(self._reason or 'closed') end
+	if self._store:is_closed() then return nil, tostring(self._store:why() or 'closed') end
+
+	local qlen = opts.queue_len or self._default_queue_len
+	local full = opts.full or self._default_full
+	local tx, rx = mailbox.new(qlen, { full = full })
+	local watch = setmetatable({
+		_owner = self,
+		_pattern = topic_copy(pattern),
+		_tx = tx,
+		_rx = rx,
+		_closed = false,
+		_reason = nil,
+	}, Watch)
+
+	if opts.replay ~= false then
+		local max_replay = opts.max_replay
+		if max_replay == nil then max_replay = self._max_replay end
+		local replay, qerr = self._store:query_limited(pattern, max_replay)
+		if not replay then
+			terminate_watch(watch, 'watch_replay_overflow')
+			return nil, (qerr == 'query_limit_exceeded') and 'watch_replay_overflow' or qerr
+		end
+		for _, msg in ipairs(replay) do
+			local ok = queue.try_admit_now(tx, msg_event('set', msg))
+			if ok ~= true then
+				terminate_watch(watch, 'watch_replay_overflow')
+				return nil, 'watch_replay_overflow'
+			end
+		end
+	end
+
+	self._watches[watch] = true
+	return watch, nil
+end
+
+function WatchOwner:terminate(reason)
+	if self._closed then return true end
+	self._closed = true
+	self._reason = reason or 'closed'
+	terminate_all(self, self._reason)
+	return true
+end
+
+function WatchOwner:why()
+	return self._reason
+end
+
+function Watch:recv_op()
+	return self._rx:recv_op():wrap(function (ev)
+		if ev == nil then
+			return nil, tostring(self._reason or self._rx:why() or 'closed')
+		end
+		return ev, nil
+	end)
+end
+
+function Watch:recv()
+	return fibers.perform(self:recv_op())
+end
+
+function Watch:terminate(reason)
+	return terminate_watch(self, reason or 'closed')
+end
+
+function Watch:why()
+	return self._reason or self._rx:why()
+end
+
+function Watch:pattern()
+	return topic_copy(self._pattern)
+end
+
+function M.new(store, opts)
+	if store == nil then error('read_model_watches.new: store required', 2) end
+	opts = opts or {}
+	return setmetatable({
+		_store = store,
+		_watches = {},
+		_closed = false,
+		_reason = nil,
+		_s_wild = opts.s_wild or '+',
+		_m_wild = opts.m_wild or '#',
+		_default_queue_len = opts.queue_len or opts.watch_queue_len or 32,
+		_default_full = opts.full or opts.watch_full or 'reject_newest',
+		_max_replay = resolve_max_replay(opts),
+	}, WatchOwner)
+end
+
+M.DEFAULT_MAX_REPLAY = DEFAULT_MAX_REPLAY
+M.WatchOwner = WatchOwner
+M.Watch = Watch
+M.msg_event = msg_event
+
+return M

--- a/src/services/ui/service.lua
+++ b/src/services/ui/service.lua
@@ -1,0 +1,617 @@
+-- services/ui/service.lua
+--
+-- Top-level UI service coordinator. It owns service-level status and starts
+-- long-lived scoped components. It does not own HTTP request work,
+-- upstream calls, or upload streams.
+
+local fibers       = require 'fibers'
+local mailbox      = require 'fibers.mailbox'
+local service_base = require 'devicecode.service_base'
+local scoped_work  = require 'devicecode.support.scoped_work'
+local sleep        = require 'fibers.sleep'
+local queue        = require 'devicecode.support.queue'
+local bus_cleanup  = require 'devicecode.support.bus_cleanup'
+local read_model   = require 'services.ui.read_model'
+local queries      = require 'services.ui.queries'
+local sessions_mod = require 'services.ui.sessions'
+local auth_mod     = require 'services.ui.auth'
+local topics       = require 'services.ui.topics'
+local supervision  = require 'services.ui.supervision'
+local config_watch = require 'devicecode.support.config_watch'
+local config_mod   = require 'services.ui.config'
+local service_events = require 'devicecode.support.service_events'
+local tablex = require 'shared.table'
+
+local M = {}
+
+local shallow_copy = tablex.shallow_copy
+
+local function component_summary(components)
+	local out = {}
+	for name, c in pairs(components or {}) do
+		out[name] = {
+			status = c.status,
+			primary = c.primary,
+			reason = c.reason,
+		}
+	end
+	return out
+end
+
+local function read_model_payload(state, snapshot)
+	local count = 0
+	for _ in pairs((snapshot and snapshot.items) or {}) do count = count + 1 end
+	return {
+		kind = 'ui.read-model',
+		version = snapshot and snapshot.version or 0,
+		items = count,
+		closed = snapshot and snapshot.closed or false,
+		reason = snapshot and snapshot.reason or nil,
+		status = state.read_model_status,
+	}
+end
+
+local function sessions_payload(state)
+	local snap = (state.sessions and type(state.sessions.snapshot) == 'function') and state.sessions:snapshot() or nil
+	return {
+		kind = 'ui.sessions',
+		version = snap and snap.version or 0,
+		count = snap and snap.count or 0,
+		last_event = snap and snap.last_event or nil,
+	}
+end
+
+local function publish_summary(state)
+	local model_snapshot = state.model and state.model:snapshot() or nil
+	local payload = queries.summary(model_snapshot,
+		state.sessions and state.sessions:count() or 0,
+		{
+			active_requests = state.active_requests,
+			rejected_requests = state.rejected_requests or 0,
+			last_rejection_reason = state.last_rejection_reason,
+			read_model_status = state.read_model_status,
+			listener_status = state.listener_status,
+			config_status = state.config_status,
+			config_generation = state.config_generation,
+			service_status = state.service_status,
+			components = component_summary(state.components),
+			last_error = state.last_error,
+		}
+	)
+	local ok, err = bus_cleanup.retain(state.conn, topics.summary(), payload)
+	if ok ~= true then error(err or 'ui summary publication failed', 0) end
+	ok, err = bus_cleanup.retain(state.conn, topics.read_model_status(), read_model_payload(state, model_snapshot))
+	if ok ~= true then error(err or 'ui read-model publication failed', 0) end
+	ok, err = bus_cleanup.retain(state.conn, topics.session_count(), sessions_payload(state))
+	if ok ~= true then error(err or 'ui sessions publication failed', 0) end
+	return payload
+end
+
+local function record_cleanup_error(state, kind, err)
+	local rec = {
+		kind = kind or 'cleanup_error',
+		err = tostring(err or 'cleanup failed'),
+	}
+	state.cleanup_errors = state.cleanup_errors or {}
+	state.cleanup_errors[#state.cleanup_errors + 1] = rec
+	state.last_cleanup_error = rec
+
+	return rec
+end
+
+local function component_identity(component, generation)
+	return {
+		kind = 'ui_component_done',
+		component = component,
+		generation = generation,
+	}
+end
+
+local function record_component_started(state, component, generation)
+	state.components = state.components or {}
+	local c = state.components[component] or {}
+	if generation ~= nil and c.generation ~= nil and c.generation ~= generation then return false, 'stale_component_start' end
+	c.status = 'running'
+	if generation ~= nil then c.generation = generation end
+	c.reason = nil
+	c.primary = nil
+	c.outcome = nil
+	state.components[component] = c
+	if component == 'read_model' then
+		state.read_model_status = 'running'
+	elseif component == 'http_listener' then
+		state.listener_status = 'running'
+	end
+end
+
+local function record_component_done(state, ev)
+	state.components = state.components or {}
+	local name = ev.component
+	if type(name) ~= 'string' or name == '' then
+		return false, 'missing_component'
+	end
+	local c = state.components[name] or {}
+	if ev.generation ~= nil and c.generation ~= nil and ev.generation ~= c.generation then
+		return false, 'stale_component_completion'
+	end
+	if c.status == 'ok' or c.status == 'failed' or c.status == 'cancelled' then
+		return false, 'stale_component_completion'
+	end
+	c.status = ev.status
+	c.outcome = ev
+	if ev.status == 'ok' then
+		c.result = ev.result
+		c.reason = type(ev.result) == 'table' and (ev.result.reason or ev.result.status) or nil
+	else
+		c.primary = ev.primary
+		c.reason = ev.primary
+	end
+	state.components[name] = c
+
+	if name == 'read_model' then
+		state.read_model_status = ev.status
+	elseif name == 'http_listener' then
+		state.listener_status = ev.status
+	end
+	return true, nil
+end
+
+local function apply_service_policy(state, ev)
+	local decision = supervision.classify_service_component_done(state, ev)
+	local action = decision.action or 'continue'
+	if action == 'continue' then
+		return { publish = true }
+	elseif action == 'degrade_service' then
+		state.service_status = 'degraded'
+		state.last_error = decision.reason or ev.primary
+		return { publish = true }
+	elseif action == 'fail_service' then
+		state.service_status = 'failed'
+		state.last_error = decision.reason or ev.primary or 'ui component failed'
+		return { publish = true, fail = state.last_error }
+	elseif action == 'cancel_service' then
+		state.service_status = 'stopping'
+		state.last_error = decision.reason or ev.primary or 'ui component cancelled'
+		if state.scope and state.scope.cancel then state.scope:cancel(state.last_error) end
+		return { publish = true }
+	end
+	error('ui.service: unknown supervision action: ' .. tostring(action), 0)
+end
+
+local function start_component(state, component, run, generation)
+	state.components[component] = { status = 'starting', generation = generation }
+	local handle, err = scoped_work.start({
+		lifetime_scope = state.scope,
+		reaper_scope = state.scope,
+		report_scope = state.scope,
+		identity = component_identity(component, generation),
+		run = function (scope)
+			return run(scope)
+		end,
+		report = service_events.reporter(
+			service_events.port(state.done_tx, {
+				service_id = state.service_id or 'ui',
+				source = 'ui_component',
+				source_id = component,
+				component = component,
+				generation = generation,
+			}, { label = 'ui_component_done_report_failed' }),
+			'ui_component_done_report_failed'
+		),
+	})
+	if not handle then error(err or ('failed to start ' .. component), 0) end
+	return handle
+end
+
+
+
+local function run_session_pruner(_, sessions, interval)
+	while true do
+		fibers.perform(sleep.sleep_op(interval))
+		sessions:prune()
+	end
+end
+
+local function listener_config_key(cfg)
+	if not cfg or not cfg.enabled or not cfg.http or cfg.http.enabled == false then return 'disabled' end
+	local h = cfg.http
+	return table.concat({
+		tostring(h.cap_id or 'main'),
+		tostring(h.host or ''),
+		tostring(h.port or ''),
+		tostring(h.path or ''),
+		tostring(h.tls or false),
+		tostring(h.max_accept_queue or ''),
+	}, '|')
+end
+
+local function build_listener_opts(state, cfg, listener_generation, listener_id)
+	local params = state.params or {}
+	local h = cfg.http or {}
+	local s = cfg.static or {}
+	local sse_cfg = cfg.sse or {}
+	local uploads = cfg.uploads or {}
+
+	local listen = {
+		host = h.host,
+		port = h.port,
+		path = h.path,
+		tls = h.tls,
+		max_accept_queue = h.max_accept_queue,
+	}
+
+	local update_opts = shallow_copy(params.update or {})
+	update_opts.max_bytes = uploads.max_bytes
+	update_opts.enabled = uploads.enabled
+	update_opts.connect = update_opts.connect or params.connect
+	update_opts.bus = update_opts.bus or params.bus
+
+	return {
+		listener = params.listener or params.server,
+		conn = state.conn,
+		listen = listen,
+		http_cap_id = h.cap_id or 'main',
+		call_opts = params.http_call_opts,
+		bus = params.bus,
+		model = state.model,
+		watch_owner = state.watch_owner,
+		sessions = state.sessions,
+		auth = state.auth,
+		connect = params.connect,
+		events_port = service_events.port(state.done_tx, {
+			service_id = state.service_id or 'ui',
+			source = 'ui_http_listener',
+			source_id = listener_id or ('http_listener:' .. tostring(listener_generation or state.listener_generation or 0)),
+			listener_id = listener_id or ('http_listener:' .. tostring(listener_generation or state.listener_generation or 0)),
+			generation = listener_generation or state.listener_generation,
+		}, { label = 'ui_http_listener_event_report_failed' }),
+		static_root = s.root,
+		static_chunk_size = s.chunk_size,
+		encode_json = params.encode_json,
+		max_active_requests = h.max_active_requests,
+		overload_reason = params.overload_reason,
+		reject_overloaded_request_now = params.reject_overloaded_request_now,
+		sse = {
+			enabled = sse_cfg.enabled,
+			queue_len = sse_cfg.queue_len,
+			max_replay = sse_cfg.max_replay,
+			replay = sse_cfg.replay,
+			pattern = sse_cfg.pattern,
+		},
+		update = update_opts,
+	}
+end
+
+local function cancel_listener(state, reason)
+	if state.listener_handle and type(state.listener_handle.cancel) == 'function' then
+		state.listener_handle:cancel(reason or 'ui_config_changed')
+	end
+	state.listener_handle = nil
+	state.listener_config_key = nil
+	state.listener_generation = (state.listener_generation or 0) + 1
+	state.components = state.components or {}
+	state.components.http_listener = { status = 'disabled', generation = state.listener_generation }
+	state.listener_status = 'disabled'
+	state.active_requests = 0
+	return true
+end
+
+local function start_configured_listener(state, cfg, generation)
+	local key = listener_config_key(cfg)
+	if key == 'disabled' then
+		cancel_listener(state, 'ui_http_disabled')
+		return true
+	end
+	if state.listener_handle and state.listener_config_key == key then return true end
+	cancel_listener(state, 'ui_http_reconfigured')
+	state.listener_generation = generation or ((state.listener_generation or 0) + 1)
+	state.listener_config_key = key
+	state.listener_status = 'starting'
+	local listener_generation = state.listener_generation
+	local listener_id = 'http_listener:' .. tostring(listener_generation)
+	state.listener_handle = start_component(state, 'http_listener', function (component_scope)
+		queue.assert_admit_required(state.done_tx, {
+			kind = 'component_started',
+			component = 'http_listener',
+			generation = listener_generation,
+		}, 'ui_http_listener_start_report_failed')
+		local listener_mod = require 'services.ui.http.listener'
+		listener_mod.run(component_scope, build_listener_opts(state, cfg, listener_generation, listener_id))
+		return { status = 'stopped' }
+	end, listener_generation)
+	return true
+end
+
+local function cancel_session_pruner(state, reason)
+	if state.session_pruner_handle and type(state.session_pruner_handle.cancel) == 'function' then
+		state.session_pruner_handle:cancel(reason or 'ui_session_pruner_reconfigured')
+	end
+	state.session_pruner_handle = nil
+	state.session_pruner_key = nil
+	state.session_pruner_generation = (state.session_pruner_generation or 0) + 1
+	state.components = state.components or {}
+	state.components.session_pruner = { status = 'disabled', generation = state.session_pruner_generation }
+	return true
+end
+
+local function start_configured_session_pruner(state, cfg, generation)
+	local sessions_cfg = cfg and cfg.sessions or {}
+	local interval = sessions_cfg.prune_interval
+	if interval == false or interval == nil then
+		cancel_session_pruner(state, 'ui_session_pruner_disabled')
+		return true
+	end
+	local key = tostring(interval)
+	if state.session_pruner_handle and state.session_pruner_key == key then return true end
+	cancel_session_pruner(state, 'ui_session_pruner_reconfigured')
+	state.session_pruner_generation = generation or ((state.session_pruner_generation or 0) + 1)
+	state.session_pruner_key = key
+	local pruner_generation = state.session_pruner_generation
+	state.session_pruner_handle = start_component(state, 'session_pruner', function (component_scope)
+		queue.assert_admit_required(state.done_tx, {
+			kind = 'component_started',
+			component = 'session_pruner',
+			generation = pruner_generation,
+		}, 'ui_session_pruner_start_report_failed')
+		return run_session_pruner(component_scope, state.sessions, interval)
+	end, pruner_generation)
+	return true
+end
+
+local function apply_config(state, raw, generation)
+	local cfg, err = config_mod.normalise(raw or {})
+	if not cfg then
+		state.config_status = 'invalid'
+		state.last_error = tostring(err or 'invalid_config')
+		state.service_status = 'degraded'
+		return { publish = true }
+	end
+
+	state.config = cfg
+	state.config_generation = generation or ((state.config_generation or 0) + 1)
+	state.config_status = 'ok'
+	if state.service_status == 'starting' or state.service_status == 'degraded' then
+		state.service_status = 'running'
+	end
+
+	if cfg.enabled == false then
+		cancel_listener(state, 'ui_disabled')
+		cancel_session_pruner(state, 'ui_disabled')
+		state.service_status = 'disabled'
+		return { publish = true }
+	end
+
+	start_configured_listener(state, cfg, state.config_generation)
+	start_configured_session_pruner(state, cfg, state.config_generation)
+	return { publish = true }
+end
+
+local function cfg_event_from_watch(ev)
+	if ev == nil then return nil end
+	if ev.kind == 'config_closed' then
+		return { kind = 'config_closed', err = ev.err }
+	end
+	return {
+		kind = 'config_changed',
+		generation = ev.generation,
+		rev = ev.rev,
+		raw = ev.raw,
+	}
+end
+
+
+local function is_session_event(ev)
+	local k = ev and ev.kind
+	return k == 'session_created'
+		or k == 'session_touched'
+		or k == 'session_deleted'
+		or k == 'session_pruned'
+		or k == 'session_count_changed'
+end
+
+local function reduce_event(state, ev)
+	if ev.kind == 'component_started' then
+		record_component_started(state, ev.component, ev.generation)
+		return { publish = true }
+	elseif ev.kind == 'config_changed' then
+		return apply_config(state, ev.raw, ev.generation)
+	elseif ev.kind == 'config_closed' then
+		state.config_status = 'closed'
+		state.last_error = ev.err
+		return { publish = true }
+	elseif ev.kind == 'ui_component_done' then
+		local accepted = record_component_done(state, ev)
+		if not accepted then return {} end
+		return apply_service_policy(state, ev)
+	elseif ev.kind == 'read_model_changed' then
+		state.model_seen = ev.version or state.model_seen
+		return { publish = true }
+	elseif ev.kind == 'session_changed' then
+		state.sessions_seen = ev.version or state.sessions_seen
+		state.last_session_event = ev.last_event or ev
+		return { publish = true }
+	elseif is_session_event(ev) then
+		state.last_session_event = ev
+		return { publish = true }
+	elseif ev.kind == 'http_request_done' then
+		if ev.generation ~= nil and state.listener_generation ~= nil and ev.generation ~= state.listener_generation then return {} end
+		if type(ev.active_requests) == 'number' then
+			state.active_requests = ev.active_requests
+		else
+			state.active_requests = math.max(0, (state.active_requests or 0) - 1)
+		end
+		return { publish = true }
+	elseif ev.kind == 'http_request_started' then
+		if ev.generation ~= nil and state.listener_generation ~= nil and ev.generation ~= state.listener_generation then return {} end
+		if type(ev.active_requests) == 'number' then
+			state.active_requests = ev.active_requests
+		else
+			state.active_requests = (state.active_requests or 0) + 1
+		end
+		return { publish = true }
+	elseif ev.kind == 'http_request_rejected' then
+		if ev.generation ~= nil and state.listener_generation ~= nil and ev.generation ~= state.listener_generation then return {} end
+		state.rejected_requests = (state.rejected_requests or 0) + 1
+		state.last_rejection_reason = ev.reason
+		return { publish = true }
+	elseif ev.kind == 'read_model_closed' then
+		state.read_model_status = 'closed'
+		return { publish = true }
+	end
+	return {}
+end
+
+local function next_event_op(state)
+	local arms = {
+		done = state.done_rx:recv_op(),
+		cfg = state.cfg_watch:recv_op():wrap(cfg_event_from_watch),
+		model = state.model:changed_op(state.model_seen):wrap(function (version, snapshot, err)
+			if version == nil then
+				return { kind = 'read_model_closed', err = err }
+			end
+			return { kind = 'read_model_changed', version = version, snapshot = snapshot }
+		end),
+	}
+
+	if state.sessions and type(state.sessions.changed_op) == 'function' then
+		arms.sessions = state.sessions:changed_op(state.sessions_seen or 0):wrap(function (version, snapshot, err)
+			if version == nil then
+				return { kind = 'session_model_closed', err = err }
+			end
+			return {
+				kind = 'session_changed',
+				version = version,
+				snapshot = snapshot,
+				last_event = snapshot and snapshot.last_event or nil,
+			}
+		end)
+	end
+
+	return fibers.named_choice(arms):wrap(function (_, ev)
+		return ev
+	end)
+end
+
+function M.run(scope, params)
+	params = params or {}
+	local conn = assert(params.conn, 'ui.service.run: conn required')
+	local done_tx, done_rx = mailbox.new(params.done_queue_len or 128, { full = 'reject_newest' })
+	local sessions = params.sessions or sessions_mod.new(params.session_opts)
+	local auth = params.auth or auth_mod.new(params.auth_opts or {})
+	local model = params.model or read_model.new(params.read_model_opts)
+	local watch_owner = params.watch_owner or params.watches or read_model.new_watches(model, params.watch_opts or params.read_model_opts)
+	local read_model_owns_model = false
+
+	local cfg_watch, cfg_err = config_watch.open(conn, 'ui', {
+		topic = params.config_topic or { 'cfg', 'ui' },
+		queue_len = params.config_queue_len or 4,
+		full = 'reject_newest',
+	})
+	if not cfg_watch then error(cfg_err or 'ui config subscribe failed', 2) end
+
+	local state = {
+		scope = scope,
+		params = params,
+		service_id = params.service_id or 'ui',
+		conn = conn,
+		cfg_watch = cfg_watch,
+		done_tx = done_tx,
+		done_rx = done_rx,
+		sessions = sessions,
+		auth = auth,
+		model = model,
+		watch_owner = watch_owner,
+		model_seen = model:version(),
+		sessions_seen = (type(sessions.version) == 'function') and sessions:version() or 0,
+		service_status = 'starting',
+		read_model_status = 'starting',
+		listener_status = 'disabled',
+		config_status = 'waiting',
+		config_generation = 0,
+		active_requests = 0,
+		rejected_requests = 0,
+		components = {},
+		last_error = nil,
+	}
+
+	scope:finally(function (_, status, primary)
+		local reason = primary or status or 'ui_service_closed'
+		cancel_listener(state, reason)
+		cancel_session_pruner(state, reason)
+		cfg_watch:close()
+		done_tx:close(reason)
+		if not read_model_owns_model then
+			watch_owner:terminate(reason)
+			model:terminate(reason)
+		end
+		local ok, err = bus_cleanup.unretain(conn, topics.summary())
+		if ok ~= true then
+			record_cleanup_error(state, 'ui_summary_unretain_failed', err)
+		end
+
+		ok, err = bus_cleanup.unretain(conn, topics.read_model_status())
+		if ok ~= true then
+			record_cleanup_error(state, 'ui_read_model_unretain_failed', err)
+		end
+
+		ok, err = bus_cleanup.unretain(conn, topics.session_count())
+		if ok ~= true then
+			record_cleanup_error(state, 'ui_sessions_unretain_failed', err)
+		end
+	end)
+
+	local read_handle = start_component(state, 'read_model', function (component_scope)
+		local read_model_opts = shallow_copy(params.read_model_opts or {})
+		read_model_opts.model = model
+		read_model_opts.watch_owner = watch_owner
+		read_model_owns_model = true
+		read_model.start(component_scope, conn, read_model_opts)
+		queue.assert_admit_required(done_tx, { kind = 'component_started', component = 'read_model' }, 'ui_read_model_start_report_failed')
+		fibers.perform(fibers.never())
+	end)
+	state.read_model_handle = read_handle
+
+	state.service_status = 'running'
+
+	publish_summary(state)
+
+	while true do
+		local ev = fibers.perform(next_event_op(state))
+		if ev == nil then error('ui service event source closed', 0) end
+		local decision = reduce_event(state, ev)
+		if decision.publish then publish_summary(state) end
+		if decision.fail then error(decision.fail, 0) end
+	end
+end
+
+function M.start(conn, opts)
+	opts = opts or {}
+	if conn == nil then error('ui.start: conn required', 2) end
+	local scope = fibers.current_scope()
+	if not scope then error('ui.start must be called inside a fiber', 2) end
+
+	local svc = service_base.new(conn, {
+		name = opts.name or 'ui',
+		env = opts.env,
+		meta = opts.meta,
+		announce = opts.announce,
+	})
+	svc:starting({ ready = false })
+
+	local params = shallow_copy(opts)
+	params.conn = conn
+	svc:running({ ready = true })
+	return M.run(scope, params)
+end
+
+M._test = {
+	reduce_event = reduce_event,
+	record_component_done = record_component_done,
+	apply_service_policy = apply_service_policy,
+	publish_summary = publish_summary,
+	record_cleanup_error = record_cleanup_error,
+	apply_config = apply_config,
+}
+
+
+return M

--- a/src/services/ui/sessions.lua
+++ b/src/services/ui/sessions.lua
@@ -1,0 +1,228 @@
+-- services/ui/sessions.lua
+--
+-- Immediate in-memory session store.
+--
+-- Session mutations are versioned with a Pulse.  Observers should use
+-- changed_op(seen) and recompute from the current snapshot/count.
+
+local ok_uuid, uuid = pcall(require, 'uuid')
+local pulse = require 'fibers.pulse'
+local tablex = require 'shared.table'
+
+local M = {}
+local Store = {}
+Store.__index = Store
+
+local function default_now()
+	local ok, fibers = pcall(require, 'fibers')
+	if ok and fibers and type(fibers.now) == 'function' then
+		return fibers.now()
+	end
+	return os.time()
+end
+
+local function new_id()
+	if ok_uuid and uuid and type(uuid.new) == 'function' then
+		return tostring(uuid.new())
+	end
+	return ('sess-%d-%d'):format(os.time(), math.random(1, 1000000000))
+end
+
+local shallow_copy = tablex.shallow_copy
+local copy_array = tablex.array_copy
+
+local function copy_event(ev)
+	if type(ev) ~= 'table' then return ev end
+	local out = {}
+	for k, v in pairs(ev) do
+		if type(v) == 'table' then
+			if k == 'session_ids' then
+				out[k] = copy_array(v)
+			elseif k == 'sessions' then
+				local arr = {}
+				for i = 1, #v do arr[i] = shallow_copy(v[i]) end
+				out[k] = arr
+			else
+				out[k] = shallow_copy(v)
+			end
+		else
+			out[k] = v
+		end
+	end
+	return out
+end
+
+local function public_view(rec)
+	if not rec then return nil end
+	return {
+		id         = rec.id,
+		principal  = rec.principal,
+		created_at = rec.created_at,
+		expires_at = rec.expires_at,
+		last_seen  = rec.last_seen,
+		data       = shallow_copy(rec.data),
+	}
+end
+
+local function is_expired(self, rec, now)
+	if not rec then return false end
+	now = now or self:now()
+	return rec.expires_at ~= nil and rec.expires_at <= now
+end
+
+function M.new(opts)
+	opts = opts or {}
+	return setmetatable({
+		_items = {},
+		_now = opts.now or default_now,
+		_default_ttl = opts.default_ttl or 3600,
+		_pulse = pulse.new(),
+		_last_event = nil,
+	}, Store)
+end
+
+function Store:_notify(ev)
+	if type(ev) ~= 'table' then ev = { kind = tostring(ev) } end
+	ev.count = self:count()
+	self._last_event = copy_event(ev)
+	self._pulse:signal()
+	return true, nil
+end
+
+function Store:version()
+	return self._pulse:version()
+end
+
+function Store:last_event()
+	return copy_event(self._last_event)
+end
+
+
+function Store:snapshot()
+	return {
+		version = self:version(),
+		count = self:count(),
+		sessions = self:list(),
+		last_event = self:last_event(),
+	}
+end
+
+function Store:changed_op(seen)
+	return self._pulse:changed_op(seen):wrap(function (version, reason)
+		if version == nil then
+			return nil, nil, reason
+		end
+		return version, self:snapshot(), nil
+	end)
+end
+
+function Store:now()
+	return self._now()
+end
+
+function Store:create(principal, opts)
+	opts = opts or {}
+	local now = self:now()
+	local ttl = opts.ttl or self._default_ttl
+	local id = opts.id or new_id()
+	local rec = {
+		id = id,
+		principal = principal,
+		created_at = now,
+		last_seen = now,
+		expires_at = now + ttl,
+		data = shallow_copy(opts.data),
+	}
+	self._items[id] = rec
+	local view = public_view(rec)
+	self:_notify({ kind = 'session_created', session_id = id, principal = principal, session = view })
+	return view
+end
+
+function Store:get(id)
+	local rec = self._items[id]
+	if not rec or is_expired(self, rec) then return nil end
+	return public_view(rec)
+end
+
+function Store:touch(id, opts)
+	opts = opts or {}
+	local rec = self._items[id]
+	if not rec then return nil, 'not_found' end
+	local now = self:now()
+	if is_expired(self, rec, now) then
+		return nil, 'expired'
+	end
+	rec.last_seen = now
+	if opts.ttl then rec.expires_at = now + opts.ttl end
+	if opts.data then rec.data = shallow_copy(opts.data) end
+	local view = public_view(rec)
+	self:_notify({ kind = 'session_touched', session_id = id, principal = rec.principal, session = view })
+	return view, nil
+end
+
+function Store:delete(id)
+	local rec = self._items[id]
+	local existed = rec ~= nil
+	self._items[id] = nil
+	if existed then
+		self:_notify({
+			kind = 'session_deleted',
+			session_id = id,
+			principal = rec.principal,
+			session = public_view(rec),
+		})
+	end
+	return existed
+end
+
+function Store:prune(now)
+	now = now or self:now()
+	local removed = {}
+	local removed_sessions = {}
+	for id, rec in pairs(self._items) do
+		if rec.expires_at and rec.expires_at <= now then
+			self._items[id] = nil
+			removed[#removed + 1] = id
+			removed_sessions[#removed_sessions + 1] = public_view(rec)
+		end
+	end
+	table.sort(removed, function (a, b) return tostring(a) < tostring(b) end)
+	if #removed > 0 then
+		self:_notify({
+			kind = 'session_pruned',
+			session_ids = copy_array(removed),
+			sessions = removed_sessions,
+			removed = #removed,
+		})
+	end
+	return removed
+end
+
+function Store:count()
+	local n = 0
+	local now = self:now()
+	for _, rec in pairs(self._items) do
+		if not is_expired(self, rec, now) then n = n + 1 end
+	end
+	return n
+end
+
+function Store:list()
+	local out = {}
+	local now = self:now()
+	for _, rec in pairs(self._items) do
+		if not is_expired(self, rec, now) then
+			out[#out + 1] = public_view(rec)
+		end
+	end
+	table.sort(out, function(a, b) return tostring(a.id) < tostring(b.id) end)
+	return out
+end
+
+function Store:public_view(id)
+	return self:get(id)
+end
+
+M.Store = Store
+return M

--- a/src/services/ui/supervision.lua
+++ b/src/services/ui/supervision.lua
@@ -1,0 +1,55 @@
+-- services/ui/supervision.lua
+--
+-- Pure supervision policy helpers for UI components.
+--
+-- These functions classify completed scoped work as data. Coordinators record
+-- the completion first, then apply the returned action. No function here may
+-- perform Ops or touch transport resources.
+
+local M = {}
+
+local function result(ev)
+	return type(ev) == 'table' and type(ev.result) == 'table' and ev.result or {}
+end
+
+local function reason_from(ev, fallback)
+	local r = result(ev)
+	return ev.primary or r.reason or r.err or r.status or ev.status or fallback
+end
+
+local function decision(class, action, reason)
+	return {
+		class = class,
+		action = action or 'continue',
+		reason = reason,
+	}
+end
+
+
+local function component_name(ev)
+	return type(ev) == 'table' and ev.component or nil
+end
+
+function M.classify_service_component_done(_, ev)
+	local component = component_name(ev) or 'component'
+
+	if ev.status == 'ok' then
+		return decision('normal_close', 'continue', reason_from(ev, component .. '_stopped'))
+	end
+
+	if ev.status == 'failed' then
+		return decision('failed', 'fail_service', ('%s failed: %s'):format(component, tostring(reason_from(ev, 'failed'))))
+	end
+
+	if ev.status == 'cancelled' then
+		return decision('cancelled_unexpected', 'fail_service', ('%s cancelled unexpectedly: %s'):format(component, tostring(reason_from(ev, 'cancelled'))))
+	end
+
+	return decision('failed', 'fail_service', ('%s ended with invalid status: %s'):format(component, tostring(ev.status)))
+end
+
+M._test = {
+	reason_from = reason_from,
+}
+
+return M

--- a/src/services/ui/topics.lua
+++ b/src/services/ui/topics.lua
@@ -1,0 +1,67 @@
+-- services/ui/topics.lua
+--
+-- Pure topic helpers for the UI service.
+
+local M = {}
+
+local function t(...)
+	return { ... }
+end
+
+function M.svc_status()
+	return t('svc', 'ui', 'status')
+end
+
+function M.svc_meta()
+	return t('svc', 'ui', 'meta')
+end
+
+
+function M.summary()
+	return t('state', 'ui', 'summary')
+end
+
+function M.read_model_status()
+	return t('state', 'ui', 'read-model')
+end
+
+function M.session_count()
+	return t('state', 'ui', 'sessions')
+end
+
+function M.default_retained_patterns()
+	return {
+		t('cfg', '#'),
+		t('svc', '#'),
+		t('state', '#'),
+		t('cap', '#'),
+		t('raw', '#'),
+	}
+end
+
+function M.topic_key(topic)
+	assert(type(topic) == 'table', 'topic_key: topic must be a table')
+	local out = {}
+	for i = 1, #topic do
+		local v = topic[i]
+		local tv = type(v)
+		if tv == 'string' then
+			out[#out + 1] = 's' .. #v .. ':' .. v
+		elseif tv == 'number' then
+			local s = tostring(v)
+			out[#out + 1] = 'n' .. #s .. ':' .. s
+		else
+			error('topic_key: topic tokens must be strings or numbers', 2)
+		end
+	end
+	return table.concat(out, '|')
+end
+
+function M.topic_string(topic)
+	if type(topic) ~= 'table' then return tostring(topic) end
+	local out = {}
+	for i = 1, #topic do out[i] = tostring(topic[i]) end
+	return table.concat(out, '/')
+end
+
+return M

--- a/src/services/ui/update/artifact_ingest.lua
+++ b/src/services/ui/update/artifact_ingest.lua
@@ -1,0 +1,154 @@
+-- services/ui/update/artifact_ingest.lua
+--
+-- Strict boundary around artifact ingest providers.
+--
+-- Production ingest providers must expose Op-returning methods for all
+-- potentially blocking work and an immediate abort_now() method for finalisers.
+-- This module deliberately does not wrap raw append/write/commit/close methods
+-- in guards, because that would hide blocking provider calls behind an Op shape.
+
+local op = require 'fibers.op'
+
+local M = {}
+
+local function is_op(v)
+	return type(v) == 'table' and getmetatable(v) == op.Op
+end
+
+local function require_op_method(obj, method, owner)
+	if type(obj) ~= 'table' or type(obj[method]) ~= 'function' then
+		return nil, (owner or 'artifact ingest object') .. ' must expose ' .. method
+	end
+	return obj[method], nil
+end
+
+local function call_op_method(obj, method, owner, ...)
+	local fn, err = require_op_method(obj, method, owner)
+	if not fn then return op.always(nil, err) end
+
+	local ok, ev_or_err = pcall(function (...)
+		return fn(obj, ...)
+	end, ...)
+
+	if not ok then
+		return op.always(nil, tostring(ev_or_err))
+	end
+	if not is_op(ev_or_err) then
+		return op.always(nil, (owner or 'artifact ingest object') .. ' ' .. method .. ' must return an Op')
+	end
+	return ev_or_err
+end
+
+function M.open_ingest_op(client, opts)
+	return call_op_method(client, 'open_ingest_op', 'artifact ingest client', opts)
+end
+
+function M.append_chunk_op(handle, chunk)
+	return call_op_method(handle, 'append_chunk_op', 'artifact ingest handle', chunk)
+end
+
+function M.commit_op(handle)
+	return call_op_method(handle, 'commit_op', 'artifact ingest handle')
+end
+
+function M.abort_now(handle, reason)
+	if handle == nil then return true, nil end
+	if type(handle) ~= 'table' or type(handle.abort_now) ~= 'function' then
+		return nil, 'artifact ingest handle must expose immediate abort_now'
+	end
+
+	local ok, a, b = pcall(function ()
+		return handle:abort_now(reason)
+	end)
+	if not ok then
+		return nil, tostring(a)
+	end
+	if is_op(a) then
+		return nil, 'artifact ingest abort_now must be immediate and must not return an Op'
+	end
+	if a == nil and b == nil then return true, nil end
+	if a == true then return true, nil end
+	if a == false or a == nil then return nil, b or 'artifact ingest abort_now failed' end
+	return true, nil
+end
+
+
+local BusHandle = {}
+BusHandle.__index = BusHandle
+
+local function ingest_rpc(method)
+	return { 'cap', 'artifact-ingest', 'main', 'rpc', method }
+end
+
+local function request_timeout(opts)
+	opts = opts or {}
+	return { timeout = opts.timeout or opts.call_timeout or 10.0 }
+end
+
+local function ingest_id_from(reply, fallback)
+	local rec = type(reply) == 'table' and (reply.ingest or reply.record or reply) or nil
+	return rec and (rec.ingest_id or rec.id) or fallback
+end
+
+function BusHandle:append_chunk_op(chunk)
+	if self._closed then return op.always(nil, 'artifact_ingest_handle_closed') end
+	return self._conn:call_op(ingest_rpc('append'), {
+		ingest_id = self.ingest_id,
+		chunk = chunk,
+	}, request_timeout(self._opts))
+end
+
+function BusHandle:commit_op()
+	if self._closed then return op.always(nil, 'artifact_ingest_handle_closed') end
+	self._closed = true
+	return self._conn:call_op(ingest_rpc('commit'), {
+		ingest_id = self.ingest_id,
+	}, request_timeout(self._opts)):wrap(function (reply, err)
+		if reply == nil or err ~= nil then return nil, err end
+		if type(reply) ~= 'table' then return reply end
+		local committed = reply.commit or reply.artifact or reply.result or reply
+		if type(committed) == 'table' then
+			return committed.artifact_id or committed.id or committed.ref or committed
+		end
+		return committed
+	end)
+end
+
+function BusHandle:abort_now(reason)
+	self._closed = true
+	self._abort_reason = reason or 'artifact_ingest_aborted'
+	return true, nil
+end
+
+local BusClient = {}
+BusClient.__index = BusClient
+
+function BusClient:open_ingest_op(opts)
+	opts = opts or {}
+	local ingest_id = opts.ingest_id or opts.id or ('ui-upload-' .. tostring(math.floor((os.clock() or 0) * 1000000)))
+	local sink = opts.sink or opts.artifact_sink
+	return self._conn:call_op(ingest_rpc('create'), {
+		ingest_id = ingest_id,
+		id = ingest_id,
+		component = opts.component or opts.target_component or opts.update_component,
+		sink = sink,
+		metadata = opts.metadata or opts.meta,
+	}, request_timeout(opts)):wrap(function (reply, err)
+		if reply == nil or err ~= nil then return nil, err end
+		return setmetatable({
+			_conn = self._conn,
+			_opts = opts,
+			ingest_id = ingest_id_from(reply, ingest_id),
+			_closed = false,
+		}, BusHandle)
+	end)
+end
+
+function M.bus_client(conn)
+	if not conn then return nil, 'artifact ingest bus client requires conn' end
+	return setmetatable({ _conn = conn }, BusClient)
+end
+
+M._test = { is_op = is_op }
+
+return M

--- a/src/services/ui/update/client.lua
+++ b/src/services/ui/update/client.lua
@@ -1,0 +1,39 @@
+-- services/ui/update/client.lua
+--
+-- Update service client boundary. Reusable upstream waits are exposed as Ops.
+
+local M = {}
+
+local function call_opts(opts, default_timeout)
+	opts = opts or {}
+	return { timeout = (opts.timeout ~= nil) and opts.timeout or (default_timeout or 10.0) }
+end
+
+local function update_manager_rpc(method)
+	return { 'cap', 'update-manager', 'main', 'rpc', method }
+end
+
+function M.create_job_op(conn, artifact_id, opts)
+	opts = opts or {}
+	local method = opts.create_method or update_manager_rpc('create-job')
+	return conn:call_op(method, {
+		artifact_id = artifact_id,
+		artifact_ref = artifact_id,
+		component = opts.component or opts.target_component or opts.update_component,
+		options = opts.options,
+		metadata = opts.metadata or opts.meta,
+		job_id = opts.job_id,
+	}, call_opts(opts, 10.0)):wrap(function (reply, err)
+		if reply == nil or err ~= nil then return nil, err end
+		if type(reply) == 'table' and reply.job ~= nil then return reply.job end
+		return reply
+	end)
+end
+
+function M.start_job_op(conn, job_id, opts)
+	opts = opts or {}
+	local method = opts.start_method or update_manager_rpc('start-job')
+	return conn:call_op(method, { job_id = job_id }, call_opts(opts, 10.0))
+end
+
+return M

--- a/src/services/ui/update/upload.lua
+++ b/src/services/ui/update/upload.lua
@@ -1,0 +1,191 @@
+-- services/ui/update/upload.lua
+--
+-- Update upload scoped operation. It owns ingest before commit, detaches
+-- abort cleanup after commit, and may hand off to the update service.
+--
+-- Upload timeout is an ownership decision: waits inside the upload scope are
+-- raced against the deadline. If the deadline wins, the upload scope is
+-- cancelled with reason "timeout" and the uncommitted ingest finaliser aborts
+-- immediately.
+
+local fibers      = require 'fibers'
+local sleep       = require 'fibers.sleep'
+local ingest      = require 'services.ui.update.artifact_ingest'
+local client      = require 'services.ui.update.client'
+local bus_cleanup = require 'devicecode.support.bus_cleanup'
+local resource    = require 'devicecode.support.resource'
+local scope_mod   = require 'fibers.scope'
+
+local M = {}
+
+local function connect_update_conn(scope, opts)
+	if opts.update_conn then
+		return opts.update_conn, false, nil
+	end
+	if opts.conn then
+		return opts.conn, false, nil
+	end
+	local conn, err
+	if type(opts.connect) == 'function' then
+		conn, err = opts.connect(opts.principal, opts)
+	elseif opts.bus and type(opts.bus.connect) == 'function' then
+		conn, err = opts.bus:connect({ principal = opts.principal })
+	end
+	if not conn then return nil, false, err or 'update connection unavailable' end
+	local conn_owner = resource.owned(conn, {
+		label = 'update upload connection cleanup',
+		terminate = function (value)
+			return bus_cleanup.disconnect(value)
+		end,
+	})
+	scope:finally(function (_, status, primary)
+		conn_owner:terminate_checked(primary or status or 'upload_closed', 'update upload connection cleanup')
+	end)
+	return conn, true, nil
+end
+
+local function read_chunk_op(body, max)
+	if type(body) == 'table' and type(body.read_chunk_op) == 'function' then
+		return body:read_chunk_op(max)
+	end
+	return fibers.always(nil, 'request body has no read_chunk_op')
+end
+
+local function deadline_from_opts(opts)
+	if type(opts.deadline) == 'number' then
+		return opts.deadline
+	end
+	local timeout = opts.upload_timeout
+	if timeout == nil then timeout = opts.timeout end
+	if type(timeout) == 'number' then
+		return fibers.now() + timeout
+	end
+	return nil
+end
+
+local function remaining_timeout(opts, deadline)
+	if deadline == nil then return opts.timeout end
+	local remaining = deadline - fibers.now()
+	if remaining < 0 then remaining = 0 end
+	return remaining
+end
+
+local function cancel_for_timeout(scope, on_timeout)
+	if on_timeout then on_timeout() end
+	if scope and type(scope.cancel) == 'function' then
+		scope:cancel('timeout')
+	end
+	error(scope_mod.cancelled('timeout'), 0)
+end
+
+local function perform_with_deadline(scope, ev, deadline, on_timeout)
+	if deadline == nil then
+		return fibers.perform(ev)
+	end
+
+	local dt = deadline - fibers.now()
+	if dt <= 0 then
+		cancel_for_timeout(scope, on_timeout)
+	end
+
+	local completed, a, b, c = fibers.perform(fibers.boolean_choice(ev, sleep.sleep_op(dt)))
+	if completed then
+		return a, b, c
+	end
+
+	cancel_for_timeout(scope, on_timeout)
+end
+
+local function upload_body_op(ctx, opts, deadline)
+	return fibers.run_scope_op(function (scope)
+		local timed_out = false
+		local function mark_timeout() timed_out = true end
+
+		local ingest_client = opts.ingest or opts.artifact_ingest
+		if ingest_client == nil then
+			local conn, _, conn_err = connect_update_conn(scope, opts)
+			if not conn then error(conn_err or 'update connection unavailable', 0) end
+			opts.update_conn = opts.update_conn or conn
+			local built, build_err = ingest.bus_client(conn)
+			if not built then error(build_err or 'artifact ingest bus client unavailable', 0) end
+			ingest_client = built
+		end
+
+		local handle, open_err = perform_with_deadline(scope, ingest.open_ingest_op(ingest_client, opts), deadline, mark_timeout)
+		if not handle then error(open_err or 'artifact ingest open failed', 0) end
+
+		local ingest_owner = resource.owned(handle, {
+			label = 'upload ingest abort',
+			terminate = function (value, reason)
+				return ingest.abort_now(value, reason)
+			end,
+		})
+		scope:finally(function (_, status, primary)
+			ingest_owner:terminate_checked(
+				timed_out and 'timeout' or primary or status or 'upload_closed',
+				'upload ingest abort'
+			)
+		end)
+
+		local body = ctx.body_stream or ctx.body or ctx.stream or ctx
+		if body == nil then error('request body has no chunk reader', 0) end
+		while true do
+			local chunk, rerr = perform_with_deadline(scope, read_chunk_op(body, opts.chunk_size or 65536), deadline, mark_timeout)
+			if rerr then error(rerr, 0) end
+			if chunk == nil or chunk == '' then break end
+			local ok, werr = perform_with_deadline(scope, ingest.append_chunk_op(handle, chunk), deadline, mark_timeout)
+			if ok == nil or ok == false then error(werr or 'artifact append failed', 0) end
+		end
+
+		local artifact_id, cerr = perform_with_deadline(scope, ingest.commit_op(handle), deadline, mark_timeout)
+		if not artifact_id then error(cerr or 'artifact commit failed', 0) end
+		local _committed_handle, detach_err = ingest_owner:detach()
+		if detach_err then error(detach_err, 0) end
+
+		local out = { status = 'ok', artifact_id = artifact_id }
+		if opts.create_job then
+			local conn, _, conn_err = connect_update_conn(scope, opts)
+			if not conn then error(conn_err or 'update connection unavailable', 0) end
+
+			local call_opts = {}
+			for k, v in pairs(opts) do call_opts[k] = v end
+			call_opts.timeout = remaining_timeout(opts, deadline)
+
+			local job, jerr = perform_with_deadline(scope, client.create_job_op(conn, artifact_id, call_opts), deadline, mark_timeout)
+			if not job then error(jerr or 'update job create failed', 0) end
+			out.job = job
+			if opts.start_job then
+				call_opts.timeout = remaining_timeout(opts, deadline)
+				local started, serr = perform_with_deadline(scope, client.start_job_op(conn, job.job_id or job.id, call_opts), deadline, mark_timeout)
+				if not started then error(serr or 'update job start failed', 0) end
+				out.started = started
+			end
+		end
+		return out
+	end)
+end
+
+function M.run(scope, owner, ctx, opts)
+	opts = opts or {}
+	local st, _, result_or_primary = fibers.perform(M.run_op(ctx, opts))
+	if st ~= 'ok' then
+		local ok, werr = fibers.perform(owner:reply_error_op(nil, result_or_primary or st))
+		if ok ~= true then error(werr or 'response write failed', 0) end
+		return { status = st, err = result_or_primary or st }
+	end
+	local ok, werr = fibers.perform(owner:reply_json_op(200, result_or_primary))
+	if ok ~= true then error(werr or 'response write failed', 0) end
+	return result_or_primary
+end
+
+function M.run_op(ctx, opts)
+	ctx = ctx or {}
+	opts = opts or {}
+
+	return fibers.guard(function ()
+		local deadline = deadline_from_opts(opts)
+		return upload_body_op(ctx, opts, deadline)
+	end)
+end
+
+return M

--- a/src/services/ui/user_operation.lua
+++ b/src/services/ui/user_operation.lua
@@ -1,0 +1,119 @@
+-- services/ui/user_operation.lua
+--
+-- Authenticated scoped upstream calls. This is for request/client operation
+-- scopes, not service coordinators.
+--
+-- Timeout is modelled as a race against the whole operation scope. If the
+-- timeout wins, run_scope_op's abort path cancels and joins the operation
+-- scope, running the owned connection finaliser before the boundary returns
+-- cancelled, "timeout".
+
+local fibers      = require 'fibers'
+local sleep       = require 'fibers.sleep'
+local bus_cleanup = require 'devicecode.support.bus_cleanup'
+local resource    = require 'devicecode.support.resource'
+
+local M = {}
+
+local function connect_for(spec)
+	if type(spec.connect) == 'function' then
+		return spec.connect(spec.principal, spec)
+	end
+	if spec.bus and type(spec.bus.connect) == 'function' then
+		return spec.bus:connect({ principal = spec.principal })
+	end
+	if spec.conn ~= nil then
+		return spec.conn
+	end
+	return nil, 'no user_operation connection source'
+end
+
+local function disconnect_if_owned(conn, spec)
+	if spec.conn ~= nil and conn == spec.conn and not spec.disconnect_borrowed then
+		return true, nil
+	end
+	return bus_cleanup.disconnect(conn)
+end
+
+local function normalise_result(result)
+	if type(result) == 'table' then return result end
+	return { value = result }
+end
+
+local function timeout_report()
+	return { id = 0, extra_errors = {}, children = {}, timeout = true }
+end
+
+local function deadline_from_spec(spec)
+	if type(spec.deadline) == 'number' then
+		return spec.deadline
+	end
+	if type(spec.timeout) == 'number' then
+		return fibers.now() + spec.timeout
+	end
+	return nil
+end
+
+local function operation_body_op(spec)
+	return fibers.run_scope_op(function (scope)
+		local conn, cerr = connect_for(spec)
+		if not conn then error(cerr or 'user connection failed', 0) end
+
+		local conn_owner = resource.owned(conn, {
+			label = 'user operation connection cleanup',
+			terminate = function (value)
+				return disconnect_if_owned(value, spec)
+			end,
+		})
+
+		scope:finally(function (_, status, primary)
+			conn_owner:terminate_checked(
+				primary or status or 'user_operation_closed',
+				'user operation connection cleanup'
+			)
+		end)
+
+		if type(spec.run_op) == 'function' then
+			local result, err = fibers.perform(spec.run_op(scope, conn))
+			if result == nil then error(err or 'user_operation_failed', 0) end
+			return normalise_result(result)
+		end
+
+		return normalise_result(spec.run(scope, conn))
+	end)
+end
+
+function M.run_op(spec)
+	spec = spec or {}
+	if type(spec.run_op) ~= 'function' and type(spec.run) ~= 'function' then
+		error('user_operation.run_op: run_op or run function required', 2)
+	end
+
+	return fibers.guard(function ()
+		local deadline = deadline_from_spec(spec)
+		local work = operation_body_op(spec)
+		if deadline == nil then
+			return work
+		end
+
+		local dt = deadline - fibers.now()
+		if dt <= 0 then
+			return fibers.always('cancelled', timeout_report(), 'timeout')
+		end
+
+		return fibers.boolean_choice(work, sleep.sleep_op(dt)):wrap(function (work_won, st, rep, value_or_primary)
+			if work_won then
+				return st, rep, value_or_primary
+			end
+			return 'cancelled', timeout_report(), 'timeout'
+		end)
+	end)
+end
+
+function M.run(spec)
+	local st, rep, a = fibers.perform(M.run_op(spec))
+	if st == 'ok' then return a, nil, rep end
+	return nil, a, rep
+end
+
+return M

--- a/tests/integration/devhost/update_public_seams_spec.lua
+++ b/tests/integration/devhost/update_public_seams_spec.lua
@@ -1,0 +1,254 @@
+-- tests/integration/devhost/update_public_seams_spec.lua
+--
+-- Public Update control-plane seam tests.  These exercise the canonical
+-- cap/... manager interfaces and retained state/workflow publication, rather
+-- than service-private command trees.
+
+local busmod = require 'bus'
+local fibers = require 'fibers'
+
+local runfibers = require 'tests.support.run_fibers'
+local probe     = require 'tests.support.bus_probe'
+
+local service = require 'services.update.service'
+local topics  = require 'services.update.topics'
+local upload  = require 'services.ui.update.upload'
+
+local T = {}
+
+local function fail(msg) error(msg or 'assertion failed', 2) end
+local function assert_eq(a, b, msg) if a ~= b then fail(msg or ('expected ' .. tostring(b) .. ', got ' .. tostring(a))) end end
+local function assert_true(v, msg) if v ~= true then fail(msg or ('expected true, got ' .. tostring(v))) end end
+local function assert_not_nil(v, msg) if v == nil then fail(msg or 'expected non-nil') end end
+
+
+local function wait_retained_payload_where(conn, topic, label, pred, opts)
+	opts = opts or {}
+	local view = conn:retained_view(topic)
+	local value = probe.wait_versioned_until(label, function ()
+		return view:version()
+	end, function (seen)
+		return view:changed_op(seen)
+	end, function ()
+		local msg = view:get(topic)
+		local payload = msg and msg.payload or nil
+		if pred(payload) then return payload end
+		return nil
+	end, opts)
+	view:close()
+	return value
+end
+
+local function has_value(list, value)
+	for _, item in ipairs(list or {}) do
+		if item == value then return true end
+	end
+	return false
+end
+
+local function update_config()
+	return {
+		schema = 'devicecode.update/1',
+		components = {
+			{ id = 'cm5' },
+			{ id = 'mcu' },
+		},
+	}
+end
+
+local function start_update(scope, params)
+	params = params or {}
+	local bus = params.bus or busmod.new()
+	local svc_conn = bus:connect()
+	local caller = bus:connect()
+	local child = assert(scope:child())
+
+	local ok, err = child:spawn(function (service_scope)
+		service.run(service_scope, {
+			conn = svc_conn,
+			service_id = 'update',
+			watch_config = false,
+			config = params.config or update_config(),
+			backend = params.backend,
+			job_store = params.job_store,
+			initial_jobs = params.initial_jobs,
+		})
+	end)
+	assert_true(ok, err)
+
+	wait_retained_payload_where(caller, topics.update_manager_status(), 'update manager available', function (p)
+		return p and p.available == true
+	end, { timeout = 1.0 })
+	return {
+		bus = bus,
+		child = child,
+		caller = caller,
+		svc_conn = svc_conn,
+	}
+end
+
+local function new_sink(artifact)
+	artifact = artifact or { artifact_id = 'artifact-1', ref = 'artifact-1' }
+	return {
+		chunks = {},
+		terminated = 0,
+		append_op = function (self, chunk)
+			self.chunks[#self.chunks + 1] = chunk
+			return fibers.always(true, nil)
+		end,
+		commit_op = function ()
+			return fibers.always(artifact, nil)
+		end,
+		terminate = function (self, reason)
+			self.terminated = self.terminated + 1
+			self.termination_reason = reason
+			return true, nil
+		end,
+	}
+end
+
+local function body_from_chunks(chunks)
+	return {
+		_chunks = chunks,
+		read_chunk_op = function (self)
+			local chunk = table.remove(self._chunks, 1)
+			return fibers.always(chunk, nil)
+		end,
+	}
+end
+
+function T.update_public_manager_retains_capabilities_and_workflow_records()
+	runfibers.run(function(scope)
+		local h = start_update(scope)
+		local conn = h.caller
+
+		local meta = probe.wait_retained_payload(conn, topics.update_manager_meta(), { timeout = 1.0 })
+		assert_eq(meta.owner, 'update')
+		assert_eq(meta.class, 'update-manager')
+		assert_true(has_value(meta.methods, 'create-job'), 'manager meta should list create-job')
+		assert_true(has_value(meta.methods, 'start-job'), 'manager meta should list start-job')
+		assert_eq(meta.workflow_family[1], 'state')
+		assert_eq(meta.workflow_family[2], 'workflow')
+		assert_eq(meta.workflow_family[3], 'update-job')
+
+		local status = wait_retained_payload_where(conn, topics.update_manager_status(), 'update manager status', function (p)
+			return p and p.available == true
+		end, { timeout = 1.0 })
+		assert_eq(status.available, true)
+
+		local summary = wait_retained_payload_where(conn, topics.update_summary(), 'update summary ready', function (p)
+			return p and p.ready == true
+		end, { timeout = 1.0 })
+		assert_eq(summary.service, 'update')
+		assert_eq(summary.ready, true)
+
+		local reply, err = conn:call(topics.update_manager_rpc('create-job'), {
+			job_id = 'j-cap-1',
+			component = 'cm5',
+			artifact_ref = 'artifact-cap-1',
+		}, { timeout = 1.0 })
+		assert_not_nil(reply, err)
+		assert_eq(reply.ok, true)
+		assert_eq(reply.job.job_id, 'j-cap-1')
+
+		local job = probe.wait_retained_payload(conn, topics.workflow_update_job('j-cap-1'), { timeout = 1.0 })
+		assert_eq(job.job_id, 'j-cap-1')
+		assert_eq(job.component, 'cm5')
+		assert_eq(job.artifact_ref, 'artifact-cap-1')
+
+		local component = probe.wait_retained_payload(conn, topics.update_component('cm5'), { timeout = 1.0 })
+		assert_eq(component.kind, 'update.component')
+		assert_not_nil(component.jobs.by_id['j-cap-1'])
+
+		h.child:cancel('test complete')
+	end, { timeout = 5.0 })
+end
+
+function T.update_artifact_ingest_uses_public_cap_and_workflow_record()
+	runfibers.run(function(scope)
+		local h = start_update(scope)
+		local conn = h.caller
+		local sink = new_sink({ artifact_id = 'artifact-ingest-1', ref = 'artifact-ingest-1' })
+
+		local meta = probe.wait_retained_payload(conn, topics.artifact_ingest_meta(), { timeout = 1.0 })
+		assert_eq(meta.owner, 'update')
+		assert_eq(meta.class, 'artifact-ingest')
+		assert_true(has_value(meta.methods, 'create'), 'ingest meta should list create')
+		assert_true(has_value(meta.methods, 'commit'), 'ingest meta should list commit')
+
+		local created, create_err = conn:call(topics.artifact_ingest_rpc('create'), {
+			ingest_id = 'ing-public-1',
+			component = 'cm5',
+			sink = sink,
+		}, { timeout = 1.0 })
+		assert_not_nil(created, create_err)
+		assert_eq(created.ok, true)
+
+		local appended, append_err = conn:call(topics.artifact_ingest_rpc('append'), {
+			ingest_id = 'ing-public-1',
+			chunk = 'abc',
+		}, { timeout = 1.0 })
+		assert_not_nil(appended, append_err)
+		assert_eq(appended.ok, true)
+		assert_eq(sink.chunks[1], 'abc')
+
+		local committed, commit_err = conn:call(topics.artifact_ingest_rpc('commit'), {
+			ingest_id = 'ing-public-1',
+		}, { timeout = 1.0 })
+		assert_not_nil(committed, commit_err)
+		assert_eq(committed.ok, true)
+		assert_eq(committed.commit.artifact.artifact_id, 'artifact-ingest-1')
+
+		local rec = wait_retained_payload_where(conn, topics.workflow_artifact_ingest('ing-public-1'), 'ingest committed', function (p)
+			return p and p.state == 'committed'
+		end, { timeout = 1.0 })
+		assert_eq(rec.ingest_id, 'ing-public-1')
+		assert_eq(rec.state, 'committed')
+		assert_eq(rec.bytes, 3)
+		assert_eq(rec.artifact.artifact_id, 'artifact-ingest-1')
+
+		h.child:cancel('test complete')
+	end, { timeout = 5.0 })
+end
+
+function T.ui_upload_drives_update_public_ingest_and_manager_caps()
+	runfibers.run(function(scope)
+		local bus = busmod.new()
+		local h = start_update(scope, { bus = bus })
+		local conn = h.caller
+		local sink = new_sink({ artifact_id = 'artifact-upload-1', ref = 'artifact-upload-1' })
+
+		local st, _, result = fibers.perform(upload.run_op({
+			body_stream = body_from_chunks({ 'hello', 'world' }),
+		}, {
+			bus = bus,
+			sink = sink,
+			component = 'cm5',
+			ingest_id = 'ing-upload-1',
+			job_id = 'j-upload-1',
+			create_job = true,
+			timeout = 1.0,
+		}))
+		assert_eq(st, 'ok')
+		assert_not_nil(result)
+		assert_not_nil(result.job)
+		assert_eq(result.job.job_id, 'j-upload-1')
+		assert_eq(sink.chunks[1], 'hello')
+		assert_eq(sink.chunks[2], 'world')
+
+		local job = probe.wait_retained_payload(conn, topics.workflow_update_job('j-upload-1'), { timeout = 1.0 })
+		assert_eq(job.job_id, 'j-upload-1')
+		assert_eq(job.component, 'cm5')
+
+		local rec = wait_retained_payload_where(conn, topics.workflow_artifact_ingest('ing-upload-1'), 'upload ingest committed', function (p)
+			return p and p.state == 'committed'
+		end, { timeout = 1.0 })
+		assert_eq(rec.state, 'committed')
+		assert_eq(rec.bytes, 10)
+		assert_eq(rec.artifact.artifact_id, 'artifact-upload-1')
+
+		h.child:cancel('test complete')
+	end, { timeout = 5.0 })
+end
+
+return T

--- a/tests/run.lua
+++ b/tests/run.lua
@@ -87,6 +87,7 @@ local files = {
 	"integration.devhost.hal_uart_spec",
 	"integration.devhost.fabric_hal_uart_smoke_spec",
 	"integration.devhost.fabric_public_service_path_spec",
+	'integration.devhost.update_public_seams_spec',
 	'integration.devhost.device_public_seams_spec',
 	'unit.support.test_scoped_work',
 	'unit.support.test_queue',
@@ -111,6 +112,17 @@ local files = {
 	'unit.http.test_structure',
 	'integration.devhost.test_http_transport_real',
 	'integration.devhost.test_http_service_real',
+	"unit.ui.test_architecture",
+	"unit.ui.test_config",
+	"unit.ui.test_http_listener",
+	"unit.ui.test_http_request",
+	"unit.ui.test_http_response_stream",
+	"unit.ui.test_read_model",
+	"unit.ui.test_service",
+	"unit.ui.test_sessions",
+	"unit.ui.test_supervision",
+	"unit.ui.test_update_upload",
+	"unit.ui.test_user_operation",
 }
 
 local function monotonic_now()

--- a/tests/unit/ui/test_architecture.lua
+++ b/tests/unit/ui/test_architecture.lua
@@ -1,0 +1,238 @@
+-- tests/unit/ui/test_architecture.lua
+
+local tests = {}
+
+local function fail(msg) error(msg or 'assertion failed', 2) end
+
+local function read_file(path)
+	local f = assert(io.open(path, 'r'))
+	local s = f:read('*a')
+	f:close()
+	return s
+end
+
+local function scan_files(root)
+	local p = io.popen(('find %s -type f -name "*.lua"'):format(root))
+	local out = {}
+	for line in p:lines() do out[#out + 1] = line end
+	p:close()
+	return out
+end
+
+function tests.test_ui_service_code_does_not_use_infrastructure_waits()
+	for _, path in ipairs(scan_files('../src/services/ui')) do
+		local s = read_file(path)
+		if s:find('perform_raw', 1, true) then fail(path .. ' uses perform_raw') end
+		if s:find('join_op', 1, true) then fail(path .. ' uses join_op') end
+		if s:find('close_op', 1, true) then fail(path .. ' uses close_op') end
+	end
+end
+
+function tests.test_ui_no_longer_owns_http_transport_backend()
+	local p = io.popen('find ../src/services/ui -type f -name "*.lua"')
+	for path in p:lines() do
+		local s = read_file(path)
+		if s:find("services.ui.transport", 1, true) then fail(path .. ' still depends on UI transport') end
+		if s:find("services.http.transport", 1, true) then fail(path .. ' reaches into HTTP transport internals') end
+		if s:find("require 'cqueues", 1, true) or s:find('require "cqueues', 1, true) then fail(path .. ' requires cqueues') end
+		if s:find("require 'http%.", 1) or s:find('require "http%.', 1) then fail(path .. ' requires raw lua-http') end
+	end
+	p:close()
+end
+
+function tests.test_ui_public_entry_has_no_websocket_export_for_first_cut()
+	local s = read_file('../src/services/ui.lua')
+	if s:find('services.ui.transport', 1, true) then fail('ui.lua exports UI transport') end
+	if s:find('services.ui.ws', 1, true) then fail('ui.lua exports WebSocket modules in first cut') end
+	if not s:find("services.ui.http.sse", 1, true) then fail('ui.lua does not export SSE helper') end
+end
+
+function tests.test_http_listener_consumes_http_sdk_not_transport()
+	local s = read_file('../src/services/ui/http/listener.lua')
+	if not s:find("services.http'.sdk", 1, true) and not s:find('services.http".sdk', 1, true) then
+		fail('http listener does not consume services.http.sdk')
+	end
+	if s:find('run_pump', 1, true) then fail('http listener still owns a transport pump') end
+	if s:find('cqueues', 1, true) or s:find('lua_http', 1, true) then fail('http listener mentions backend internals') end
+	if not s:find('obtain_listener_op', 1, true) then fail('http listener lacks cap/http listen boundary') end
+	if not s:find('http_request_rejected', 1, true) then fail('http listener lacks explicit overload rejection path') end
+end
+
+
+function tests.test_ui_listener_lifecycle_uses_service_event_ports()
+	local service = read_file('../src/services/ui/service.lua')
+	if not service:find('devicecode.support.service_events', 1, true) then fail('ui service does not use service event helper') end
+	if not service:find('events_port = service_events.port', 1, true) then fail('ui listener is not wired through an event port') end
+	if not service:find('listener_id', 1, true) or not service:find('listener_generation', 1, true) then
+		fail('ui listener events do not carry listener identity/generation')
+	end
+
+	local listener = read_file('../src/services/ui/http/listener.lua')
+	if not listener:find('opts.events_port', 1, true) then fail('ui http listener does not prefer events_port') end
+end
+
+function tests.test_ui_service_starts_listener_from_cfg_ui_not_main_options()
+	local s = read_file('../src/services/ui/service.lua')
+	if s:find('params%.http[^_%w]') then fail('ui service still reads HTTP config from start params') end
+	if s:find('params.verify_login', 1, true) then fail('ui service still reads verifier from start params') end
+	if not s:find("{ 'cfg', 'ui' }", 1, true) then fail('ui service does not watch cfg/ui') end
+	if not s:find('http_cap_id', 1, true) then fail('ui service does not pass configured HTTP capability id') end
+	if s:find('start_transport_pump', 1, true) then fail('ui service still starts transport pump') end
+end
+
+function tests.test_ui_and_http_do_not_consume_main_legacy_injection_fields()
+	for _, root in ipairs({ '../src/services/ui', '../src/services/http' }) do
+		for _, path in ipairs(scan_files(root)) do
+			local s = read_file(path)
+			for _, needle in ipairs({ 'run_http', 'verify_login', 'from_legacy_params', 'params.http_listen', 'opts.http_listen' }) do
+				if s:find(needle, 1, true) then fail(path .. ' consumes legacy main field ' .. needle) end
+			end
+		end
+	end
+end
+
+function tests.test_read_model_store_has_no_queue_or_mailbox_fanout()
+	local s = read_file('../src/services/ui/read_model_store.lua')
+	if s:find("devicecode.support.queue", 1, true) then fail('read_model_store depends on queue') end
+	if s:find("fibers.mailbox", 1, true) then fail('read_model_store depends on mailbox') end
+	if s:find("fibers.perform", 1, true) then fail('read_model_store performs Ops') end
+	if s:find("perform_raw", 1, true) then fail('read_model_store uses perform_raw') end
+end
+
+function tests.test_read_model_watches_owns_watch_fanout_boundary()
+	local s = read_file('../src/services/ui/read_model_watches.lua')
+	if not s:find("devicecode.support.queue", 1, true) then fail('read_model_watches does not own queue fanout') end
+	if not s:find("fibers.mailbox", 1, true) then fail('read_model_watches does not own bounded watch queues') end
+	if not s:find('watch_open', 1, true) then fail('read_model_watches does not expose watch_open') end
+end
+
+function tests.test_ui_service_wires_same_store_into_read_model_component()
+	local s = read_file('../src/services/ui/service.lua')
+	if not s:find('read_model_opts.model = model', 1, true) then
+		fail('ui service does not pass service model into read_model.start')
+	end
+	if not s:find('read_model_opts.watch_owner = watch_owner', 1, true) then
+		fail('ui service does not pass watch owner into read_model.start')
+	end
+end
+
+function tests.test_ui_service_records_component_outcomes_before_policy()
+	local s = read_file('../src/services/ui/service.lua')
+	if not s:find('record_component_done', 1, true) then fail('ui service does not record component outcomes') end
+	if not s:find('classify_service_component_done', 1, true) then fail('ui service component completion does not use supervision classifier') end
+end
+
+function tests.test_upload_accepts_only_read_chunk_op_body_boundary()
+	local upload = read_file('../src/services/ui/update/upload.lua')
+	if upload:find('read_some_op', 1, true) or upload:find('read_op', 1, true) then
+		fail('upload accepts non read_chunk_op body compatibility path')
+	end
+	if not upload:find('request body has no read_chunk_op', 1, true) then fail('upload does not require read_chunk_op') end
+end
+
+
+function tests.test_ui_command_forwarding_is_op_first()
+	local request = read_file('../src/services/ui/http/request.lua')
+	if not request:find('user_operation.run_op', 1, true) then fail('command forwarding does not use user_operation.run_op') end
+	if not request:find('conn:call_op', 1, true) then fail('command forwarding does not use conn:call_op') end
+	if request:find('conn:call(', 1, true) then fail('command forwarding still hides blocking conn:call') end
+
+	local user_operation = read_file('../src/services/ui/user_operation.lua')
+	if not user_operation:find('spec.run_op', 1, true) then fail('user_operation does not accept op-first specs') end
+end
+
+function tests.test_ui_upload_and_user_operation_have_timeout_races()
+	local upload = read_file('../src/services/ui/update/upload.lua')
+	if not upload:find('upload_timeout', 1, true) then fail('upload timeout option missing') end
+	if not upload:find('boolean_choice', 1, true) then fail('upload timeout is not an explicit race') end
+
+	local user_operation = read_file('../src/services/ui/user_operation.lua')
+	if not user_operation:find('boolean_choice', 1, true) then fail('user_operation timeout is not an explicit race') end
+	if user_operation:find("require 'fibers.mailbox'", 1, true) then fail('user_operation still uses mailbox timeout worker') end
+end
+
+function tests.test_http_response_writes_are_op_only()
+	local response = read_file('../src/services/ui/http/response.lua')
+	if response:find('function Response:reply%(') then fail('response exposes non-op reply') end
+	if response:find('function Response:reply_json%(') then fail('response exposes non-op reply_json') end
+	if response:find('function Response:reply_error%(') then fail('response exposes non-op reply_error') end
+	if not response:find('function Response:abandon_now%(') then fail('response lacks immediate abandon_now') end
+	if not response:find('function Response:terminate%(') then fail('response lacks finaliser-safe terminate') end
+	if not response:find('write_headers_op', 1, true) then fail('response does not use write_headers_op') end
+	if not response:find('write_chunk_op', 1, true) then fail('response does not use write_chunk_op') end
+
+	for _, path in ipairs(scan_files('../src/services/ui')) do
+		local src = read_file(path)
+		if src:find('owner:reply%(') then fail(path .. ' uses non-op response reply') end
+		if src:find('owner:reply_json%(') then fail(path .. ' uses non-op response reply_json') end
+		if src:find('owner:reply_error%(') then fail(path .. ' uses non-op response reply_error') end
+	end
+end
+
+function tests.test_sse_is_request_owned_streaming_http_not_transport_code()
+	local s = read_file('../src/services/ui/http/sse.lua')
+	if not s:find('watch_open', 1, true) then fail('SSE does not open a read-model watch') end
+	if not s:find('text/event%-stream') then fail('SSE does not emit event-stream headers') end
+	if s:find('cqueues', 1, true) or s:find('lua_http', 1, true) then fail('SSE mentions backend internals') end
+end
+
+function tests.test_artifact_ingest_boundary_has_no_raw_blocking_fallbacks()
+	local ingest = read_file('../src/services/ui/update/artifact_ingest.lua')
+	for _, raw in ipairs({ 'open_ingest(', ':append(', ':write(', ':commit(', ':abort(', ':close(' }) do
+		if ingest:find(raw, 1, true) then fail('artifact_ingest contains raw blocking fallback: ' .. raw) end
+	end
+	if not ingest:find('open_ingest_op', 1, true) then fail('artifact_ingest lacks open_ingest_op boundary') end
+	if not ingest:find('append_chunk_op', 1, true) then fail('artifact_ingest lacks append_chunk_op boundary') end
+	if not ingest:find('commit_op', 1, true) then fail('artifact_ingest lacks commit_op boundary') end
+	if not ingest:find('abort_now', 1, true) then fail('artifact_ingest lacks abort_now boundary') end
+end
+
+function tests.test_read_model_store_declares_first_token_replay_index()
+	local store = read_file('../src/services/ui/read_model_store.lua')
+	if not store:find('_index_first', 1, true) then fail('read_model_store lacks first-token index') end
+	if not store:find('_candidate_keys', 1, true) then fail('read_model_store lacks indexed candidate selection') end
+end
+
+function tests.test_ui_service_observes_session_pulse_not_event_sink()
+	local service = read_file('../src/services/ui/service.lua')
+	local store = read_file('../src/services/ui/sessions.lua')
+	if service:find('set_event_sink', 1, true) or store:find('set_event_sink', 1, true) then fail('ui still exposes session event sink') end
+	if store:find('event_sink', 1, true) or store:find('on_event', 1, true) then fail('session store still accepts event-sink compatibility options') end
+	if not service:find('sessions:changed_op', 1, true) and not service:find('state.sessions:changed_op', 1, true) then
+		fail('ui service does not observe session changed_op')
+	end
+end
+
+function tests.test_read_model_component_uses_scope_aware_never_wait()
+	local service = read_file('../src/services/ui/service.lua')
+	if service:find('component_scope:not_ok_op()', 1, true) then fail('read-model component waits on its own not_ok_op') end
+	if not service:find('fibers.perform(fibers.never())', 1, true) then fail('read-model component does not use never() as long-lived wait') end
+end
+
+function tests.test_response_headers_state_is_committed_after_transport_write()
+	local response = read_file('../src/services/ui/http/response.lua')
+	local guard_pos = response:find('function Response:write_headers_op', 1, true)
+	local token_pos = response:find('acquire_start_token', guard_pos, true)
+	local state_pos = response:find("self._state = opts.end_stream and 'ended' or 'headers_sent'", guard_pos, true)
+	if not token_pos then fail('write_headers_op does not use start token') end
+	if not state_pos then fail('write_headers_op does not commit headers_sent after write') end
+	if state_pos < token_pos then fail('headers state appears to be committed before start token/write path') end
+end
+
+function tests.test_response_headers_op_does_not_mutate_in_guard_path()
+	local response = read_file('../src/services/ui/http/response.lua')
+	local start_pos = response:find('function Response:write_headers_op', 1, true)
+	local end_pos = response:find('function Response:write_chunk_op', start_pos, true)
+	local body = response:sub(start_pos, end_pos - 1)
+	if body:find('fibers.guard(function', 1, true) then fail('write_headers_op still uses a mutating guard path') end
+	if not body:find('acquire_start_token_op', 1, true) then fail('write_headers_op does not use the choice-safe start token op') end
+end
+
+function tests.test_ui_summary_unretain_cleanup_is_explicitly_recorded()
+	local service = read_file('../src/services/ui/service.lua')
+	if not service:find("record_cleanup_error(state, 'ui_summary_unretain_failed'", 1, true) then
+		fail('ui summary unretain failure is not explicitly recorded')
+	end
+end
+
+return tests

--- a/tests/unit/ui/test_config.lua
+++ b/tests/unit/ui/test_config.lua
@@ -1,0 +1,45 @@
+local config = require 'services.ui.config'
+
+local M = {}
+
+local function eq(a, b, msg)
+	if a ~= b then error((msg or 'assertion failed') .. ': expected ' .. tostring(b) .. ', got ' .. tostring(a), 2) end
+end
+local function ok(v, msg) if not v then error(msg or 'assertion failed', 2) end return v end
+
+function M.test_normalise_supplies_http_static_sse_and_upload_defaults()
+	local cfg = ok(config.normalise({ schema = config.SCHEMA }))
+	eq(cfg.enabled, true)
+	eq(cfg.http.enabled, true)
+	eq(cfg.http.cap_id, 'main')
+	eq(cfg.http.port, 8080)
+	eq(cfg.static.root, 'www')
+	eq(cfg.sse.enabled, true)
+	eq(cfg.uploads.enabled, true)
+end
+
+function M.test_can_disable_http_listener_without_disabling_service()
+	local cfg = ok(config.normalise({ schema = config.SCHEMA, http = { enabled = false } }))
+	eq(cfg.enabled, true)
+	eq(cfg.http.enabled, false)
+end
+
+function M.test_config_is_explicit_not_derived_from_main_options()
+	eq(config.from_legacy_params, nil)
+	local cfg = ok(config.normalise({
+		schema = config.SCHEMA,
+		http = { host = '127.0.0.1', port = 9000, cap_id = 'main' },
+		static = { root = '/srv/ui' },
+	}))
+	eq(cfg.http.host, '127.0.0.1')
+	eq(cfg.http.port, 9000)
+	eq(cfg.static.root, '/srv/ui')
+end
+
+function M.test_rejects_unknown_fields()
+	local cfg, err = config.normalise({ schema = config.SCHEMA, transport = {} })
+	eq(cfg, nil)
+	ok(tostring(err):find('unknown field', 1, true))
+end
+
+return M

--- a/tests/unit/ui/test_http_listener.lua
+++ b/tests/unit/ui/test_http_listener.lua
@@ -1,0 +1,241 @@
+-- tests/unit/ui/test_http_listener.lua
+
+local fibers = require 'fibers'
+local mailbox = require 'fibers.mailbox'
+local pulse = require 'fibers.pulse'
+local run_fibers = require 'tests.support.run_fibers'
+local listener_mod = require 'services.ui.http.listener'
+
+local tests = {}
+
+local function fail(msg) error(msg or 'assertion failed', 2) end
+local function assert_eq(a, b, msg) if a ~= b then fail(msg or ('expected '..tostring(b)..', got '..tostring(a))) end end
+local function assert_true(v, msg) if v ~= true then fail(msg or ('expected true, got '..tostring(v))) end end
+local function assert_not_nil(v, msg) if v == nil then fail(msg or 'expected non-nil') end end
+
+local FakeContext = {}
+FakeContext.__index = FakeContext
+
+local function make_ctx(spec)
+	spec = spec or {}
+	return setmetatable({
+		_id = spec.id,
+		_method = spec.method or 'GET',
+		_path = spec.path or '/',
+		terminated = false,
+		terminate_reason = nil,
+	}, FakeContext)
+end
+
+function FakeContext:id() return self._id end
+function FakeContext:method() return self._method end
+function FakeContext:path() return self._path end
+function FakeContext:terminate(reason)
+	self.terminated = true
+	self.terminate_reason = reason
+	return true, nil
+end
+local FakeListener = {}
+FakeListener.__index = FakeListener
+
+local function fake_listener()
+	local tx, rx = mailbox.new(16, { full = 'reject_newest' })
+	local accept_started = pulse.new()
+	return setmetatable({
+		_tx = tx,
+		_rx = rx,
+		_accept_started = accept_started,
+		_accept_seen = accept_started:version(),
+		_terminated = false,
+		_reason = nil,
+	}, FakeListener)
+end
+
+function FakeListener:accept_now(ctx)
+	return self._tx:send(ctx)
+end
+
+function FakeListener:accept_op()
+	self._accept_started:signal()
+	return self._rx:recv_op():wrap(function (ctx)
+		if ctx == nil then return nil, tostring(self._rx:why() or 'closed') end
+		return ctx, nil
+	end)
+end
+
+function FakeListener:terminate(reason)
+	if self._terminated then return true, nil end
+	self._terminated = true
+	self._reason = reason or 'closed'
+	self._tx:close(self._reason)
+	return true, nil
+end
+function FakeListener:terminated() return self._terminated end
+function FakeListener:accept_started_op() return self._accept_started:changed_op(self._accept_seen) end
+
+local function recv_kind(rx, kind)
+	while true do
+		local ev = fibers.perform(rx:recv_op())
+		assert_not_nil(ev, 'event stream closed before '..kind)
+		if ev.kind == kind then return ev end
+	end
+end
+
+function tests.test_accept_transfers_context_to_request_scope_and_reports_started_done()
+	run_fibers.run(function (scope)
+		local done_tx, done_rx = mailbox.new(16, { full = 'reject_newest' })
+		local listener = fake_listener()
+		local seen_in_request = false
+
+		local ok, err = scope:spawn(function (s)
+			listener_mod.run(s, {
+				listener = listener,
+				done_tx = done_tx,
+				run_request = function (_request_scope, ctx)
+					seen_in_request = true
+					assert_eq(ctx:method(), 'GET')
+					assert_eq(ctx:path(), '/status')
+					return { status = 'ok' }
+				end,
+			})
+		end)
+		assert_true(ok, err)
+
+		local raw = make_ctx({ id = 'req-1', method = 'GET', path = '/status' })
+		assert_true(listener:accept_now(raw))
+
+		local started = recv_kind(done_rx, 'http_request_started')
+		assert_eq(started.request_id, 'req-1')
+		assert_eq(started.active_requests, 1)
+
+		local done = recv_kind(done_rx, 'http_request_done')
+		assert_eq(done.request_id, 'req-1')
+		assert_eq(done.status, 'ok')
+		assert_eq(done.active_requests, 0)
+		assert_true(seen_in_request)
+		assert_true(raw.terminated)
+	end)
+end
+
+function tests.test_listener_can_obtain_handle_from_http_capability_sdk()
+	run_fibers.run(function (scope)
+		local done_tx, done_rx = mailbox.new(16, { full = 'reject_newest' })
+		local listener = fake_listener()
+		local call_topic
+		local call_payload
+		local conn = {
+			call_op = function(_, topic, payload)
+				call_topic = topic
+				call_payload = payload
+				return fibers.always({ listener = listener }, nil)
+			end,
+		}
+
+		local ok, err = scope:spawn(function (s)
+			listener_mod.run(s, {
+				conn = conn,
+				listen = { host = '127.0.0.1', port = 8080 },
+				done_tx = done_tx,
+				run_request = function () return { status = 'ok' } end,
+			})
+		end)
+		assert_true(ok, err)
+
+		local raw = make_ctx({ id = 'req-cap', method = 'GET', path = '/' })
+		assert_true(listener:accept_now(raw))
+		local started = recv_kind(done_rx, 'http_request_started')
+		assert_eq(started.request_id, 'req-cap')
+		assert_not_nil(call_topic)
+		assert_eq(call_topic[1], 'cap')
+		assert_eq(call_topic[2], 'http')
+		assert_eq(call_topic[3], 'main')
+		assert_eq(call_topic[4], 'rpc')
+		assert_eq(call_topic[5], 'listen')
+		assert_eq(call_payload.host, '127.0.0.1')
+	end)
+end
+
+function tests.test_overloaded_listener_rejects_without_request_scope()
+	run_fibers.run(function (scope)
+		local done_tx, done_rx = mailbox.new(8, { full = 'reject_newest' })
+		local listener = fake_listener()
+		local ran_request = false
+
+		local ok, err = scope:spawn(function (s)
+			listener_mod.run(s, {
+				listener = listener,
+				done_tx = done_tx,
+				max_active_requests = 0,
+				overload_reason = 'too_many_requests',
+				run_request = function ()
+					ran_request = true
+					return { status = 'unexpected' }
+				end,
+			})
+		end)
+		assert_true(ok, err)
+
+		local raw = make_ctx({ id = 'req-2', method = 'GET', path = '/' })
+		assert_true(listener:accept_now(raw))
+
+		local rejected = recv_kind(done_rx, 'http_request_rejected')
+		assert_eq(rejected.request_id, 'req-2')
+		assert_eq(rejected.reason, 'too_many_requests')
+		assert_eq(rejected.active_requests, 0)
+		assert_eq(rejected.max_active_requests, 0)
+		assert_true(rejected.cleanup_ok)
+		assert_true(raw.terminated)
+		assert_eq(raw.terminate_reason, 'too_many_requests')
+		assert_eq(ran_request, false)
+	end)
+end
+
+function tests.test_request_scope_finaliser_owns_context_on_failure()
+	run_fibers.run(function (scope)
+		local done_tx, done_rx = mailbox.new(8, { full = 'reject_newest' })
+		local listener = fake_listener()
+
+		local ok, err = scope:spawn(function (s)
+			listener_mod.run(s, {
+				listener = listener,
+				done_tx = done_tx,
+				run_request = function () error('boom', 0) end,
+			})
+		end)
+		assert_true(ok, err)
+
+		local raw = make_ctx({ id = 'req-3', method = 'GET', path = '/boom' })
+		assert_true(listener:accept_now(raw))
+
+		local done = recv_kind(done_rx, 'http_request_done')
+		assert_eq(done.request_id, 'req-3')
+		assert_eq(done.status, 'failed')
+		assert_eq(done.primary, 'boom')
+		assert_true(raw.terminated)
+		assert_eq(raw.terminate_reason, 'boom')
+	end)
+end
+
+function tests.test_listener_finaliser_terminates_http_listener_handle()
+	run_fibers.run(function (scope)
+		local listener = fake_listener()
+		local owner, cerr = scope:child()
+		assert_not_nil(owner, cerr)
+		local ok, err = owner:spawn(function (s)
+			listener_mod.run(s, {
+				listener = listener,
+				run_request = function () return { status = 'ok' } end,
+			})
+		end)
+		assert_true(ok, err)
+
+		local _, wait_err = fibers.perform(listener:accept_started_op())
+		assert_eq(wait_err, nil)
+
+		owner:cancel('test_cancel')
+		fibers.perform(owner:join_op())
+		assert_true(listener:terminated())
+	end)
+end
+
+return tests

--- a/tests/unit/ui/test_http_request.lua
+++ b/tests/unit/ui/test_http_request.lua
@@ -1,0 +1,112 @@
+-- tests/unit/ui/test_http_request.lua
+
+local run_fibers = require 'tests.support.run_fibers'
+local fibers = require 'fibers'
+local channel = require 'fibers.channel'
+local request = require 'services.ui.http.request'
+local read_model = require 'services.ui.read_model'
+
+local tests = {}
+
+local function fail(msg) error(msg or 'assertion failed', 2) end
+local function assert_eq(a, b, msg) if a ~= b then fail(msg or ('expected '..tostring(b)..', got '..tostring(a))) end end
+local function assert_not_nil(v, msg) if v == nil then fail(msg or 'expected non-nil') end end
+
+local function fake_ctx(method, path)
+	return {
+		method = method,
+		path = path,
+		replies = {},
+		_current = nil,
+		write_headers_op = function(self, status, headers, opts)
+			return fibers.always(function ()
+				self._current = { status = status, body = '', headers = headers, end_stream = opts and opts.end_stream }
+				if opts and opts.end_stream then
+					self.replies[#self.replies + 1] = self._current
+					self._current = nil
+				end
+				return true, nil
+			end):wrap(function (th)
+				return th()
+			end)
+		end,
+		write_chunk_op = function(self, chunk, opts)
+			return fibers.always(function ()
+				assert(self._current, 'no response headers')
+				self._current.body = self._current.body .. tostring(chunk or '')
+				if opts and opts.end_stream then
+					self.replies[#self.replies + 1] = self._current
+					self._current = nil
+				end
+				return true, nil
+			end):wrap(function (th)
+				return th()
+			end)
+		end,
+		terminate = function(self, reason)
+			self.abandoned = reason
+			return true
+		end,
+	}
+end
+
+function tests.test_http_read_request_uses_model_and_replies_once()
+	run_fibers.run(function (scope)
+		local model = read_model.new()
+		model:set({ 'svc', 'ui', 'status' }, { state = 'running' })
+		local ctx = fake_ctx('GET', '/api/state/svc/ui/status')
+		local result = request.run(scope, ctx, { model = model })
+		assert_eq(result.status, 'ok')
+		assert_eq(#ctx.replies, 1)
+		assert_eq(ctx.replies[1].status, 200)
+		assert_not_nil(ctx.replies[1].body)
+	end)
+end
+
+
+function tests.test_http_response_writer_may_yield_inside_request_scope_without_blocking_peers()
+	run_fibers.run(function (scope)
+		local model = read_model.new()
+		model:set({ 'svc', 'ui', 'status' }, { state = 'running' })
+
+		local started_ch = channel.new()
+		local resume_ch = channel.new()
+		local events = {}
+		local ctx = fake_ctx('GET', '/api/state/svc/ui/status')
+		ctx.write_headers_op = function(self, status, headers, opts)
+			events[#events + 1] = 'reply-start'
+			started_ch:put(true)
+			return resume_ch:get_op():wrap(function (token)
+				events[#events + 1] = 'reply-finish:' .. tostring(token)
+				self._current = { status = status, body = '', headers = headers, end_stream = opts and opts.end_stream }
+				return true, nil
+			end)
+		end
+
+		fibers.spawn(function ()
+			started_ch:get()
+			events[#events + 1] = 'peer-fiber-ran'
+			resume_ch:put('resumed')
+		end)
+
+		local result = request.run(scope, ctx, { model = model })
+		assert_eq(result.status, 'ok')
+		assert_eq(#ctx.replies, 1)
+		assert_eq(ctx.replies[1].status, 200)
+		assert_eq(events[1], 'reply-start')
+		assert_eq(events[2], 'peer-fiber-ran')
+		assert_eq(events[3], 'reply-finish:resumed')
+	end)
+end
+
+function tests.test_unknown_route_replies_not_found_once()
+	run_fibers.run(function (scope)
+		local ctx = fake_ctx('GET', '/api/nope')
+		local result = request.run(scope, ctx, { model = read_model.new() })
+		assert_eq(result.status, 'not_found')
+		assert_eq(#ctx.replies, 1)
+		assert_eq(ctx.replies[1].status, 404)
+	end)
+end
+
+return tests

--- a/tests/unit/ui/test_http_response_stream.lua
+++ b/tests/unit/ui/test_http_response_stream.lua
@@ -1,0 +1,164 @@
+-- tests/unit/ui/test_http_response_stream.lua
+
+local fibers = require 'fibers'
+local response = require 'services.ui.http.response'
+
+local tests = {}
+
+local function fail(msg) error(msg or 'assertion failed', 2) end
+local function assert_eq(a, b, msg) if a ~= b then fail(msg or ('expected '..tostring(b)..', got '..tostring(a))) end end
+local function assert_nil(v, msg) if v ~= nil then fail(msg or ('expected nil, got '..tostring(v))) end end
+local function assert_true(v, msg) if v ~= true then fail(msg or ('expected true, got '..tostring(v))) end end
+local function assert_not_nil(v, msg) if v == nil then fail(msg or 'expected non-nil') end end
+
+local function ctx()
+	return {
+		calls = {},
+		write_headers_op = function(self, status, headers, opts)
+			return fibers.always(function()
+				self.calls[#self.calls + 1] = { kind = 'headers', status = status, headers = headers, end_stream = opts and opts.end_stream }
+				return true, nil
+			end):wrap(function(th) return th() end)
+		end,
+		write_chunk_op = function(self, chunk, opts)
+			return fibers.always(function()
+				self.calls[#self.calls + 1] = { kind = 'chunk', chunk = chunk, end_stream = opts and opts.end_stream }
+				return true, nil
+			end):wrap(function(th) return th() end)
+		end,
+		terminate = function(self, reason)
+			self.abandoned = reason
+			return true, nil
+		end,
+	}
+end
+
+function tests.test_stream_headers_chunks_and_end_state()
+	fibers.run(function()
+		local raw = ctx()
+		local owner = response.new(raw)
+		local ok, err = fibers.perform(owner:write_headers_op(200, { ['content-type'] = 'text/plain' }))
+		assert_true(ok, err)
+		ok, err = fibers.perform(owner:write_chunk_op('abc'))
+		assert_true(ok, err)
+		ok, err = fibers.perform(owner:end_stream_op())
+		assert_true(ok, err)
+		assert_eq(owner:state(), 'ended')
+		assert_eq(raw.calls[1].kind, 'headers')
+		assert_eq(raw.calls[2].chunk, 'abc')
+		assert_eq(raw.calls[3].end_stream, true)
+	end)
+end
+
+function tests.test_invalid_response_state_transitions_fail()
+	fibers.run(function()
+		local owner = response.new(ctx())
+		local ok, err = fibers.perform(owner:write_chunk_op('late'))
+		assert_nil(ok)
+		assert_eq(err, 'response stream is not open')
+		ok, err = fibers.perform(owner:write_headers_op(200, {}))
+		assert_true(ok, err)
+		ok, err = fibers.perform(owner:reply_op(200, 'body', {}))
+		assert_nil(ok)
+		assert_eq(err, 'response already resolved')
+	end)
+end
+
+function tests.test_reply_op_uses_streaming_transport()
+	fibers.run(function()
+		local raw = ctx()
+		local owner = response.new(raw)
+		local ok, err = fibers.perform(owner:reply_op(201, 'hello', { ['content-type'] = 'text/plain' }))
+		assert_true(ok, err)
+		assert_eq(owner:state(), 'replied')
+		assert_eq(#raw.calls, 2)
+		assert_eq(raw.calls[1].kind, 'headers')
+		assert_eq(raw.calls[1].status, 201)
+		assert_eq(raw.calls[2].kind, 'chunk')
+		assert_eq(raw.calls[2].chunk, 'hello')
+		assert_eq(raw.calls[2].end_stream, true)
+	end)
+end
+
+function tests.test_terminate_abandons_without_writing()
+	local raw = ctx()
+	local owner = response.new(raw)
+	local ok, err = owner:terminate('closed')
+	assert_true(ok, err)
+	assert_eq(raw.abandoned, 'closed')
+	assert_eq(#raw.calls, 0)
+	assert_eq(owner:state(), 'abandoned')
+end
+
+function tests.test_transport_write_failure_abandons_response()
+	fibers.run(function()
+		local raw = ctx()
+		raw.write_chunk_op = function()
+			return fibers.always(nil, 'chunk_failed')
+		end
+		local owner = response.new(raw)
+		local ok, err = fibers.perform(owner:write_headers_op(200, {}))
+		assert_true(ok, err)
+		ok, err = fibers.perform(owner:write_chunk_op('abc'))
+		assert_nil(ok)
+		assert_eq(err, 'chunk_failed')
+		assert_eq(owner:state(), 'abandoned')
+	end)
+end
+
+function tests.test_cancellation_while_streaming_chunk_abandons_response_now()
+	fibers.run(function()
+		local raw = ctx()
+		local abandoned
+		raw.terminate = function(_, reason)
+			abandoned = reason
+			return true, nil
+		end
+		raw.write_chunk_op = function()
+			return require('fibers.sleep').sleep_op(1):wrap(function () return true, nil end)
+		end
+
+		local owner = response.new(raw)
+		local ok, err = fibers.perform(owner:write_headers_op(200, {}))
+		assert_true(ok, err)
+
+		local completed = fibers.perform(fibers.boolean_choice(
+			owner:write_chunk_op('slow'),
+			require('fibers.sleep').sleep_op(0.01)
+		))
+		assert_eq(completed, false)
+		assert_eq(owner:state(), 'abandoned')
+		assert_eq(abandoned, 'response_chunk_aborted')
+	end)
+end
+
+
+function tests.test_headers_op_losing_choice_releases_start_token_and_abandons()
+	fibers.run(function()
+		local sleep = require 'fibers.sleep'
+		local raw = ctx()
+		local abandoned
+		raw.terminate = function(_, reason)
+			abandoned = reason
+			return true, nil
+		end
+		raw.write_headers_op = function()
+			return sleep.sleep_op(1):wrap(function () return true, nil end)
+		end
+
+		local owner = response.new(raw)
+		local completed = fibers.perform(fibers.boolean_choice(
+			owner:write_headers_op(200, {}),
+			sleep.sleep_op(0.01)
+		))
+		assert_eq(completed, false)
+		assert_eq(owner:state(), 'abandoned')
+		assert_eq(abandoned, 'response_headers_aborted')
+
+		local ok, err = fibers.perform(owner:write_headers_op(200, {}))
+		assert_nil(ok)
+		assert_eq(err, 'response already started')
+	end)
+end
+
+return tests

--- a/tests/unit/ui/test_read_model.lua
+++ b/tests/unit/ui/test_read_model.lua
@@ -1,0 +1,155 @@
+-- tests/unit/ui/test_read_model.lua
+
+local fibers = require 'fibers'
+local read_model = require 'services.ui.read_model'
+local store_mod = require 'services.ui.read_model_store'
+local watches_mod = require 'services.ui.read_model_watches'
+local run_fibers = require 'tests.support.run_fibers'
+
+local tests = {}
+
+local function fail(msg) error(msg or 'assertion failed', 2) end
+local function assert_eq(a, b, msg) if a ~= b then fail(msg or ('expected '..tostring(b)..', got '..tostring(a))) end end
+local function assert_nil(v, msg) if v ~= nil then fail(msg or ('expected nil, got '..tostring(v))) end end
+local function assert_not_nil(v, msg) if v == nil then fail(msg or 'expected non-nil') end end
+
+function tests.test_store_snapshot_changed_op_and_material_change()
+	run_fibers.run(function ()
+		local model = read_model.new()
+		local seen = model:version()
+
+		model:set({ 'svc', 'ui', 'status' }, { state = 'running' })
+		local version, snap, err = fibers.perform(model:changed_op(seen))
+		assert_nil(err)
+		assert_eq(version, 1)
+		assert_not_nil(snap.items)
+
+		local a, b = fibers.perform(model:changed_op(version):or_else(function ()
+			return nil, 'not_ready'
+		end))
+		assert_nil(a)
+		assert_eq(b, 'not_ready')
+
+		model:set({ 'svc', 'ui', 'status' }, { state = 'running' })
+		local c, d = fibers.perform(model:changed_op(version):or_else(function ()
+			return nil, 'not_ready'
+		end))
+		assert_nil(c)
+		assert_eq(d, 'not_ready')
+	end)
+end
+
+function tests.test_store_close_changed_op_returns_reason_shape()
+	run_fibers.run(function ()
+		local model = store_mod.new()
+		local seen = model:version()
+		model:terminate('done')
+		local version, snap, err = fibers.perform(model:changed_op(seen))
+		assert_nil(version)
+		assert_nil(snap)
+		assert_eq(err, 'done')
+	end)
+end
+
+function tests.test_watch_replay_overflow_fails_open()
+	run_fibers.run(function ()
+		local model = store_mod.new()
+		local watch_owner = watches_mod.new(model)
+		model:set({ 'state', 'a' }, 1)
+		model:set({ 'state', 'b' }, 2)
+
+		local watch, err = watch_owner:watch_open({ 'state', '#' }, { queue_len = 1, full = 'reject_newest' })
+		assert_nil(watch)
+		assert_eq(err, 'watch_replay_overflow')
+	end)
+end
+
+
+function tests.test_watch_replay_default_bound_fails_large_replay()
+	run_fibers.run(function ()
+		local model = store_mod.new()
+		local watch_owner = watches_mod.new(model)
+		for i = 1, watches_mod.DEFAULT_MAX_REPLAY + 1 do
+			model:set({ 'state', i }, i)
+		end
+
+		local watch, err = watch_owner:watch_open({ 'state', '#' }, { queue_len = 128, full = 'reject_newest' })
+		assert_nil(watch)
+		assert_eq(err, 'watch_replay_overflow')
+	end)
+end
+
+function tests.test_watch_receives_live_events_and_closes_on_overflow()
+	run_fibers.run(function ()
+		local model = store_mod.new()
+		local watch_owner = watches_mod.new(model)
+		local watch = assert(watch_owner:watch_open({ 'state', '#' }, { queue_len = 1, replay = false }))
+		watch_owner:set({ 'state', 'a' }, 1)
+		local ev = fibers.perform(watch:recv_op())
+		assert_eq(ev.op, 'set')
+		assert_eq(ev.topic[1], 'state')
+
+		watch_owner:set({ 'state', 'b' }, 2)
+		watch_owner:set({ 'state', 'c' }, 3)
+		assert_eq(watch:why(), 'watch_overflow')
+	end)
+end
+
+function tests.test_read_model_start_uses_supplied_store_and_watch_owner()
+	run_fibers.run(function (scope)
+		local store = store_mod.new()
+		local watch_owner = watches_mod.new(store)
+		local returned_store, returned_watches = read_model.start(scope, nil, {
+			model = store,
+			watch_owner = watch_owner,
+		})
+		assert_eq(returned_store, store)
+		assert_eq(returned_watches, watch_owner)
+
+		local watch = assert(watch_owner:watch_open({ 'svc', '#' }, { replay = false }))
+		watch_owner:ingest({ op = 'retain', topic = { 'svc', 'ui' }, payload = { status = 'running' } })
+		local ev = fibers.perform(watch:recv_op())
+		assert_eq(ev.op, 'set')
+		assert_eq(store:get({ 'svc', 'ui' }).payload.status, 'running')
+	end)
+end
+
+function tests.test_query_limited_stops_before_materialising_large_replay()
+	local model = store_mod.new()
+	for i = 1, 5 do model:set({ 'state', i }, i) end
+	local items, err = model:query_limited({ 'state', '#' }, 3)
+	assert_nil(items)
+	assert_eq(err, 'query_limit_exceeded')
+	items, err = model:query_limited({ 'state', '#' }, 5)
+	assert_not_nil(items, err)
+	assert_eq(#items, 5)
+end
+
+function tests.test_read_model_query_uses_first_token_index_for_replay_candidates()
+	local model = store_mod.new()
+	for i = 1, 10 do model:set({ 'state', i }, i) end
+	model:set({ 'svc', 'ui' }, 'ui')
+	model:set({ 'svc', 'fabric' }, 'fabric')
+
+	assert_eq(store_mod._test.candidate_count(model, { 'svc', '#' }), 2)
+	assert_eq(store_mod._test.candidate_count(model, { 'state', '#' }), 10)
+	assert_eq(store_mod._test.candidate_count(model, { '#'}), 12)
+
+	local items, err = model:query_limited({ 'svc', '#' }, 2)
+	assert_not_nil(items, err)
+	assert_eq(#items, 2)
+end
+
+function tests.test_read_model_index_updates_on_delete()
+	local model = store_mod.new()
+	model:set({ 'svc', 'ui' }, 'ui')
+	model:set({ 'svc', 'fabric' }, 'fabric')
+	assert_eq(store_mod._test.candidate_count(model, { 'svc', '#' }), 2)
+	model:delete({ 'svc', 'ui' })
+	assert_eq(store_mod._test.candidate_count(model, { 'svc', '#' }), 1)
+	local items = model:query({ 'svc', '#' })
+	assert_eq(#items, 1)
+	assert_eq(items[1].topic[2], 'fabric')
+end
+
+return tests

--- a/tests/unit/ui/test_service.lua
+++ b/tests/unit/ui/test_service.lua
@@ -1,0 +1,160 @@
+-- tests/unit/ui/test_service.lua
+
+local service = require 'services.ui.service'
+
+local tests = {}
+
+local function fail(msg) error(msg or 'assertion failed', 2) end
+local function assert_eq(a, b, msg) if a ~= b then fail(msg or ('expected '..tostring(b)..', got '..tostring(a))) end end
+local function assert_true(v, msg) if v ~= true then fail(msg or 'expected true') end end
+
+local function base_state()
+	return {
+		components = {
+			read_model = { status = 'running' },
+			http_listener = { status = 'running' },
+		},
+		service_status = 'running',
+		read_model_status = 'running',
+		listener_status = 'running',
+	}
+end
+
+function tests.test_records_component_completion_before_policy()
+	local state = base_state()
+	local decision = service._test.reduce_event(state, {
+		kind = 'ui_component_done',
+		component = 'read_model',
+		status = 'ok',
+		result = { status = 'stopped' },
+	})
+	assert_true(decision.publish)
+	assert_eq(state.components.read_model.status, 'ok')
+	assert_eq(state.read_model_status, 'ok')
+end
+
+function tests.test_read_model_failure_marks_service_failed()
+	local state = base_state()
+	local decision = service._test.reduce_event(state, {
+		kind = 'ui_component_done',
+		component = 'read_model',
+		status = 'failed',
+		primary = 'boom',
+	})
+	assert_true(decision.publish)
+	assert_eq(decision.fail, 'read_model failed: boom')
+	assert_eq(state.service_status, 'failed')
+	assert_eq(state.last_error, 'read_model failed: boom')
+	assert_eq(state.components.read_model.status, 'failed')
+end
+
+function tests.test_http_listener_failure_marks_service_failed()
+	local state = base_state()
+	local decision = service._test.reduce_event(state, {
+		kind = 'ui_component_done',
+		component = 'http_listener',
+		status = 'failed',
+		primary = 'listen failed',
+	})
+	assert_eq(decision.fail, 'http_listener failed: listen failed')
+	assert_eq(state.service_status, 'failed')
+	assert_eq(state.listener_status, 'failed')
+end
+
+function tests.test_stale_component_completion_is_ignored()
+	local state = base_state()
+	service._test.reduce_event(state, {
+		kind = 'ui_component_done',
+		component = 'read_model',
+		status = 'ok',
+		result = { status = 'stopped' },
+	})
+	local decision = service._test.reduce_event(state, {
+		kind = 'ui_component_done',
+		component = 'read_model',
+		status = 'failed',
+		primary = 'late',
+	})
+	assert_eq(next(decision), nil)
+	assert_eq(state.components.read_model.status, 'ok')
+end
+
+
+
+function tests.test_publish_summary_fails_on_retain_failure()
+	local state = base_state()
+	state.conn = {
+		retain = function () return nil, 'retain_failed' end,
+	}
+	state.sessions = { count = function () return 0 end }
+	state.active_requests = 0
+	state.rejected_requests = 0
+
+	local ok, err = pcall(function ()
+		service._test.publish_summary(state)
+	end)
+
+	if ok then fail('expected publish_summary to fail') end
+	if not tostring(err):find('retain_failed', 1, true) then
+		fail('expected retain failure, got ' .. tostring(err))
+	end
+end
+
+function tests.test_session_events_are_first_class_service_events()
+	local state = base_state()
+	local decision = service._test.reduce_event(state, {
+		kind = 'session_created',
+		session_id = 's1',
+		count = 1,
+	})
+	assert_true(decision.publish)
+	assert_eq(state.last_session_event.kind, 'session_created')
+	assert_eq(state.last_session_event.session_id, 's1')
+
+	decision = service._test.reduce_event(state, {
+		kind = 'session_pruned',
+		session_ids = { 's1' },
+		count = 0,
+	})
+	assert_true(decision.publish)
+	assert_eq(state.last_session_event.kind, 'session_pruned')
+end
+
+
+
+function tests.test_stale_http_listener_request_events_are_ignored()
+	local state = base_state()
+	state.listener_generation = 3
+	state.active_requests = 0
+	state.rejected_requests = 0
+
+	local decision = service._test.reduce_event(state, {
+		kind = 'http_request_started',
+		generation = 2,
+		listener_id = 'http_listener:2',
+		request_id = 'old',
+		active_requests = 1,
+	})
+	assert_eq(next(decision), nil)
+	assert_eq(state.active_requests, 0)
+
+	decision = service._test.reduce_event(state, {
+		kind = 'http_request_started',
+		generation = 3,
+		listener_id = 'http_listener:3',
+		request_id = 'new',
+		active_requests = 1,
+	})
+	assert_true(decision.publish)
+	assert_eq(state.active_requests, 1)
+end
+
+function tests.test_cleanup_error_recording_is_explicit_and_non_throwing()
+	local state = base_state()
+	local rec = service._test.record_cleanup_error(state, 'ui_summary_unretain_failed', 'unretain_failed')
+	assert_eq(rec.kind, 'ui_summary_unretain_failed')
+	assert_eq(rec.err, 'unretain_failed')
+	assert_eq(state.last_cleanup_error, rec)
+end
+
+return tests

--- a/tests/unit/ui/test_sessions.lua
+++ b/tests/unit/ui/test_sessions.lua
@@ -1,0 +1,128 @@
+-- tests/unit/ui/test_sessions.lua
+
+local sessions = require 'services.ui.sessions'
+
+local tests = {}
+
+local function fail(msg) error(msg or 'assertion failed', 2) end
+local function assert_eq(a, b, msg) if a ~= b then fail(msg or ('expected '..tostring(b)..', got '..tostring(a))) end end
+local function assert_true(v, msg) if v ~= true then fail(msg or 'expected true') end end
+local function assert_nil(v, msg) if v ~= nil then fail(msg or ('expected nil, got '..tostring(v))) end end
+local function assert_not_nil(v, msg) if v == nil then fail(msg or 'expected non-nil') end end
+
+function tests.test_create_touch_delete_and_prune_are_immediate()
+	local now = 100
+	local store = sessions.new({ now = function() return now end, default_ttl = 10 })
+
+	local s = store:create('alice', { id = 's1', data = { role = 'admin' } })
+	assert_eq(s.id, 's1')
+	assert_eq(s.principal, 'alice')
+	assert_eq(store:count(), 1)
+
+	now = 105
+	local touched, err = store:touch('s1', { ttl = 20 })
+	assert_not_nil(touched, err)
+	assert_eq(touched.expires_at, 125)
+
+	assert_true(store:delete('s1'))
+	assert_nil(store:get('s1'))
+
+	store:create('bob', { id = 's2', ttl = 1 })
+	store:create('carol', { id = 's3', ttl = 100 })
+	now = 107
+	local removed = store:prune()
+	assert_eq(#removed, 1)
+	assert_eq(removed[1], 's2')
+	assert_eq(store:count(), 1)
+end
+
+function tests.test_session_mutations_record_first_class_last_event()
+	local now = 100
+	local store = sessions.new({
+		now = function() return now end,
+		default_ttl = 10,
+	})
+
+	store:create('alice', { id = 's1' })
+	assert_eq(store:last_event().kind, 'session_created')
+	assert_eq(store:last_event().session_id, 's1')
+	assert_eq(store:last_event().count, 1)
+
+	store:touch('s1')
+	assert_eq(store:last_event().kind, 'session_touched')
+
+	store:delete('s1')
+	assert_eq(store:last_event().kind, 'session_deleted')
+	assert_eq(store:last_event().count, 0)
+
+	store:create('bob', { id = 's2', ttl = 1 })
+	assert_eq(store:last_event().kind, 'session_created')
+
+	now = 102
+	store:prune()
+	assert_eq(store:last_event().kind, 'session_pruned')
+	assert_eq(store:last_event().session_ids[1], 's2')
+	assert_eq(store:last_event().count, 0)
+end
+
+function tests.test_expired_session_get_is_pure_and_prune_records_event()
+	local now = 100
+	local store = sessions.new({
+		now = function() return now end,
+	})
+	store:create('alice', { id = 's1', ttl = 1 })
+	local created = store:last_event()
+	assert_eq(created.kind, 'session_created')
+	now = 102
+	assert_nil(store:get('s1'))
+	assert_eq(store:last_event().kind, 'session_created')
+	assert_eq(store:count(), 0)
+	local removed = store:prune()
+	assert_eq(removed[1], 's1')
+	assert_eq(store:last_event().kind, 'session_pruned')
+	assert_eq(store:last_event().session_ids[1], 's1')
+	assert_eq(store:last_event().count, 0)
+end
+
+
+function tests.test_session_mutations_signal_versioned_changed_op()
+	local fibers = require 'fibers'
+	fibers.run(function()
+		local now = 100
+		local store = sessions.new({ now = function() return now end, default_ttl = 10 })
+		local seen = store:version()
+
+		store:create('alice', { id = 's1' })
+		local version, snap, err = fibers.perform(store:changed_op(seen))
+		assert_nil(err)
+		assert_eq(version, 1)
+		assert_eq(snap.count, 1)
+		assert_eq(snap.last_event.kind, 'session_created')
+		assert_eq(snap.last_event.session_id, 's1')
+
+		local v2, _, e2 = fibers.perform(store:changed_op(version):or_else(function()
+			return nil, nil, 'not_ready'
+		end))
+		assert_nil(v2)
+		assert_eq(e2, 'not_ready')
+	end)
+end
+
+function tests.test_session_store_ignores_legacy_event_sink_options()
+	local now = 100
+	local called = false
+	local store = sessions.new({
+		now = function() return now end,
+		on_event = function() called = true end,
+		event_sink = function() called = true end,
+	})
+
+	local sess = store:create('alice', { id = 's1' })
+	assert_eq(sess.id, 's1')
+	assert_eq(store:count(), 1)
+	assert_eq(store:version(), 1)
+	assert_eq(called, false)
+	assert_eq(store:last_event().kind, 'session_created')
+end
+
+return tests

--- a/tests/unit/ui/test_supervision.lua
+++ b/tests/unit/ui/test_supervision.lua
@@ -1,0 +1,42 @@
+-- tests/unit/ui/test_supervision.lua
+
+local supervision = require 'services.ui.supervision'
+
+local tests = {}
+
+local function fail(msg) error(msg or 'assertion failed', 2) end
+local function assert_eq(a, b, msg) if a ~= b then fail(msg or ('expected '..tostring(b)..', got '..tostring(a))) end end
+
+function tests.test_service_core_component_ok_continues()
+	local d = supervision.classify_service_component_done({}, {
+		component = 'http_listener',
+		status = 'ok',
+		result = { status = 'stopped' },
+	})
+	assert_eq(d.class, 'normal_close')
+	assert_eq(d.action, 'continue')
+end
+
+function tests.test_service_core_component_failure_fails_service()
+	local d = supervision.classify_service_component_done({}, {
+		component = 'read_model',
+		status = 'failed',
+		primary = 'boom',
+	})
+	assert_eq(d.class, 'failed')
+	assert_eq(d.action, 'fail_service')
+	assert_eq(d.reason, 'read_model failed: boom')
+end
+
+function tests.test_service_core_component_cancellation_fails_service()
+	local d = supervision.classify_service_component_done({}, {
+		component = 'http_listener',
+		status = 'cancelled',
+		primary = 'lost',
+	})
+	assert_eq(d.class, 'cancelled_unexpected')
+	assert_eq(d.action, 'fail_service')
+	assert_eq(d.reason, 'http_listener cancelled unexpectedly: lost')
+end
+
+return tests

--- a/tests/unit/ui/test_update_upload.lua
+++ b/tests/unit/ui/test_update_upload.lua
@@ -1,0 +1,212 @@
+-- tests/unit/ui/test_update_upload.lua
+
+local fibers = require 'fibers'
+local sleep = require 'fibers.sleep'
+local upload = require 'services.ui.update.upload'
+
+local tests = {}
+
+local function fail(msg) error(msg or 'assertion failed', 2) end
+local function assert_eq(a, b, msg) if a ~= b then fail(msg or ('expected '..tostring(b)..', got '..tostring(a))) end end
+local function assert_nil(v, msg) if v ~= nil then fail(msg or ('expected nil, got '..tostring(v))) end end
+local function assert_not_nil(v, msg) if v == nil then fail(msg or 'expected non-nil') end end
+
+local function body_from_chunks(chunks)
+	return {
+		_chunks = chunks,
+		read_chunk_op = function (self)
+			local chunk = table.remove(self._chunks, 1)
+			return fibers.always(chunk, nil)
+		end,
+	}
+end
+
+local function ingest_client(handle)
+	return {
+		open_ingest_op = function ()
+			return fibers.always(handle, nil)
+		end,
+	}
+end
+
+function tests.test_upload_abort_finaliser_runs_when_append_fails()
+	fibers.run(function ()
+		local handle = {
+			aborted = nil,
+			append_chunk_op = function () return fibers.always(nil, 'append_failed') end,
+			commit_op = function () error('commit must not be called') end,
+			abort_now = function (self, reason) self.aborted = reason; return true end,
+		}
+
+		local st, _, primary = fibers.perform(upload.run_op({
+			body_stream = body_from_chunks({ 'abc' }),
+		}, {
+			ingest = ingest_client(handle),
+		}))
+
+		assert_eq(st, 'failed')
+		assert_eq(primary, 'append_failed')
+		assert_eq(handle.aborted, 'append_failed')
+	end)
+end
+
+function tests.test_committed_artifact_is_not_aborted_when_update_job_create_fails()
+	fibers.run(function ()
+		local handle = {
+			aborted = nil,
+			chunks = {},
+			append_chunk_op = function (self, chunk) self.chunks[#self.chunks + 1] = chunk; return fibers.always(true, nil) end,
+			commit_op = function () return fibers.always('artifact-1', nil) end,
+			abort_now = function (self, reason) self.aborted = reason; return true end,
+		}
+		local conn = {
+			call_op = function () return fibers.always(nil, 'create_failed') end,
+		}
+
+		local st, _, primary = fibers.perform(upload.run_op({
+			body_stream = body_from_chunks({ 'abc' }),
+		}, {
+			ingest = ingest_client(handle),
+			create_job = true,
+			conn = conn,
+		}))
+
+		assert_eq(st, 'failed')
+		assert_eq(primary, 'create_failed')
+		assert_nil(handle.aborted)
+		assert_eq(handle.chunks[1], 'abc')
+	end)
+end
+
+function tests.test_upload_disconnects_owned_update_connection_after_success()
+	fibers.run(function ()
+		local handle = {
+			append_chunk_op = function () return fibers.always(true, nil) end,
+			commit_op = function () return fibers.always('artifact-2', nil) end,
+			abort_now = function () error('abort must not be called after commit') end,
+		}
+		local disconnected = false
+		local conn = {
+			call_op = function (_, topic)
+				if topic[4] == 'create' then return fibers.always({ job_id = 'job-1' }, nil) end
+				return fibers.always({ started = true }, nil)
+			end,
+			disconnect = function () disconnected = true; return true end,
+		}
+
+		local st, _, result = fibers.perform(upload.run_op({
+			body_stream = body_from_chunks({ 'abc' }),
+		}, {
+			ingest = ingest_client(handle),
+			create_job = true,
+			start_job = true,
+			connect = function () return conn, nil end,
+		}))
+
+		assert_eq(st, 'ok')
+		assert_eq(result.artifact_id, 'artifact-2')
+		assert_not_nil(result.job)
+		assert_not_nil(result.started)
+		assert_eq(disconnected, true)
+	end)
+end
+
+
+function tests.test_upload_timeout_cancels_scope_and_aborts_uncommitted_ingest()
+	fibers.run(function ()
+		local handle = {
+			aborted = nil,
+			append_chunk_op = function () return fibers.always(true, nil) end,
+			commit_op = function () return fibers.always('artifact-timeout', nil) end,
+			abort_now = function (self, reason) self.aborted = reason; return true end,
+		}
+		local body = {
+			read_chunk_op = function ()
+				return sleep.sleep_op(1):wrap(function () return 'late', nil end)
+			end,
+		}
+
+		local st, _, primary = fibers.perform(upload.run_op({
+			body_stream = body,
+		}, {
+			ingest = ingest_client(handle),
+			upload_timeout = 0.01,
+		}))
+
+		assert_eq(st, 'cancelled')
+		assert_eq(primary, 'timeout')
+		assert_eq(handle.aborted, 'timeout')
+	end)
+end
+
+
+function tests.test_upload_requires_read_chunk_op_body_contract()
+	fibers.run(function ()
+		local handle = {
+			append_chunk_op = function () error('append must not be called') end,
+			commit_op = function () error('commit must not be called') end,
+			abort_now = function (self, reason) self.aborted = reason; return true end,
+		}
+
+		local st, _, primary = fibers.perform(upload.run_op({
+			body_stream = { read_op = function () error('compat path must not be used') end },
+		}, {
+			ingest = ingest_client(handle),
+		}))
+
+		assert_eq(st, 'failed')
+		assert_eq(primary, 'request body has no read_chunk_op')
+		assert_eq(handle.aborted, 'request body has no read_chunk_op')
+	end)
+end
+
+function tests.test_artifact_ingest_boundary_requires_op_methods_and_abort_now()
+	local ingest = require 'services.ui.update.artifact_ingest'
+	fibers.run(function ()
+		local handle, err = fibers.perform(ingest.open_ingest_op({ open_ingest = function () return {} end }, {}))
+		assert_nil(handle)
+		assert_eq(err, 'artifact ingest client must expose open_ingest_op')
+
+		local ok, aerr = fibers.perform(ingest.append_chunk_op({ append = function () return true end }, 'abc'))
+		assert_nil(ok)
+		assert_eq(aerr, 'artifact ingest handle must expose append_chunk_op')
+
+		local artifact, cerr = fibers.perform(ingest.commit_op({ commit = function () return 'artifact' end }))
+		assert_nil(artifact)
+		assert_eq(cerr, 'artifact ingest handle must expose commit_op')
+	end)
+
+	local ok, err = ingest.abort_now({ abort = function () return true end }, 'closed')
+	assert_nil(ok)
+	assert_eq(err, 'artifact ingest handle must expose immediate abort_now')
+
+	ok, err = ingest.abort_now({ abort_now = function () return fibers.always(true, nil) end }, 'closed')
+	assert_nil(ok)
+	assert_eq(err, 'artifact ingest abort_now must be immediate and must not return an Op')
+end
+
+function tests.test_upload_timeout_while_append_pending_aborts_uncommitted_ingest()
+	fibers.run(function ()
+		local handle = {
+			aborted = nil,
+			append_chunk_op = function ()
+				return sleep.sleep_op(1):wrap(function () return true, nil end)
+			end,
+			commit_op = function () error('commit must not be called') end,
+			abort_now = function (self, reason) self.aborted = reason; return true end,
+		}
+
+		local st, _, primary = fibers.perform(upload.run_op({
+			body_stream = body_from_chunks({ 'abc' }),
+		}, {
+			ingest = ingest_client(handle),
+			upload_timeout = 0.01,
+		}))
+
+		assert_eq(st, 'cancelled')
+		assert_eq(primary, 'timeout')
+		assert_eq(handle.aborted, 'timeout')
+	end)
+end
+
+return tests

--- a/tests/unit/ui/test_user_operation.lua
+++ b/tests/unit/ui/test_user_operation.lua
@@ -1,0 +1,65 @@
+-- tests/unit/ui/test_user_operation.lua
+
+local fibers = require 'fibers'
+local sleep = require 'fibers.sleep'
+local user_operation = require 'services.ui.user_operation'
+
+local tests = {}
+
+local function fail(msg) error(msg or 'assertion failed', 2) end
+local function assert_eq(a, b, msg) if a ~= b then fail(msg or ('expected '..tostring(b)..', got '..tostring(a))) end end
+local function assert_nil(v, msg) if v ~= nil then fail(msg or ('expected nil, got '..tostring(v))) end end
+local function assert_not_nil(v, msg) if v == nil then fail(msg or 'expected non-nil') end end
+
+function tests.test_user_operation_success_disconnects_owned_connection()
+	fibers.run(function ()
+		local disconnected = false
+		local conn = { disconnect = function () disconnected = true; return true end }
+		local result, err = user_operation.run {
+			principal = 'alice',
+			connect = function () return conn, nil end,
+			run = function (_, c)
+				assert_eq(c, conn)
+				return { ok = true }
+			end,
+		}
+		assert_not_nil(result, err)
+		assert_eq(result.ok, true)
+		assert_eq(disconnected, true)
+	end)
+end
+
+function tests.test_user_operation_timeout_returns_cancelled_shape_and_disconnects()
+	fibers.run(function ()
+		local disconnected = false
+		local conn = { disconnect = function () disconnected = true; return true end }
+		local result, err, rep = user_operation.run {
+			principal = 'alice',
+			connect = function () return conn, nil end,
+			timeout = 0.01,
+			run = function ()
+				fibers.perform(sleep.sleep_op(1))
+				return { late = true }
+			end,
+		}
+		assert_nil(result)
+		assert_eq(err, 'timeout')
+		assert_not_nil(rep)
+		assert_eq(disconnected, true)
+	end)
+end
+
+function tests.test_user_operation_borrowed_connection_is_not_disconnected_by_default()
+	fibers.run(function ()
+		local disconnected = false
+		local conn = { disconnect = function () disconnected = true; return true end }
+		local result, err = user_operation.run {
+			conn = conn,
+			run = function () return { ok = true } end,
+		}
+		assert_not_nil(result, err)
+		assert_eq(disconnected, false)
+	end)
+end
+
+return tests


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] 🍕 Feature
- [x] 📝 Documentation Update
- [x] 🧑‍💻 Code Refactor
- [x] ✅ Test

## Description

This PR implements **ui**, which provides the local operator-facing application layer. It consumes the HTTP capability service, owns UI sessions, read-model projection, request handling, upload orchestration and user-facing routes, while delegating update and ingest workflows to their canonical public manager capabilities. This service is described in `/docs/specs/ui.md`, which should be read in conjunction with `docs/service-architecture.md`.

Changes include:

  - Adds UI design documentation:
    - `docs/specs/ui.md`
    - `services/ui/architecture.md`
  - Adds the public `services.ui` entrypoint.
  - Adds UI service components for:
    - configuration normalisation
    - service shell and component supervision
    - authentication and session handling
    - user operation ownership
    - read-model store, queries and watches
    - HTTP listener integration through the HTTP capability service
    - request routing
    - streamed HTTP responses
    - static file serving
    - server-sent events
    - Update artifact ingest client
    - Update manager client
    - upload orchestration
  - Keeps UI transport-free: UI uses the HTTP service SDK and does not own raw `cqueues` or `lua-http` transport objects.
  - Routes Update upload flows through canonical public capabilities:
    - `cap/artifact-ingest/main/rpc/...`
    - `cap/update-manager/main/rpc/...`
  - Adds devhost integration coverage for Update public seams and UI upload through those canonical capabilities.
  - Adds unit coverage for:
    - UI config normalisation
    - HTTP listener ownership and request-scope handoff
    - HTTP request routing
    - streamed response state transitions and cancellation
    - read-model store, replay and watch behaviour
    - service supervision and component completion policy
    - session lifecycle
    - Update upload success, timeout and failure paths
    - user operation ownership and timeout handling
    - static architecture rules, including no transport ownership and Op-first boundaries
  - Updates the test runner to include UI unit and integration coverage.

## Related Issues, Tickets & Documents

Depends on #222 

Relevant design context:

  - Disciplined `fibers` service guide
  - Canonical bus naming and capability namespace guide
  - UI specification added in this PR
  - UI architecture note added in this PR

## Screenshots/Recordings

Not applicable. This PR has no visual changes.

## Manual test
- [x] 👍 yes

## Manual test description

Ran the Lua test suite locally:

```sh
cd tests
lua run.lua
````

Result:

```text
695 tests, 0 failed, 0 skipped
```

## Added tests?

* [x] 👍 yes

## Added to documentation?

* [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?

No deployment task is required for this PR.

Follow-up work should add broader end-to-end tests for full UI-over-HTTP flows against the real HTTP service, including authenticated read-model queries, SSE watch behaviour and upload cancellation through a real HTTP request body.
