### PR TITLE
http: adds http service + tests

### DIFF
--- a/docs/specs/http.md
+++ b/docs/specs/http.md
@@ -1,0 +1,115 @@
+# HTTP service guide
+
+## Purpose
+
+HTTP owns the transport boundary for HTTP and WebSocket work.
+
+It is responsible for:
+
+```text
+cqueues/lua-http integration
+HTTP listener creation
+HTTP client exchange
+server-side accepted contexts
+WebSocket transport handles
+request/response command loops
+immediate transport termination
+HTTP capability publication
+transport observability
+```
+
+HTTP is an infrastructure service. UI and other services consume it through public HTTP capability handles.
+
+## Lifetime shape
+
+```mermaid
+flowchart TD
+  HttpScope["http service scope"] --> Coordinator["coordinator"]
+  HttpScope --> Registry["handle registry"]
+  HttpScope --> Backend["transport driver scope"]
+  HttpScope --> Publisher["cap/http publisher"]
+
+  Coordinator --> Listener["listener scopes"]
+  Coordinator --> Exchange["client exchange scopes"]
+  Coordinator --> WS["websocket scopes"]
+
+  Listener --> Context["accepted HttpContext handles"]
+  Context --> Consumer["consumer request scope"]
+  Exchange --> Backend
+  WS --> Backend
+
+  Publisher --> Cap["cap/http/main/..."]
+  Publisher --> Stats["cap/http/main/state/stats"]
+  Publisher --> Obs["obs/v1/http/metric/main/stats"]
+```
+
+Callbacks from transport code must not mutate service model state directly. They may update backend-local state and wake an Op-facing boundary.
+
+## Public surfaces
+
+HTTP should publish:
+
+```text
+svc/http/status
+svc/http/meta
+cfg/http
+
+cap/http/main/meta
+cap/http/main/status
+cap/http/main/rpc/listen
+cap/http/main/rpc/open-exchange
+cap/http/main/rpc/connect-ws
+cap/http/main/state/stats
+
+obs/v1/http/metric/main/stats
+```
+
+`cap/http/main/state/stats` is a narrow interface-scoped adjunct. Canonical domain state should not be hidden there.
+
+## Consumption pattern
+
+A consumer should use the SDK:
+
+```lua
+local http = require('services.http').sdk
+local ref = http.new_ref(conn, 'main')
+
+local reply = fibers.perform(ref:listen_op({
+  host = '127.0.0.1',
+  port = 8080,
+}))
+
+local listener = reply.listener
+```
+
+The consumer owns accepted contexts after handoff. HTTP owns unaccepted contexts and transport handles until ownership transfer.
+
+## Op-only boundary
+
+Transport operations should be Op-first:
+
+```text
+construct Op
+admit command to driver
+run backend step
+return public wrapper or result
+terminate immediately on losing choice/cancellation
+```
+
+Transport wrappers must provide `terminate(reason)`.
+
+Graceful protocol closure belongs in `close_op()` and only in request/worker scopes that may wait.
+
+## Reviewer checklist
+
+```text
+Only transport modules require cqueues or lua-http.
+Service code does not use perform_raw.
+Public methods use kebab-case.
+Returned handles are public wrappers, not backend objects.
+Callbacks do not reduce service state directly.
+Accepted context ownership transfer is explicit.
+Losing HTTP/WebSocket Ops terminate active backend work.
+Stats under cap/.../state are narrow.
+Metrics also appear under obs/v1/http/...
+```

--- a/src/services/http.lua
+++ b/src/services/http.lua
@@ -1,0 +1,19 @@
+-- services/http.lua
+-- Public entry point for the HTTP capability service.
+
+local service = require 'services.http.service'
+
+return {
+	start = service.start,
+	service = service,
+	sdk = require 'services.http.sdk',
+	headers = require 'services.http.headers',
+	config = require 'services.http.config',
+	policy = require 'services.http.policy',
+	client = require 'services.http.client',
+	listener = require 'services.http.listener',
+	context = require 'services.http.context',
+	websocket = require 'services.http.websocket',
+	body = require 'services.http.body',
+	topics = require 'services.http.topics',
+}

--- a/src/services/http/backend.lua
+++ b/src/services/http/backend.lua
@@ -1,0 +1,119 @@
+-- services/http/backend.lua
+-- Named backend component owner for the HTTP service.
+--
+-- The real backend pump is long-running service work with its own identity and
+-- completion.  It is represented through devicecode.support.scoped_work so that
+-- backend failure/termination is reported as ordinary data to the HTTP
+-- coordinator.  The small start()-only path is retained only for simple unit
+-- fakes that have no pump to reap; production drivers should expose run() and
+-- terminate().
+
+local scoped_work = require 'devicecode.support.scoped_work'
+
+local M = {}
+
+local function copy(t)
+	local out = {}
+	for k, v in pairs(t or {}) do out[k] = v end
+	return out
+end
+
+function M.start(spec)
+	if type(spec) ~= 'table' then return nil, 'invalid_args' end
+	local lifetime_scope = spec.lifetime_scope
+	local driver = spec.driver
+	local events_port = spec.events_port
+	if events_port ~= nil and (type(events_port) ~= 'table' or type(events_port.emit_required) ~= 'function') then
+		return nil, 'events_port_required'
+	end
+	local function emit(ev, label)
+		if not events_port then return true, nil end
+		return events_port:emit_required(ev, label or 'http_backend_event_report_failed')
+	end
+	if not lifetime_scope or type(lifetime_scope.spawn) ~= 'function' then return nil, 'lifetime_scope_required' end
+	if not driver then return nil, 'driver_required' end
+
+	local identity = copy(spec.identity or {})
+	identity.kind = identity.kind or 'backend_done'
+	identity.component = identity.component or 'backend'
+	identity.component_id = identity.component_id or 'http_backend'
+	identity.generation = identity.generation or spec.generation or 1
+
+	local component = {
+		driver = driver,
+		scope = nil,
+		closed = false,
+		_work = nil,
+		_identity = identity,
+	}
+
+	function component:terminate(reason)
+		local why = reason or 'backend_terminated'
+		if self.closed then return true end
+		self.closed = true
+		if self._work and type(self._work.cancel) == 'function' then self._work:cancel(why) end
+		if self.scope and type(self.scope.cancel) == 'function' then self.scope:cancel(why) end
+		if driver and type(driver.terminate) == 'function' then driver:terminate(why) end
+		return true
+	end
+
+	function component:identity()
+		return copy(self._identity)
+	end
+
+	function component:outcome_op()
+		if self._work and type(self._work.outcome_op) == 'function' then return self._work:outcome_op() end
+		return nil, 'backend_has_no_outcome_op'
+	end
+
+	function component:outcome()
+		if self._work and type(self._work.outcome) == 'function' then return self._work:outcome() end
+		return nil
+	end
+
+	-- Preferred path: the backend pump is named scoped work.  The worker owns the
+	-- driver pump and installs immediate termination as its finaliser.  The
+	-- coordinator observes the stored completion through a reporter event.
+	if type(driver.run) == 'function' then
+		local handle, err = scoped_work.start({
+			lifetime_scope = lifetime_scope,
+			reaper_scope = lifetime_scope,
+			report_scope = lifetime_scope,
+			identity = identity,
+			run = function (scope)
+				component.scope = scope
+				scope:finally(function (_, status, primary)
+					if type(driver.terminate) == 'function' then
+						driver:terminate(primary or status or 'backend_scope_finalised')
+					end
+				end)
+
+				local ok, run_err = driver:run()
+				if ok == nil or ok == false then error(run_err or 'backend_failed', 0) end
+				return { reason = 'backend_run_returned' }
+			end,
+			report = function (ev)
+				return emit(ev, 'http_backend_done_report_failed')
+			end,
+		})
+		if not handle then return nil, err or 'backend_start_failed' end
+		component._work = handle
+		emit({ kind = 'backend_ready', component = 'backend', component_id = identity.component_id, generation = identity.generation }, 'http_backend_ready_report_failed')
+		return component, nil
+	end
+
+	-- Compatibility path for simple unit fakes.  There is no pump, and therefore
+	-- no meaningful backend completion to reap.  This is deliberately not the
+	-- production backend shape; it exists so isolated service tests can supply a
+	-- small object with start()/terminate().
+	if type(driver.start) == 'function' then
+		local ok, err = driver:start(lifetime_scope)
+		if ok ~= true then return nil, err or 'backend_start_failed' end
+		emit({ kind = 'backend_ready', component = 'backend', component_id = identity.component_id, generation = identity.generation }, 'http_backend_ready_report_failed')
+		return component, nil
+	end
+
+	return nil, 'backend_driver_has_no_run_or_start'
+end
+
+return M

--- a/src/services/http/body.lua
+++ b/src/services/http/body.lua
@@ -1,0 +1,201 @@
+-- services/http/body.lua
+-- Descriptor validation and service-owned source/sink lease registries. Bytes do
+-- not travel over the bus; descriptors are resolved to local leases inside
+-- operation scopes.
+
+local fibers = require 'fibers'
+local op     = require 'fibers.op'
+
+local M = {}
+local Registry = {}
+Registry.__index = Registry
+
+local function copy(t)
+	local out = {}
+	for k, v in pairs(t or {}) do out[k] = v end
+	return out
+end
+
+local function is_descriptor(desc)
+	return type(desc) == 'table' and type(desc.kind) == 'string' and desc.kind ~= ''
+end
+
+function M.validate_descriptor(desc, direction)
+	if desc == nil then return nil, nil end
+	if type(desc) ~= 'table' then return nil, 'invalid_args' end
+	if type(desc.kind) ~= 'string' or desc.kind == '' then return nil, 'invalid_args' end
+	-- Keep raw bytes, hidden iterators and handles off the bus/control plane.
+	if desc.data ~= nil or desc.chunk ~= nil or desc.chunks ~= nil or desc.body ~= nil then return nil, 'invalid_args' end
+	if desc.handle ~= nil or desc.object ~= nil or desc.iterator ~= nil or desc.file ~= nil then return nil, 'invalid_args' end
+	if desc.bytes ~= nil and (type(desc.bytes) ~= 'number' or desc.bytes < 0) then return nil, 'invalid_args' end
+	if desc.direction ~= nil and direction ~= nil and desc.direction ~= direction then return nil, 'invalid_args' end
+	local out = copy(desc)
+	out.direction = direction or out.direction
+	return out, nil
+end
+
+function M.validate_exchange_descriptors(args)
+	args = args or {}
+	if args.body ~= nil or args.body_chunks ~= nil or args.response_body ~= nil or args.body_string ~= nil then
+		return nil, 'invalid_args'
+	end
+	local source, serr = M.validate_descriptor(args.body_source or args.source, 'source')
+	if serr then return nil, serr end
+	local sink, skerr = M.validate_descriptor(args.response_sink or args.sink, 'sink')
+	if skerr then return nil, skerr end
+	return { source = source, sink = sink }, nil
+end
+
+local function normalise_resolver_result(value, err)
+	if value == nil then return nil, err or 'invalid_args' end
+	if type(value) ~= 'table' then return nil, 'invalid_args' end
+	return value, nil
+end
+
+function M.new_registry(opts)
+	opts = opts or {}
+	local self = setmetatable({ _resolvers = {} }, Registry)
+	for kind, resolver in pairs(opts.resolvers or opts or {}) do
+		if type(kind) == 'string' and type(resolver) == 'function' then
+			self:register_resolver(kind, resolver)
+		end
+	end
+	return self
+end
+
+function Registry:register_resolver(kind, resolver)
+	if type(kind) ~= 'string' or kind == '' then return nil, 'invalid_args' end
+	if type(resolver) ~= 'function' then return nil, 'invalid_args' end
+	self._resolvers[kind] = resolver
+	return true
+end
+
+function Registry:resolve_op(desc, ctx)
+	return op.guard(function ()
+		if desc == nil then return op.always(nil, nil) end
+		local checked, err = M.validate_descriptor(desc, ctx and ctx.direction)
+		if not checked then return op.always(nil, err) end
+
+		local resolver = self._resolvers[checked.kind]
+		if not resolver then return op.always(nil, 'invalid_args') end
+
+		local ok, result, rerr = pcall(function ()
+			return resolver(checked, ctx or {})
+		end)
+		if not ok then
+			return op.always(nil, 'invalid_args')
+		end
+
+		if type(result) == 'table' and type(result.wrap) == 'function' then
+			return result:wrap(normalise_resolver_result)
+		end
+
+		return op.always(normalise_resolver_result(result, rerr))
+	end)
+end
+
+local default_registry = M.new_registry()
+
+-- Compatibility only for direct unit construction. Services should use their
+-- own registry instance so authority and provider state are service-owned.
+function M.register_resolver(kind, resolver) return default_registry:register_resolver(kind, resolver) end
+function M.clear_resolvers_for_test() default_registry = M.new_registry(); return true end
+function M.resolve_op(desc, ctx) return default_registry:resolve_op(desc, ctx) end
+
+local function terminate(obj, reason)
+	if obj and type(obj.terminate) == 'function' then return obj:terminate(reason) end
+	return true
+end
+
+function M.terminate(obj, reason)
+	return terminate(obj, reason)
+end
+
+local function unwrap_scope_result(scope_op)
+	return scope_op:wrap(function (st, _rep, result_or_primary, err)
+		if st == 'ok' then
+			if result_or_primary == nil and err ~= nil then return nil, err end
+			return result_or_primary, nil
+		end
+		return nil, result_or_primary or st
+	end)
+end
+
+function M.copy_response_to_sink_op(response, sink, opts)
+	opts = opts or {}
+	return unwrap_scope_result(fibers.run_scope_op(function ()
+		local max_chunk = opts.max_chunk or 65536
+		local limit = opts.max_bytes or math.huge
+		local copied = 0
+		while true do
+			local chunk, err = fibers.perform(response:read_chunk_op(max_chunk))
+			if chunk == nil then
+				if err then return nil, err end
+				break
+			end
+			copied = copied + #chunk
+			if copied > limit then return nil, opts.too_large_error or 'response_body_too_large' end
+			local ok, werr = fibers.perform(sink:write_chunk_op(chunk))
+			if not ok then return nil, werr end
+		end
+		if sink.finish_op then
+			local ok, ferr = fibers.perform(sink:finish_op())
+			if not ok then return nil, ferr end
+		elseif sink.commit_op then
+			local ok, ferr = fibers.perform(sink:commit_op())
+			if not ok then return nil, ferr end
+		end
+		return { bytes = copied }
+	end))
+end
+
+function M.drain_response_op(response, opts)
+	opts = opts or {}
+	return unwrap_scope_result(fibers.run_scope_op(function ()
+		local max_chunk = opts.max_chunk or 65536
+		local limit = opts.max_bytes or math.huge
+		local copied = 0
+		while true do
+			local chunk, err = fibers.perform(response:read_chunk_op(max_chunk))
+			if chunk == nil then
+				if err then return nil, err end
+				break
+			end
+			copied = copied + #chunk
+			if copied > limit then return nil, opts.too_large_error or 'response_body_too_large' end
+		end
+		return { bytes = copied }
+	end))
+end
+
+function M.copy_source_to_sink_op(source, sink, opts)
+	opts = opts or {}
+	return unwrap_scope_result(fibers.run_scope_op(function ()
+		local max_chunk = opts.max_chunk or 65536
+		local limit = opts.max_bytes or math.huge
+		local copied = 0
+		while true do
+			local chunk, err = fibers.perform(source:read_chunk_op(max_chunk))
+			if chunk == nil then
+				if err then return nil, err end
+				break
+			end
+			copied = copied + #chunk
+			if copied > limit then return nil, opts.too_large_error or 'response_body_too_large' end
+			local ok, werr = fibers.perform(sink:write_chunk_op(chunk))
+			if not ok then return nil, werr end
+		end
+		if sink.finish_op then
+			local ok, ferr = fibers.perform(sink:finish_op())
+			if not ok then return nil, ferr end
+		elseif sink.commit_op then
+			local ok, ferr = fibers.perform(sink:commit_op())
+			if not ok then return nil, ferr end
+		end
+		return { bytes = copied }
+	end))
+end
+
+M.is_descriptor = is_descriptor
+M.Registry = Registry
+return M

--- a/src/services/http/cap_surface.lua
+++ b/src/services/http/cap_surface.lua
@@ -1,0 +1,69 @@
+-- services/http/cap_surface.lua
+-- Bus-facing HTTP capability surface.  The surface owns endpoint bindings and
+-- retained capability metadata/status; service.lua supplies the handlers.
+
+local bus_cleanup = require 'devicecode.support.bus_cleanup'
+local topics = require 'services.http.topics'
+
+local M = {}
+
+local OFFERINGS = {
+	'status',
+	'listen',
+	'open-exchange',
+	'exchange',
+	'connect-ws',
+}
+
+local function offerings_map()
+	local out = {}
+	for _, name in ipairs(OFFERINGS) do out[name] = true end
+	return out
+end
+
+function M.retain_static(conn, id, status, stats)
+	conn:retain(topics.meta(id), {
+		kind = 'cap.http',
+		class = 'http',
+		id = id or 'main',
+		owner = 'http',
+		methods = offerings_map(),
+		offerings = offerings_map(),
+		local_handles = { listen = true, ['open-exchange'] = true, ['connect-ws'] = true },
+		control_plane_only = true,
+		state = { stats = topics.state(id, 'stats') },
+		observability = { stats = topics.obs_metric(id, 'stats') },
+	})
+	conn:retain(topics.status(id), status or { state = 'starting', available = false })
+	conn:retain(topics.state(id, 'stats'), stats or {})
+	conn:retain(topics.obs_metric(id, 'stats'), stats or {})
+end
+
+function M.unretain_static(conn, id)
+	conn:unretain(topics.meta(id))
+	conn:unretain(topics.status(id))
+	conn:unretain(topics.state(id, 'stats'))
+	conn:unretain(topics.obs_metric(id, 'stats'))
+end
+
+function M.bind(conn, id, handlers, opts)
+	opts = opts or {}
+	local endpoints = {}
+	for _, verb in ipairs(OFFERINGS) do
+		local ep, err = bus_cleanup.bind(conn, topics.rpc(id, verb), opts.endpoint_opts)
+		if not ep then
+			for _, prev in pairs(endpoints) do bus_cleanup.unbind(conn, prev) end
+			return nil, err
+		end
+		endpoints[verb] = ep
+	end
+	return endpoints
+end
+
+function M.unbind(conn, endpoints)
+	for _, ep in pairs(endpoints or {}) do bus_cleanup.unbind(conn, ep) end
+	return true
+end
+
+M.OFFERINGS = OFFERINGS
+return M

--- a/src/services/http/client.lua
+++ b/src/services/http/client.lua
@@ -1,0 +1,205 @@
+-- services/http/client.lua
+-- Policy-facing outgoing HTTP client operations. lua-http request machinery is
+-- confined to services.http.transport.client; descriptor leases and response
+-- copying are owned here by operation scopes.
+
+local fibers = require 'fibers'
+local op = require 'fibers.op'
+local policy = require 'services.http.policy'
+local transport_client = require 'services.http.transport.client'
+local request_body = require 'services.http.transport.request_body'
+local exchange = require 'services.http.exchange'
+local body = require 'services.http.body'
+
+local M = {}
+
+local function copy(t)
+	local out = {}
+	for k, v in pairs(t or {}) do out[k] = v end
+	return out
+end
+
+local function checked_args(args, opts)
+	if not opts.driver or type(opts.driver.run_op) ~= 'function' then return nil, 'driver_required' end
+	-- Service operations may pass the already-normalised table returned by
+	-- policy.validate_exchange_args.  Do not send that internal shape back
+	-- through the public-payload allow-list.
+	if type(args) == 'table' and args._uri ~= nil then return args end
+	return policy.validate_exchange_args(args, opts.policy or opts)
+end
+
+local function unwrap(scope_op)
+	return scope_op:wrap(function (st, _rep, result_or_primary, err)
+		if st == 'ok' then
+			if result_or_primary == nil and err ~= nil then return nil, err end
+			return result_or_primary, nil
+		end
+		return nil, result_or_primary or st
+	end)
+end
+
+local function resolve_registry(opts)
+	return opts.body_registry or body.new_registry(opts.body_resolvers or {})
+end
+
+local function install_request_source(scope, checked, registry, opts)
+	if not checked.body_source then return checked, nil end
+
+	local source, serr = fibers.perform(registry:resolve_op(checked.body_source, {
+		direction = 'source',
+		principal = opts.principal,
+		origin = opts.origin,
+		policy = opts.policy or opts,
+	}))
+	if not source then return nil, serr or 'invalid_args' end
+
+	local source_owned = true
+	scope:finally(function (_, status, primary)
+		if source_owned then body.terminate(source, primary or status or 'exchange_source_finalised') end
+	end)
+
+	if type(source.read_chunk_op) ~= 'function' then
+		return nil, 'request_body_source_invalid'
+	end
+
+	local pipe, perr = request_body.new_pipe({
+		max_buffered_chunks = opts.max_request_body_buffer_chunks or 8,
+		condition_factory = opts.request_body_condition_factory,
+	})
+	if not pipe then return nil, perr or 'request_body_pipe_failed' end
+
+	local pipe_owned = true
+	scope:finally(function (_, status, primary)
+		if pipe_owned then pipe:terminate(primary or status or 'exchange_request_body_finalised') end
+	end)
+
+	local spawned, spawn_err = scope:spawn(function ()
+		local copied, cerr = fibers.perform(body.copy_source_to_sink_op(source, pipe, {
+			max_bytes = opts.max_request_body_bytes or math.huge,
+			max_chunk = opts.max_request_body_chunk or 65536,
+			too_large_error = 'request_body_too_large',
+		}))
+		if not copied then
+			pipe:fail(cerr or 'request_body_source_failed')
+			error(cerr or 'request_body_source_failed', 0)
+		end
+		return true
+	end)
+	if spawned ~= true then
+		pipe:terminate(spawn_err or 'request_body_spawn_failed')
+		return nil, spawn_err or 'request_body_spawn_failed'
+	end
+
+	local prepared = copy(checked)
+	prepared._request_body = pipe:body_iterator()
+	return prepared, {
+		source = source,
+		pipe = pipe,
+		abort_now = function (reason)
+			local why = reason or 'request_body_aborted'
+			body.terminate(source, why)
+			pipe:terminate(why)
+			return true
+		end,
+		mark_done = function ()
+			-- req:go() has returned response headers; lua-http has consumed the
+			-- request body iterator.  The source is still operation-owned and is
+			-- released by the operation finaliser; the pipe is no longer needed.
+			pipe_owned = false
+			pipe:terminate('request_body_consumed')
+			return true
+		end,
+	}
+end
+
+local function open_exchange_result_op(driver, checked, opts)
+	local registry = resolve_registry(opts)
+	return unwrap(fibers.run_scope_op(function (scope)
+		local prepared, req_body = install_request_source(scope, checked, registry, opts)
+		if not prepared then return nil, req_body end
+
+		local response_headers, stream_or_err = fibers.perform(transport_client.open_exchange_op(driver, prepared, opts))
+		if not response_headers then
+			if req_body and req_body.abort_now then req_body.abort_now(stream_or_err or 'open_exchange_failed') end
+			return nil, stream_or_err
+		end
+		if req_body then req_body.mark_done() end
+		return { response_headers = response_headers, stream = stream_or_err }
+	end))
+end
+
+function M.open_exchange_op(driver, args, opts)
+	opts = opts or {}
+	return op.guard(function ()
+		local checked, perr = checked_args(args, { driver = driver, policy = opts.policy or opts })
+		if not checked then return op.always(nil, perr) end
+		return open_exchange_result_op(driver, checked, opts):wrap(function (opened, err)
+			if not opened then return nil, err end
+			return exchange.make(driver, opened.response_headers, opened.stream, opts), nil
+		end)
+	end)
+end
+
+function M.exchange_op(driver, args, opts)
+	opts = opts or {}
+	return op.guard(function ()
+		local checked, perr = checked_args(args, { driver = driver, policy = opts.policy or opts })
+		if not checked then return op.always(nil, perr) end
+		local registry = resolve_registry(opts)
+
+		return unwrap(fibers.run_scope_op(function (scope)
+			local sink, ex
+			local sink_owned, ex_owned = false, false
+			local sink_final_reason, ex_final_reason = 'exchange_sink_finalised', 'exchange_finalised'
+
+			if checked.response_sink then
+				sink = fibers.perform(registry:resolve_op(checked.response_sink, {
+					direction = 'sink',
+					principal = opts.principal,
+					origin = opts.origin,
+					policy = opts.policy or opts,
+				}))
+				if not sink then return nil, 'invalid_args' end
+				sink_owned = true
+				scope:finally(function (_, status, primary)
+					if sink_owned then body.terminate(sink, sink_final_reason or primary or status or 'exchange_sink_finalised') end
+				end)
+			end
+
+			local err
+			ex, err = fibers.perform(M.open_exchange_op(driver, checked, opts))
+			if not ex then sink_final_reason = 'failed'; return nil, err end
+			ex_owned = true
+			scope:finally(function (_, status, primary)
+				if ex_owned and not ex:is_closed() then ex:terminate(ex_final_reason or primary or status or 'exchange_finalised') end
+			end)
+
+			local sink_result
+			if sink then
+				local written, werr = fibers.perform(body.copy_response_to_sink_op(ex, sink, {
+					max_bytes = opts.max_response_body_bytes or math.huge,
+					max_chunk = opts.max_response_body_chunk or 65536,
+				}))
+				if not written then sink_final_reason = 'failed'; ex_final_reason = 'failed'; return nil, werr end
+				sink_owned = false
+				sink_result = { bytes = written.bytes }
+			else
+				local drained, derr = fibers.perform(body.drain_response_op(ex, {
+					max_bytes = opts.max_response_body_bytes or math.huge,
+					max_chunk = opts.max_response_body_chunk or 65536,
+				}))
+				if not drained then ex_final_reason = 'failed'; return nil, derr end
+				sink_result = nil
+			end
+
+			return {
+				status = ex:status(),
+				headers = ex:response_headers_table(),
+				response_sink = sink_result,
+			}
+		end))
+	end)
+end
+
+M.HttpExchange = exchange.HttpExchange
+return M

--- a/src/services/http/config.lua
+++ b/src/services/http/config.lua
@@ -1,0 +1,147 @@
+-- services/http/config.lua
+--
+-- Pure HTTP capability-service configuration normaliser.
+-- This module performs no I/O and starts no Fibres.
+
+local M = {}
+
+M.SCHEMA = 'devicecode.config/http/1'
+
+local DEFAULTS = {
+	enabled = true,
+	id = 'main',
+	policy = {
+		allowed_schemes = { http = true, https = true, ws = true, wss = true },
+		allow_loopback = true,
+		max_request_body = 16 * 1024 * 1024,
+		max_response_body = 16 * 1024 * 1024,
+	},
+}
+
+local ROOT_KEYS = {
+	schema = true,
+	enabled = true,
+	id = true,
+	policy = true,
+}
+
+local POLICY_KEYS = {
+	allowed_schemes = true,
+	allowed_hosts = true,
+	denied_hosts = true,
+	allow_loopback = true,
+	max_request_body = true,
+	max_response_body = true,
+}
+
+local function fail(msg) return nil, msg end
+
+local function copy_plain(v)
+	if type(v) ~= 'table' then return v end
+	local out = {}
+	for k, subv in pairs(v) do out[k] = copy_plain(subv) end
+	return out
+end
+
+local function allowed(t, keys, path)
+	for k in pairs(t or {}) do
+		if not keys[k] then return nil, path .. ' has unknown field: ' .. tostring(k) end
+	end
+	return true, nil
+end
+
+local function bool_or_nil(v, path)
+	if v == nil then return nil, nil end
+	if type(v) ~= 'boolean' then return nil, path .. ' must be boolean' end
+	return v, nil
+end
+
+local function non_empty_string_or_nil(v, path)
+	if v == nil then return nil, nil end
+	if type(v) ~= 'string' or v == '' then return nil, path .. ' must be a non-empty string' end
+	return v, nil
+end
+
+local function positive_number_or_nil(v, path)
+	if v == nil then return nil, nil end
+	if type(v) ~= 'number' or v < 0 then return nil, path .. ' must be a non-negative number' end
+	return v, nil
+end
+
+local function string_bool_map_or_nil(v, path)
+	if v == nil then return nil, nil end
+	if type(v) ~= 'table' then return nil, path .. ' must be a table' end
+	local out = {}
+	for k, allowed_value in pairs(v) do
+		if type(k) ~= 'string' or k == '' then return nil, path .. ' keys must be non-empty strings' end
+		if type(allowed_value) ~= 'boolean' then return nil, path .. ' values must be boolean' end
+		out[k] = allowed_value
+	end
+	return out, nil
+end
+
+local function normalise_policy(raw)
+	if raw == nil then raw = {} end
+	if type(raw) ~= 'table' then return fail('policy must be a table') end
+	local ok, err = allowed(raw, POLICY_KEYS, 'policy')
+	if not ok then return nil, err end
+
+	local out = copy_plain(DEFAULTS.policy)
+	local v
+
+	v, err = string_bool_map_or_nil(raw.allowed_schemes, 'policy.allowed_schemes')
+	if err then return nil, err end
+	if v ~= nil then out.allowed_schemes = v end
+
+	v, err = string_bool_map_or_nil(raw.allowed_hosts, 'policy.allowed_hosts')
+	if err then return nil, err end
+	if v ~= nil then out.allowed_hosts = v end
+
+	v, err = string_bool_map_or_nil(raw.denied_hosts, 'policy.denied_hosts')
+	if err then return nil, err end
+	if v ~= nil then out.denied_hosts = v end
+
+	v, err = bool_or_nil(raw.allow_loopback, 'policy.allow_loopback')
+	if err then return nil, err end
+	if v ~= nil then out.allow_loopback = v end
+
+	v, err = positive_number_or_nil(raw.max_request_body, 'policy.max_request_body')
+	if err then return nil, err end
+	if v ~= nil then out.max_request_body = v end
+
+	v, err = positive_number_or_nil(raw.max_response_body, 'policy.max_response_body')
+	if err then return nil, err end
+	if v ~= nil then out.max_response_body = v end
+
+	return out, nil
+end
+
+function M.normalise(raw)
+	if raw == nil then raw = {} end
+	if type(raw) ~= 'table' then return fail('http config must be a table') end
+	local ok, err = allowed(raw, ROOT_KEYS, 'http config')
+	if not ok then return nil, err end
+
+	if raw.schema ~= nil and raw.schema ~= M.SCHEMA then
+		return nil, 'http config schema must be ' .. M.SCHEMA
+	end
+
+	local enabled, eerr = bool_or_nil(raw.enabled, 'enabled')
+	if eerr then return nil, eerr end
+
+	local id, ierr = non_empty_string_or_nil(raw.id, 'id')
+	if ierr then return nil, ierr end
+
+	local policy, perr = normalise_policy(raw.policy)
+	if not policy then return nil, perr end
+
+	return {
+		schema = M.SCHEMA,
+		enabled = enabled ~= false,
+		id = id or DEFAULTS.id,
+		policy = policy,
+	}, nil
+end
+
+M.DEFAULTS = DEFAULTS
+return M

--- a/src/services/http/context.lua
+++ b/src/services/http/context.lua
@@ -1,0 +1,152 @@
+-- services/http/context.lua
+-- Public server-side HTTP context handle.
+--
+-- The transport context is deliberately kept behind this wrapper.  Consumers get
+-- Fibers-native Ops and an immediate termination path; lua-http/cqueues details
+-- stay below services/http/transport.
+
+local M = {}
+local HttpContext = {}
+HttpContext.__index = HttpContext
+
+local function registry_id_for(raw)
+	local id = (raw and type(raw.id) == 'function') and raw:id() or tostring(raw)
+	return 'ctx' .. tostring(id)
+end
+
+function M.wrap(raw, opts)
+	if raw == nil then return nil, 'context_required' end
+	if type(raw) == 'table' and raw._http_public_context then return raw._http_public_context end
+
+	opts = opts or {}
+	local self = setmetatable({
+		_raw = raw,
+		_listener = opts.listener,
+		_registry_id = opts.registry_id or registry_id_for(raw),
+		_on_terminate = opts.on_terminate,
+		_on_server_websocket = opts.on_server_websocket,
+		_closed = false,
+	}, HttpContext)
+
+	if type(raw) == 'table' then raw._http_public_context = self end
+	return self
+end
+
+function HttpContext:_raw_context()
+	return self._raw
+end
+
+function HttpContext:_raw_stream_for_test()
+	return self._raw and self._raw._raw_stream_for_test and self._raw:_raw_stream_for_test()
+end
+
+function HttpContext:_raw_server_for_test()
+	return self._raw and self._raw._raw_server_for_test and self._raw:_raw_server_for_test()
+end
+
+function HttpContext:id()
+	return self._raw:id()
+end
+
+function HttpContext:registry_id()
+	return self._registry_id
+end
+
+function HttpContext:is_closed()
+	return self._closed or self._raw:is_closed()
+end
+
+function HttpContext:why()
+	return self._raw:why()
+end
+
+function HttpContext:run_stream_op(label, fn, opts)
+	return self._raw:run_stream_op(label, function (stream)
+		return fn(stream, self)
+	end, opts)
+end
+
+function HttpContext:get_headers_op()
+	return self._raw:get_headers_op()
+end
+
+function HttpContext:read_chunk_op(max)
+	return self._raw:read_chunk_op(max)
+end
+
+function HttpContext:read_chars_op(n)
+	return self._raw:read_chars_op(n)
+end
+
+function HttpContext:read_body_as_string_op()
+	return self._raw:read_body_as_string_op()
+end
+
+function HttpContext:write_headers_op(headers, end_stream)
+	return self._raw:write_headers_op(headers, end_stream)
+end
+
+function HttpContext:write_chunk_op(chunk, end_stream)
+	return self._raw:write_chunk_op(chunk, end_stream)
+end
+
+function HttpContext:write_body_from_string_op(str)
+	return self._raw:write_body_from_string_op(str)
+end
+
+function HttpContext:peername_op()
+	return self._raw:peername_op()
+end
+
+function HttpContext:localname_op()
+	return self._raw:localname_op()
+end
+
+function HttpContext:checktls_op()
+	return self._raw:checktls_op()
+end
+
+function HttpContext:connection_version_op()
+	return self._raw:connection_version_op()
+end
+
+function HttpContext:write_continue_op()
+	return self._raw:write_continue_op()
+end
+
+function HttpContext:unget_op(str)
+	return self._raw:unget_op(str)
+end
+
+function HttpContext:shutdown_op()
+	return self._raw:shutdown_op()
+end
+
+function HttpContext:_notify_terminated(reason)
+	if self._closed then return true end
+	self._closed = true
+	local hook = self._on_terminate
+	self._on_terminate = nil
+	if hook then hook(self, reason or (self._raw and self._raw:why()) or 'closed') end
+	return true
+end
+
+function HttpContext:terminate(reason)
+	local ok, err = self._raw:terminate(reason)
+	self:_notify_terminated(reason or (self._raw and self._raw:why()) or 'closed')
+	return ok, err
+end
+
+function HttpContext:_register_server_websocket(ws)
+	local hook = self._on_server_websocket
+	if hook then return hook(self, ws) end
+	return true
+end
+
+function HttpContext:upgrade_websocket_op(headers, opts)
+	return require('services.http.websocket').from_context_op(self, headers, opts)
+end
+
+M.HttpContext = HttpContext
+M.registry_id_for = registry_id_for
+return M

--- a/src/services/http/errors.lua
+++ b/src/services/http/errors.lua
@@ -1,0 +1,35 @@
+-- services/http/errors.lua
+
+local M = {}
+
+local stable = {
+	invalid_args = true,
+	forbidden = true,
+	unsupported_scheme = true,
+	host_denied = true,
+	backend_unavailable = true,
+	connect_failed = true,
+	tls_failed = true,
+	timeout = true,
+	request_body_too_large = true,
+	response_body_too_large = true,
+	accept_queue_full = true,
+	closed = true,
+	cancelled = true,
+	aborted = true,
+	not_local = true,
+	unsupported_remote_handle = true,
+}
+
+function M.normalise(err)
+	if type(err) == 'table' and err.code then return err end
+	local s = tostring(err or 'failed')
+	if stable[s] then return { code = s, message = s } end
+	return { code = 'backend_unavailable', message = s }
+end
+
+function M.code(err)
+	return M.normalise(err).code
+end
+
+return M

--- a/src/services/http/exchange.lua
+++ b/src/services/http/exchange.lua
@@ -1,0 +1,100 @@
+-- services/http/exchange.lua
+-- Client-side HTTP exchange handle.  Stream operations run inside the cqueues
+-- driver so callers compose Fibers Ops rather than lua-http timeouts.
+
+local op = require 'fibers.op'
+local headers_mod = require 'services.http.headers'
+local terminate = require 'services.http.transport.terminate'
+
+local M = {}
+local HttpExchange = {}
+HttpExchange.__index = HttpExchange
+
+local function make(driver, response_headers, stream, opts)
+	return setmetatable({
+		_driver = driver,
+		_headers = response_headers,
+		_stream = stream,
+		_closed = false,
+		_close_reason = nil,
+		_id = opts and opts.id,
+		_on_terminate = opts and opts.on_terminate,
+	}, HttpExchange)
+end
+
+function HttpExchange:response_headers()
+	return self._headers
+end
+
+function HttpExchange:response_headers_table()
+	return headers_mod.to_table(self._headers)
+end
+
+function HttpExchange:status()
+	return headers_mod.get_one(self._headers, ':status')
+end
+
+function HttpExchange:is_closed()
+	return self._closed
+end
+
+function HttpExchange:why()
+	return self._close_reason
+end
+
+function HttpExchange:_stream_op(label, fn)
+	if self._closed then return op.always(nil, self._close_reason or 'closed') end
+	return self._driver:run_op(label, fn, {
+		on_active_abort = function (reason)
+			self:terminate(reason or 'exchange_op_aborted')
+		end,
+	})
+end
+
+function HttpExchange:read_chunk_op(_max)
+	return self:_stream_op('http.exchange.read_chunk', function ()
+		return self._stream:get_next_chunk()
+	end)
+end
+
+function HttpExchange:read_chars_op(n)
+	return self:_stream_op('http.exchange.read_chars', function ()
+		return self._stream:get_body_chars(n)
+	end)
+end
+
+function HttpExchange:read_body_as_string_op()
+	return self:_stream_op('http.exchange.read_body_as_string', function ()
+		return self._stream:get_body_as_string()
+	end)
+end
+
+function HttpExchange:shutdown_op()
+	return self:_stream_op('http.exchange.shutdown', function ()
+		if type(self._stream.shutdown) == 'function' then return self._stream:shutdown() end
+		return true
+	end):wrap(function (ok, err)
+		self._closed = true
+		self._close_reason = err or 'closed'
+		local hook = self._on_terminate
+		self._on_terminate = nil
+		if hook then pcall(hook, self, self._close_reason) end
+		return ok, err
+	end)
+end
+
+function HttpExchange:terminate(reason)
+	if self._closed then return true end
+	self._closed = true
+	self._close_reason = reason or 'closed'
+	local hook = self._on_terminate
+	self._on_terminate = nil
+	terminate.terminate_stream(self._stream, self._close_reason)
+	if hook then pcall(hook, self, self._close_reason) end
+	return true
+end
+
+M.make = make
+M.HttpExchange = HttpExchange
+
+return M

--- a/src/services/http/headers.lua
+++ b/src/services/http/headers.lua
@@ -1,0 +1,3 @@
+-- services/http/headers.lua
+-- Public header boundary.  Backend-specific construction lives in transport.
+return require 'services.http.transport.headers'

--- a/src/services/http/listener.lua
+++ b/src/services/http/listener.lua
@@ -1,0 +1,163 @@
+-- services/http/listener.lua
+-- Public listener handle boundary above the lua-http transport listener.
+
+local lua_http = require 'services.http.transport.lua_http'
+local context_mod = require 'services.http.context'
+
+local M = {}
+local HttpListener = {}
+HttpListener.__index = HttpListener
+
+local function copy(t)
+	local out = {}
+	for k, v in pairs(t or {}) do out[k] = v end
+	return out
+end
+
+local function make(raw, opts)
+	opts = opts or {}
+	local self = setmetatable({
+		_raw = raw,
+		_contexts = setmetatable({}, { __mode = 'k' }),
+		_admitted_raw = setmetatable({}, { __mode = 'k' }),
+		_events_port = opts.events_port,
+	}, HttpListener)
+	return self
+end
+
+function HttpListener:_wrap_context(raw)
+	if raw == nil then return nil end
+	local ctx = self._contexts[raw]
+	if ctx == nil then
+		ctx = assert(context_mod.wrap(raw, {
+			listener = self,
+			on_server_websocket = function (public_ctx, ws)
+				return self:_emit_context_event('server_websocket_registered', public_ctx, { websocket = ws })
+			end,
+			on_terminate = function (public_ctx, reason)
+				return self:_emit_context_event('context_terminated', public_ctx, { reason = reason })
+			end,
+		}))
+		self._contexts[raw] = ctx
+	end
+	return ctx
+end
+
+function M.listen(opts)
+	opts = opts or {}
+	local transport_opts = copy(opts)
+	transport_opts.on_context = nil
+	transport_opts.on_context_admitted = nil
+	transport_opts.on_context_transferred = nil
+	transport_opts.on_context_terminated = nil
+	transport_opts.on_server_websocket = nil
+
+	local raw, err = lua_http.listen(transport_opts)
+	if not raw then return nil, err end
+	return make(raw, opts)
+end
+
+
+local function context_id_of(ctx)
+	if ctx and type(ctx.id) == 'function' then return ctx:id() end
+	if ctx and ctx.id ~= nil then return ctx.id end
+	return nil
+end
+
+function HttpListener:_emit_context_event(kind, ctx, extra)
+	local ev = {
+		kind = kind,
+		ctx = ctx,
+		context_id = context_id_of(ctx),
+	}
+	for k, v in pairs(extra or {}) do ev[k] = v end
+	local port = self._events_port
+	if port and type(port.emit_required) == 'function' then
+		return port:emit_required(ev, 'http_listener_context_event_report_failed')
+	end
+
+	return true
+end
+
+function HttpListener:_raw_listener()
+	return self._raw
+end
+
+function HttpListener:_raw_server_for_test()
+	return self._raw and self._raw:_raw_server_for_test()
+end
+
+function HttpListener:localname()
+	return self._raw:localname()
+end
+
+function HttpListener:is_closed()
+	return self._raw:is_closed()
+end
+
+function HttpListener:why()
+	return self._raw:why()
+end
+
+function HttpListener:listen_op()
+	return self._raw:listen_op()
+end
+
+function HttpListener:pump_once_op()
+	return self._raw:pump_once_op()
+end
+
+function HttpListener:run()
+	return self._raw:run()
+end
+
+function HttpListener:start(scope)
+	return self._raw:start(scope)
+end
+
+function HttpListener:_admit_raw_context(raw_ctx)
+	if raw_ctx == nil then return nil, 'context_required' end
+	local ctx = self:_wrap_context(raw_ctx)
+	if not self._admitted_raw[raw_ctx] then
+		local ok, err = self:_emit_context_event('context_admitted', ctx)
+		if ok == nil or ok == false then return nil, err or 'context_admission_report_failed' end
+		self._admitted_raw[raw_ctx] = true
+	end
+	if ctx:is_closed() then ctx:_notify_terminated(ctx:why() or 'closed') end
+	return ctx, nil
+end
+
+function HttpListener:context_admission_op()
+	return self._raw:admission_op():wrap(function (raw_ctx, err)
+		if raw_ctx == nil then return nil, err end
+		return self:_admit_raw_context(raw_ctx)
+	end)
+end
+
+function HttpListener:accept_op()
+	return self._raw:accept_op():wrap(function (raw_ctx, err)
+		if raw_ctx == nil then return nil, err end
+		local ctx, aerr = self:_admit_raw_context(raw_ctx)
+		if ctx == nil then return nil, aerr end
+		local ok, terr = self:_emit_context_event('context_transferred', ctx)
+		if ok == nil or ok == false then return nil, terr or 'context_transfer_report_failed' end
+		return ctx, nil
+	end)
+end
+
+function HttpListener:pause()
+	return self._raw:pause()
+end
+
+function HttpListener:resume()
+	return self._raw:resume()
+end
+
+function HttpListener:terminate(reason)
+	return self._raw:terminate(reason)
+end
+
+M.listen = M.listen
+M.HttpListener = HttpListener
+M.Listener = HttpListener
+return M

--- a/src/services/http/listener_owner.lua
+++ b/src/services/http/listener_owner.lua
@@ -1,0 +1,157 @@
+-- services/http/listener_owner.lua
+-- Named listener runtime owner.
+--
+-- A listen RPC performs setup only until the listener is bound.  The listener
+-- runtime then lives in a child owner scope under the HTTP service.  Accepted
+-- contexts transfer to caller/request scopes via accept_op().  Runtime
+-- completion is reported as an identity-bearing scoped-work completion.
+
+local fibers = require 'fibers'
+local cond   = require 'fibers.cond'
+
+local listener_mod = require 'services.http.listener'
+local scoped_work  = require 'devicecode.support.scoped_work'
+
+local M = {}
+
+local function copy(t)
+	local out = {}
+	for k, v in pairs(t or {}) do out[k] = v end
+	return out
+end
+
+local function make_listener(opts)
+	local made, err = listener_mod.listen(opts)
+	if not made then return nil, err or 'listen_create_failed' end
+	return made, nil
+end
+
+function M.start(spec)
+	if type(spec) ~= 'table' then return nil, 'invalid_args' end
+	local lifetime_scope = spec.lifetime_scope
+	if not lifetime_scope or type(lifetime_scope.child) ~= 'function' then return nil, 'lifetime_scope_required' end
+
+	local opts = copy(spec.listen_opts or {})
+	local events_port = spec.events_port
+	local identity = {
+		kind = 'listener_done',
+		handle_id = spec.handle_id,
+		generation = spec.generation or 1,
+	}
+	if events_port ~= nil and (type(events_port) ~= 'table' or type(events_port.emit_required) ~= 'function') then
+		return nil, 'events_port_required'
+	end
+	local function emit(ev, label)
+		if not events_port then return true, nil end
+		return events_port:emit_required(ev, label or 'http_listener_owner_event_report_failed')
+	end
+
+	local ready = cond.new()
+	local ready_done = false
+	local ready_listener, ready_err
+
+	local function signal_ready(listener, err)
+		if ready_done then return end
+		ready_done = true
+		ready_listener = listener
+		ready_err = err
+		ready:signal()
+	end
+
+	local handle, err, setup = scoped_work.start({
+		lifetime_scope = lifetime_scope,
+		reaper_scope = lifetime_scope,
+		report_scope = lifetime_scope,
+		identity = identity,
+
+		setup = function ()
+			local listener, lerr = make_listener(opts)
+			if not listener then return nil, lerr or 'listen_create_failed' end
+			return {
+				listener = listener,
+				cancel_owned_now = function (reason)
+					listener:terminate(reason or 'listener_start_cancelled')
+					return true
+				end,
+			}
+		end,
+
+		run = function (scope, run_setup)
+			local listener = assert(run_setup.listener)
+			scope:finally(function (_, status, primary)
+				listener:terminate(primary or status or 'listener_scope_finalised')
+			end)
+
+			local ok, lerr = fibers.perform(listener:listen_op())
+			if not ok then
+				listener:terminate(lerr or 'listener_listen_failed')
+				signal_ready(nil, lerr or 'listener_listen_failed')
+				error(lerr or 'listener_listen_failed', 0)
+			end
+
+			local spawned, spawn_err = scope:spawn(function ()
+				while true do
+					local ctx, cerr = fibers.perform(listener:context_admission_op())
+					if ctx == nil then
+						if cerr == nil or tostring(cerr):match('closed') or tostring(cerr):match('listener') then
+							return true
+						end
+						error(cerr, 0)
+					end
+				end
+			end)
+			if spawned ~= true then
+				listener:terminate(spawn_err or 'listener_context_manager_spawn_failed')
+				signal_ready(nil, spawn_err or 'listener_context_manager_spawn_failed')
+				error(spawn_err or 'listener_context_manager_spawn_failed', 0)
+			end
+
+			emit({
+				kind = 'listener_owner_started',
+				handle_id = identity.handle_id,
+				generation = identity.generation,
+			})
+			signal_ready(listener, nil)
+
+			local rok, rerr = listener:run()
+			if not rok then error(rerr or 'listener_runtime_failed', 0) end
+			return {
+				handle_id = identity.handle_id,
+				reason = listener:why() or 'listener_runtime_ended',
+			}
+		end,
+
+		report = function (ev)
+			return emit(ev, 'http_listener_owner_done_report_failed')
+		end,
+	})
+
+	if not handle then
+		return nil, err or 'listener_start_failed'
+	end
+
+	local listener, wait_err = fibers.perform(ready:wait_op():wrap(function ()
+		return ready_listener, ready_err
+	end):on_abort(function ()
+		handle:cancel('listener_start_cancelled')
+	end))
+	if not listener then
+		handle:cancel(wait_err or 'listener_start_failed')
+		return nil, wait_err or 'listener_start_failed'
+	end
+
+	return {
+		listener = listener,
+		scope = setup and setup.scope,
+		work = handle,
+		cancel = function (_, reason)
+			handle:cancel(reason or 'listener_cancelled')
+			listener:terminate(reason or 'listener_cancelled')
+			return true
+		end,
+		outcome_op = function () return handle:outcome_op() end,
+		outcome = function () return handle:outcome() end,
+	}, nil
+end
+
+return M

--- a/src/services/http/model.lua
+++ b/src/services/http/model.lua
@@ -1,0 +1,40 @@
+-- services/http/model.lua
+-- Pulse-backed HTTP service model.
+
+local base_model = require 'devicecode.support.model'
+local tablex     = require 'shared.table'
+
+local M = {}
+
+local function equals(a, b)
+	for k, v in pairs(a or {}) do if (b or {})[k] ~= v then return false end end
+	for k in pairs(b or {}) do if (a or {})[k] == nil then return false end end
+	return true
+end
+
+function M.initial()
+	return {
+		state = 'starting',
+		backend = 'starting',
+		ready = false,
+		active_listeners = 0,
+		active_contexts = 0,
+		active_exchanges = 0,
+		active_websockets = 0,
+		completed_exchanges = 0,
+		failed_exchanges = 0,
+		rejected_requests = 0,
+		last_error = nil,
+		policy_generation = 1,
+	}
+end
+
+function M.new(initial)
+	return base_model.new(initial or M.initial(), {
+		copy = tablex.shallow_copy,
+		equals = equals,
+		label = 'http.model',
+	})
+end
+
+return M

--- a/src/services/http/operation_owner.lua
+++ b/src/services/http/operation_owner.lua
@@ -1,0 +1,104 @@
+-- services/http/operation_owner.lua
+-- Request-owner and scoped_work glue for HTTP capability operations.
+
+local request_owner = require 'devicecode.support.request_owner'
+local scoped_work = require 'devicecode.support.scoped_work'
+local service_events = require 'devicecode.support.service_events'
+
+local M = {}
+
+function M.next_request(service, verb, req)
+	service._next_request_id = service._next_request_id + 1
+	local request_id = 'req' .. tostring(service._next_request_id)
+	local owner = request_owner.new(req)
+	service._owned_requests[request_id] = owner
+	return request_id, owner
+end
+
+function M.operation_identity(service, verb, request_id)
+	service._next_operation_id = service._next_operation_id + 1
+	return {
+		kind = 'http_operation_done',
+		operation = verb,
+		operation_id = 'op' .. tostring(service._next_operation_id),
+		request_id = request_id,
+		generation = service._generation,
+	}
+end
+
+function M.operation_setup(service, owner)
+	return function (scope)
+		scope:finally(function (_, status, primary)
+			if status ~= 'ok' then
+				owner:finalise_unresolved(primary or status or 'http_request_finalised')
+			end
+		end)
+		return {
+			owner = owner,
+			reserved_handles = {},
+			cancel_owned_now = function (reason)
+				owner:finalise_unresolved(reason or 'scoped_work_start_failed')
+				return true
+			end,
+		}
+	end
+end
+
+function M.start(service, verb, req, request_id, owner, run)
+	local identity = M.operation_identity(service, verb, request_id)
+	service._state.operations[identity.operation_id] = {
+		operation_id = identity.operation_id,
+		generation = identity.generation,
+		operation = verb,
+		request_id = request_id,
+		state = 'admitted',
+	}
+	local reqrec = service._state.requests[request_id]
+	if reqrec then reqrec.state = 'running'; reqrec.operation_id = identity.operation_id end
+	service:_log_event { kind = 'operation_started', operation = verb, operation_id = identity.operation_id, request_id = request_id, generation = identity.generation }
+
+	local setup_fn = function (scope)
+		local setup = M.operation_setup(service, owner)(scope)
+		local old_cancel = setup.cancel_owned_now
+		setup.cancel_owned_now = function (reason)
+			old_cancel(reason)
+			for _, handle_id in ipairs(setup.reserved_handles or {}) do service:_terminate_handle(handle_id, reason or 'operation_start_failed') end
+			return true
+		end
+		return setup
+	end
+
+	local events_port = service._event_port and service:_event_port({
+		source = 'http_operation',
+		source_id = identity.operation_id,
+		operation_id = identity.operation_id,
+		operation = verb,
+		request_id = request_id,
+		generation = identity.generation,
+	}, { label = 'http_operation_done_report_failed' })
+	local report_event = events_port and service_events.reporter(events_port, 'http_operation_done_report_failed')
+		or function (ev) return service:_submit_event(ev, 'http_operation_done_report_failed', { fatal = true }) end
+
+	local handle, err = scoped_work.start({
+		lifetime_scope = service._scope,
+		reaper_scope = service._scope,
+		report_scope = service._scope,
+		identity = identity,
+		setup = setup_fn,
+		run = run,
+		report = report_event,
+	})
+	if not handle then
+		local rec = service._state.operations[identity.operation_id]
+		if rec then rec.state = 'completed'; rec.status = 'failed'; rec.primary = err or 'operation_start_failed' end
+		service:_finish_request(request_id, 'failed', err or 'operation_start_failed')
+		owner:finalise_unresolved(err or 'operation_start_failed')
+		service._state.last_error = err or 'operation_start_failed'
+		return true
+	end
+	service._state.operations[identity.operation_id].state = 'running'
+	service._state.operations[identity.operation_id].handle = handle
+	return true
+end
+
+return M

--- a/src/services/http/operations.lua
+++ b/src/services/http/operations.lua
@@ -1,0 +1,205 @@
+-- services/http/operations.lua
+-- Capability operation validation and worker bodies. Coordinator code calls this
+-- module to admit named scoped work; workers may perform Ops inside their own
+-- scopes.
+
+local fibers = require 'fibers'
+
+local client = require 'services.http.client'
+local websocket = require 'services.http.websocket'
+local policy = require 'services.http.policy'
+local listener_owner = require 'services.http.listener_owner'
+local operation_owner = require 'services.http.operation_owner'
+local service_events = require 'devicecode.support.service_events'
+
+local M = {}
+local perform = fibers.perform
+
+local function copy(t)
+	local out = {}
+	for k, v in pairs(t or {}) do out[k] = v end
+	return out
+end
+
+
+local function event_port_from_submit(tx, submit, identity, default_label)
+	local events_port = service_events.port(tx, identity, {
+		label = default_label or 'http_event_report_failed',
+	})
+	return {
+		emit_required = function (_, ev, label)
+			if type(ev) ~= 'table' then return nil, 'invalid_event' end
+			return submit(events_port:event(ev), label or default_label or 'http_event_report_failed')
+		end,
+		event = function (_, ev, attrs)
+			return events_port:event(ev, attrs)
+		end,
+		identity = function ()
+			return events_port:identity()
+		end,
+	}
+end
+
+local function terminate_handle(h, reason)
+	if h and type(h.terminate) == 'function' then return h:terminate(reason) end
+	return true
+end
+
+local function assert_local(service, req)
+	return policy.require_local_origin(req and req.origin)
+end
+
+local function policy_opts(service)
+	return service._opts.policy or service._opts
+end
+
+local function normalise_verb(verb)
+	return tostring(verb or ''):gsub('-', '_')
+end
+
+function M.validate_cap_request(service, verb, req)
+	verb = normalise_verb(verb)
+	if verb == 'status' then return true end
+	if verb == 'listen' or verb == 'open_exchange' or verb == 'connect_ws' then
+		local ok, lerr = assert_local(service, req)
+		if not ok then return nil, lerr end
+	end
+	if verb == 'listen' then
+		local args, err = policy.validate_listen_args(req.payload or {})
+		if not args then return nil, err end
+		req.payload = args
+	elseif verb == 'open_exchange' or verb == 'exchange' then
+		local checked, err = policy.validate_exchange_args(req.payload or {}, policy_opts(service))
+		if not checked then return nil, err end
+		req.payload = checked
+	elseif verb == 'connect_ws' then
+		local checked, err = policy.validate_connect_ws_args(req.payload or {}, policy_opts(service))
+		if not checked then return nil, err end
+		req.payload = checked
+	else
+		return nil, 'invalid_args'
+	end
+	return true
+end
+
+local function run_listen(service, scope, req, setup)
+	local owner = setup.owner
+	local args = req.payload or {}
+	local opts = copy(args)
+	opts.driver = service._driver
+	opts.http_server = service._opts.http_server
+	opts.backend_timeout = service._opts.backend_timeout
+	opts.connection_setup_timeout = service._opts.connection_setup_timeout
+	opts.intra_stream_timeout = service._opts.intra_stream_timeout
+	opts.context_terminator = service._opts.context_terminator
+	opts.max_accept_queue = args.max_accept_queue or service._opts.max_accept_queue or 64
+
+	local handle_id = assert(service:_reserve_handle('listener', { owner = 'http_service' }))
+	table.insert(setup.reserved_handles, handle_id)
+	local generation = service._generation
+	opts.events_port = event_port_from_submit(service._event_tx, function (ev, label)
+		return service:_submit_registry_event(ev, label or 'http_listener_context_event_report_failed')
+	end, {
+		service_id = service._id,
+		source = 'http_listener',
+		source_id = handle_id,
+		listener_id = handle_id,
+		handle_id = handle_id,
+		generation = generation,
+	}, 'http_listener_context_event_report_failed')
+	local component, cerr = listener_owner.start({
+		lifetime_scope = service._scope,
+		listen_opts = opts,
+		handle_id = handle_id,
+		generation = generation,
+		events_port = service:_event_port({
+			source = 'http_listener_owner',
+			source_id = handle_id,
+			listener_id = handle_id,
+			handle_id = handle_id,
+			generation = generation,
+		}, {
+			label = 'http_listener_owner_event_report_failed',
+		}),
+	})
+	if not component then
+		owner:fail_once(cerr)
+		service:_remove_handle(handle_id, cerr or 'listener_start_failed')
+		error(cerr or 'listener_start_failed', 0)
+	end
+
+	scope:finally(function (_, status, primary)
+		if status ~= 'ok' then component:cancel(primary or status or 'listen_setup_finalised') end
+	end)
+
+	service:_register_handle('listener', component.listener, { id = handle_id, owner = 'http_service' })
+	return { listener = component.listener, handle_id = handle_id }
+end
+
+local function run_open_exchange(service, scope, req, setup)
+	local owner = setup.owner
+	local handle_id = assert(service:_reserve_handle('exchange', { owner = 'http_service' }))
+	table.insert(setup.reserved_handles, handle_id)
+	local opts = copy(service._opts)
+	for k, v in pairs(opts.policy or {}) do opts[k] = v end
+	opts.origin = req.origin
+	opts.principal = req.origin and req.origin.principal
+	opts.body_registry = service._body_registry
+	opts.on_terminate = function (_, reason)
+		service:_remove_handle(handle_id, reason or 'exchange_terminated')
+	end
+	local ex, err = perform(client.open_exchange_op(service._driver, req.payload or {}, opts))
+	if not ex then owner:fail_once(err); service:_remove_handle(handle_id, err or 'open_exchange_failed'); error(err or 'open_exchange_failed', 0) end
+
+	scope:finally(function (_, status, primary)
+		if status ~= 'ok' then terminate_handle(ex, primary or status or 'open_exchange_finalised') end
+	end)
+
+	service:_register_handle('exchange', ex, { id = handle_id, owner = 'http_service' })
+	return { exchange = ex, handle_id = handle_id }
+end
+
+local function run_exchange(service, _scope, req, _setup)
+	local opts = copy(service._opts)
+	for k, v in pairs(opts.policy or {}) do opts[k] = v end
+	opts.origin = req.origin
+	opts.principal = req.origin and req.origin.principal
+	opts.body_registry = service._body_registry
+	local result, err = perform(client.exchange_op(service._driver, req.payload or {}, opts))
+	if not result then error(err or 'exchange_failed', 0) end
+	return { result = result }
+end
+
+local function run_connect_ws(service, scope, req, setup)
+	local owner = setup.owner
+	local handle_id = assert(service:_reserve_handle('websocket', { owner = 'http_service' }))
+	table.insert(setup.reserved_handles, handle_id)
+	local opts = copy(service._opts)
+	opts.origin = req.origin
+	opts.principal = req.origin and req.origin.principal
+	opts.on_terminate = function (_, reason)
+		service:_remove_handle(handle_id, reason or 'websocket_terminated')
+	end
+	local ws, err = perform(websocket.connect_op(service._driver, req.payload or {}, opts))
+	if not ws then owner:fail_once(err); service:_remove_handle(handle_id, err or 'connect_ws_failed'); error(err or 'connect_ws_failed', 0) end
+
+	scope:finally(function (_, status, primary)
+		if status ~= 'ok' then terminate_handle(ws, primary or status or 'connect_ws_finalised') end
+	end)
+
+	service:_register_handle('websocket', ws, { id = handle_id, owner = 'http_service' })
+	return { websocket = ws, handle_id = handle_id }
+end
+
+function M.start_operation(service, verb, req, request_id, owner)
+	verb = normalise_verb(verb)
+	local run
+	if verb == 'listen' then run = function (scope, setup) return run_listen(service, scope, req, setup) end
+	elseif verb == 'open_exchange' then run = function (scope, setup) return run_open_exchange(service, scope, req, setup) end
+	elseif verb == 'exchange' then run = function (scope, setup) return run_exchange(service, scope, req, setup) end
+	elseif verb == 'connect_ws' then run = function (scope, setup) return run_connect_ws(service, scope, req, setup) end
+	else return service:_reject_request(request_id, owner, 'invalid_args') end
+	return operation_owner.start(service, verb, req, request_id, owner, run)
+end
+
+return M

--- a/src/services/http/policy.lua
+++ b/src/services/http/policy.lua
@@ -1,0 +1,170 @@
+-- services/http/policy.lua
+-- Validation, locality and basic egress policy.  This module is deliberately
+-- conservative: it rejects before backend admission where it can.
+
+local body = require 'services.http.body'
+local uri_util = require 'services.http.transport.uri'
+
+local M = {}
+
+local SAFE_METHODS = { GET = true, HEAD = true, OPTIONS = true }
+local METHODS = {
+	GET = true, HEAD = true, POST = true, PUT = true, PATCH = true,
+	DELETE = true, OPTIONS = true,
+}
+
+local function copy_headers(h)
+	if h == nil then return nil end
+	if type(h) ~= 'table' then return nil, 'invalid_args' end
+	local out = {}
+	for k, v in pairs(h) do
+		if type(k) ~= 'string' then return nil, 'invalid_args' end
+		if type(v) ~= 'string' and type(v) ~= 'number' then return nil, 'invalid_args' end
+		out[k] = tostring(v)
+	end
+	return out, nil
+end
+
+local function reject_backend_payload_fields(args)
+	local forbidden = {
+		server = true, server_options = true, http_server = true, request_module = true,
+		websocket_module = true, cq = true, driver = true, socket = true, onstream = true,
+		onerror = true, condition_factory = true, context_terminator = true,
+		on_context = true, on_context_transferred = true, on_context_terminated = true,
+		on_terminate = true, stream = true, ws = true, exchange = true, listener = true,
+	}
+	for k in pairs(args or {}) do
+		if forbidden[k] then return nil, 'invalid_args' end
+	end
+	return true
+end
+
+local function require_only_fields(args, allowed)
+	local ok, ferr = reject_backend_payload_fields(args)
+	if not ok then return nil, ferr end
+	for k in pairs(args or {}) do
+		if not allowed[k] then return nil, 'invalid_args' end
+	end
+	return true
+end
+
+function M.is_local_origin(origin)
+	return origin
+		and origin.kind == 'local'
+		and origin.link_id == nil
+		and origin.peer_node == nil
+		and origin.peer_sid == nil
+end
+
+function M.require_local_origin(origin)
+	if M.is_local_origin(origin) then return true, nil end
+	return nil, 'not_local'
+end
+
+
+function M.validate_method(method)
+	method = tostring(method or 'GET'):upper()
+	if not METHODS[method] then return nil, 'invalid_args' end
+	return method
+end
+
+function M.is_safe_method(method)
+	return SAFE_METHODS[tostring(method or ''):upper()] or false
+end
+
+function M.validate_uri(uri, opts)
+	opts = opts or {}
+	local parsed, perr = uri_util.parse(uri)
+	if not parsed then return nil, perr or 'invalid_args' end
+
+	local allowed = opts.allowed_schemes or { http = true, https = true, ws = true, wss = true }
+	if not allowed[parsed.scheme] then return nil, 'unsupported_scheme' end
+
+	return {
+		uri = parsed.uri,
+		scheme = parsed.scheme,
+		authority = parsed.authority,
+		host = parsed.host,
+		port = parsed.port,
+		path = parsed.path,
+	}, nil
+end
+
+function M.validate_listen_args(args)
+	args = args or {}
+	if type(args) ~= 'table' then return nil, 'invalid_args' end
+	local ok, ferr = require_only_fields(args, { host = true, port = true, path = true, tls = true, max_accept_queue = true })
+	if not ok then return nil, ferr end
+	local out = {}
+	if args.host ~= nil and type(args.host) ~= 'string' then return nil, 'invalid_args' end
+	if args.port ~= nil and (type(args.port) ~= 'number' or args.port < 0 or args.port > 65535) then
+		return nil, 'invalid_args'
+	end
+	if args.path ~= nil and type(args.path) ~= 'string' then return nil, 'invalid_args' end
+	if args.tls ~= nil and type(args.tls) ~= 'boolean' then return nil, 'invalid_args' end
+	if args.max_accept_queue ~= nil and (type(args.max_accept_queue) ~= 'number' or args.max_accept_queue < 0) then return nil, 'invalid_args' end
+	out.host = args.host
+	out.port = args.port
+	out.path = args.path
+	out.tls = args.tls
+	out.max_accept_queue = args.max_accept_queue
+	if out.host == nil and out.path == nil then out.host = '127.0.0.1' end
+	if out.port == nil and out.path == nil then out.port = 0 end
+	if out.tls == nil then out.tls = false end
+	return out, nil
+end
+
+local function host_denied(parsed_uri, opts)
+	local host = parsed_uri and parsed_uri.host or nil
+	if host == nil then return true end
+	if opts.denied_hosts and opts.denied_hosts[host] then return true end
+	if opts.allowed_hosts and not opts.allowed_hosts[host] then return true end
+	if opts.allow_loopback == false and (host == '127.0.0.1' or host == 'localhost' or host == '::1') then return true end
+	return false
+end
+
+function M.validate_exchange_args(args, opts)
+	opts = opts or {}
+	if type(args) ~= 'table' then return nil, 'invalid_args' end
+	local ok, ferr = require_only_fields(args, { uri = true, method = true, headers = true, body_source = true, source = true, response_sink = true, sink = true })
+	if not ok then return nil, ferr end
+	local uri, uerr = M.validate_uri(args.uri, opts)
+	if not uri then return nil, uerr end
+	if uri.scheme == 'ws' or uri.scheme == 'wss' then return nil, 'unsupported_scheme' end
+	if host_denied(uri, opts) then return nil, 'host_denied' end
+	local method, merr = M.validate_method(args.method or 'GET')
+	if not method then return nil, merr end
+	local headers, herr = copy_headers(args.headers)
+	if herr then return nil, herr end
+
+	local descriptors, derr = body.validate_exchange_descriptors(args)
+	if not descriptors then return nil, derr end
+
+	return {
+		uri = uri.uri,
+		method = method,
+		headers = headers,
+		_uri = uri,
+		body_source = descriptors.source,
+		response_sink = descriptors.sink,
+	}, nil
+end
+
+function M.validate_connect_ws_args(args, opts)
+	opts = opts or {}
+	if type(args) ~= 'table' then return nil, 'invalid_args' end
+	local ok, ferr = require_only_fields(args, { uri = true, headers = true })
+	if not ok then return nil, ferr end
+	local uri, uerr = M.validate_uri(args.uri, opts)
+	if not uri then return nil, uerr end
+	if uri.scheme ~= 'ws' and uri.scheme ~= 'wss' then return nil, 'unsupported_scheme' end
+	if host_denied(uri, opts) then return nil, 'host_denied' end
+	local headers, herr = copy_headers(args.headers)
+	if herr then return nil, herr end
+	return { uri = uri.uri, headers = headers, _uri = uri }, nil
+end
+
+M._reject_backend_payload_fields = reject_backend_payload_fields
+M._require_only_fields = require_only_fields
+
+return M

--- a/src/services/http/registry.lua
+++ b/src/services/http/registry.lua
@@ -1,0 +1,202 @@
+-- services/http/registry.lua
+-- HTTP handle registry.  The registry is an accounting and shutdown backstop;
+-- callers own normal protocol use after handoff.
+--
+-- The registry is deliberately not the service reducer.  It emits identity-
+-- bearing events and provides immediate, idempotent termination/removal paths.
+
+local M = {}
+local Registry = {}
+Registry.__index = Registry
+
+local function copy(t)
+	local out = {}
+	for k, v in pairs(t or {}) do out[k] = v end
+	return out
+end
+
+local function copy_record(rec)
+	return {
+		kind = rec.kind,
+		handle = rec.handle,
+		handle_id = rec.handle_id,
+		generation = rec.generation,
+		owner = rec.owner,
+		state = rec.state,
+		listener_id = rec.listener_id,
+		context_id = rec.context_id,
+	}
+end
+
+local function event_for(rec, suffix, extra)
+	local kind = rec.kind .. '_' .. suffix
+	if rec.kind == 'context' and suffix == 'registered' then kind = 'context_admitted' end
+	local ev = {
+		kind = kind,
+		handle_id = rec.handle_id,
+		generation = rec.generation,
+		listener_id = rec.listener_id,
+		context_id = rec.context_id,
+	}
+	for k, v in pairs(extra or {}) do ev[k] = v end
+	return ev
+end
+
+function M.new(opts)
+	opts = opts or {}
+	return setmetatable({
+		_next_id = 0,
+		_records = {},
+		_events_port = opts.events_port,
+	}, Registry)
+end
+
+function Registry:_new_id()
+	while true do
+		self._next_id = self._next_id + 1
+		local id = 'h' .. tostring(self._next_id)
+		if self._records[id] == nil then return id end
+	end
+end
+
+function Registry:_emit(ev)
+	local port = self._events_port
+	if port and type(port.emit_required) == 'function' then
+		return port:emit_required(copy(ev), 'http_registry_event_report_failed')
+	end
+
+	return true
+end
+
+local function apply_opts(rec, opts)
+	rec.generation = opts.generation or rec.generation or 1
+	rec.owner = opts.owner or rec.owner or 'http_service'
+	if opts.listener_id ~= nil then rec.listener_id = opts.listener_id end
+	if opts.context_id ~= nil then rec.context_id = opts.context_id end
+	return rec
+end
+
+function Registry:reserve(kind, opts)
+	opts = opts or {}
+	local id = opts.id or self:_new_id()
+	if self._records[id] ~= nil then return nil, 'handle_exists' end
+	local rec = apply_opts({
+		kind = kind,
+		handle = nil,
+		handle_id = id,
+		state = 'reserved',
+	}, opts)
+	self._records[id] = rec
+	return id, copy_record(rec)
+end
+
+function Registry:register(kind, handle, opts)
+	opts = opts or {}
+	local id = opts.id
+	local rec
+	if id ~= nil then
+		rec = self._records[id]
+		if rec ~= nil then
+			if rec.kind ~= kind then return nil, 'handle_kind_mismatch' end
+			if rec.state ~= 'reserved' then return nil, 'handle_not_reserved' end
+		else
+			rec = {
+				kind = kind,
+				handle_id = id,
+				state = 'reserved',
+			}
+			self._records[id] = rec
+		end
+	else
+		id = self:_new_id()
+		rec = {
+			kind = kind,
+			handle_id = id,
+			state = 'reserved',
+		}
+		self._records[id] = rec
+	end
+
+	rec.handle = handle
+	apply_opts(rec, opts)
+	rec.state = 'registered'
+	self:_emit(event_for(rec, 'registered'))
+	return id, copy_record(rec)
+end
+
+function Registry:get(id)
+	return self._records[id]
+end
+
+function Registry:mark_transferred(id, generation)
+	local rec = self._records[id]
+	if not rec then return nil, 'stale_handle' end
+	if generation ~= nil and rec.generation ~= generation then return nil, 'stale_handle' end
+	if rec.state == 'terminated' then return nil, 'stale_handle' end
+	if rec.owner == 'caller_after_handoff' and rec.state == 'transferred' then return true end
+	rec.owner = 'caller_after_handoff'
+	rec.state = 'transferred'
+	self:_emit(event_for(rec, 'transferred'))
+	return true
+end
+
+function Registry:remove(id, reason, generation)
+	local rec = self._records[id]
+	if not rec then return false, 'stale_handle' end
+	if generation ~= nil and rec.generation ~= generation then return false, 'stale_handle' end
+	self._records[id] = nil
+	local prev_state = rec.state
+	rec.state = 'terminated'
+	rec.reason = reason or 'closed'
+	-- Reserved-only records were never externally live.  Removing them should be
+	-- idempotent cleanup, not an active-handle termination event.
+	if prev_state ~= 'reserved' then
+		self:_emit(event_for(rec, 'terminated', { reason = rec.reason }))
+	end
+	return true
+end
+
+function Registry:terminate(id, reason, generation)
+	local rec = self._records[id]
+	if not rec then return false, 'stale_handle' end
+	if generation ~= nil and rec.generation ~= generation then return false, 'stale_handle' end
+	local h = rec.handle
+	if h and type(h.terminate) == 'function' then h:terminate(reason or 'http_service_shutdown') end
+	return self:remove(id, reason, generation)
+end
+
+function Registry:terminate_all(reason)
+	local ids = {}
+	for id in pairs(self._records) do ids[#ids + 1] = id end
+	for _, id in ipairs(ids) do self:terminate(id, reason or 'http_service_shutdown') end
+	return true
+end
+
+function Registry:count(kind)
+	local n = 0
+	for _, rec in pairs(self._records) do
+		if rec.state ~= 'reserved' and rec.state ~= 'terminated' and (kind == nil or rec.kind == kind) then
+			n = n + 1
+		end
+	end
+	return n
+end
+
+function Registry:snapshot()
+	local out = {}
+	for id, rec in pairs(self._records) do
+		out[id] = {
+			handle_id = rec.handle_id,
+			kind = rec.kind,
+			generation = rec.generation,
+			owner = rec.owner,
+			state = rec.state,
+			listener_id = rec.listener_id,
+			context_id = rec.context_id,
+		}
+	end
+	return out
+end
+
+M.Registry = Registry
+return M

--- a/src/services/http/sdk.lua
+++ b/src/services/http/sdk.lua
@@ -1,0 +1,25 @@
+-- services/http/sdk.lua
+-- Op-native bus client for cap/http/<id>.
+
+local topics = require 'services.http.topics'
+
+local M = {}
+local Ref = {}
+Ref.__index = Ref
+
+function M.new_ref(conn, id)
+	return setmetatable({ conn = conn, id = id or 'main' }, Ref)
+end
+
+function Ref:call_op(verb, args, opts)
+	return self.conn:call_op(topics.rpc(self.id, verb), args or {}, opts)
+end
+
+function Ref:status_op(opts) return self:call_op('status', {}, opts) end
+function Ref:listen_op(args, opts) return self:call_op('listen', args or {}, opts) end
+function Ref:open_exchange_op(args, opts) return self:call_op('open-exchange', args or {}, opts) end
+function Ref:exchange_op(args, opts) return self:call_op('exchange', args or {}, opts) end
+function Ref:connect_ws_op(args, opts) return self:call_op('connect-ws', args or {}, opts) end
+
+M.Ref = Ref
+return M

--- a/src/services/http/service.lua
+++ b/src/services/http/service.lua
@@ -1,0 +1,787 @@
+-- services/http/service.lua
+-- System HTTP capability service. It owns backend lifetime, handle registry,
+-- retained status and bus endpoints. Protocol I/O lives in handles/workers.
+
+local fibers  = require 'fibers'
+local mailbox = require 'fibers.mailbox'
+
+local driver_mod = require 'services.http.transport.cqueues_driver'
+local backend_mod = require 'services.http.backend'
+local model_mod = require 'services.http.model'
+local topics = require 'services.http.topics'
+local cap_surface = require 'services.http.cap_surface'
+local registry_mod = require 'services.http.registry'
+local operations = require 'services.http.operations'
+local operation_owner = require 'services.http.operation_owner'
+local body = require 'services.http.body'
+local queue = require 'devicecode.support.queue'
+local config_watch = require 'devicecode.support.config_watch'
+local config_mod = require 'services.http.config'
+local service_events = require 'devicecode.support.service_events'
+
+local M = {}
+local perform = fibers.perform
+
+local function normalise_initial_config(opts)
+	local raw = opts.config
+	if raw == nil then raw = { id = opts.id, policy = opts.policy } end
+	local cfg, err = config_mod.normalise(raw)
+	if not cfg then return nil, err end
+	return cfg, nil
+end
+
+local HttpService = {}
+HttpService.__index = HttpService
+
+local function copy(t)
+	local out = {}
+	for k, v in pairs(t or {}) do out[k] = v end
+	return out
+end
+
+local function copy_event(ev)
+	local out = {}
+	for k, v in pairs(ev or {}) do
+		if k ~= 'req' and k ~= 'owner' and k ~= 'ctx' and k ~= 'websocket' then out[k] = v end
+	end
+	return out
+end
+
+
+-- Event ingress is a documented immediate Fibers-side attempt.  All code in
+-- this system runs inside Fibers, so use the public Op interface rather than
+-- probing primitive internals.
+local function try_admit_event_now(tx, ev, label)
+	local prefix = label or 'http_event_report_failed'
+	if not tx or type(tx.send_op) ~= 'function' then
+		return nil, prefix .. ': closed'
+	end
+	return queue.try_admit_required(tx, ev, prefix)
+end
+
+local function fail_req(req, reason)
+	if req and type(req.fail) == 'function' then return req:fail(reason) end
+	return false, 'request has no fail'
+end
+
+local function terminate_handle(h, reason)
+	if h and type(h.terminate) == 'function' then return h:terminate(reason) end
+	return true
+end
+
+local function is_live_handle(rec)
+	return rec and rec.state ~= 'reserved' and rec.state ~= 'terminated'
+end
+
+local function count_where(t, pred)
+	local n = 0
+	for _, rec in pairs(t or {}) do if pred(rec) then n = n + 1 end end
+	return n
+end
+
+function HttpService:_derive_snapshot()
+	local st = self._state
+	return {
+		state = st.service_state,
+		backend = st.backend,
+		ready = st.ready,
+		active_listeners = count_where(st.listeners, is_live_handle),
+		active_contexts = count_where(st.contexts, function (rec) return rec.state ~= 'terminated' end),
+		active_exchanges = count_where(st.exchanges, is_live_handle),
+		active_websockets = count_where(st.websockets, is_live_handle),
+		completed_exchanges = count_where(st.operations, function (rec)
+			return rec.operation == 'exchange' and rec.state == 'completed' and rec.status == 'ok'
+		end),
+		failed_exchanges = count_where(st.operations, function (rec)
+			return rec.operation == 'exchange' and rec.state == 'completed' and rec.status ~= 'ok'
+		end),
+		rejected_requests = count_where(st.requests, function (rec) return rec.state == 'rejected' end),
+		last_error = st.last_error,
+		policy_generation = st.policy_generation,
+	}
+end
+
+function HttpService:_publish_model()
+	if self._closed and not self._publishing_after_close then return end
+	local snap = self._model:snapshot()
+	self._conn:retain(topics.status(self._id), {
+		state = snap.state,
+		available = snap.ready,
+		backend = snap.backend,
+		last_error = snap.last_error,
+	})
+	self._conn:retain(topics.state(self._id, 'stats'), snap)
+	self._conn:retain(topics.obs_metric(self._id, 'stats'), snap)
+end
+
+function HttpService:_refresh_model()
+	local changed = self._model:set_snapshot(self:_derive_snapshot())
+	if changed ~= nil then self:_publish_model() end
+	return true
+end
+
+function HttpService:_log_event(ev)
+	if not ev or not ev.kind then return true end
+	self._event_seq = self._event_seq + 1
+	local saved = copy_event(ev)
+	saved.seq = self._event_seq
+	self._events[#self._events + 1] = saved
+	return true
+end
+
+function HttpService:_submit_event(ev, label, opts)
+	opts = opts or {}
+	if not ev or not ev.kind then return nil, 'invalid_event' end
+	local ok, err = try_admit_event_now(self._event_tx, ev, label or 'http_event_report_failed')
+	if ok == true then return true end
+
+	self._event_admission_failure = err or 'http_event_report_failed'
+	-- Once service shutdown has begun, the observing scope is no longer healthy.
+	-- Late stored completions may try to report after the event queue has been
+	-- closed; that must not turn orderly shutdown into reporter failure.
+	if self._closed and tostring(self._event_admission_failure):match('closed') then
+		return true, nil
+	end
+	if opts.fail_request and ev.owner then ev.owner:fail_once(self._event_admission_failure) end
+	if opts.fatal and self._scope then
+		local reason = self._event_admission_failure
+		if type(self._scope.spawn) == 'function' then
+			local spawned = self._scope:spawn(function () error(reason, 0) end)
+			if spawned ~= true and type(self._scope.cancel) == 'function' then self._scope:cancel(reason) end
+		elseif type(self._scope.cancel) == 'function' then
+			self._scope:cancel(reason)
+		end
+	end
+	return nil, self._event_admission_failure
+end
+
+
+-- Registry callbacks may run from the caller's scope, including while that
+-- scope is being actively cancelled because a public handle Op lost interest.
+-- A normal scope-aware immediate send is then rejected before it can even probe
+-- the service event queue.  Preserve the event-driven model by falling back to
+-- a tiny reporter fibre in the HTTP service scope; the coordinator still sees a
+-- semantic event and remains the only reducer.
+
+function HttpService:_event_port(identity, opts)
+	opts = opts or {}
+	local attrs = {
+		service_id = self._id,
+		source = identity and identity.source or 'http_service',
+		source_id = identity and identity.source_id or self._id,
+		generation = identity and identity.generation or self._generation,
+	}
+	for k, v in pairs(identity or {}) do attrs[k] = v end
+
+	-- Build event envelopes with the shared helper, but route admission through
+	-- _submit_event.  That preserves the HTTP service's shutdown policy: late
+	-- component completions after service termination are benign, while admission
+	-- failure during a healthy service remains explicit/fatal where requested.
+	local base = service_events.port(self._event_tx, attrs, opts)
+	local svc = self
+	local default_label = opts.label or 'http_service_event_report_failed'
+	return {
+		emit_required = function (_, ev, label)
+			return svc:_submit_event(base:event(ev), label or default_label, { fatal = opts.fatal ~= false })
+		end,
+		event = function (_, ev, extra)
+			return base:event(ev, extra)
+		end,
+		identity = function () return base:identity() end,
+	}
+end
+
+function HttpService:_submit_registry_event(ev, label)
+	local ok, r1, r2 = pcall(function ()
+		return self:_submit_event(ev, label or 'http_registry_event_report_failed', { fatal = true })
+	end)
+	if ok then return r1, r2 end
+
+	if self._closed or not self._scope or type(self._scope.spawn) ~= 'function' then
+		return nil, r1
+	end
+
+	local spawned, serr = self._scope:spawn(function ()
+		local admitted, aerr = self:_submit_event(ev, label or 'http_registry_event_report_failed', { fatal = true })
+		if admitted ~= true then error(aerr or 'http_registry_event_report_failed', 0) end
+	end)
+	if spawned == true then return true, nil end
+	return nil, serr or r1
+end
+
+function HttpService:_next_request_identity(verb, req)
+	return operation_owner.next_request(self, verb, req)
+end
+
+function HttpService:_finish_request(request_id, state, reason)
+	local rec = self._state.requests[request_id]
+	if rec then
+		rec.state = state or rec.state or 'resolved'
+		rec.reason = reason
+	end
+	self._owned_requests[request_id] = nil
+	return true
+end
+
+function HttpService:_reject_request(request_id, owner, reason)
+	if owner then owner:fail_once(reason or 'invalid_args') end
+	local rec = self._state.requests[request_id]
+	if rec then
+		rec.state = 'rejected'
+		rec.reason = reason or 'invalid_args'
+	end
+	self._state.last_error = reason or 'invalid_args'
+	self:_log_event { kind = 'cap_request_rejected', request_id = request_id, reason = reason or 'invalid_args' }
+	self._owned_requests[request_id] = nil
+	return true
+end
+
+function HttpService:_reserve_handle(kind, opts)
+	opts = opts or {}
+	return self._registry:reserve(kind, {
+		generation = opts.generation or self._generation,
+		owner = opts.owner or 'http_service',
+	})
+end
+
+function HttpService:_register_handle(kind, handle, opts)
+	opts = opts or {}
+	return self._registry:register(kind, handle, {
+		id = opts.id,
+		generation = opts.generation or self._generation,
+		owner = opts.owner or 'http_service',
+	})
+end
+
+function HttpService:_remove_handle(id, reason)
+	return self._registry:remove(id, reason or 'closed')
+end
+
+function HttpService:_terminate_handle(id, reason)
+	return self._registry:terminate(id, reason or 'http_service_shutdown')
+end
+
+function HttpService:_context_registry_id(ctx)
+	if ctx and type(ctx.registry_id) == 'function' then return ctx:registry_id() end
+	if ctx and type(ctx.id) == 'function' then return 'ctx' .. tostring(ctx:id()) end
+	return nil
+end
+
+function HttpService:_register_context(listener_id, ctx)
+	local id = self:_context_registry_id(ctx)
+	if not id then return nil, 'context_missing_identity' end
+	return self._registry:register('context', ctx, {
+		id = id,
+		generation = self._generation,
+		owner = 'listener',
+		listener_id = listener_id,
+		context_id = (ctx and type(ctx.id) == 'function') and ctx:id() or id,
+	})
+end
+
+function HttpService:_mark_context_transferred(ctx)
+	local id = self:_context_registry_id(ctx)
+	if not id then return nil, 'context_missing_identity' end
+	return self._registry:mark_transferred(id, self._generation)
+end
+
+function HttpService:_remove_context(ctx, reason)
+	local id = self:_context_registry_id(ctx)
+	if not id then return nil, 'context_missing_identity' end
+	return self._registry:remove(id, reason or 'context_terminated', self._generation)
+end
+
+function HttpService:_register_server_websocket(ctx, ws)
+	if self._closed then
+		terminate_handle(ws, 'service_closed')
+		return nil, 'service_closed'
+	end
+
+	local handle_id, err = self:_register_handle('websocket', ws, {
+		generation = self._generation,
+		owner = 'caller_after_handoff',
+		context_id = ctx and type(ctx.id) == 'function' and ctx:id() or nil,
+	})
+	if not handle_id then return nil, err or 'websocket_register_failed' end
+
+	if ws and type(ws.add_terminate_hook) == 'function' then
+		ws:add_terminate_hook(function (_, reason)
+			self:_remove_handle(handle_id, reason or 'websocket_terminated')
+		end)
+	end
+
+	self._registry:mark_transferred(handle_id, self._generation)
+	return true, handle_id
+end
+
+function HttpService:_record_handle_event(ev)
+	local kind, id = ev.kind, ev.handle_id
+	local generation = ev.generation or self._generation
+	if not id then return true end
+
+	local function table_for(k)
+		if k:match('^listener_') then return self._state.listeners, 'listener' end
+		if k:match('^exchange_') then return self._state.exchanges, 'exchange' end
+		if k:match('^websocket_') then return self._state.websockets, 'websocket' end
+		return nil, nil
+	end
+
+	local tbl, hkind = table_for(kind)
+	if not tbl then return true end
+	local rec = tbl[id]
+	if rec and rec.generation ~= generation then return true end
+
+	if kind == hkind .. '_registered' then
+		tbl[id] = rec or { handle_id = id, generation = generation, kind = hkind }
+		tbl[id].state = 'registered'
+		tbl[id].owner = 'http_service'
+	elseif kind == hkind .. '_transferred' then
+		if not rec then
+			tbl[id] = { handle_id = id, generation = generation, kind = hkind, state = 'transferred', owner = 'caller_after_handoff' }
+		else
+			rec.state = 'transferred'
+			rec.owner = 'caller_after_handoff'
+		end
+	elseif kind == hkind .. '_terminated' then
+		if not rec then
+			tbl[id] = { handle_id = id, generation = generation, kind = hkind, state = 'terminated', reason = ev.reason }
+		elseif rec.state ~= 'terminated' then
+			rec.state = 'terminated'
+			rec.reason = ev.reason
+		end
+	end
+	return true
+end
+
+function HttpService:_record_context_event(ev)
+	local context_id = ev.context_id
+	if context_id == nil then
+		self._state.last_error = 'context_event_missing_identity'
+		return true
+	end
+	local id = tostring(context_id)
+	local rec = self._state.contexts[id]
+	local generation = ev.generation or self._generation
+	if rec and rec.generation ~= generation then return true end
+
+	-- Context handles may report from caller/request scopes through an event port.
+	-- The coordinator remains the owner of the public model; registry operations
+	-- here are immediate accounting/termination backstop updates.
+	if ev.ctx ~= nil then
+		if ev.kind == 'context_admitted' or ev.kind == 'context_registered' then
+			self:_register_context(ev.listener_id, ev.ctx)
+		elseif ev.kind == 'context_transferred' then
+			self:_mark_context_transferred(ev.ctx)
+		elseif ev.kind == 'context_terminated' then
+			self:_remove_context(ev.ctx, ev.reason or 'context_terminated')
+		end
+	end
+	if ev.kind == 'context_admitted' or ev.kind == 'context_registered' then
+		if not rec then
+			self._state.contexts[id] = {
+				context_id = context_id,
+				listener_id = ev.listener_id,
+				generation = generation,
+				state = 'admitted',
+				owner = 'listener',
+			}
+		end
+	elseif ev.kind == 'context_transferred' then
+		if not rec then
+			self._state.contexts[id] = {
+				context_id = context_id,
+				listener_id = ev.listener_id,
+				generation = generation,
+				state = 'transferred',
+				owner = 'caller_after_handoff',
+			}
+		else
+			rec.state = 'transferred'
+			rec.owner = 'caller_after_handoff'
+		end
+	elseif ev.kind == 'context_terminated' then
+		if not rec then
+			self._state.contexts[id] = {
+				context_id = context_id,
+				listener_id = ev.listener_id,
+				generation = generation,
+				state = 'terminated',
+				reason = ev.reason,
+			}
+		elseif rec.state ~= 'terminated' then
+			rec.state = 'terminated'
+			rec.reason = ev.reason
+		end
+	end
+	return true
+end
+
+function HttpService:_handle_cap_request(ev)
+	local verb, req, request_id, owner = ev.verb, ev.req, ev.request_id, ev.owner
+	if not request_id or not owner then
+		return nil, 'cap_request_missing_owner'
+	end
+
+	if not self._state.requests[request_id] then
+		self._state.requests[request_id] = {
+			request_id = request_id,
+			generation = ev.generation or self._generation,
+			verb = verb,
+			owner = owner,
+			state = 'received',
+		}
+	end
+
+	if type(owner.done) == 'function' and owner:done() then
+		self:_finish_request(request_id, 'cancelled', 'request_already_resolved')
+		return true
+	end
+
+	if verb ~= 'status' and self._state.config and self._state.config.enabled == false then
+		return self:_reject_request(request_id, owner, 'disabled')
+	end
+
+	if verb == 'status' then
+		local ok, err = owner:reply_once({ status = self._model:snapshot() })
+		if ok ~= true then return nil, err or 'request_reply_failed' end
+		self:_finish_request(request_id, 'resolved')
+		return true
+	end
+
+	local ok, err = operations.validate_cap_request(self, verb, req)
+	if not ok then return self:_reject_request(request_id, owner, err or 'invalid_args') end
+	return operations.start_operation(self, verb, req, request_id, owner)
+end
+
+function HttpService:_handle_operation_done(ev)
+	local rec = self._state.operations[ev.operation_id]
+	if not rec or rec.generation ~= ev.generation then
+		return true
+	end
+	if rec.state == 'completed' then return true end
+
+	rec.state = 'completed'
+	rec.status = ev.status
+	rec.report = ev.report
+	rec.result = ev.result
+	rec.primary = ev.primary
+	if ev.status ~= 'ok' then self._state.last_error = ev.primary or ev.status end
+
+	local owner = self._owned_requests[rec.request_id]
+	local reqrec = self._state.requests[rec.request_id]
+	if ev.status == 'ok' then
+		local reply = ev.result or {}
+		local ok, rerr = true, nil
+		if owner and not owner:done() then
+			ok, rerr = owner:reply_once(reply)
+		end
+		if ok == true then
+			if reply.handle_id then self._registry:mark_transferred(reply.handle_id) end
+			if reqrec then reqrec.state = 'resolved' end
+		else
+			if reply.handle_id then self:_terminate_handle(reply.handle_id, rerr or 'reply_failed') end
+			if reqrec then reqrec.state = 'failed'; reqrec.reason = rerr or 'reply_failed' end
+			self._state.last_error = rerr or 'reply_failed'
+		end
+	else
+		if owner and not owner:done() then owner:fail_once(ev.primary or ev.status or 'operation_failed') end
+		if reqrec then reqrec.state = ev.status or 'failed'; reqrec.reason = ev.primary end
+	end
+	self._owned_requests[rec.request_id] = nil
+	self:_log_event(ev)
+	return true
+end
+
+
+function HttpService:_handle_config_changed(ev)
+	local cfg, err = config_mod.normalise(ev.raw or {})
+	if not cfg then
+		self._state.last_error = tostring(err or 'invalid_config')
+		self._state.service_state = 'degraded'
+		return true
+	end
+
+	if cfg.id ~= self._id then
+		self._state.last_error = 'config_id_mismatch'
+		self._state.service_state = 'degraded'
+		return true
+	end
+
+	self._state.config = cfg
+	self._state.config_generation = ev.generation or (self._state.config_generation + 1)
+	self._state.policy_generation = self._state.config_generation
+	self._opts.policy = cfg.policy
+	if cfg.enabled == false then
+		self._state.service_state = 'disabled'
+		self._state.ready = false
+	else
+		self._state.ready = self._state.backend == 'ready'
+		if self._state.backend == 'ready' then self._state.service_state = 'ready' end
+	end
+	self._state.last_error = nil
+	self:_log_event({ kind = 'policy_changed', generation = self._state.policy_generation })
+	return true
+end
+
+function HttpService:_reduce_event(ev)
+	local k = ev.kind
+	if k == 'backend_ready' then
+		self._state.backend = 'ready'
+		if self._state.config and self._state.config.enabled == false then
+			self._state.service_state = 'disabled'; self._state.ready = false
+		else
+			self._state.service_state = 'ready'; self._state.ready = true
+		end
+	elseif k == 'backend_failed' then
+		self._state.backend = 'failed'; self._state.service_state = 'failed'; self._state.ready = false; self._state.last_error = ev.reason
+		if self._registry then self._registry:terminate_all(ev.reason or 'backend_failed') end
+	elseif k == 'backend_terminated' then
+		self._state.backend = 'terminated'; self._state.service_state = 'closed'; self._state.ready = false; self._state.last_error = ev.reason
+		if self._registry then self._registry:terminate_all(ev.reason or 'backend_terminated') end
+	elseif k == 'backend_done' then
+		if ev.generation and ev.generation ~= self._generation then return true end
+		if ev.status == 'ok' then
+			self._state.backend = 'terminated'; self._state.service_state = 'closed'; self._state.ready = false
+			self._state.last_error = ev.result and ev.result.reason or 'backend_done'
+			if self._registry then self._registry:terminate_all(self._state.last_error or 'backend_done') end
+		elseif ev.status == 'cancelled' then
+			self._state.backend = 'terminated'; self._state.service_state = 'closed'; self._state.ready = false
+			self._state.last_error = ev.primary or 'backend_cancelled'
+			if self._registry then self._registry:terminate_all(ev.primary or 'backend_cancelled') end
+		else
+			self._state.backend = 'failed'; self._state.service_state = 'failed'; self._state.ready = false
+			self._state.last_error = ev.primary or ev.status or 'backend_failed'
+			if self._registry then self._registry:terminate_all(self._state.last_error or 'backend_failed') end
+		end
+		return true
+	elseif k == 'config_changed' then
+		return self:_handle_config_changed(ev)
+	elseif k == 'cap_request_received' then
+		return self:_handle_cap_request(ev)
+	elseif k == 'http_operation_done' then
+		return self:_handle_operation_done(ev)
+	elseif k == 'listener_registered' or k == 'listener_transferred' or k == 'listener_terminated'
+		or k == 'exchange_registered' or k == 'exchange_transferred' or k == 'exchange_terminated'
+		or k == 'websocket_registered' or k == 'websocket_transferred' or k == 'websocket_terminated' then
+		return self:_record_handle_event(ev)
+	elseif k == 'context_admitted' or k == 'context_registered' or k == 'context_transferred' or k == 'context_terminated' then
+		return self:_record_context_event(ev)
+	elseif k == 'server_websocket_registered' then
+		if ev.ctx ~= nil and ev.websocket ~= nil then
+			local ok, err = self:_register_server_websocket(ev.ctx, ev.websocket)
+			if ok ~= true then self._state.last_error = err or 'server_websocket_register_failed' end
+		end
+		return true
+	elseif k == 'listener_done' then
+		if ev.status ~= 'ok' then self._state.last_error = ev.primary or ev.status end
+		if ev.handle_id then
+			local reason = ev.primary or (ev.result and ev.result.reason) or ev.status or 'listener_done'
+			self:_remove_handle(ev.handle_id, reason)
+		end
+		return true
+	elseif k == 'policy_changed' then
+		self._state.policy_generation = ev.generation or (self._state.policy_generation + 1)
+	end
+	return true
+end
+
+function HttpService:_handle_event(ev)
+	if not ev or not ev.kind then return nil, 'invalid_event' end
+	local log_now = ev.kind ~= 'http_operation_done'
+	if log_now then self:_log_event(ev) end
+	local ok, err = self:_reduce_event(ev)
+	self:_refresh_model()
+	return ok, err
+end
+
+function HttpService:_coordinator_loop()
+	while true do
+		local ev, err = perform(self._event_rx:recv_op())
+		if not ev then return nil, err end
+		local ok, herr = self:_handle_event(ev)
+		if ok == nil or ok == false then error(herr or 'http_coordinator_event_failed', 0) end
+	end
+end
+
+function HttpService:_config_loop()
+	while not self._closed do
+		local ev = perform(self._cfg_watch:recv_op())
+		if ev == nil or ev.kind == 'config_closed' then
+			return nil, ev and ev.err or 'config_closed'
+		end
+		local ok, err = self:_submit_event({
+			kind = 'config_changed',
+			generation = ev.generation,
+			rev = ev.rev,
+			raw = ev.raw,
+		}, 'http_config_event_report_failed', { fatal = true })
+		if ok ~= true then error(err or 'http_config_event_report_failed', 0) end
+	end
+	return true
+end
+
+function HttpService:_endpoint_loop(verb, ep)
+	while not self._closed do
+		local req, err = perform(ep:recv_op())
+		if not req then return nil, err end
+		local request_id, owner = self:_next_request_identity(verb, req)
+		local ok, qerr = self:_submit_event({
+			kind = 'cap_request_received', verb = verb, req = req, request_id = request_id, owner = owner, generation = self._generation,
+		}, 'http_cap_request_admission_failed')
+		if ok ~= true then
+			self._owned_requests[request_id] = nil
+			owner:fail_once(qerr or 'service_busy')
+		end
+	end
+	return true
+end
+
+function HttpService:terminate(reason)
+	if self._closed then return true end
+	local why = reason or 'closed'
+	self._closed = true
+	self._publishing_after_close = true
+	for _, rec in pairs(self._state.operations or {}) do
+		if rec.handle and type(rec.handle.cancel) == 'function' and rec.state ~= 'completed' then rec.handle:cancel(why) end
+	end
+	for request_id, owner in pairs(self._owned_requests or {}) do
+		owner:finalise_unresolved(why)
+		local rec = self._state.requests[request_id]
+		if rec and rec.state ~= 'resolved' then rec.state = 'cancelled'; rec.reason = why end
+		self._owned_requests[request_id] = nil
+	end
+	if self._registry then self._registry:terminate_all(why) end
+	if self._cfg_watch then self._cfg_watch:close(); self._cfg_watch = nil end
+	if self._backend then self._backend:terminate(why)
+	elseif self._driver then self._driver:terminate(why) end
+	if self._event_tx then
+		self:_submit_event({ kind = 'backend_terminated', reason = why }, 'http_backend_terminated_report_failed')
+		if type(self._event_tx.close) == 'function' then self._event_tx:close(why) end
+	end
+	if self._endpoints then cap_surface.unbind(self._conn, self._endpoints) end
+	cap_surface.unretain_static(self._conn, self._id)
+	self._model:terminate(why)
+	return true
+end
+
+function HttpService:stats()
+	local snap = self._model:snapshot()
+	snap.handles = self._registry:snapshot()
+	return snap
+end
+
+function HttpService:events()
+	local out = {}
+	for i, ev in ipairs(self._events) do out[i] = copy(ev) end
+	return out
+end
+
+function M.start(conn, opts)
+	opts = opts or {}
+	local scope = fibers.current_scope()
+	if not scope then return nil, 'http service must start inside a scope' end
+
+	local initial_config, config_err = normalise_initial_config(opts)
+	if not initial_config then return nil, config_err or 'invalid_http_config' end
+	local driver = opts.driver or assert(driver_mod.new(opts.driver_options or { label = 'http-service' }))
+	opts.policy = initial_config.policy
+	local model = model_mod.new()
+	local event_tx, event_rx = mailbox.new(opts.event_queue_len or 64, { full = 'reject_newest' })
+	local self = setmetatable({
+		_conn = conn,
+		_scope = scope,
+		_id = opts.id or 'main',
+		_opts = opts,
+		_driver = driver,
+		_backend = nil,
+		_body_registry = opts.body_registry or body.new_registry(opts.body_resolvers or {}),
+		_model = model,
+		_event_tx = event_tx,
+		_event_rx = event_rx,
+		_next_operation_id = 0,
+		_next_request_id = 0,
+		_generation = 1,
+		_config = initial_config,
+		_closed = false,
+		_events = {},
+		_event_seq = 0,
+		_owned_requests = {},
+		_state = {
+			service_state = 'starting',
+			backend = 'starting',
+			ready = false,
+			last_error = nil,
+			policy_generation = 1,
+			config_generation = 1,
+			config = initial_config,
+			requests = {},
+			operations = {},
+			listeners = {},
+			contexts = {},
+			exchanges = {},
+			websockets = {},
+		},
+	}, HttpService)
+	self._registry = registry_mod.new({
+		events_port = {
+			emit_required = function (_, ev, label)
+				return self:_submit_registry_event(ev, label or 'http_registry_event_report_failed')
+			end,
+		},
+	})
+
+	local cfg_watch, cfg_err = config_watch.open(conn, 'http', {
+		topic = opts.config_topic or { 'cfg', 'http' },
+		queue_len = opts.config_queue_len or 4,
+		full = 'reject_newest',
+	})
+	if not cfg_watch then self:terminate(cfg_err); return nil, cfg_err or 'http config subscribe failed' end
+	self._cfg_watch = cfg_watch
+
+	scope:finally(function (_, status, primary)
+		self:terminate(primary or status or 'scope_finalised')
+	end)
+
+	cap_surface.retain_static(conn, self._id, { state = 'starting', available = false, backend = 'starting' }, model:snapshot())
+	self._endpoints = assert(cap_surface.bind(conn, self._id, {}, { endpoint_opts = { queue_len = opts.endpoint_queue_len or 10 } }))
+
+	local ok_coord, cerr = scope:spawn(function () return self:_coordinator_loop() end)
+	if not ok_coord then self:terminate(cerr); return nil, cerr end
+
+	local ok_cfg, cfg_loop_err = scope:spawn(function () return self:_config_loop() end)
+	if not ok_cfg then self:terminate(cfg_loop_err); return nil, cfg_loop_err end
+
+	local backend, derr = backend_mod.start({
+		lifetime_scope = scope,
+		driver = driver,
+		generation = self._generation,
+		identity = {
+			kind = 'backend_done',
+			component = 'backend',
+			component_id = 'http_backend',
+			generation = self._generation,
+		},
+		events_port = self:_event_port({
+			source = 'http_backend',
+			source_id = 'http_backend',
+			component = 'backend',
+			component_id = 'http_backend',
+		}, { label = 'http_backend_event_report_failed' }),
+	})
+	if not backend then
+		self:_submit_event({ kind = 'backend_failed', reason = derr }, 'http_backend_failed_report_failed')
+		self:terminate(derr or 'backend_failed')
+		return nil, derr
+	end
+	self._backend = backend
+
+	for verb, ep in pairs(self._endpoints) do
+		local spawned, serr = scope:spawn(function () return self:_endpoint_loop(verb, ep) end)
+		if not spawned then self:terminate(serr); return nil, serr end
+	end
+
+	return self
+end
+
+M.HttpService = HttpService
+return M

--- a/src/services/http/tls.lua
+++ b/src/services/http/tls.lua
@@ -1,0 +1,3 @@
+-- services/http/tls.lua
+-- Public TLS policy boundary; lua-http details live in transport.
+return require 'services.http.transport.tls'

--- a/src/services/http/topics.lua
+++ b/src/services/http/topics.lua
@@ -1,0 +1,20 @@
+-- services/http/topics.lua
+-- Pure topic helpers for cap/http/<id>.
+
+local topic = require 'shared.topic'
+
+local M = {}
+
+local function cap(id)
+	return { 'cap', 'http', id or 'main' }
+end
+
+function M.base(id) return cap(id) end
+function M.meta(id) return topic.append(cap(id), 'meta') end
+function M.status(id) return topic.append(cap(id), 'status') end
+function M.state(id, key) return topic.append(cap(id), 'state', key) end
+function M.event(id, name) return topic.append(cap(id), 'event', name) end
+function M.obs_metric(id, name) return { 'obs', 'v1', 'http', 'metric', id or 'main', name } end
+function M.rpc(id, verb) return topic.append(cap(id), 'rpc', verb) end
+
+return M

--- a/src/services/http/transport/client.lua
+++ b/src/services/http/transport/client.lua
@@ -1,0 +1,74 @@
+-- services/http/transport/client.lua
+-- lua-http request integration. This layer constructs requests and returns
+-- raw lua-http response headers and streams; public handles are built above this layer.
+
+local op = require 'fibers.op'
+local headers_mod = require 'services.http.headers'
+local terminate = require 'services.http.transport.terminate'
+
+local M = {}
+
+local function require_request(opts)
+	if opts and opts.request_module then return opts.request_module end
+	local ok, mod = pcall(require, 'http.request')
+	if not ok then return nil, mod end
+	return mod
+end
+
+local function apply_headers(req, fields)
+	if not fields then return true end
+	for _, pair in ipairs(headers_mod.to_pairs(fields)) do
+		req.headers:append(tostring(pair[1]), tostring(pair[2] or ''))
+	end
+	return true
+end
+
+local function build_request(request_module, args)
+	local req, err = request_module.new_from_uri(args.uri)
+	if not req then return nil, err end
+	if args.method then req.headers:upsert(':method', args.method) end
+	apply_headers(req, args.headers)
+	if args._request_body ~= nil then
+		if type(req.set_body) == 'function' then req:set_body(args._request_body)
+		else return nil, 'request_body_not_supported' end
+	end
+	return req, nil
+end
+
+function M.open_exchange_op(driver, checked_args, opts)
+	opts = opts or {}
+	return op.guard(function ()
+		local request_module, rerr = require_request(opts)
+		if not request_module then return op.always(nil, rerr) end
+		local active = { request = nil, stream = nil }
+		return driver:run_op('http.client.open_exchange', function ()
+			local req, berr = build_request(request_module, checked_args)
+			if not req then return nil, berr end
+			active.request = req
+			local response_headers, stream = req:go(opts.backend_timeout)
+			if not response_headers then return nil, stream or 'connect_failed' end
+			active.stream = stream
+			return response_headers, stream
+		end, {
+			on_active_abort = function (reason)
+				local why = reason or 'open_exchange_aborted'
+				if active.stream then
+					terminate.terminate_stream(active.stream, why)
+				elseif active.request then
+					terminate.terminate_request(active.request, why)
+				elseif driver and driver.terminate then
+					driver:terminate(why)
+				end
+			end,
+		})
+	end)
+end
+
+-- One-shot exchange setup only. Body copy/drain/commit is owned by
+-- services.http.client so leases and finalisers are installed in that operation
+-- scope, not inside the transport job.
+function M.exchange_open_op(driver, checked_args, opts)
+	return M.open_exchange_op(driver, checked_args, opts)
+end
+
+return M

--- a/src/services/http/transport/cqueues_driver.lua
+++ b/src/services/http/transport/cqueues_driver.lua
@@ -1,0 +1,519 @@
+-- services/http/transport/cqueues_driver.lua
+--
+-- Fibers-facing bridge for cqueues-style pollable objects.
+--
+-- This module is the only place that knows how to wait for a cqueues/lua-http
+-- pollable from Fibers.  The seam is deliberately small:
+--   * wait on pollfd()/events()/timeout() with Fibers waitable2;
+--   * treat readiness as a hint to call step(0);
+--   * expose cqueues coroutine work as Fibers Ops;
+--   * provide immediate termination for finalisers and abort paths.
+
+local op        = require 'fibers.op'
+local wait      = require 'fibers.wait'
+local poller    = require 'fibers.io.poller'
+local performer = require 'fibers.performer'
+local runtime   = require 'fibers.runtime'
+local safe      = require 'coxpcall'
+
+local perform = performer.perform
+local unpack  = rawget(table, 'unpack') or _G.unpack
+local pack    = rawget(table, 'pack') or function (...)
+	return { n = select('#', ...), ... }
+end
+
+local M = {}
+
+local Driver = {}
+Driver.__index = Driver
+
+local function identity(...)
+	return ...
+end
+
+local function tostring_error(e)
+	if type(e) == 'string' or type(e) == 'number' then
+		return e
+	end
+	return tostring(e)
+end
+
+local function is_timeout_error(err)
+	if err == nil then return false end
+	local s = tostring(err):lower()
+	return s:find('timeout', 1, true) ~= nil
+		or s:find('timed out', 1, true) ~= nil
+		or s:find('again', 1, true) ~= nil
+end
+
+--- Map cqueues event strings to Fibers poll directions.
+--- cqueues commonly uses r/w/p style event strings; p is treated as read-side
+--- progress because it asks the outer loop to step the pollable.
+local function event_wants(events)
+	events = events or 'r'
+	events = tostring(events)
+
+	local rd = events:find('r', 1, true) ~= nil
+		or events:find('p', 1, true) ~= nil
+	local wr = events:find('w', 1, true) ~= nil
+
+	return rd, wr
+end
+
+M.event_wants = event_wants
+
+local function notify_waitset(waitset, key)
+	local sched = runtime.current_scheduler
+	if sched then waitset:notify_all(key, sched) end
+end
+
+local function new_default_cqueue()
+	local ok, cqueues = pcall(require, 'cqueues')
+	if not ok or not cqueues then
+		return nil, 'cqueues module is not available'
+	end
+	return cqueues.new()
+end
+
+--- Create a new driver.
+---
+--- opts.controller may be supplied by tests or by lua-http server construction.
+--- The controller needs the cqueues pollable protocol for run()/start() and
+--- :wrap(fn) for run_op().
+function M.new(opts)
+	opts = opts or {}
+
+	local controller = opts.controller
+	local err
+	if controller == nil and opts.create_controller ~= false then
+		controller, err = new_default_cqueue()
+		if not controller then return nil, err end
+	end
+
+	local self = setmetatable({
+		_controller     = controller,
+		_label          = opts.label or 'cqueues_driver',
+		_closed         = false,
+		_close_reason   = nil,
+		_state_waiters  = wait.new_waitset(),
+		_poke_pending   = false,
+		_job_waiters    = wait.new_waitset(),
+		_jobs           = {},
+		_pump_started   = false,
+		_step_fn        = opts.step_fn,
+		_wrap_fn        = opts.wrap_fn,
+		_terminate_fn   = opts.terminate_fn,
+	}, Driver)
+
+	return self
+end
+
+function Driver:label()
+	return self._label
+end
+
+function Driver:controller()
+	return self._controller
+end
+
+function Driver:is_closed()
+	return self._closed
+end
+
+function Driver:why()
+	return self._close_reason
+end
+
+function Driver:_signal_changed()
+	self._poke_pending = true
+	notify_waitset(self._state_waiters, 'state')
+end
+
+--- Wake the pump.  Used when new work was queued into cqueues, and by tests.
+function Driver:poke()
+	self:_signal_changed()
+end
+
+function Driver:terminate(reason)
+	if self._closed then return true end
+
+	self._closed = true
+	self._close_reason = reason or 'closed'
+
+	local term = self._terminate_fn
+	if term then safe.pcall(term, self._controller, self._close_reason) end
+
+	for job in pairs(self._jobs) do
+		job.abandoned = true
+		job.abort_reason = self._close_reason
+		job.phase = 'abandoned'
+		notify_waitset(self._job_waiters, job)
+	end
+
+	self:_signal_changed()
+	return true
+end
+
+local function step_return(ok, a, b, ...)
+	if not ok then
+		return nil, tostring_error(a)
+	end
+
+	if a == nil or a == false then
+		if is_timeout_error(b) then
+			-- A spurious readiness hint should not kill the bridge.
+			return true, nil
+		end
+		return nil, b or 'cqueues step failed', ...
+	end
+
+	return true, nil
+end
+
+function Driver:_step_controller_now()
+	local controller = self._controller
+	if not controller then return nil, 'driver has no cqueues controller' end
+
+	local step_fn = self._step_fn
+	return step_return(safe.pcall(function ()
+		if step_fn then return step_fn(controller, 0) end
+		return controller:step(0)
+	end))
+end
+
+function Driver:step_controller_now()
+	return self:_step_controller_now()
+end
+
+function Driver:_step_pollable_now(pollable, step_fn)
+	if self._closed then return nil, self._close_reason or 'closed' end
+
+	return step_return(safe.pcall(function ()
+		if step_fn then return step_fn(pollable, 0) end
+		return pollable:step(0)
+	end))
+end
+
+function Driver:step_pollable_now(pollable, step_fn)
+	return self:_step_pollable_now(pollable, step_fn)
+end
+
+local function token2(tokens)
+	return {
+		unlink = function ()
+			for i = 1, #tokens do
+				local t = tokens[i]
+				if t and t.unlink then t:unlink() end
+				tokens[i] = nil
+			end
+			return false
+		end,
+	}
+end
+
+--- Wait until a cqueues-style pollable should be stepped.
+---
+--- Implemented with waitable2 because readiness is only a hint: after any fd,
+--- timer, or explicit state wake, the operation reports that the pollable should
+--- be stepped by its owner.
+---
+--- Returns: reason, err
+---   reason: 'fd' | 'timeout' | 'poke'
+---   err:    non-nil only when the driver is closed before readiness
+function Driver:pollable_ready_op(pollable, opts)
+	opts = opts or {}
+
+	return op.guard(function ()
+		assert(type(pollable) == 'table' or type(pollable) == 'userdata',
+			'pollable_ready_op: pollable object required')
+
+		local wake_reason
+
+		local function compute_interest()
+			if self._closed then
+				return true, nil, self._close_reason or 'closed'
+			end
+
+			if self._poke_pending then
+				self._poke_pending = false
+				return true, 'poke', nil
+			end
+
+			local timeout
+			if type(pollable.timeout) == 'function' then
+				timeout = pollable:timeout()
+			end
+			if type(timeout) == 'number' and timeout <= 0 then
+				return true, 'timeout', nil
+			end
+
+			local fd
+			if type(pollable.pollfd) == 'function' then
+				fd = pollable:pollfd()
+			end
+
+			local rd, wr = false, false
+			if fd ~= nil then
+				local events = 'r'
+				if type(pollable.events) == 'function' then
+					events = pollable:events()
+				end
+				rd, wr = event_wants(events)
+			end
+
+			return false, {
+				fd = fd,
+				rd = rd,
+				wr = wr,
+				timeout = timeout,
+				state = true,
+			}
+		end
+
+		local function probe_step()
+			return compute_interest()
+		end
+
+		local function run_step()
+			if wake_reason ~= nil then
+				local r = wake_reason
+				wake_reason = nil
+				if self._closed then return true, nil, self._close_reason or 'closed' end
+				return true, r, nil
+			end
+			return compute_interest()
+		end
+
+		local function register(task, waker, want)
+			local tokens = {}
+			local active = true
+
+			local function make_wake(reason)
+				return {
+					run = function ()
+						if not active then return end
+						wake_reason = reason
+						active = false
+						task:run()
+					end,
+				}
+			end
+
+			if type(want) == 'table' then
+				if want.fd ~= nil then
+					if want.rd then
+						tokens[#tokens + 1] = poller.get():wait(want.fd, 'rd', make_wake('fd'))
+					end
+					if want.wr then
+						tokens[#tokens + 1] = poller.get():wait(want.fd, 'wr', make_wake('fd'))
+					end
+				end
+
+				if type(want.timeout) == 'number' then
+					waker:after(want.timeout, make_wake('timeout'))
+				end
+			end
+
+			tokens[#tokens + 1] = self._state_waiters:add('state', make_wake('poke'))
+
+			return {
+				unlink = function ()
+					active = false
+					return token2(tokens):unlink()
+				end,
+			}
+		end
+
+		return wait.waitable2(register, probe_step, run_step)
+	end)
+end
+
+M.pollable_ready_op = function (driver, pollable, opts)
+	return driver:pollable_ready_op(pollable, opts)
+end
+
+--- Wait until a pollable is ready, then call step(0).
+function Driver:pollable_step_op(pollable, step_fn)
+	return self:pollable_ready_op(pollable):wrap(function (reason, err)
+		if reason == nil then return nil, err end
+		return self:_step_pollable_now(pollable, step_fn)
+	end)
+end
+
+function Driver:_complete_job(job, ok, results_or_err)
+	if job.done or job.abandoned then return end
+
+	job.done = true
+	job.phase = 'done'
+	job.ok = ok
+	if ok then job.results = results_or_err or pack() else job.err = results_or_err end
+
+	self._jobs[job] = nil
+	notify_waitset(self._job_waiters, job)
+	self:_signal_changed()
+end
+
+function Driver:_abandon_job(job, reason)
+	if job.done or job.abandoned then return end
+
+	local abort_reason = reason or 'aborted'
+	local phase = job.phase or 'queued'
+
+	job.abandoned = true
+	job.abort_reason = abort_reason
+	job.phase = 'abandoned'
+	self._jobs[job] = nil
+
+	if phase == 'active' then
+		local on_active_abort = job.on_active_abort
+		if on_active_abort then
+			safe.pcall(on_active_abort, abort_reason, job)
+		else
+			-- Once cqueues/lua-http work is active, a plain loss of interest is
+			-- not enough.  If no narrower owner supplied an active-abort hook,
+			-- the driver is the only safe owner boundary left.
+			self:terminate(abort_reason)
+		end
+	else
+		local on_abort = job.on_abort
+		if on_abort then safe.pcall(on_abort, abort_reason, job) end
+	end
+
+	notify_waitset(self._job_waiters, job)
+	self:_signal_changed()
+end
+
+function Driver:_start_job(label, fn, opts)
+	opts = opts or {}
+	assert(type(fn) == 'function', 'run_op expects a function')
+
+	if self._closed then return nil, self._close_reason or 'closed' end
+
+	local controller = self._controller
+	if not controller then return nil, 'driver has no cqueues controller' end
+
+	local job = {
+		label = label or 'cqueues job',
+		phase = 'queued',
+		done = false,
+		ok = nil,
+		results = nil,
+		err = nil,
+		abandoned = false,
+		abort_reason = nil,
+		on_abort = opts.on_abort,
+		on_active_abort = opts.on_active_abort,
+	}
+
+	self._jobs[job] = true
+
+	local function body()
+		if job.abandoned then return end
+		job.phase = 'active'
+		local ok, result = safe.xpcall(function ()
+			return pack(fn())
+		end, function (e, tb)
+			return tb or tostring_error(e)
+		end)
+
+		if job.abandoned then return end
+
+		if ok then
+			self:_complete_job(job, true, result)
+		else
+			self:_complete_job(job, false, result or 'cqueues job failed')
+		end
+	end
+
+	local ok, err = safe.pcall(function ()
+		local wrap_fn = self._wrap_fn
+		if wrap_fn then return wrap_fn(controller, body) end
+		return controller:wrap(body)
+	end)
+
+	if not ok then
+		self._jobs[job] = nil
+		return nil, tostring_error(err)
+	end
+
+	self:_signal_changed()
+	return job, nil
+end
+
+function Driver:_job_outcome_op(job)
+	local function step()
+		if job.done then
+			if job.ok then
+				local r = job.results or pack()
+				return true, unpack(r, 1, r.n)
+			end
+			return true, nil, job.err or 'cqueues job failed'
+		end
+
+		if job.abandoned then return true, nil, job.abort_reason or 'aborted' end
+		if self._closed then return true, nil, self._close_reason or 'closed' end
+
+		return false
+	end
+
+	local function register(task)
+		return self._job_waiters:add(job, task)
+	end
+
+	return wait.waitable(register, step, identity)
+end
+
+--- Run a cqueues coroutine operation and expose its result as a Fibers Op.
+--- The function is executed inside the driver's cqueues controller.
+function Driver:run_op(label, fn, opts)
+	return op.guard(function ()
+		local job, err = self:_start_job(label, fn, opts)
+		if not job then return op.always(nil, err) end
+
+		return self:_job_outcome_op(job):on_abort(function ()
+			self:_abandon_job(job, 'aborted')
+		end)
+	end)
+end
+
+--- Pump the driver's own cqueues controller until terminated.
+function Driver:run()
+	while not self._closed do
+		local ok, err = perform(self:pollable_step_op(self._controller, function ()
+			return self:_step_controller_now()
+		end))
+		if ok == nil then
+			self:terminate(err or 'cqueues pump failed')
+			return nil, err
+		end
+	end
+	return true, nil
+end
+
+function Driver:start(scope)
+	assert(scope and scope.spawn, 'Driver:start expects a scope')
+	if self._pump_started then return true, nil end
+	self._pump_started = true
+
+	local ok, err = scope:spawn(function (owning_scope)
+		-- A scope that has already started may only have finalisers installed
+		-- from code running inside that same scope. Driver:start may be called
+		-- by setup work in a child scope, so the ownership finaliser is
+		-- installed by the pump fibre itself.
+		owning_scope:finally(function ()
+			self:terminate('scope_finalised')
+		end)
+
+		return self:run()
+	end)
+	if not ok then
+		self._pump_started = false
+		return nil, err
+	end
+
+	return true, nil
+end
+
+M.Driver = Driver
+
+return M

--- a/src/services/http/transport/headers.lua
+++ b/src/services/http/transport/headers.lua
@@ -1,0 +1,141 @@
+-- services/http/headers.lua
+--
+-- Small boundary around lua-http header objects.  The rest of the service should
+-- not hand-build backend header objects or depend on their metatable shape.
+
+local M = {}
+
+local function require_headers()
+	local ok, mod = pcall(require, 'http.headers')
+	if not ok then return nil, mod end
+	return mod
+end
+
+local function new_raw()
+	local headers, err = require_headers()
+	if not headers then return nil, err end
+	return headers.new()
+end
+
+local function append_all(h, values)
+	for _, item in ipairs(values) do
+		if type(item) == 'table' then
+			h:append(tostring(item[1]), tostring(item[2] or ''))
+		else
+			return nil, 'invalid_header_value'
+		end
+	end
+	return true
+end
+
+local function apply_table(h, tbl)
+	for k, v in pairs(tbl or {}) do
+		if type(k) == 'number' then
+			if type(v) ~= 'table' then return nil, 'invalid_header_pair' end
+			h:append(tostring(v[1]), tostring(v[2] or ''))
+		elseif type(v) == 'table' then
+			for _, vv in ipairs(v) do h:append(tostring(k), tostring(vv)) end
+		else
+			h:append(tostring(k), tostring(v))
+		end
+	end
+	return true
+end
+
+function M.is_backend_headers(v)
+	return type(v) == 'table' and type(v.get) == 'function' and type(v.append) == 'function'
+end
+
+function M.new(fields)
+	local h, err = new_raw()
+	if not h then return nil, err end
+	local ok, aerr
+	if type(fields) == 'table' and fields[1] ~= nil and type(fields[1]) == 'table' then
+		ok, aerr = append_all(h, fields)
+	else
+		ok, aerr = apply_table(h, fields or {})
+	end
+	if not ok then return nil, aerr end
+	return h
+end
+
+function M.request(method, path, authority, scheme, fields)
+	local h, err = M.new(fields or {})
+	if not h then return nil, err end
+	if method ~= nil then h:upsert(':method', tostring(method)) end
+	if path ~= nil then h:upsert(':path', tostring(path)) end
+	if authority ~= nil then h:upsert(':authority', tostring(authority)) end
+	if scheme ~= nil then h:upsert(':scheme', tostring(scheme)) end
+	return h
+end
+
+function M.status(status, fields)
+	local h, err = M.new(fields or {})
+	if not h then return nil, err end
+	h:upsert(':status', tostring(status or 200))
+	return h
+end
+
+function M.clone(headers)
+	if headers and type(headers.clone) == 'function' then return headers:clone() end
+	return M.new(M.to_table(headers))
+end
+
+function M.get_one(headers, name)
+	if not headers or type(headers.get) ~= 'function' then return nil end
+	return headers:get(string.lower(tostring(name)))
+end
+
+function M.get_all(headers, name)
+	local out = {}
+	if not headers then return out end
+	name = string.lower(tostring(name))
+	if type(headers.each) == 'function' then
+		for k, v in headers:each() do
+			if tostring(k):lower() == name then out[#out + 1] = v end
+		end
+		return out
+	end
+	local v = M.get_one(headers, name)
+	if v ~= nil then out[1] = v end
+	return out
+end
+
+function M.to_table(headers)
+	local out = {}
+	if not headers then return out end
+	if type(headers.each) == 'function' then
+		for k, v in headers:each() do
+			k = tostring(k)
+			if out[k] == nil then
+				out[k] = v
+			elseif type(out[k]) == 'table' then
+				out[k][#out[k] + 1] = v
+			else
+				out[k] = { out[k], v }
+			end
+		end
+		return out
+	end
+	for k, v in pairs(headers) do out[k] = v end
+	return out
+end
+
+function M.to_pairs(headers)
+	local out = {}
+	if not headers then return out end
+	if type(headers.each) == 'function' then
+		for k, v in headers:each() do out[#out + 1] = { k, v } end
+		return out
+	end
+	for k, v in pairs(headers) do
+		if type(v) == 'table' then
+			for _, vv in ipairs(v) do out[#out + 1] = { k, vv } end
+		else
+			out[#out + 1] = { k, v }
+		end
+	end
+	return out
+end
+
+return M

--- a/src/services/http/transport/init.lua
+++ b/src/services/http/transport/init.lua
@@ -1,0 +1,9 @@
+-- services/http/transport/init.lua
+
+return {
+	cqueues_driver = require 'services.http.transport.cqueues_driver',
+	lua_http       = require 'services.http.transport.lua_http',
+	websocket      = require 'services.http.transport.websocket',
+	request_body   = require 'services.http.transport.request_body',
+	terminate      = require 'services.http.transport.terminate',
+}

--- a/src/services/http/transport/lua_http.lua
+++ b/src/services/http/transport/lua_http.lua
@@ -1,0 +1,613 @@
+-- services/http/transport/lua_http.lua
+--
+-- Fibers-facing lua-http backend wrapper.
+--
+-- lua-http still owns HTTP parsing, HTTP/2 stream state, WebSocket handshake
+-- plumbing, and cqueues coroutine execution.  UI service code sees Fibers Ops
+-- and transport-shaped objects.  The lua-http onstream callback is kept at this
+-- edge: it creates an HttpContext, admits it to the listener queue, and then
+-- runs the stream command loop.
+
+local op      = require 'fibers.op'
+local wait    = require 'fibers.wait'
+local fifo    = require 'fibers.utils.fifo'
+local runtime = require 'fibers.runtime'
+local safe    = require 'coxpcall'
+
+local cqueues_driver = require 'services.http.transport.cqueues_driver'
+local terminate = require 'services.http.transport.terminate'
+
+local unpack = rawget(table, 'unpack') or _G.unpack
+local pack   = rawget(table, 'pack') or function (...)
+	return { n = select('#', ...), ... }
+end
+
+local M = {}
+
+local Listener = {}
+Listener.__index = Listener
+
+local HttpContext = {}
+HttpContext.__index = HttpContext
+
+local function copy_table(t)
+	local out = {}
+	if not t then return out end
+	for k, v in pairs(t) do out[k] = v end
+	return out
+end
+
+local function tostring_error(e)
+	if type(e) == 'string' or type(e) == 'number' then return e end
+	return tostring(e)
+end
+
+local function notify_waitset(ws, key)
+	local sched = runtime.current_scheduler
+	if sched then ws:notify_all(key, sched) end
+end
+
+local function default_condition_factory()
+	local ok, cc = pcall(require, 'cqueues.condition')
+	if not ok or not cc then return nil, 'cqueues.condition module is not available' end
+	if type(cc.new) == 'function' then return cc.new() end
+	if type(cc) == 'function' then return cc() end
+	return nil, 'cqueues.condition has no constructor'
+end
+
+local function signal_condition(cv)
+	if cv and type(cv.signal) == 'function' then return cv:signal() end
+	return nil, 'condition has no signal method'
+end
+
+local function wait_condition(cv)
+	if cv and type(cv.wait) == 'function' then return cv:wait() end
+	return nil, 'condition has no wait method'
+end
+
+local function make_server(opts)
+	if opts.server then return opts.server end
+
+	local http_server = opts.http_server
+	if not http_server then
+		local ok, mod = pcall(require, 'http.server')
+		if not ok then return nil, mod end
+		http_server = mod
+	end
+
+	local listen_opts = copy_table(opts.server_options or opts)
+	listen_opts.server = nil
+	listen_opts.http_server = nil
+	listen_opts.driver = nil
+	listen_opts.driver_options = nil
+	listen_opts.max_accept_queue = nil
+	listen_opts.condition_factory = nil
+	listen_opts.context_terminator = nil
+	listen_opts.on_context = nil
+	listen_opts.on_context_admitted = nil
+	listen_opts.on_context_transferred = nil
+	listen_opts.on_context_terminated = nil
+	listen_opts.on_terminate = nil
+	listen_opts.backend_timeout = nil
+
+	return http_server.listen(listen_opts)
+end
+
+local next_context_id = 0
+
+local function new_context(listener, server, stream)
+	next_context_id = next_context_id + 1
+
+	local factory = listener._condition_factory or default_condition_factory
+	local cv, err = factory()
+	if not cv then error(err or 'failed to create cqueues condition', 2) end
+
+	return setmetatable({
+		_id               = next_context_id,
+		_listener         = listener,
+		_driver           = listener._driver,
+		_server           = server,
+		_stream           = stream,
+		_cmdq             = fifo.new(),
+		_cmd_cv           = cv,
+		_cmd_waiters      = wait.new_waitset(),
+		_closed           = false,
+		_close_reason     = nil,
+		_terminator       = listener._context_terminator,
+		_active_cmd       = nil,
+		_commands_started = 0,
+		_commands_done    = 0,
+	}, HttpContext)
+end
+
+function HttpContext:id() return self._id end
+function HttpContext:_raw_stream_for_test() return self._stream end
+function HttpContext:_raw_server_for_test() return self._server end
+function HttpContext:is_closed() return self._closed end
+function HttpContext:why() return self._close_reason end
+
+function HttpContext:_notify_public_terminated(reason)
+	local ws = rawget(self, '_http_transport_websocket')
+	if ws and type(ws._notify_terminated) == 'function' then
+		ws:_notify_terminated(reason or self._close_reason or 'closed')
+	end
+
+	local public = rawget(self, '_http_public_context')
+	if public and type(public._notify_terminated) == 'function' then
+		public:_notify_terminated(reason or self._close_reason or 'closed')
+	end
+end
+
+function HttpContext:_complete_command(cmd, ok, results_or_err)
+	if cmd.done or cmd.abandoned then return end
+	cmd.done = true
+	cmd.phase = 'done'
+	cmd.ok = ok
+	if ok then cmd.results = results_or_err or pack() else cmd.err = results_or_err end
+	self._commands_done = self._commands_done + 1
+	notify_waitset(self._cmd_waiters, cmd)
+end
+
+function HttpContext:_abandon_command(cmd, reason)
+	if cmd.done or cmd.abandoned then return end
+
+	local abort_reason = reason or 'aborted'
+	local phase = cmd.phase or 'queued'
+
+	cmd.abandoned = true
+	cmd.abort_reason = abort_reason
+	cmd.phase = 'abandoned'
+
+	if phase == 'active' then
+		if cmd.on_active_abort then
+			safe.pcall(cmd.on_active_abort, abort_reason, cmd)
+		else
+			-- Active stream work may already have consumed request bytes, emitted
+			-- response bytes, or changed HTTP/2 stream state.  Losing interest in
+			-- the Fibers waiter must therefore close the owning context.
+			self:terminate(abort_reason)
+		end
+	elseif cmd.on_abort then
+		safe.pcall(cmd.on_abort, abort_reason, cmd)
+	end
+
+	notify_waitset(self._cmd_waiters, cmd)
+end
+
+function HttpContext:_enqueue_command(label, fn, opts)
+	opts = opts or {}
+	if self._closed then return nil, self._close_reason or 'closed' end
+	assert(type(fn) == 'function', 'run_stream_op expects a function')
+
+	local cmd = {
+		label = label or 'http_stream_command',
+		phase = 'queued',
+		fn = fn,
+		done = false,
+		ok = nil,
+		results = nil,
+		err = nil,
+		abandoned = false,
+		abort_reason = nil,
+		on_abort = opts.on_abort,
+		on_active_abort = opts.on_active_abort,
+	}
+
+	self._commands_started = self._commands_started + 1
+	self._cmdq:push(cmd)
+	-- The onstream coroutine waits on a cqueues condition.  Signalling that
+	-- condition is the precise wake-up; poking the shared HTTP driver here also
+	-- wakes unrelated listener pumps and can turn a context command into a
+	-- service-wide busy loop under simple pollable fakes.
+	signal_condition(self._cmd_cv)
+	return cmd, nil
+end
+
+function HttpContext:_command_outcome_op(cmd)
+	local function step()
+		if cmd.done then
+			if cmd.ok then
+				local r = cmd.results or pack()
+				return true, unpack(r, 1, r.n)
+			end
+			return true, nil, cmd.err or 'http stream command failed'
+		end
+		if cmd.abandoned then return true, nil, cmd.abort_reason or 'aborted' end
+		if self._closed then return true, nil, self._close_reason or 'closed' end
+		return false
+	end
+
+	local function register(task)
+		return self._cmd_waiters:add(cmd, task)
+	end
+
+	return wait.waitable(register, step)
+end
+
+--- Run fn(stream, context) inside the original lua-http onstream coroutine.
+function HttpContext:run_stream_op(label, fn, opts)
+	return op.guard(function ()
+		local cmd, err = self:_enqueue_command(label, fn, opts)
+		if not cmd then return op.always(nil, err) end
+
+		return self:_command_outcome_op(cmd):on_abort(function ()
+			self:_abandon_command(cmd, 'aborted')
+		end)
+	end)
+end
+
+function HttpContext:_run_one_command(cmd)
+	if cmd.abandoned then return end
+
+	cmd.phase = 'active'
+	self._active_cmd = cmd
+	local ok, results_or_err = safe.xpcall(function ()
+		return pack(cmd.fn(self._stream, self))
+	end, function (e, tb)
+		return tb or tostring_error(e)
+	end)
+	self._active_cmd = nil
+
+	if cmd.abandoned then return end
+	if ok then
+		self:_complete_command(cmd, true, results_or_err)
+	else
+		self:_complete_command(cmd, false, results_or_err)
+	end
+end
+
+-- Test hook: run one queued command without a real cqueues condition loop.
+function HttpContext:_drain_one_for_test()
+	if self._cmdq:empty() then return false end
+	local cmd = self._cmdq:pop()
+	self:_run_one_command(cmd)
+	return true
+end
+
+--- Runs inside lua-http's onstream cqueues coroutine.
+function HttpContext:_command_loop()
+	while not self._closed do
+		local cmd
+		if not self._cmdq:empty() then cmd = self._cmdq:pop() end
+
+		if cmd then
+			self:_run_one_command(cmd)
+		else
+			wait_condition(self._cmd_cv)
+		end
+	end
+end
+
+function HttpContext:terminate(reason)
+	if self._closed then return true end
+
+	self._closed = true
+	self._close_reason = reason or 'closed'
+
+	while not self._cmdq:empty() do
+		self:_abandon_command(self._cmdq:pop(), self._close_reason)
+	end
+	if self._active_cmd then self:_abandon_command(self._active_cmd, self._close_reason) end
+
+	local term = self._terminator
+	if term then
+		safe.pcall(term, self._stream, self._close_reason, self)
+	else
+		terminate.terminate_stream(self._stream, self._close_reason)
+	end
+
+	-- Wake only the owning onstream command loop.  Listener/server pump
+	-- termination is handled by Listener:terminate().
+	signal_condition(self._cmd_cv)
+
+	self:_notify_public_terminated(self._close_reason)
+
+	local listener = self._listener
+	if listener then listener._contexts[self] = nil end
+	return true
+end
+
+-- HTTP stream-shaped Ops ------------------------------------------------------
+
+function HttpContext:get_headers_op()
+	return self:run_stream_op('http.get_headers', function (stream)
+		return stream:get_headers()
+	end)
+end
+
+function HttpContext:read_chunk_op(_max)
+	return self:run_stream_op('http.get_next_chunk', function (stream)
+		return stream:get_next_chunk()
+	end)
+end
+
+function HttpContext:read_chars_op(n)
+	return self:run_stream_op('http.get_body_chars', function (stream)
+		return stream:get_body_chars(n)
+	end)
+end
+
+function HttpContext:read_body_as_string_op()
+	return self:run_stream_op('http.get_body_as_string', function (stream)
+		return stream:get_body_as_string()
+	end)
+end
+
+function HttpContext:write_headers_op(headers, end_stream)
+	return self:run_stream_op('http.write_headers', function (stream)
+		return stream:write_headers(headers, not not end_stream)
+	end)
+end
+
+function HttpContext:write_chunk_op(chunk, end_stream)
+	return self:run_stream_op('http.write_chunk', function (stream)
+		return stream:write_chunk(chunk, not not end_stream)
+	end)
+end
+
+function HttpContext:write_body_from_string_op(str)
+	return self:run_stream_op('http.write_body_from_string', function (stream)
+		return stream:write_body_from_string(str)
+	end)
+end
+
+function HttpContext:peername_op()
+	return self:run_stream_op('http.peername', function (stream)
+		if type(stream.peername) ~= 'function' then return nil, 'peername_not_available' end
+		return stream:peername()
+	end)
+end
+
+function HttpContext:localname_op()
+	return self:run_stream_op('http.localname', function (stream)
+		if type(stream.localname) ~= 'function' then return nil, 'localname_not_available' end
+		return stream:localname()
+	end)
+end
+
+function HttpContext:checktls_op()
+	return self:run_stream_op('http.checktls', function (stream)
+		if type(stream.checktls) ~= 'function' then return nil, 'checktls_not_available' end
+		return stream:checktls()
+	end)
+end
+
+function HttpContext:connection_version_op()
+	return self:run_stream_op('http.connection_version', function (stream)
+		if type(stream.connection_version) ~= 'function' then return nil, 'connection_version_not_available' end
+		return stream:connection_version()
+	end)
+end
+
+function HttpContext:write_continue_op()
+	return self:run_stream_op('http.write_continue', function (stream)
+		if type(stream.write_continue) ~= 'function' then return nil, 'write_continue_not_available' end
+		return stream:write_continue()
+	end)
+end
+
+function HttpContext:unget_op(str)
+	return self:run_stream_op('http.unget', function (stream)
+		if type(stream.unget) ~= 'function' then return nil, 'unget_not_available' end
+		return stream:unget(str)
+	end)
+end
+
+function HttpContext:shutdown_op()
+	return self:run_stream_op('http.stream_shutdown', function (stream)
+		return stream:shutdown()
+	end)
+end
+
+-- Listener -------------------------------------------------------------------
+
+function Listener:_notify_accept()
+	local sched = runtime.current_scheduler
+	if sched then self._accept_waiters:notify_one('accept', sched) end
+end
+
+function Listener:_notify_admission()
+	local sched = runtime.current_scheduler
+	if sched then self._admission_waiters:notify_one('admission', sched) end
+end
+
+function Listener:admission_op()
+	local function step()
+		if not self._admissionq:empty() then
+			return true, self._admissionq:pop(), nil
+		end
+		if self._closed then return true, nil, self._close_reason or 'closed' end
+		return false
+	end
+
+	local function register(task)
+		return self._admission_waiters:add('admission', task)
+	end
+
+	return wait.waitable(register, step)
+end
+
+function Listener:_admit_context(ctx)
+	if self._closed then
+		ctx:terminate(self._close_reason or 'listener_closed')
+		return nil, 'closed'
+	end
+
+	if self._acceptq:length() >= self._max_accept_queue then
+		ctx:terminate('accept_queue_full')
+		return nil, 'accept_queue_full'
+	end
+
+	self._contexts[ctx] = true
+	self._acceptq:push(ctx)
+	self._admissionq:push(ctx)
+	self:_notify_admission()
+	self:_notify_accept()
+	return true, nil
+end
+
+function Listener:_onstream(server, stream)
+	local ctx = new_context(self, server, stream)
+	local ok = self:_admit_context(ctx)
+	if not ok then return end
+	ctx:_command_loop()
+end
+
+function M.listen(opts)
+	opts = opts or {}
+
+	local driver = opts.driver
+	if not driver then driver = assert(cqueues_driver.new(opts.driver_options or {})) end
+
+	local self = setmetatable({
+		_driver             = driver,
+		_server             = nil,
+		_acceptq            = fifo.new(),
+		_accept_waiters     = wait.new_waitset(),
+		_admissionq         = fifo.new(),
+		_admission_waiters  = wait.new_waitset(),
+		_closed             = false,
+		_close_reason       = nil,
+		_max_accept_queue   = opts.max_accept_queue or 64,
+		_contexts           = {},
+		_condition_factory  = opts.condition_factory,
+		_context_terminator = opts.context_terminator,
+		_backend_timeout    = opts.backend_timeout,
+	}, Listener)
+
+	local server_opts = copy_table(opts)
+	if server_opts.cq == nil and driver.controller then server_opts.cq = driver:controller() end
+	server_opts.onstream = function (server, stream)
+		return self:_onstream(server, stream)
+	end
+	server_opts.driver = nil
+	server_opts.max_accept_queue = nil
+	server_opts.condition_factory = nil
+	server_opts.context_terminator = nil
+	server_opts.on_context = nil
+	server_opts.on_context_admitted = nil
+	server_opts.on_context_transferred = nil
+	server_opts.on_context_terminated = nil
+	server_opts.on_terminate = nil
+	server_opts.driver_options = nil
+	server_opts.backend_timeout = nil
+
+	local server, err = make_server(server_opts)
+	if not server then return nil, err end
+	self._server = server
+	return self
+end
+
+function Listener:_raw_server_for_test() return self._server end
+function Listener:localname()
+	if self._server and type(self._server.localname) == 'function' then return self._server:localname() end
+	return nil, 'localname_not_available'
+end
+function Listener:is_closed() return self._closed end
+function Listener:why() return self._close_reason end
+
+function Listener:accept_op()
+	local function step()
+		if not self._acceptq:empty() then
+			local ctx = self._acceptq:pop()
+			-- Ownership transfer: once accepted, the caller/request scope owns
+			-- normal use and graceful response work.  The listener keeps only
+			-- unaccepted contexts for listener-close cleanup.
+			self._contexts[ctx] = nil
+			return true, ctx
+		end
+		if self._closed then return true, nil, self._close_reason or 'closed' end
+		return false
+	end
+
+	local function register(task)
+		return self._accept_waiters:add('accept', task)
+	end
+
+	return wait.waitable(register, step)
+end
+
+function Listener:pump_once_op()
+	return self._driver:pollable_step_op(self._server, function (server)
+		return server:step(0)
+	end)
+end
+
+function Listener:run()
+	local perform = require 'fibers.performer'.perform
+	while not self._closed do
+		local ok, err = perform(self:pump_once_op())
+		if ok == nil then
+			self:terminate(err or 'lua-http server pump failed')
+			return nil, err
+		end
+	end
+	return true, nil
+end
+
+function Listener:start(scope)
+	assert(scope and scope.spawn, 'Listener:start expects a scope')
+	local ok, err = scope:spawn(function (owning_scope)
+		-- Listener:start may be called from a setup or request operation while
+		-- the listener pump is deliberately owned by another scope, typically
+		-- the HTTP service scope.  Once that target scope has started, its
+		-- finalisers must be installed from inside it.
+		owning_scope:finally(function ()
+			self:terminate('scope_finalised')
+		end)
+
+		return self:run()
+	end)
+	if not ok then return nil, err end
+	return true, nil
+end
+
+function Listener:listen_op()
+	return self._driver:run_op('http.server.listen', function ()
+		return self._server:listen(self._backend_timeout)
+	end)
+end
+
+function Listener:pause()
+	if self._server and type(self._server.pause) == 'function' then return self._server:pause() end
+	return true
+end
+
+function Listener:resume()
+	if self._server and type(self._server.resume) == 'function' then return self._server:resume() end
+	return true
+end
+
+function Listener:terminate(reason)
+	if self._closed then return true end
+
+	self._closed = true
+	self._close_reason = reason or 'closed'
+
+	terminate.terminate_server(self._server, self._close_reason)
+
+	local contexts = {}
+	for ctx in pairs(self._contexts) do contexts[#contexts + 1] = ctx end
+	for _, ctx in ipairs(contexts) do ctx:terminate(self._close_reason) end
+	while not self._acceptq:empty() do
+		local ctx = self._acceptq:pop()
+		if ctx and (type(ctx.is_closed) ~= 'function' or not ctx:is_closed()) then
+			ctx:terminate(self._close_reason)
+		end
+	end
+
+	local sched = runtime.current_scheduler
+	if sched then
+		self._accept_waiters:notify_all('accept', sched)
+		self._admission_waiters:notify_all('admission', sched)
+	end
+	if self._driver and self._driver.poke then self._driver:poke() end
+	return true
+end
+
+M.Listener = Listener
+M.HttpContext = HttpContext
+M._new_context_for_test = new_context
+M._default_condition_factory = default_condition_factory
+
+return M

--- a/src/services/http/transport/request_body.lua
+++ b/src/services/http/transport/request_body.lua
@@ -1,0 +1,153 @@
+-- services/http/transport/request_body.lua
+-- Bounded bridge from a Fibers-native body source into lua-http's request body
+-- iterator contract.  Bytes stay in process-local memory and never cross the
+-- bus.  The iterator is consumed by lua-http in a cqueues coroutine; the source
+-- side is written by a Fibers worker through write_chunk_op()/finish_op().
+
+local op   = require 'fibers.op'
+local cond = require 'fibers.cond'
+
+local M = {}
+local Pipe = {}
+Pipe.__index = Pipe
+
+local function default_condition_factory()
+	local cc = require 'cqueues.condition'
+	if type(cc.new) == 'function' then return cc.new() end
+	if type(cc) == 'function' then return cc() end
+	return nil, 'cqueues.condition has no constructor'
+end
+
+local function signal_condition(cv)
+	if cv and type(cv.signal) == 'function' then return cv:signal() end
+	return nil, 'condition has no signal method'
+end
+
+local function wait_condition(cv)
+	if cv and type(cv.wait) == 'function' then return cv:wait() end
+	return nil, 'condition has no wait method'
+end
+
+local function new_space_cond(self)
+	self._space_cond = cond.new()
+	return self._space_cond
+end
+
+local function signal_space(self)
+	local c = self._space_cond
+	new_space_cond(self)
+	if c then c:signal() end
+end
+
+local function pop_first(q)
+	local v = q[1]
+	for i = 1, #q - 1 do q[i] = q[i + 1] end
+	q[#q] = nil
+	return v
+end
+
+function M.new_pipe(opts)
+	opts = opts or {}
+	local factory = opts.condition_factory or default_condition_factory
+	local cv, err = factory()
+	if not cv then return nil, err or 'request_body_condition_failed' end
+
+	local max_chunks = opts.max_buffered_chunks or 8
+	if type(max_chunks) ~= 'number' or max_chunks < 1 then return nil, 'invalid_args' end
+
+	local self = setmetatable({
+		_cv = cv,
+		_q = {},
+		_max_chunks = max_chunks,
+		_closed = false,
+		_done = false,
+		_err = nil,
+		_bytes = 0,
+	}, Pipe)
+	new_space_cond(self)
+	return self, nil
+end
+
+function Pipe:stats()
+	return {
+		queued = #self._q,
+		bytes = self._bytes,
+		closed = self._closed,
+		done = self._done,
+		err = self._err,
+	}
+end
+
+function Pipe:_push(chunk)
+	if self._closed then return nil, self._err or 'closed' end
+	if self._done then return nil, 'request_body_finished' end
+	if type(chunk) ~= 'string' then return nil, 'invalid_args' end
+	self._q[#self._q + 1] = chunk
+	self._bytes = self._bytes + #chunk
+	signal_condition(self._cv)
+	return true, nil
+end
+
+function Pipe:write_chunk_op(chunk)
+	return op.guard(function ()
+		if self._closed then return op.always(nil, self._err or 'closed') end
+		if #self._q < self._max_chunks then return op.always(self:_push(chunk)) end
+
+		return self._space_cond:wait_op():wrap(function ()
+			if self._closed then return nil, self._err or 'closed' end
+			if #self._q >= self._max_chunks then return nil, 'request_body_backpressure_wake_failed' end
+			return self:_push(chunk)
+		end)
+	end)
+end
+
+function Pipe:finish_op()
+	return op.guard(function ()
+		if self._closed then return op.always(nil, self._err or 'closed') end
+		self._done = true
+		signal_condition(self._cv)
+		return op.always(true, nil)
+	end)
+end
+
+function Pipe:fail(reason)
+	if self._closed then return true end
+	self._err = reason or 'request_body_failed'
+	self._closed = true
+	self._q = {}
+	signal_condition(self._cv)
+	signal_space(self)
+	return true
+end
+
+function Pipe:terminate(reason)
+	return self:fail(reason or 'request_body_terminated')
+end
+
+function Pipe:body_iterator()
+	return function ()
+		while not self._closed and not self._done and #self._q == 0 do
+			local ok, err = wait_condition(self._cv)
+			if ok == nil and err ~= nil then error(err, 0) end
+		end
+
+		if self._closed then error(self._err or 'request_body_closed', 0) end
+
+		if #self._q > 0 then
+			local chunk = pop_first(self._q)
+			signal_space(self)
+			return chunk
+		end
+
+		return nil
+	end
+end
+
+function M.new_body(opts)
+	local pipe, err = M.new_pipe(opts)
+	if not pipe then return nil, err end
+	return pipe:body_iterator(), pipe
+end
+
+M.Pipe = Pipe
+return M

--- a/src/services/http/transport/terminate.lua
+++ b/src/services/http/transport/terminate.lua
@@ -1,0 +1,58 @@
+-- services/http/transport/terminate.lua
+-- Immediate backend termination helpers. These are the only transport-level
+-- helpers intended for finaliser-safe shutdown paths. Graceful protocol close
+-- remains Op-based work owned by callers.
+
+local safe = require 'coxpcall'
+
+local M = {}
+
+local unpack = rawget(table, 'unpack') or _G.unpack
+
+local function call(method, obj, ...)
+	if obj and type(obj[method]) == 'function' then
+		local args = { n = select('#', ...), ... }
+		return safe.pcall(function () return obj[method](obj, unpack(args, 1, args.n)) end)
+	end
+	return false, 'method_missing'
+end
+
+function M.terminate_stream(stream, reason)
+	if not stream then return true end
+	local ok = call('shutdown', stream)
+	if ok then return true end
+	ok = call('close', stream)
+	if ok then return true end
+	return true
+end
+
+function M.terminate_server(server, reason)
+	if not server then return true end
+	local ok = call('close', server)
+	if ok then return true end
+	return true
+end
+
+function M.terminate_websocket(ws, reason)
+	if not ws then return true end
+	-- This is deliberately not graceful. It gives lua-http/cqueues a bounded
+	-- immediate wake/close path for finalisers and service shutdown.
+	local ok = call('close', ws, 1006, reason or 'terminated', 0)
+	if ok then return true end
+	ok = call('shutdown', ws)
+	if ok then return true end
+	return true
+end
+
+function M.terminate_request(req, reason)
+	if not req then return true end
+	local ok = call('shutdown', req)
+	if ok then return true end
+	ok = call('close', req)
+	if ok then return true end
+	ok = call('cancel', req, reason or 'terminated')
+	if ok then return true end
+	return true
+end
+
+return M

--- a/src/services/http/transport/tls.lua
+++ b/src/services/http/transport/tls.lua
@@ -1,0 +1,20 @@
+-- services/http/transport/tls.lua
+local M = {}
+local function require_tls()
+	local ok, mod = pcall(require, 'http.tls')
+	if not ok then return nil, mod end
+	return mod
+end
+function M.new_server_context(opts)
+	local tls, err = require_tls()
+	if not tls then return nil, err end
+	if type(tls.new_server_context) == 'function' then return tls.new_server_context(opts or {}) end
+	return nil, 'http.tls.new_server_context is not available'
+end
+function M.new_client_context(opts)
+	local tls, err = require_tls()
+	if not tls then return nil, err end
+	if type(tls.new_client_context) == 'function' then return tls.new_client_context(opts or {}) end
+	return nil, 'http.tls.new_client_context is not available'
+end
+return M

--- a/src/services/http/transport/uri.lua
+++ b/src/services/http/transport/uri.lua
@@ -1,0 +1,76 @@
+-- services/http/transport/uri.lua
+-- lua-http-backed URI parsing boundary for the HTTP capability service.
+--
+-- Policy code should not keep a separate hand-written parser for the same URI
+-- shape that lua-http will later consume.  This module uses lua-http's request
+-- constructor and utility helpers to produce the small normalised view needed by
+-- service policy without starting any network work.
+
+local http_request = require 'http.request'
+local http_util    = require 'http.util'
+
+local M = {}
+
+local function normalise_error(err)
+	local s = tostring(err or ''):lower()
+	if s:find('scheme not valid', 1, true) or s:find('unknown scheme', 1, true) then
+		return 'unsupported_scheme'
+	end
+	return 'invalid_args'
+end
+
+local function leading_scheme(uri)
+	return uri:match('^([%a][%w+.-]*)://')
+end
+
+local function lua_http_uri(uri, scheme)
+	-- http.request.new_from_uri is the authority/path parser used by the
+	-- backend.  WebSocket URIs are HTTP Upgrade requests, but lua-http's
+	-- request constructor is deliberately HTTP(S)-shaped, so parse ws/wss via
+	-- the corresponding HTTP scheme and restore the public scheme below.
+	if scheme == 'ws' then
+		return 'http://' .. uri:sub(6), 'http'
+	end
+	if scheme == 'wss' then
+		return 'https://' .. uri:sub(7), 'https'
+	end
+	return uri, scheme
+end
+
+function M.parse(uri)
+	if type(uri) ~= 'string' or uri == '' then return nil, 'invalid_args' end
+
+	local public_scheme = leading_scheme(uri)
+	if type(public_scheme) ~= 'string' then return nil, 'invalid_args' end
+	public_scheme = public_scheme:lower()
+
+	local parse_uri, authority_scheme = lua_http_uri(uri, public_scheme)
+	local ok, req_or_err = pcall(function ()
+		return http_request.new_from_uri(parse_uri)
+	end)
+	if not ok or not req_or_err then return nil, normalise_error(req_or_err) end
+
+	local req = req_or_err
+	local headers = req.headers
+	local parsed_scheme = headers and headers:get(':scheme') or nil
+	local authority = headers and headers:get(':authority') or nil
+	local path = headers and headers:get(':path') or nil
+	if type(parsed_scheme) ~= 'string' or parsed_scheme == '' then return nil, 'invalid_args' end
+	if type(authority) ~= 'string' or authority == '' then return nil, 'invalid_args' end
+
+	local ok_split, host, port = pcall(http_util.split_authority, authority, authority_scheme)
+	if not ok_split then return nil, 'invalid_args' end
+	if type(host) ~= 'string' or host == '' then return nil, 'invalid_args' end
+
+	return {
+		uri = uri,
+		scheme = public_scheme,
+		authority = authority,
+		host = host,
+		port = port,
+		path = path,
+		request = req,
+	}, nil
+end
+
+return M

--- a/src/services/http/transport/websocket.lua
+++ b/src/services/http/transport/websocket.lua
@@ -1,0 +1,251 @@
+-- services/http/transport/websocket.lua
+--
+-- Fibers-facing WebSocket wrapper for lua-http WebSocket objects.
+-- Underlying WebSocket methods run through the owning HttpContext command loop,
+-- so service code sees Ops and does not depend on cqueues callbacks.
+
+local op = require 'fibers.op'
+local terminate = require 'services.http.transport.terminate'
+local headers_mod = require 'services.http.headers'
+
+local M = {}
+
+local WebSocket = {}
+WebSocket.__index = WebSocket
+
+local function websocket_module(opts)
+	if opts and opts.websocket_module then return opts.websocket_module end
+	local ok, mod = pcall(require, 'http.websocket')
+	if not ok then return nil, mod end
+	return mod
+end
+
+local function apply_headers(ws, fields)
+	if fields == nil then return true end
+	local headers = ws and ws.headers
+	if headers == nil then return nil, 'websocket_headers_not_supported' end
+	for _, pair in ipairs(headers_mod.to_pairs(fields)) do
+		local k, v = tostring(pair[1]), tostring(pair[2] or '')
+		if type(headers.append) == 'function' then headers:append(k, v)
+		elseif type(headers.upsert) == 'function' then headers:upsert(k, v)
+		elseif type(headers.set) == 'function' then headers:set(k, v)
+		else return nil, 'websocket_headers_not_supported' end
+	end
+	return true
+end
+
+local function wrap(ctx, ws, opts)
+	local self = setmetatable({
+		_ctx = ctx,
+		_ws = ws,
+		_closed = false,
+		_close_reason = nil,
+		_on_terminate = opts and opts.on_terminate,
+	}, WebSocket)
+	if type(ctx) == 'table' then ctx._http_transport_websocket = self end
+	return self
+end
+
+function M.from_context_op(ctx, headers, opts)
+	opts = opts or {}
+	return op.guard(function ()
+		local websocket, err = websocket_module(opts)
+		if not websocket then return op.always(nil, err) end
+
+		return ctx:run_stream_op('websocket.new_from_stream', function (stream)
+			return websocket.new_from_stream(stream, headers)
+		end):wrap(function (ws, werr)
+			if not ws then return nil, werr or 'not_websocket' end
+			return wrap(ctx, ws, opts), nil
+		end)
+	end)
+end
+
+function WebSocket:_raw_websocket_for_test() return self._ws end
+function WebSocket:context() return self._ctx end
+
+function WebSocket:_notify_terminated(reason)
+	if self._closed then return true end
+	self._closed = true
+	self._close_reason = reason or 'closed'
+	local hook = self._on_terminate
+	self._on_terminate = nil
+	if hook then pcall(hook, self, self._close_reason) end
+	return true
+end
+
+function WebSocket:is_closed()
+	return self._closed or (self._ctx and self._ctx:is_closed())
+end
+
+function WebSocket:why()
+	return self._close_reason or (self._ctx and self._ctx:why())
+end
+
+function WebSocket:accept_op(options)
+	return self._ctx:run_stream_op('websocket.accept', function ()
+		return self._ws:accept(options or {})
+	end)
+end
+
+function WebSocket:receive_op()
+	return self._ctx:run_stream_op('websocket.receive', function ()
+		return self._ws:receive()
+	end)
+end
+
+function WebSocket:send_op(data, opcode)
+	return self._ctx:run_stream_op('websocket.send', function ()
+		return self._ws:send(data, opcode)
+	end)
+end
+
+function WebSocket:send_ping_op(data)
+	return self._ctx:run_stream_op('websocket.send_ping', function ()
+		return self._ws:send_ping(data)
+	end)
+end
+
+function WebSocket:send_pong_op(data)
+	return self._ctx:run_stream_op('websocket.send_pong', function ()
+		return self._ws:send_pong(data)
+	end)
+end
+
+function WebSocket:close_op(code, reason)
+	return self._ctx:run_stream_op('websocket.close', function ()
+		return self._ws:close(code, reason)
+	end):wrap(function (ok, err)
+		self:_notify_terminated(reason or err or 'closed')
+		return ok, err
+	end)
+end
+
+--- Immediate termination path for finalisers.  This is not a graceful protocol
+--- close; graceful close belongs in close_op() inside a worker scope.
+function WebSocket:terminate(reason)
+	if self._closed then return true end
+	local why = reason or 'closed'
+	if self._ctx then self._ctx:terminate(why) end
+	return self:_notify_terminated(why)
+end
+
+-- Client-side WebSocket transport --------------------------------------------
+
+local ClientWebSocket = {}
+ClientWebSocket.__index = ClientWebSocket
+
+local function wrap_client(driver, ws, opts)
+	return setmetatable({
+		_driver = driver,
+		_ws = ws,
+		_closed = false,
+		_close_reason = nil,
+		_on_terminate = opts and opts.on_terminate,
+	}, ClientWebSocket)
+end
+
+function M.connect_op(driver, args, opts)
+	opts = opts or {}
+	args = args or {}
+	return op.guard(function ()
+		if not driver or type(driver.run_op) ~= 'function' then
+			return op.always(nil, 'driver_required')
+		end
+		local websocket, werr = websocket_module(opts)
+		if not websocket then return op.always(nil, werr) end
+		if type(args.uri) ~= 'string' then return op.always(nil, 'invalid_args') end
+
+		local active = { ws = nil }
+		return driver:run_op('http.websocket.connect', function ()
+			local ws, err = websocket.new_from_uri(args.uri)
+			if not ws then return nil, err end
+			active.ws = ws
+			local hok, herr = apply_headers(ws, args.headers)
+			if hok ~= true then return nil, herr end
+			local ok, cerr = ws:connect(opts.backend_timeout)
+			if not ok then return nil, cerr end
+			return ws
+		end, {
+			on_active_abort = function (reason)
+				if active.ws then
+					terminate.terminate_websocket(active.ws, reason or 'websocket_connect_aborted')
+				elseif driver and driver.terminate then
+					driver:terminate(reason or 'websocket_connect_aborted')
+				end
+			end,
+		}):wrap(function (ws, err)
+			if not ws then return nil, err end
+			return wrap_client(driver, ws, opts), nil
+		end)
+	end)
+end
+
+function ClientWebSocket:_raw_websocket_for_test() return self._ws end
+function ClientWebSocket:is_closed() return self._closed end
+function ClientWebSocket:why() return self._close_reason end
+
+function ClientWebSocket:_run(label, fn)
+	if self._closed then return op.always(nil, self._close_reason or 'closed') end
+	return self._driver:run_op(label, fn, {
+		on_active_abort = function (reason)
+			self:terminate(reason or 'websocket_op_aborted')
+		end,
+	})
+end
+
+function ClientWebSocket:receive_op()
+	return self:_run('http.websocket.receive', function ()
+		return self._ws:receive()
+	end)
+end
+
+function ClientWebSocket:send_op(data, opcode)
+	return self:_run('http.websocket.send', function ()
+		return self._ws:send(data, opcode)
+	end)
+end
+
+function ClientWebSocket:send_ping_op(data)
+	return self:_run('http.websocket.ping', function ()
+		return self._ws:send_ping(data)
+	end)
+end
+
+function ClientWebSocket:send_pong_op(data)
+	return self:_run('http.websocket.pong', function ()
+		return self._ws:send_pong(data)
+	end)
+end
+
+function ClientWebSocket:close_op(code, reason)
+	return self:_run('http.websocket.close', function ()
+		return self._ws:close(code, reason)
+	end):wrap(function (ok, err)
+		self:_notify_terminated(reason or err or 'closed')
+		return ok, err
+	end)
+end
+
+function ClientWebSocket:_notify_terminated(reason)
+	if self._closed then return true end
+	self._closed = true
+	self._close_reason = reason or 'closed'
+	local hook = self._on_terminate
+	self._on_terminate = nil
+	if hook then pcall(hook, self, self._close_reason) end
+	return true
+end
+
+function ClientWebSocket:terminate(reason)
+	if self._closed then return true end
+	local why = reason or 'closed'
+	terminate.terminate_websocket(self._ws, why)
+	return self:_notify_terminated(why)
+end
+
+M.ClientWebSocket = ClientWebSocket
+
+M.WebSocket = WebSocket
+
+return M

--- a/src/services/http/websocket.lua
+++ b/src/services/http/websocket.lua
@@ -1,0 +1,249 @@
+-- services/http/websocket.lua
+-- Public WebSocket transport handle boundary above services.http.transport.
+
+local transport_ws = require 'services.http.transport.websocket'
+local op = require 'fibers.op'
+
+local M = {}
+
+local WebSocket = {}
+WebSocket.__index = WebSocket
+
+local ClientWebSocket = {}
+ClientWebSocket.__index = ClientWebSocket
+
+local function copy(t)
+	local out = {}
+	for k, v in pairs(t or {}) do out[k] = v end
+	return out
+end
+
+local function raw_context(ctx)
+	if ctx and type(ctx._raw_context) == 'function' then return ctx:_raw_context() end
+	return ctx
+end
+
+local function notify_terminated(self, reason)
+	if self._closed then return true end
+	self._closed = true
+	self._close_reason = reason or 'closed'
+	local hooks = self._terminate_hooks or {}
+	self._terminate_hooks = {}
+	local hook = self._on_terminate
+	self._on_terminate = nil
+	if hook then pcall(hook, self, self._close_reason) end
+	for _, f in ipairs(hooks) do pcall(f, self, self._close_reason) end
+	return true
+end
+
+local function wrap_server(raw, opts)
+	if raw == nil then return nil, 'websocket_required' end
+	if type(raw) == 'table' and raw._http_public_websocket then return raw._http_public_websocket end
+	local self = setmetatable({
+		_raw = raw,
+		_closed = false,
+		_close_reason = nil,
+		_on_terminate = opts and opts.on_terminate,
+		_terminate_hooks = {},
+	}, WebSocket)
+	if type(raw) == 'table' then raw._http_public_websocket = self end
+	return self
+end
+
+local function wrap_client(raw, opts)
+	if raw == nil then return nil, 'websocket_required' end
+	if type(raw) == 'table' and raw._http_public_client_websocket then return raw._http_public_client_websocket end
+	local self = setmetatable({
+		_raw = raw,
+		_closed = false,
+		_close_reason = nil,
+		_on_terminate = opts and opts.on_terminate,
+		_terminate_hooks = {},
+	}, ClientWebSocket)
+	if type(raw) == 'table' then raw._http_public_client_websocket = self end
+	return self
+end
+
+function M.from_context_op(ctx, headers, opts)
+	opts = opts or {}
+	return op.guard(function ()
+		local public
+		local transport_opts = copy(opts)
+		transport_opts.on_terminate = function (_, reason)
+			if public then return public:_notify_terminated(reason) end
+			local hook = opts.on_terminate
+			if hook then return hook(nil, reason) end
+			return true
+		end
+		return transport_ws.from_context_op(raw_context(ctx), headers, transport_opts):wrap(function (raw_ws, err)
+			if not raw_ws then return nil, err end
+			public = assert(wrap_server(raw_ws, opts))
+			if ctx and type(ctx._register_server_websocket) == 'function' then
+				local ok, rerr = ctx:_register_server_websocket(public)
+				if ok == nil or ok == false then
+					public:terminate(rerr or 'websocket_registration_failed')
+					return nil, rerr or 'websocket_registration_failed'
+				end
+			end
+			return public, nil
+		end)
+	end)
+end
+
+function M.connect_op(driver, args, opts)
+	opts = opts or {}
+	return op.guard(function ()
+		local public
+		local transport_opts = copy(opts)
+		transport_opts.on_terminate = function (_, reason)
+			if public then return public:_notify_terminated(reason) end
+			local hook = opts.on_terminate
+			if hook then return hook(nil, reason) end
+			return true
+		end
+		return transport_ws.connect_op(driver, args, transport_opts):wrap(function (raw_ws, err)
+			if not raw_ws then return nil, err end
+			public = assert(wrap_client(raw_ws, opts))
+			return public, nil
+		end)
+	end)
+end
+
+function WebSocket:_raw_websocket_for_test()
+	return self._raw and self._raw._raw_websocket_for_test and self._raw:_raw_websocket_for_test()
+end
+
+function WebSocket:_notify_terminated(reason)
+	return notify_terminated(self, reason)
+end
+
+function WebSocket:add_terminate_hook(fn)
+	if type(fn) ~= 'function' then return nil, 'invalid_args' end
+	if self._closed then fn(self, self._close_reason or 'closed'); return function () end end
+	local hooks = self._terminate_hooks or {}
+	self._terminate_hooks = hooks
+	hooks[#hooks + 1] = fn
+	local active = true
+	return function ()
+		if not active then return end
+		active = false
+		for i, h in ipairs(hooks) do
+			if h == fn then table.remove(hooks, i); break end
+		end
+	end
+end
+
+
+function WebSocket:context()
+	local raw_ctx = self._raw and self._raw.context and self._raw:context()
+	return raw_ctx
+end
+
+function WebSocket:is_closed()
+	return self._closed or (self._raw and self._raw:is_closed())
+end
+
+function WebSocket:why()
+	return self._close_reason or (self._raw and self._raw:why())
+end
+
+function WebSocket:accept_op(options)
+	return self._raw:accept_op(options)
+end
+
+function WebSocket:receive_op()
+	return self._raw:receive_op()
+end
+
+function WebSocket:send_op(data, opcode)
+	return self._raw:send_op(data, opcode)
+end
+
+function WebSocket:send_ping_op(data)
+	return self._raw:send_ping_op(data)
+end
+
+function WebSocket:send_pong_op(data)
+	return self._raw:send_pong_op(data)
+end
+
+function WebSocket:close_op(code, reason)
+	return self._raw:close_op(code, reason):wrap(function (ok, err)
+		self:_notify_terminated(reason or err or 'closed')
+		return ok, err
+	end)
+end
+
+function WebSocket:terminate(reason)
+	if self._closed then return true end
+	if self._raw and self._raw.terminate then self._raw:terminate(reason or 'closed') end
+	return self:_notify_terminated(reason or 'closed')
+end
+
+function ClientWebSocket:_raw_websocket_for_test()
+	return self._raw and self._raw._raw_websocket_for_test and self._raw:_raw_websocket_for_test()
+end
+
+function ClientWebSocket:_notify_terminated(reason)
+	return notify_terminated(self, reason)
+end
+
+function ClientWebSocket:add_terminate_hook(fn)
+	if type(fn) ~= 'function' then return nil, 'invalid_args' end
+	if self._closed then fn(self, self._close_reason or 'closed'); return function () end end
+	local hooks = self._terminate_hooks or {}
+	self._terminate_hooks = hooks
+	hooks[#hooks + 1] = fn
+	local active = true
+	return function ()
+		if not active then return end
+		active = false
+		for i, h in ipairs(hooks) do
+			if h == fn then table.remove(hooks, i); break end
+		end
+	end
+end
+
+
+function ClientWebSocket:is_closed()
+	return self._closed or (self._raw and self._raw:is_closed())
+end
+
+function ClientWebSocket:why()
+	return self._close_reason or (self._raw and self._raw:why())
+end
+
+function ClientWebSocket:receive_op()
+	return self._raw:receive_op()
+end
+
+function ClientWebSocket:send_op(data, opcode)
+	return self._raw:send_op(data, opcode)
+end
+
+function ClientWebSocket:send_ping_op(data)
+	return self._raw:send_ping_op(data)
+end
+
+function ClientWebSocket:send_pong_op(data)
+	return self._raw:send_pong_op(data)
+end
+
+function ClientWebSocket:close_op(code, reason)
+	return self._raw:close_op(code, reason):wrap(function (ok, err)
+		self:_notify_terminated(reason or err or 'closed')
+		return ok, err
+	end)
+end
+
+function ClientWebSocket:terminate(reason)
+	if self._closed then return true end
+	if self._raw and self._raw.terminate then self._raw:terminate(reason or 'closed') end
+	return self:_notify_terminated(reason or 'closed')
+end
+
+M.wrap_server = wrap_server
+M.wrap_client = wrap_client
+M.WebSocket = WebSocket
+M.ClientWebSocket = ClientWebSocket
+return M

--- a/tests/integration/devhost/test_http_service_real.lua
+++ b/tests/integration/devhost/test_http_service_real.lua
@@ -1,0 +1,376 @@
+-- Real devhost integration for cap/http/main over the local bus.
+--
+-- These tests use the real cqueues/lua-http backend.  They focus on the
+-- capability-service seam: local handle return, listener/context ownership
+-- transfer, service shutdown backstop termination, outgoing exchange, and
+-- outgoing WebSocket transport.
+
+local fibers = require 'fibers'
+local sleep  = require 'fibers.sleep'
+local runtime = require 'fibers.runtime'
+local bus    = require 'bus'
+
+local http_request   = require 'http.request'
+local http_headers   = require 'http.headers'
+local http_server    = require 'http.server'
+local http_websocket = require 'http.websocket'
+
+local http_service = require 'services.http.service'
+local sdk_mod      = require 'services.http.sdk'
+local driver_mod   = require 'services.http.transport.cqueues_driver'
+local lua_http     = require 'services.http.transport.lua_http'
+local ws_wrap      = require 'services.http.transport.websocket'
+local body_mod     = require 'services.http.body'
+
+local M = {}
+
+local function eq(a, b, msg)
+	if a ~= b then error((msg or 'assertion failed') .. ': expected ' .. tostring(b) .. ', got ' .. tostring(a), 2) end
+end
+local function ok(v, msg) if not v then error(msg or 'assertion failed', 2) end return v end
+
+local function yield_once()
+	runtime.yield()
+end
+
+local function yield_many(n)
+	for _ = 1, n do yield_once() end
+end
+
+local function wait_until(predicate, timeout, label)
+	local deadline = runtime.now() + (timeout or 5)
+	while not predicate() do
+		if runtime.now() >= deadline then
+			error('timed out waiting for ' .. (label or 'condition'), 2)
+		end
+		fibers.perform(sleep.sleep_op(0.01))
+	end
+end
+
+local function response_headers(status, content_type)
+	local h = http_headers.new()
+	h:append(':status', tostring(status or 200))
+	if content_type then h:append('content-type', content_type) end
+	return h
+end
+
+local function http_uri(port, path)
+	return ('http://127.0.0.1:%d%s'):format(port, path or '/')
+end
+
+local function ws_uri(port, path)
+	return ('ws://127.0.0.1:%d%s'):format(port, path or '/ws')
+end
+
+local function start_cap_service(opts)
+	opts = opts or {}
+	local memory_sinks = opts.memory_sinks or {}
+	local memory_sources = opts.memory_sources or {}
+	local registry = opts.body_registry or body_mod.new_registry()
+	registry:register_resolver('memory_sink', function (desc)
+		local key = desc.ref or 'default'
+		memory_sinks[key] = memory_sinks[key] or { chunks = {} }
+		local rec = memory_sinks[key]
+		return {
+			write_chunk_op = function (_, chunk) rec.chunks[#rec.chunks + 1] = chunk; return fibers.always(true) end,
+			finish_op = function () rec.finished = true; return fibers.always(true) end,
+			terminate = function (_, reason) rec.terminated = reason or true; return true end,
+		}
+	end)
+	registry:register_resolver('memory_source', function (desc)
+		local key = desc.ref or 'default'
+		local chunks = memory_sources[key] or {}
+		local i = 0
+		return {
+			read_chunk_op = function ()
+				return fibers.guard(function ()
+					i = i + 1
+					return fibers.always(chunks[i], nil)
+				end)
+			end,
+			terminate = function (_, reason) memory_sources[key .. '_terminated'] = reason or true; return true end,
+		}
+	end)
+	local b = bus.new()
+	local svc_conn = b:connect({ origin_base = { kind = 'local' } })
+	local svc = ok(http_service.start(svc_conn, {
+		id = opts.id or 'main',
+		backend_timeout = opts.backend_timeout or 2,
+		connection_setup_timeout = opts.connection_setup_timeout or 2,
+		intra_stream_timeout = opts.intra_stream_timeout or 2,
+		max_accept_queue = opts.max_accept_queue or 32,
+		body_registry = registry,
+	}))
+
+	local user_conn = b:connect({ origin_base = { kind = 'local' } })
+	local ref = sdk_mod.new_ref(user_conn, opts.id or 'main')
+	return b, svc, ref, memory_sinks
+end
+
+local function new_backend_listener(opts)
+	opts = opts or {}
+	local driver = ok(driver_mod.new { label = opts.label or 'http-service-real-backend' })
+	local listener = ok(lua_http.listen {
+		driver = driver,
+		http_server = http_server,
+		host = '127.0.0.1',
+		port = 0,
+		tls = false,
+		max_accept_queue = opts.max_accept_queue or 32,
+		connection_setup_timeout = opts.connection_setup_timeout or 2,
+		intra_stream_timeout = opts.intra_stream_timeout or 2,
+	})
+	return listener, driver
+end
+
+local function start_backend_listener(scope, opts)
+	local listener, driver = new_backend_listener(opts)
+	ok(driver:start(scope), 'backend driver should start')
+	ok(listener:start(scope), 'backend listener should start')
+	ok(fibers.perform(listener:listen_op()), 'backend listener should bind')
+	local _, _, port = listener:localname()
+	ok(type(port) == 'number' and port > 0, 'backend listener should bind an ephemeral port')
+	return listener, driver, port
+end
+
+local function run_http_client(driver, uri, body, method)
+	return fibers.perform(driver:run_op('real-http-service-test-client', function ()
+		local req = http_request.new_from_uri(uri)
+		if method then req.headers:upsert(':method', method) end
+		if body ~= nil then
+			req.headers:upsert(':method', method or 'POST')
+			req:set_body(body)
+		end
+
+		local headers, stream = assert(req:go(2))
+		local response_body = assert(stream:get_body_as_string(2))
+		return headers:get(':status'), response_body
+	end))
+end
+
+function M.test_real_http_service_listen_returns_local_listener_handle()
+	fibers.run(function ()
+		local _, svc, ref = start_cap_service()
+
+		local rep = ok(fibers.perform(ref:listen_op({
+			host = '127.0.0.1',
+			port = 0,
+			tls = false,
+		}, { timeout = 3 })))
+		local listener = ok(rep.listener, 'listen should return a local listener handle')
+		local _, _, port = listener:localname()
+		ok(type(port) == 'number' and port > 0, 'listener should bind an ephemeral port')
+
+		ok(fibers.spawn(function ()
+			local ctx = ok(fibers.perform(listener:accept_op()))
+			local req_headers = ok(fibers.perform(ctx:get_headers_op()))
+			eq(req_headers:get(':path'), '/cap-test')
+			ok(fibers.perform(ctx:write_headers_op(response_headers(200, 'text/plain'))))
+			ok(fibers.perform(ctx:write_body_from_string_op('served-by-cap-http')))
+		end))
+
+		local status, body = run_http_client(svc._driver, http_uri(port, '/cap-test'))
+		eq(status, '200')
+		eq(body, 'served-by-cap-http')
+		yield_many(8)
+		local saw_context = false
+		for _, ev in ipairs(svc:events()) do
+			if ev.kind == 'context_admitted' then
+				saw_context = true
+				ok(ev.listener_id ~= nil, 'context_admitted should carry listener identity')
+				ok(ev.context_id ~= nil, 'context_admitted should carry context identity')
+			end
+		end
+		ok(saw_context, 'expected context_admitted event')
+
+		svc:terminate('done')
+	end)
+end
+
+function M.test_real_service_shutdown_terminates_live_listener_and_wakes_accept_op()
+	fibers.run(function (scope)
+		local _, svc, ref = start_cap_service()
+
+		local rep = ok(fibers.perform(ref:listen_op({ host = '127.0.0.1', port = 0, tls = false }, { timeout = 3 })))
+		local listener = ok(rep.listener)
+		local accepted, accept_err
+
+		ok(scope:spawn(function ()
+			accepted, accept_err = fibers.perform(listener:accept_op())
+		end))
+
+		yield_many(4)
+		svc:terminate('service_shutdown')
+		yield_many(8)
+
+		eq(accepted, nil)
+		eq(accept_err, 'service_shutdown')
+		ok(listener:is_closed(), 'service shutdown should terminate the live listener handle')
+	end)
+end
+
+function M.test_real_accepted_context_survives_listener_close_after_ownership_transfer()
+	fibers.run(function (scope)
+		local _, svc, ref = start_cap_service()
+
+		local rep = ok(fibers.perform(ref:listen_op({ host = '127.0.0.1', port = 0, tls = false }, { timeout = 3 })))
+		local listener = ok(rep.listener)
+		local _, _, port = listener:localname()
+		local served = false
+
+		ok(scope:spawn(function ()
+			local ctx = ok(fibers.perform(listener:accept_op()))
+			local req_headers = ok(fibers.perform(ctx:get_headers_op()))
+			eq(req_headers:get(':path'), '/accepted-transfer')
+
+			listener:terminate('listener_closed')
+			ok(not ctx:is_closed(), 'accepted context should no longer be listener-owned')
+
+			ok(fibers.perform(ctx:write_headers_op(response_headers(200, 'text/plain'))))
+			ok(fibers.perform(ctx:write_body_from_string_op('context-still-owned-by-request')))
+			served = true
+		end))
+
+		local status, body = run_http_client(svc._driver, http_uri(port, '/accepted-transfer'))
+		eq(status, '200')
+		eq(body, 'context-still-owned-by-request')
+		ok(served, 'request scope should finish response after listener close')
+		ok(listener:is_closed(), 'listener should be closed')
+
+		svc:terminate('done')
+	end)
+end
+
+function M.test_real_cap_exchange_get_and_post_round_trip_to_local_server()
+	fibers.run(function (scope)
+		local listener, driver, port = start_backend_listener(scope, { label = 'http-service-real-exchange-backend' })
+		local _, svc, ref, sinks = start_cap_service({
+			memory_sources = { post = { 'upload-', 'payload' } },
+		})
+		local handled = 0
+
+		for _ = 1, 2 do
+			ok(scope:spawn(function ()
+				local ctx = ok(fibers.perform(listener:accept_op()))
+				local req_headers = ok(fibers.perform(ctx:get_headers_op()))
+				local method = req_headers:get(':method') or 'GET'
+				local path = req_headers:get(':path') or '/'
+				local payload = ''
+				if method == 'POST' then
+					payload = ':' .. ok(fibers.perform(ctx:read_body_as_string_op()))
+				end
+				handled = handled + 1
+				ok(fibers.perform(ctx:write_headers_op(response_headers(200, 'text/plain'))))
+				ok(fibers.perform(ctx:write_body_from_string_op(method .. ':' .. path .. payload)))
+			end))
+		end
+
+		local get_rep = ok(fibers.perform(ref:exchange_op({
+			uri = http_uri(port, '/out-get'),
+			method = 'GET',
+			headers = { ['x-test'] = 'get' },
+			response_sink = { kind = 'memory_sink', ref = 'get' },
+		}, { timeout = 3 })))
+		eq(get_rep.result.status, '200')
+		eq(table.concat(sinks.get.chunks), 'GET:/out-get')
+
+		local post_rep = ok(fibers.perform(ref:exchange_op({
+			uri = http_uri(port, '/out-post'),
+			method = 'POST',
+			headers = { ['x-test'] = 'post' },
+			body_source = { kind = 'memory_source', ref = 'post' },
+			response_sink = { kind = 'memory_sink', ref = 'post' },
+		}, { timeout = 3 })))
+		eq(post_rep.result.status, '200')
+		eq(table.concat(sinks.post.chunks), 'POST:/out-post:upload-payload')
+		eq(handled, 2)
+
+		svc:terminate('done')
+		listener:terminate('done')
+		driver:terminate('done')
+	end)
+end
+
+function M.test_real_open_exchange_handle_is_terminated_by_service_shutdown_backstop()
+	fibers.run(function (scope)
+		local listener, driver, port = start_backend_listener(scope, { label = 'http-service-real-open-exchange-backend' })
+		local _, svc, ref = start_cap_service()
+		local server_ready = false
+		local release_server = false
+		local server_done = false
+
+		ok(scope:spawn(function ()
+			local ctx = ok(fibers.perform(listener:accept_op()))
+			ok(fibers.perform(ctx:get_headers_op()))
+			ok(fibers.perform(ctx:write_headers_op(response_headers(200, 'text/plain'))))
+			server_ready = true
+
+			-- Keep the response stream open while the returned exchange handle is
+			-- handed off to the caller and then terminated by the HTTP service
+			-- shutdown backstop.  Do not leave an independent sleeper behind after
+			-- the assertion: fibers.run would otherwise wait for it at scope exit.
+			while not release_server do
+				fibers.perform(sleep.sleep_op(0.01))
+			end
+
+			ctx:terminate('server_done')
+			server_done = true
+		end))
+
+		local rep = ok(fibers.perform(ref:open_exchange_op({ uri = http_uri(port, '/held-open'), method = 'GET' }, { timeout = 3 })))
+		local exchange = ok(rep.exchange, 'open_exchange should return a local exchange handle')
+		eq(exchange:status(), '200')
+		ok(server_ready, 'server should have written response headers')
+		ok(not exchange:is_closed(), 'returned exchange should survive setup operation handoff')
+
+		svc:terminate('service_shutdown')
+		ok(exchange:is_closed(), 'service shutdown should terminate handed-off exchange as backend backstop')
+		eq(exchange:why(), 'service_shutdown')
+
+		release_server = true
+		wait_until(function () return server_done end, 1, 'held-open server handler to finish')
+
+		listener:terminate('done')
+		driver:terminate('done')
+	end)
+end
+
+function M.test_real_cap_connect_ws_send_receive_and_close_round_trip()
+	fibers.run(function (scope)
+		local listener, driver, port = start_backend_listener(scope, { label = 'http-service-real-ws-backend' })
+		local _, svc, ref = start_cap_service()
+		local server_done = false
+
+		ok(scope:spawn(function ()
+			local ctx = ok(fibers.perform(listener:accept_op()))
+			local req_headers = ok(fibers.perform(ctx:get_headers_op()))
+			local ws = ok(fibers.perform(ws_wrap.from_context_op(ctx, req_headers, {
+				websocket_module = http_websocket,
+			})))
+			ok(fibers.perform(ws:accept_op({})))
+
+			local data, opcode = fibers.perform(ws:receive_op())
+			ok(data, 'server websocket should receive data')
+			eq(opcode, 'text')
+			ok(fibers.perform(ws:send_op(data .. ':via-cap-http', 'text')))
+			fibers.perform(ws:close_op(1000, 'server_done'))
+			server_done = true
+		end))
+
+		local rep = ok(fibers.perform(ref:connect_ws_op({ uri = ws_uri(port, '/ws') }, { timeout = 3 })))
+		local ws = ok(rep.websocket, 'connect_ws should return a local WebSocket handle')
+		ok(fibers.perform(ws:send_op('ping', 'text')))
+		local data, opcode = fibers.perform(ws:receive_op())
+		eq(data, 'ping:via-cap-http')
+		eq(opcode, 'text')
+		fibers.perform(ws:close_op(1000, 'client_done'))
+
+		wait_until(function () return server_done end, 5, 'websocket server close')
+
+		svc:terminate('done')
+		listener:terminate('done')
+		driver:terminate('done')
+	end)
+end
+
+return M

--- a/tests/integration/devhost/test_http_transport_real.lua
+++ b/tests/integration/devhost/test_http_transport_real.lua
@@ -1,0 +1,356 @@
+-- tests/integration/devhost/test_http_transport_real.lua
+--
+-- Real devhost integration tests for the HTTP transport seam.
+--
+-- These tests intentionally use real cqueues and lua-http modules. There are no
+-- fakes or mocks in this file. Add this module to the top-level integration
+-- runner when the devhost/CI image has cqueues and lua-http installed.
+
+local fibers = require 'fibers'
+local sleep  = require 'fibers.sleep'
+local runtime = require 'fibers.runtime'
+
+local cqueues_condition = require 'cqueues.condition'
+local http_server       = require 'http.server'
+local http_request      = require 'http.request'
+local http_headers      = require 'http.headers'
+local http_websocket    = require 'http.websocket'
+
+local driver_mod = require 'services.http.transport.cqueues_driver'
+local lua_http   = require 'services.http.transport.lua_http'
+local ws_wrap    = require 'services.http.transport.websocket'
+local terminate  = require 'services.http.transport.terminate'
+
+local M = {}
+
+local function eq(a, b, msg)
+	if a ~= b then
+		error((msg or 'assertion failed') .. ': expected ' .. tostring(b) .. ', got ' .. tostring(a), 2)
+	end
+end
+
+local function ok(v, msg)
+	if not v then error(msg or 'assertion failed', 2) end
+	return v
+end
+
+local function yield_once()
+	runtime.yield()
+end
+
+local function yield_many(n)
+	for _ = 1, n do yield_once() end
+end
+
+local function wait_until(predicate, timeout, label)
+	local deadline = runtime.now() + (timeout or 5)
+	while not predicate() do
+		if runtime.now() >= deadline then
+			error('timed out waiting for ' .. (label or 'condition'), 2)
+		end
+		fibers.perform(sleep.sleep_op(0.01))
+	end
+end
+
+local function response_headers(status, content_type)
+	local h = http_headers.new()
+	h:append(':status', tostring(status or 200))
+	if content_type then h:append('content-type', content_type) end
+	return h
+end
+
+local function http_uri(port, path)
+	return ('http://127.0.0.1:%d%s'):format(port, path or '/')
+end
+
+local function ws_uri(port, path)
+	return ('ws://127.0.0.1:%d%s'):format(port, path or '/ws')
+end
+
+local function new_listener(opts)
+	opts = opts or {}
+
+	local driver = ok(driver_mod.new {
+		label = opts.label or 'http-transport-real-integration',
+	})
+
+	local listener = ok(lua_http.listen {
+		driver = driver,
+		http_server = http_server,
+		host = '127.0.0.1',
+		port = 0,
+		tls = false,
+		max_accept_queue = opts.max_accept_queue or 32,
+		connection_setup_timeout = opts.connection_setup_timeout or 2,
+		intra_stream_timeout = opts.intra_stream_timeout or 2,
+	})
+
+	return listener, driver
+end
+
+local function start_listener(scope, listener, driver)
+	ok(driver:start(scope), 'driver should start')
+	ok(listener:start(scope), 'listener should start')
+	ok(fibers.perform(listener:listen_op()), 'listener:listen should succeed')
+
+	local family, addr, port = listener:_raw_server_for_test():localname()
+	ok(family, 'server:localname should return a family')
+	ok(addr, 'server:localname should return an address')
+	ok(type(port) == 'number' and port > 0, 'server should bind an ephemeral TCP port')
+
+	return port
+end
+
+local function run_http_client(driver, uri, body, method)
+	return fibers.perform(driver:run_op('real-http-client', function ()
+		local req = http_request.new_from_uri(uri)
+		if method then req.headers:upsert(':method', method) end
+		if body ~= nil then
+			req.headers:upsert(':method', method or 'POST')
+			req:set_body(body)
+		end
+
+		local headers, stream = assert(req:go(5))
+		local response_body = assert(stream:get_body_as_string(5))
+		return headers:get(':status'), response_body
+	end))
+end
+
+
+function M.test_real_transport_terminate_server_helper_closes_lua_http_server()
+	fibers.run(function (scope)
+		local listener, driver = new_listener({ label = 'http-transport-real-terminate-helper' })
+		local port = start_listener(scope, listener, driver)
+		ok(type(port) == 'number' and port > 0)
+		ok(terminate.terminate_server(listener:_raw_server_for_test(), 'helper_close'))
+		listener:terminate('done')
+		driver:terminate('done')
+	end)
+end
+
+function M.test_real_http_get_round_trips_through_listener_context()
+	fibers.run(function (scope)
+		local listener, driver = new_listener()
+		local port = start_listener(scope, listener, driver)
+
+		local seen_path
+		ok(scope:spawn(function ()
+			local ctx = ok(fibers.perform(listener:accept_op()))
+			local req_headers = ok(fibers.perform(ctx:get_headers_op()))
+			seen_path = req_headers:get(':path')
+
+			ok(fibers.perform(ctx:write_headers_op(response_headers(200, 'text/plain'))))
+			ok(fibers.perform(ctx:write_body_from_string_op('hello from fibers')))
+		end))
+
+		local status, body = run_http_client(driver, http_uri(port, '/hello'))
+		eq(status, '200')
+		eq(body, 'hello from fibers')
+		eq(seen_path, '/hello')
+
+		listener:terminate('done')
+		driver:terminate('done')
+	end)
+end
+
+function M.test_real_http_post_body_is_read_and_echoed()
+	fibers.run(function (scope)
+		local listener, driver = new_listener()
+		local port = start_listener(scope, listener, driver)
+
+		ok(scope:spawn(function ()
+			local ctx = ok(fibers.perform(listener:accept_op()))
+			local req_headers = ok(fibers.perform(ctx:get_headers_op()))
+			eq(req_headers:get(':method'), 'POST')
+
+			local payload = ok(fibers.perform(ctx:read_body_as_string_op()))
+			ok(fibers.perform(ctx:write_headers_op(response_headers(201, 'text/plain'))))
+			ok(fibers.perform(ctx:write_body_from_string_op('echo:' .. payload)))
+		end))
+
+		local status, body = run_http_client(driver, http_uri(port, '/upload'), 'abc123', 'POST')
+		eq(status, '201')
+		eq(body, 'echo:abc123')
+
+		listener:terminate('done')
+		driver:terminate('done')
+	end)
+end
+
+function M.test_real_multiple_concurrent_http_requests_complete()
+	fibers.run(function (scope)
+		local listener, driver = new_listener()
+		local port = start_listener(scope, listener, driver)
+		local n = 5
+		local handled = 0
+		local completed = 0
+		local results = {}
+
+		for _ = 1, n do
+			ok(scope:spawn(function ()
+				local ctx = ok(fibers.perform(listener:accept_op()))
+				local req_headers = ok(fibers.perform(ctx:get_headers_op()))
+				local path = req_headers:get(':path') or '/none'
+				handled = handled + 1
+				ok(fibers.perform(ctx:write_headers_op(response_headers(200, 'text/plain'))))
+				ok(fibers.perform(ctx:write_body_from_string_op('seen:' .. path)))
+			end))
+		end
+
+		for i = 1, n do
+			ok(scope:spawn(function ()
+				local status, body = run_http_client(driver, http_uri(port, '/r' .. i))
+				results[i] = { status = status, body = body }
+				completed = completed + 1
+			end))
+		end
+
+		wait_until(function () return completed == n end, 5, 'concurrent HTTP clients')
+
+		for i = 1, n do
+			eq(results[i].status, '200')
+			eq(results[i].body, 'seen:/r' .. i)
+		end
+		eq(handled, n)
+
+		listener:terminate('done')
+		driver:terminate('done')
+	end)
+end
+
+function M.test_real_websocket_echo_round_trip_uses_context_wrapper()
+	fibers.run(function (scope)
+		local listener, driver = new_listener()
+		local port = start_listener(scope, listener, driver)
+
+		ok(scope:spawn(function ()
+			local ctx = ok(fibers.perform(listener:accept_op()))
+			local req_headers = ok(fibers.perform(ctx:get_headers_op()))
+			local ws = ok(fibers.perform(ws_wrap.from_context_op(ctx, req_headers, {
+				websocket_module = http_websocket,
+			})))
+			ok(fibers.perform(ws:accept_op({})))
+
+			local data, opcode = fibers.perform(ws:receive_op())
+			ok(data, 'server WebSocket receive should return data')
+			eq(opcode, 'text')
+
+			ok(fibers.perform(ws:send_op(data .. ':echo', 'text')))
+			fibers.perform(ws:close_op(1000, 'done'))
+		end))
+
+		local client_data, client_opcode = fibers.perform(driver:run_op('real-websocket-client', function ()
+			local ws = assert(http_websocket.new_from_uri(ws_uri(port, '/ws')))
+			assert(ws:connect(5))
+			assert(ws:send('ping', 'text', 5))
+			local data, opcode = assert(ws:receive(5))
+			ws:close(1000, 'client_done', 5)
+			return data, opcode
+		end))
+
+		eq(client_data, 'ping:echo')
+		eq(client_opcode, 'text')
+
+		listener:terminate('done')
+		driver:terminate('done')
+	end)
+end
+
+function M.test_real_losing_driver_run_op_aborts_before_controller_pump()
+	local driver = ok(driver_mod.new { label = 'http-transport-losing-run-op' })
+	local ran = false
+
+	fibers.run(function (scope)
+		local which = fibers.perform(fibers.named_choice {
+			winner = fibers.always('now'),
+			loser = driver:run_op('must-not-run', function ()
+				ran = true
+				return 'bad'
+			end),
+		})
+		eq(which, 'winner')
+
+		ok(driver:start(scope))
+		yield_many(8)
+		ok(not ran, 'aborted cqueues job must not run after losing choice')
+
+		driver:terminate('done')
+	end)
+end
+
+function M.test_real_multiple_concurrent_driver_run_ops_complete()
+	local driver = ok(driver_mod.new { label = 'http-transport-concurrent-run-ops' })
+
+	fibers.run(function (scope)
+		ok(driver:start(scope))
+
+		local n = 6
+		local completed = 0
+		local results = {}
+
+		for i = 1, n do
+			ok(scope:spawn(function ()
+				local value, err = fibers.perform(driver:run_op('real-job-' .. i, function ()
+					return i * 10
+				end))
+				results[i] = { value = value, err = err }
+				completed = completed + 1
+			end))
+		end
+
+		wait_until(function () return completed == n end, 5, 'concurrent cqueues jobs')
+
+		for i = 1, n do
+			eq(results[i].value, i * 10)
+			eq(results[i].err, nil)
+		end
+
+		driver:terminate('done')
+	end)
+end
+
+function M.test_real_listener_termination_wakes_pending_accept()
+	fibers.run(function (scope)
+		local listener, driver = new_listener()
+		start_listener(scope, listener, driver)
+
+		local got, err
+		ok(scope:spawn(function ()
+			got, err = fibers.perform(listener:accept_op())
+		end))
+
+		yield_many(4)
+		listener:terminate('listener_closed')
+		yield_many(4)
+
+		eq(got, nil)
+		eq(err, 'listener_closed')
+
+		driver:terminate('done')
+	end)
+end
+
+function M.test_real_driver_termination_wakes_pending_cqueues_job()
+	fibers.run(function (scope)
+		local driver = ok(driver_mod.new { label = 'http-transport-driver-termination' })
+		ok(driver:start(scope))
+
+		local result, err
+		ok(scope:spawn(function ()
+			result, err = fibers.perform(driver:run_op('blocked-real-cqueues-job', function ()
+				local cv = cqueues_condition.new and cqueues_condition.new() or cqueues_condition()
+				cv:wait()
+				return 'unexpected'
+			end))
+		end))
+
+		yield_many(8)
+		driver:terminate('driver_stopped')
+		yield_many(8)
+
+		eq(result, nil)
+		eq(err, 'driver_stopped')
+	end)
+end
+
+return M

--- a/tests/run.lua
+++ b/tests/run.lua
@@ -96,6 +96,21 @@ local files = {
 	'unit.support.test_bus_cleanup',
 	'unit.support.test_config_watch',
 	'unit.support.test_service_events',
+	'unit.http.transport.test_cqueues_driver',
+	'unit.http.transport.test_lua_http',
+	'unit.http.transport.test_websocket',
+	'unit.http.transport.test_terminate',
+	'unit.http.test_headers',
+	'unit.http.test_body',
+	'unit.http.test_policy',
+	'unit.http.test_config',
+	'unit.http.test_client',
+	'unit.http.test_websocket_client',
+	'unit.http.test_service',
+	'unit.http.test_service_architecture',
+	'unit.http.test_structure',
+	'integration.devhost.test_http_transport_real',
+	'integration.devhost.test_http_service_real',
 }
 
 local function monotonic_now()

--- a/tests/unit/http/test_body.lua
+++ b/tests/unit/http/test_body.lua
@@ -1,0 +1,117 @@
+local fibers = require 'fibers'
+local body = require 'services.http.body'
+
+local M = {}
+
+local function eq(a, b, msg)
+	if a ~= b then error((msg or 'assertion failed') .. ': expected ' .. tostring(b) .. ', got ' .. tostring(a), 2) end
+end
+local function ok(v, msg) if not v then error(msg or 'assertion failed', 2) end return v end
+
+function M.test_descriptor_rejects_inline_bytes()
+	local desc, err = body.validate_descriptor({ kind = 'x', data = 'bytes' }, 'source')
+	eq(desc, nil)
+	eq(err, 'invalid_args')
+end
+
+function M.test_source_and_sink_leases_copy_inside_ops()
+	fibers.run(function ()
+		body.clear_resolvers_for_test()
+		body.register_resolver('unit_source', function ()
+			local chunks = { 'ab', 'cd' }
+			local i = 0
+			return {
+				terminated = false,
+				read_chunk_op = function ()
+					return fibers.guard(function ()
+						i = i + 1
+						return fibers.always(chunks[i], nil)
+					end)
+				end,
+				terminate = function (self, reason) self.terminated = reason or true; return true end,
+			}
+		end)
+		local written = {}
+		body.register_resolver('unit_sink', function ()
+			return {
+				write_chunk_op = function (_, chunk) return fibers.always((table.insert(written, chunk) and true) or true) end,
+				finish_op = function () return fibers.always(true) end,
+				terminate = function () return true end,
+			}
+		end)
+
+		local source = ok(fibers.perform(body.resolve_op({ kind = 'unit_source' }, { direction = 'source' })))
+		local sink = ok(fibers.perform(body.resolve_op({ kind = 'unit_sink' }, { direction = 'sink' })))
+		local rep = ok(fibers.perform(body.copy_source_to_sink_op(source, sink, { max_bytes = 16 })))
+		eq(rep.bytes, 4)
+		eq(table.concat(written), 'abcd')
+	end)
+end
+
+function M.test_resolver_registries_are_service_owned()
+	fibers.run(function ()
+		local r1 = body.new_registry()
+		local r2 = body.new_registry()
+		r1:register_resolver('x', function () return { marker = 'r1' } end)
+		r2:register_resolver('x', function () return { marker = 'r2' } end)
+		local a = ok(fibers.perform(r1:resolve_op({ kind = 'x' }, { direction = 'source' })))
+		local b = ok(fibers.perform(r2:resolve_op({ kind = 'x' }, { direction = 'source' })))
+		eq(a.marker, 'r1')
+		eq(b.marker, 'r2')
+	end)
+end
+
+function M.test_request_body_pipe_is_a_bounded_fibers_sink_and_lua_http_iterator()
+	fibers.run(function ()
+		local request_body = require 'services.http.transport.request_body'
+		local c = require 'fibers.cond'
+		local wake = c.new()
+		local pipe = ok(request_body.new_pipe({
+			condition_factory = function ()
+				return {
+					wait = function () return fibers.perform(wake:wait_op()) end,
+					signal = function () wake:signal(); wake = c.new(); return true end,
+				}
+			end,
+			max_buffered_chunks = 2,
+		}))
+
+		ok(fibers.perform(pipe:write_chunk_op('ab')))
+		ok(fibers.perform(pipe:write_chunk_op('cd')))
+		ok(fibers.perform(pipe:finish_op()))
+		local iter = pipe:body_iterator()
+		eq(iter(), 'ab')
+		eq(iter(), 'cd')
+		eq(iter(), nil)
+	end)
+end
+
+
+function M.test_resolver_is_called_when_resolve_op_is_performed_not_constructed()
+	fibers.run(function ()
+		local registry = body.new_registry()
+		local calls = 0
+		registry:register_resolver('late_source', function ()
+			calls = calls + 1
+			return { terminate = function () return true end }
+		end)
+
+		local resolve = registry:resolve_op({ kind = 'late_source' }, { direction = 'source' })
+		eq(calls, 0, 'resolver must not run at Op construction time')
+		local lease = ok(fibers.perform(resolve))
+		eq(calls, 1)
+		ok(lease)
+	end)
+end
+
+function M.test_resolver_errors_are_caught_and_normalised()
+	fibers.run(function ()
+		local registry = body.new_registry()
+		registry:register_resolver('boom', function () error('backend exploded', 0) end)
+		local lease, err = fibers.perform(registry:resolve_op({ kind = 'boom' }, { direction = 'source' }))
+		eq(lease, nil)
+		eq(err, 'invalid_args', 'resolver exceptions should become a stable public error')
+	end)
+end
+
+return M

--- a/tests/unit/http/test_client.lua
+++ b/tests/unit/http/test_client.lua
@@ -1,0 +1,338 @@
+local fibers = require 'fibers'
+local runtime = require 'fibers.runtime'
+local driver_mod = require 'services.http.transport.cqueues_driver'
+local client = require 'services.http.client'
+local body = require 'services.http.body'
+
+local M = {}
+
+local function eq(a, b, msg)
+	if a ~= b then error((msg or 'assertion failed') .. ': expected ' .. tostring(b) .. ', got ' .. tostring(a), 2) end
+end
+local function ok(v, msg) if not v then error(msg or 'assertion failed', 2) end return v end
+
+local function yield_once()
+	runtime.yield()
+end
+
+local function yield_until(pred, msg)
+	for _ = 1, 50 do
+		if pred() then return true end
+		yield_once()
+	end
+	error(msg or 'condition was not reached', 2)
+end
+
+local function fake_controller()
+	local q = {}
+	return {
+		wrap = function (self, fn) q[#q + 1] = fn; return self end,
+		step = function () local fn = table.remove(q, 1); if fn then fn() end; return true end,
+		pollfd = function () return nil end,
+		events = function () return '' end,
+		timeout = function () return nil end,
+	}
+end
+
+local function fake_driver()
+	return {
+		run_op = function (_, _, fn)
+			return fibers.guard(function () return fibers.always(fn()) end)
+		end,
+	}
+end
+
+local function fake_condition_factory()
+	local c = require 'fibers.cond'
+	local wake = c.new()
+	return {
+		wait = function () return fibers.perform(wake:wait_op()) end,
+		signal = function () wake:signal(); wake = c.new(); return true end,
+	}
+end
+
+local function fake_headers(status)
+	return {
+		get = function (_, name) if name == ':status' then return tostring(status or 200) end end,
+		each = function ()
+			local rows = { { ':status', tostring(status or 200) }, { 'content-type', 'text/plain' } }
+			local i = 0
+			return function ()
+				i = i + 1
+				local row = rows[i]
+				if row then return row[1], row[2] end
+			end
+		end,
+	}
+end
+
+local function request_module(body_text)
+	return {
+		new_from_uri = function (uri)
+			return {
+				uri = uri,
+				headers = {
+					set = {},
+					upsert = function (self, k, v) self.set[k] = v end,
+					append = function (self, k, v) self.set[k] = v end,
+				},
+				set_body = function (self, body_iter) self.body_iter = body_iter end,
+				go = function (self)
+					local chunks = { body_text or ('body for ' .. self.uri) }
+					local i = 0
+					return fake_headers(202), {
+						get_next_chunk = function () i = i + 1; return chunks[i] end,
+						shutdown = function () self.shutdown = true; return true end,
+					}
+				end,
+			}
+		end,
+	}
+end
+
+function M.test_exchange_op_streams_response_to_sink_without_returning_body()
+	fibers.run(function ()
+		local written = {}
+		local registry = body.new_registry()
+		registry:register_resolver('unit_sink', function ()
+			return {
+				write_chunk_op = function (_, chunk) written[#written + 1] = chunk; return fibers.always(true) end,
+				finish_op = function () return fibers.always(true) end,
+				terminate = function () return true end,
+			}
+		end)
+		local result = ok(fibers.perform(client.exchange_op(fake_driver(), {
+			uri = 'http://example.test/path',
+			method = 'GET',
+			headers = { ['x-test'] = 'yes' },
+			response_sink = { kind = 'unit_sink' },
+		}, { request_module = request_module('hello'), body_registry = registry })))
+		eq(result.status, '202')
+		eq(result.body, nil)
+		eq(result.response_sink.bytes, 5)
+		eq(table.concat(written), 'hello')
+		eq(result.headers['content-type'], 'text/plain')
+	end)
+end
+
+function M.test_open_exchange_rejects_raw_body_before_backend_job()
+	fibers.run(function ()
+		local called = false
+		local drv = { run_op = function () called = true; return fibers.always('bad') end }
+		local ex, err = fibers.perform(client.open_exchange_op(drv, {
+			uri = 'http://example.test/',
+			method = 'POST',
+			body = 'raw bytes',
+		}, { request_module = request_module() }))
+		eq(ex, nil)
+		eq(err, 'invalid_args')
+		eq(called, false)
+	end)
+end
+
+function M.test_request_source_streams_through_fibers_native_body_pipe()
+	local ctl = fake_controller()
+	local drv = assert(driver_mod.new { controller = ctl })
+	local sent_body = {}
+	local request_mod = {
+		new_from_uri = function (uri)
+			return {
+				uri = uri,
+				headers = {
+					set = {},
+					upsert = function (self, k, v) self.set[k] = v end,
+					append = function (self, k, v) self.set[k] = v end,
+				},
+				set_body = function (self, iter) self.body_iter = iter end,
+				go = function (self)
+					while true do
+						local chunk = self.body_iter and self.body_iter() or nil
+						if chunk == nil then break end
+						sent_body[#sent_body + 1] = chunk
+					end
+					local chunks = { 'ok' }
+					local i = 0
+					return fake_headers(201), {
+						get_next_chunk = function () i = i + 1; return chunks[i] end,
+						shutdown = function () return true end,
+					}
+				end,
+			}
+		end,
+	}
+
+	fibers.run(function (scope)
+		assert(drv:start(scope))
+		local registry = body.new_registry()
+		registry:register_resolver('op_source_only', function ()
+			local chunks = { 'ab', 'cd' }
+			local i = 0
+			return {
+				read_chunk_op = function ()
+					return fibers.guard(function ()
+						i = i + 1
+						return fibers.always(chunks[i], nil)
+					end)
+				end,
+				terminate = function () return true end,
+			}
+		end)
+		local result = ok(fibers.perform(client.exchange_op(drv, {
+			uri = 'http://example.test/', method = 'POST', body_source = { kind = 'op_source_only' },
+		}, {
+			request_module = request_mod,
+			body_registry = registry,
+			request_body_condition_factory = fake_condition_factory,
+		})))
+		eq(result.status, '201')
+		eq(table.concat(sent_body), 'abcd')
+		drv:terminate('done')
+	end)
+end
+
+
+function M.test_exchange_op_does_not_terminate_committed_response_sink_after_success()
+	fibers.run(function ()
+		local committed = false
+		local terminated = nil
+		local registry = body.new_registry()
+		registry:register_resolver('committing_sink', function ()
+			return {
+				write_chunk_op = function () return fibers.always(true) end,
+				commit_op = function () committed = true; return fibers.always(true) end,
+				terminate = function (_, reason) terminated = reason or true; return true end,
+			}
+		end)
+
+		local result = ok(fibers.perform(client.exchange_op(fake_driver(), {
+			uri = 'http://example.test/path',
+			method = 'GET',
+			response_sink = { kind = 'committing_sink' },
+		}, { request_module = request_module('hello'), body_registry = registry })))
+		eq(result.response_sink.bytes, 5)
+		eq(committed, true, 'sink commit must run')
+		eq(terminated, nil, 'committed sink ownership must not be reclaimed by the exchange finaliser')
+	end)
+end
+
+function M.test_exchange_op_terminates_uncommitted_response_sink_on_copy_failure()
+	fibers.run(function ()
+		local terminated = nil
+		local registry = body.new_registry()
+		registry:register_resolver('failing_sink', function ()
+			return {
+				write_chunk_op = function () return fibers.always(nil, 'sink_failed') end,
+				commit_op = function () error('commit must not run after write failure', 0) end,
+				terminate = function (_, reason) terminated = reason or true; return true end,
+			}
+		end)
+
+		local result, err = fibers.perform(client.exchange_op(fake_driver(), {
+			uri = 'http://example.test/path',
+			method = 'GET',
+			response_sink = { kind = 'failing_sink' },
+		}, { request_module = request_module('hello'), body_registry = registry }))
+		eq(result, nil)
+		eq(err, 'sink_failed')
+		eq(terminated, 'failed', 'uncommitted sink must be terminated by the operation scope')
+	end)
+end
+
+
+function M.test_request_body_source_without_read_op_rejects_before_request_construction()
+	fibers.run(function ()
+		local registry = body.new_registry()
+		local constructed = 0
+		registry:register_resolver('bad_source', function ()
+			return { terminate = function () return true end }
+		end)
+		local request_mod = {
+			new_from_uri = function () constructed = constructed + 1; return request_module().new_from_uri('http://example.test/') end,
+		}
+		local result, err = fibers.perform(client.exchange_op(fake_driver(), {
+			uri = 'http://example.test/', method = 'POST', body_source = { kind = 'bad_source' },
+		}, { request_module = request_mod, body_registry = registry }))
+		eq(result, nil)
+		eq(err, 'request_body_source_invalid')
+		eq(constructed, 0, 'invalid request source must reject before lua-http request construction')
+	end)
+end
+
+function M.test_open_exchange_active_abort_terminates_active_request_not_driver()
+	local ctl = fake_controller()
+	local drv = assert(driver_mod.new { controller = ctl })
+	local go_active = false
+	local req_closed = false
+	local request_mod = {
+		new_from_uri = function (uri)
+			return {
+				uri = uri,
+				headers = {
+					upsert = function () end,
+					append = function () end,
+				},
+				go = function (self)
+					go_active = true
+					while not req_closed do runtime.yield() end
+					return nil, 'closed'
+				end,
+				shutdown = function () req_closed = true; return true end,
+			}
+		end,
+	}
+
+	fibers.run(function (scope)
+		assert(drv:start(scope))
+		local waiter = assert(scope:child())
+		assert(waiter:spawn(function ()
+			fibers.perform(client.open_exchange_op(drv, {
+				uri = 'http://example.test/',
+				method = 'GET',
+			}, { request_module = request_mod }))
+		end))
+
+		yield_until(function () return go_active end, 'request go should become active')
+		waiter:cancel('stop_waiting')
+		fibers.perform(waiter:join_op())
+		ok(req_closed, 'active open_exchange abort should terminate the request')
+		ok(not drv:is_closed(), 'request termination is the narrow owner; driver should survive')
+		drv:terminate('done')
+	end)
+end
+
+function M.test_exchange_read_active_abort_terminates_exchange_not_driver()
+	local ctl = fake_controller()
+	local drv = assert(driver_mod.new { controller = ctl })
+	local read_active = false
+	local stream = {
+		terminated = false,
+		get_next_chunk = function (self)
+			read_active = true
+			while not self.terminated do runtime.yield() end
+			return nil
+		end,
+		shutdown = function (self)
+			self.terminated = true
+			return true
+		end,
+	}
+	local ex = client.HttpExchange and client.HttpExchange.make
+	-- The public client module exposes the class for type checks; construct via
+	-- the ordinary open path shape by requiring the handle module directly here.
+	ex = require('services.http.exchange').make(drv, fake_headers(200), stream, {})
+
+	fibers.run(function (scope)
+		assert(drv:start(scope))
+		local waiter = assert(scope:child())
+		assert(waiter:spawn(function () fibers.perform(ex:read_chunk_op()) end))
+		yield_until(function () return read_active end, 'exchange read should become active')
+		waiter:cancel('stop_waiting')
+		fibers.perform(waiter:join_op())
+		ok(stream.terminated, 'active exchange read abort should terminate stream')
+		ok(ex:is_closed(), 'exchange handle should be marked closed')
+		ok(not drv:is_closed(), 'exchange is the narrow owner; driver should survive')
+		drv:terminate('done')
+	end)
+end
+
+return M

--- a/tests/unit/http/test_config.lua
+++ b/tests/unit/http/test_config.lua
@@ -1,0 +1,43 @@
+local config = require 'services.http.config'
+
+local M = {}
+
+local function eq(a, b, msg)
+	if a ~= b then error((msg or 'assertion failed') .. ': expected ' .. tostring(b) .. ', got ' .. tostring(a), 2) end
+end
+local function ok(v, msg) if not v then error(msg or 'assertion failed', 2) end return v end
+
+function M.test_normalise_supplies_safe_defaults()
+	local cfg = ok(config.normalise({ schema = config.SCHEMA }))
+	eq(cfg.id, 'main')
+	eq(cfg.enabled, true)
+	eq(cfg.policy.allowed_schemes.http, true)
+	eq(cfg.policy.allowed_schemes.https, true)
+	eq(cfg.policy.allowed_schemes.ws, true)
+	eq(cfg.policy.allowed_schemes.wss, true)
+end
+
+function M.test_policy_updates_are_copied_and_validated()
+	local raw = {
+		schema = config.SCHEMA,
+		policy = {
+			allowed_schemes = { https = true },
+			allow_loopback = false,
+			allowed_hosts = { ['example.com'] = true },
+		},
+	}
+	local cfg = ok(config.normalise(raw))
+	eq(cfg.policy.allowed_schemes.https, true)
+	eq(cfg.policy.allowed_schemes.http, nil)
+	eq(cfg.policy.allow_loopback, false)
+	raw.policy.allowed_hosts['example.com'] = false
+	eq(cfg.policy.allowed_hosts['example.com'], true, 'normalised config must not alias raw tables')
+end
+
+function M.test_rejects_unknown_fields()
+	local cfg, err = config.normalise({ schema = config.SCHEMA, backend = {} })
+	eq(cfg, nil)
+	ok(tostring(err):find('unknown field', 1, true))
+end
+
+return M

--- a/tests/unit/http/test_headers.lua
+++ b/tests/unit/http/test_headers.lua
@@ -1,0 +1,35 @@
+local headers = require 'services.http.headers'
+
+local M = {}
+
+local function eq(a, b, msg)
+	if a ~= b then error((msg or 'assertion failed') .. ': expected ' .. tostring(b) .. ', got ' .. tostring(a), 2) end
+end
+
+local function ok(v, msg)
+	if not v then error(msg or 'assertion failed', 2) end
+	return v
+end
+
+function M.test_status_headers_round_trip_to_table()
+	local h = ok(headers.status(201, { ['content-type'] = 'text/plain' }))
+	eq(headers.get_one(h, ':status'), '201')
+	eq(headers.get_one(h, 'content-type'), 'text/plain')
+	local t = headers.to_table(h)
+	eq(t[':status'], '201')
+	eq(t['content-type'], 'text/plain')
+end
+
+function M.test_request_helpers_set_pseudo_headers_and_repeated_values()
+	local h = ok(headers.request('POST', '/upload', 'example.test', 'https', {
+		['x-test'] = { 'a', 'b' },
+	}))
+	eq(headers.get_one(h, ':method'), 'POST')
+	eq(headers.get_one(h, ':path'), '/upload')
+	local all = headers.get_all(h, 'x-test')
+	eq(#all, 2)
+	eq(all[1], 'a')
+	eq(all[2], 'b')
+end
+
+return M

--- a/tests/unit/http/test_policy.lua
+++ b/tests/unit/http/test_policy.lua
@@ -1,0 +1,70 @@
+local policy = require 'services.http.policy'
+
+local M = {}
+
+local function eq(a, b, msg)
+	if a ~= b then error((msg or 'assertion failed') .. ': expected ' .. tostring(b) .. ', got ' .. tostring(a), 2) end
+end
+
+local function ok(v, msg)
+	if not v then error(msg or 'assertion failed', 2) end
+	return v
+end
+
+function M.test_locality_requires_local_origin_without_fabric_peer_fields()
+	ok(policy.is_local_origin({ kind = 'local' }))
+	eq(policy.require_local_origin({ kind = 'fabric', peer_node = 'n1' }), nil)
+	local allowed, err = policy.require_local_origin({ kind = 'local', link_id = 'l1' })
+	eq(allowed, nil)
+	eq(err, 'not_local')
+end
+
+
+function M.test_validate_uri_uses_lua_http_authority_boundary()
+	local parsed = ok(policy.validate_uri('http://example.test:8080/path?q=1'))
+	eq(parsed.scheme, 'http')
+	eq(parsed.authority, 'example.test:8080')
+	eq(parsed.host, 'example.test')
+	eq(parsed.port, 8080)
+	local ws = ok(policy.validate_uri('wss://example.test/ws'))
+	eq(ws.scheme, 'wss')
+	eq(ws.host, 'example.test')
+	local plain_ws = ok(policy.validate_uri('ws://example.test/ws'))
+	eq(plain_ws.scheme, 'ws')
+	eq(plain_ws.host, 'example.test')
+end
+
+function M.test_validate_uri_rejects_missing_authority_via_lua_http_boundary()
+	local parsed, err = policy.validate_uri('http:///missing-host')
+	eq(parsed, nil)
+	eq(err, 'invalid_args')
+end
+
+function M.test_validate_exchange_rejects_raw_body_bytes_over_control_plane()
+	local checked = ok(policy.validate_exchange_args { uri = 'http://example.test/', method = 'GET' })
+	eq(checked.method, 'GET')
+	local bad, err = policy.validate_exchange_args { uri = 'http://example.test/', method = 'POST', body = 'bytes' }
+	eq(bad, nil)
+	eq(err, 'invalid_args')
+end
+
+function M.test_validate_listen_defaults_loopback_ephemeral_port()
+	local args = ok(policy.validate_listen_args {})
+	eq(args.host, '127.0.0.1')
+	eq(args.port, 0)
+	eq(args.tls, false)
+end
+
+function M.test_public_payload_validation_rejects_backend_objects()
+	local listen, lerr = policy.validate_listen_args { host = '127.0.0.1', port = 0, backend_timeout = 2 }
+	eq(listen, nil)
+	eq(lerr, 'invalid_args')
+	local exchange, eerr = policy.validate_exchange_args { uri = 'http://example.test/', request_module = {} }
+	eq(exchange, nil)
+	eq(eerr, 'invalid_args')
+	local ws, werr = policy.validate_connect_ws_args { uri = 'ws://example.test/', websocket_module = {} }
+	eq(ws, nil)
+	eq(werr, 'invalid_args')
+end
+
+return M

--- a/tests/unit/http/test_registry.lua
+++ b/tests/unit/http/test_registry.lua
@@ -1,0 +1,83 @@
+local registry = require 'services.http.registry'
+
+local M = {}
+
+local function eq(a, b, msg)
+	if a ~= b then error((msg or 'assertion failed') .. ': expected ' .. tostring(b) .. ', got ' .. tostring(a), 2) end
+end
+local function ok(v, msg) if not v then error(msg or 'assertion failed', 2) end return v end
+
+local function event_port(events)
+	return {
+		emit_required = function (_, ev)
+			events[#events + 1] = ev
+			return true, nil
+		end,
+	}
+end
+
+function M.test_registry_records_transfer_and_shutdown_termination()
+	local events = {}
+	local reg = registry.new({ events_port = event_port(events) })
+	local handle = { closed = false, terminate = function (self, reason) self.closed = reason or true; return true end }
+	local id = ok(reg:register('exchange', handle, { generation = 7 }))
+	eq(reg:count('exchange'), 1)
+	ok(reg:mark_transferred(id, 7))
+	reg:terminate_all('shutdown')
+	eq(handle.closed, 'shutdown')
+	eq(reg:count('exchange'), 0)
+	eq(events[1].kind, 'exchange_registered')
+	eq(events[2].kind, 'exchange_transferred')
+	eq(events[#events].kind, 'exchange_terminated')
+end
+
+
+function M.test_registry_can_report_through_service_event_port()
+	local events = {}
+	local port = {
+		emit_required = function (_, ev)
+			events[#events + 1] = ev
+			return true, nil
+		end,
+	}
+	local reg = registry.new({ events_port = port })
+	local id = ok(reg:register('listener', { terminate = function () return true end }, { generation = 4 }))
+	ok(reg:mark_transferred(id, 4))
+	eq(events[1].kind, 'listener_registered')
+	eq(events[2].kind, 'listener_transferred')
+end
+
+function M.test_registry_ignores_stale_generation_removal()
+	local reg = registry.new()
+	local id = ok(reg:register('listener', { terminate = function () return true end }, { generation = 1 }))
+	local removed, err = reg:remove(id, 'stale', 2)
+	eq(removed, false)
+	eq(err, 'stale_handle')
+	eq(reg:count('listener'), 1)
+end
+
+
+function M.test_registry_reserve_register_transfer_remove_is_stale_safe()
+	local events = {}
+	local reg = registry.new({ events_port = event_port(events) })
+	local id = ok(reg:reserve('listener', { generation = 3 }))
+	eq(reg:count('listener'), 0, 'reserved handles are not active')
+	eq(#events, 0, 'reserve should not emit an active-handle event')
+	local handle = { terminated = nil, terminate = function (self, reason) self.terminated = reason; return true end }
+	local rid = ok(reg:register('listener', handle, { id = id, generation = 3 }))
+	eq(rid, id)
+	eq(reg:count('listener'), 1)
+	ok(reg:mark_transferred(id, 3))
+	local stale, serr = reg:remove(id, 'stale', 99)
+	eq(stale, false)
+	eq(serr, 'stale_handle')
+	eq(reg:count('listener'), 1)
+	ok(reg:terminate(id, 'shutdown', 3))
+	eq(handle.terminated, 'shutdown')
+	eq(reg:count('listener'), 0)
+	eq(events[1].kind, 'listener_registered')
+	eq(events[2].kind, 'listener_transferred')
+	eq(events[3].kind, 'listener_terminated')
+end
+
+return M

--- a/tests/unit/http/test_service.lua
+++ b/tests/unit/http/test_service.lua
@@ -1,0 +1,1000 @@
+local fibers = require 'fibers'
+local runtime = require 'fibers.runtime'
+local mailbox = require 'fibers.mailbox'
+local bus    = require 'bus'
+
+local http_service = require 'services.http.service'
+local sdk_mod      = require 'services.http.sdk'
+local listener_owner = require 'services.http.listener_owner'
+local lua_http      = require 'services.http.transport.lua_http'
+local public_ws     = require 'services.http.websocket'
+local driver_mod    = require 'services.http.transport.cqueues_driver'
+
+local M = {}
+
+local function eq(a, b, msg)
+	if a ~= b then error((msg or 'assertion failed') .. ': expected ' .. tostring(b) .. ', got ' .. tostring(a), 2) end
+end
+
+local function ok(v, msg)
+	if not v then error(msg or 'assertion failed', 2) end
+	return v
+end
+
+local function yield_many(n)
+	for _ = 1, n do runtime.yield() end
+end
+
+
+local function yield_until(pred, msg)
+	for _ = 1, 80 do
+		if pred() then return true end
+		runtime.yield()
+	end
+	error(msg or 'condition was not reached', 2)
+end
+
+local function fake_controller()
+	local q = {}
+	return {
+		wrap = function (self, fn) q[#q + 1] = fn; return self end,
+		step = function () local fn = table.remove(q, 1); if fn then fn() end; return true end,
+		pollfd = function () return nil end,
+		events = function () return '' end,
+		timeout = function () return nil end,
+	}
+end
+
+local function fake_driver()
+	return {
+		started = false,
+		terminated = nil,
+		start = function (self) self.started = true; return true end,
+		terminate = function (self, reason) self.terminated = reason or true; return true end,
+		run_op = function (_, _, fn) return fibers.guard(function () return fibers.always(fn()) end) end,
+	}
+end
+
+function M.test_service_retains_capability_metadata_and_status()
+	fibers.run(function ()
+		local b = bus.new()
+		local root = b:connect({ origin_base = { kind = 'local' } })
+		local drv = fake_driver()
+		local svc = ok(http_service.start(root, { driver = drv, id = 'main' }))
+		local user = b:connect({ origin_base = { kind = 'local' } })
+		local ref = sdk_mod.new_ref(user, 'main')
+		local rep = ok(fibers.perform(ref:status_op()))
+		ok(rep.status.ready, 'service should report ready')
+		svc:terminate('done')
+		eq(drv.terminated, 'done')
+	end)
+end
+
+function M.test_non_local_handle_returning_call_is_rejected_before_backend_work()
+	fibers.run(function ()
+		local b = bus.new()
+		local root = b:connect({ origin_base = { kind = 'local' } })
+		local drv = fake_driver()
+		local svc = ok(http_service.start(root, { driver = drv, id = 'main' }))
+		local remote = b:connect({ origin_base = { kind = 'local', link_id = 'fabric-link' } })
+		local ref = sdk_mod.new_ref(remote, 'main')
+		local reply, err = fibers.perform(ref:listen_op({ host = '127.0.0.1', port = 0 }))
+		eq(reply, nil)
+		eq(err, 'not_local')
+		svc:terminate('done')
+	end)
+end
+
+
+function M.test_registry_callbacks_do_not_mutate_model_until_coordinator_receives_event()
+	fibers.run(function ()
+		local b = bus.new()
+		local root = b:connect({ origin_base = { kind = 'local' } })
+		local svc = ok(http_service.start(root, { driver = fake_driver(), id = 'main' }))
+		yield_many(4)
+		eq(svc:stats().active_listeners, 0)
+		eq(svc._emit, nil, 'legacy direct reducer ingress should not exist')
+
+		local real_tx = svc._event_tx
+		local captured = {}
+		svc._event_tx = {
+			send_op = function (_, ev)
+				captured[#captured + 1] = ev
+				return fibers.always(true, nil)
+			end,
+		}
+		local id = ok(svc._registry:register('listener', { terminate = function () return true end }, { generation = svc._generation }))
+		eq(svc:stats().active_listeners, 0, 'registry callback must only enqueue an event')
+		eq(captured[1].kind, 'listener_registered')
+		svc._event_tx = real_tx
+		ok(svc:_submit_event(captured[1]))
+		yield_many(4)
+		eq(svc:stats().active_listeners, 1)
+		svc._registry:remove(id, 'done')
+		yield_many(4)
+		eq(svc:stats().active_listeners, 0)
+		svc:terminate('done')
+	end)
+end
+
+function M.test_model_fields_are_recomputed_from_identity_records_and_duplicate_termination_is_idempotent()
+	fibers.run(function ()
+		local b = bus.new()
+		local root = b:connect({ origin_base = { kind = 'local' } })
+		local svc = ok(http_service.start(root, { driver = fake_driver(), id = 'main' }))
+		yield_many(4)
+
+		ok(svc:_submit_event({ kind = 'listener_registered', handle_id = 'l1', generation = 1 }))
+		ok(svc:_submit_event({ kind = 'listener_registered', handle_id = 'l2', generation = 1 }))
+		ok(svc:_submit_event({ kind = 'listener_terminated', handle_id = 'l1', generation = 1 }))
+		ok(svc:_submit_event({ kind = 'listener_terminated', handle_id = 'l1', generation = 1 }))
+		yield_many(8)
+		eq(svc:stats().active_listeners, 1, 'duplicate termination must not decrement a derived count twice')
+
+		ok(svc:_submit_event({ kind = 'exchange_registered', handle_id = 'e1', generation = 1 }))
+		ok(svc:_submit_event({ kind = 'websocket_registered', handle_id = 'w1', generation = 1 }))
+		ok(svc:_submit_event({ kind = 'context_admitted', listener_id = 'l2', context_id = 'c1', generation = 1 }))
+		yield_many(8)
+		local snap = svc:stats()
+		eq(snap.active_listeners, 1)
+		eq(snap.active_exchanges, 1)
+		eq(snap.active_websockets, 1)
+		eq(snap.active_contexts, 1)
+		svc:terminate('done')
+	end)
+end
+
+function M.test_stale_generation_events_are_ignored()
+	fibers.run(function ()
+		local b = bus.new()
+		local root = b:connect({ origin_base = { kind = 'local' } })
+		local svc = ok(http_service.start(root, { driver = fake_driver(), id = 'main' }))
+		yield_many(4)
+
+		ok(svc:_submit_event({ kind = 'listener_registered', handle_id = 'l1', generation = 1 }))
+		yield_many(4)
+		eq(svc:stats().active_listeners, 1)
+		ok(svc:_submit_event({ kind = 'listener_terminated', handle_id = 'l1', generation = 2 }))
+		yield_many(4)
+		eq(svc:stats().active_listeners, 1, 'stale handle generation must not terminate the live record')
+
+		svc._state.operations.op_live = { operation_id = 'op_live', generation = 1, operation = 'exchange', state = 'running' }
+		ok(svc:_submit_event({ kind = 'http_operation_done', operation_id = 'op_live', operation = 'exchange', generation = 2, status = 'ok', result = {} }))
+		yield_many(4)
+		eq(svc:stats().completed_exchanges, 0, 'stale operation completion must not be counted')
+		svc:terminate('done')
+	end)
+end
+
+function M.test_cap_request_received_then_service_shutdown_finalises_request_owner()
+	fibers.run(function ()
+		local b = bus.new()
+		local root = b:connect({ origin_base = { kind = 'local' } })
+		local svc = ok(http_service.start(root, { driver = fake_driver(), id = 'main' }))
+		local failed
+		local req = {
+			payload = {},
+			origin = { kind = 'local' },
+			reply = function () return true end,
+			fail = function (_, reason) failed = reason; return true end,
+		}
+		local request_id, owner = svc:_next_request_identity('status', req)
+		ok(svc:_submit_event({ kind = 'cap_request_received', verb = 'status', req = req, request_id = request_id, owner = owner, generation = svc._generation }))
+		svc:terminate('service_shutdown')
+		eq(failed, 'service_shutdown')
+	end)
+end
+
+function M.test_event_queue_overflow_for_completion_fails_observing_service()
+	fibers.run(function (scope)
+		local child = ok(scope:child())
+		local tx, rx = mailbox.new(1, { full = 'reject_newest' })
+		ok(child:spawn(function ()
+			local b = bus.new()
+			local root = b:connect({ origin_base = { kind = 'local' } })
+			local svc = ok(http_service.start(root, { driver = fake_driver(), id = 'main', event_queue_len = 1 }))
+			return fibers.perform(tx:send_op(svc))
+		end))
+		local svc = ok(fibers.perform(rx:recv_op()))
+		-- Replace the event sender with a would-block sender. This exercises the
+		-- same required-admission path as a full bounded queue without relying on
+		-- scheduler timing around a live coordinator.
+		svc._event_tx = {
+			send_op = function () return fibers.never() end,
+		}
+		local ok_report, err = svc:_submit_event({ kind = 'http_operation_done', operation_id = 'op-missing', generation = 1, status = 'ok' }, 'http_operation_done_report_failed', { fatal = true })
+		eq(ok_report, nil)
+		ok(tostring(err):match('http_operation_done_report_failed'), 'overflow should use the completion report label')
+		ok(svc._event_admission_failure and tostring(svc._event_admission_failure):match('http_operation_done_report_failed'))
+		local st, _rep, primary = fibers.perform(child:join_op())
+		eq(st, 'failed')
+		ok(tostring(primary):match('http_operation_done_report_failed'))
+	end)
+end
+
+function M.test_service_shutdown_terminates_registry_handles_and_finalises_unresolved_requests()
+	fibers.run(function ()
+		local b = bus.new()
+		local root = b:connect({ origin_base = { kind = 'local' } })
+		local svc = ok(http_service.start(root, { driver = fake_driver(), id = 'main' }))
+		local terminated
+		local id = ok(svc._registry:register('exchange', { terminate = function (_, reason) terminated = reason; return true end }, { generation = svc._generation }))
+		yield_many(4)
+		local failed
+		local req = { fail = function (_, reason) failed = reason; return true end }
+		local request_id, owner = svc:_next_request_identity('exchange', req)
+		svc._state.requests[request_id] = { request_id = request_id, verb = 'exchange', owner = owner, state = 'received' }
+		svc:terminate('shutdown')
+		eq(terminated, 'shutdown')
+		eq(failed, 'shutdown')
+		eq(svc._registry:get(id), nil)
+	end)
+end
+
+
+function M.test_context_transfer_keeps_context_active_after_listener_termination_until_context_terminates()
+	fibers.run(function ()
+		local b = bus.new()
+		local root = b:connect({ origin_base = { kind = 'local' } })
+		local svc = ok(http_service.start(root, { driver = fake_driver(), id = 'main' }))
+		yield_many(4)
+		ok(svc:_submit_event({ kind = 'listener_registered', handle_id = 'l1', generation = 1 }))
+		ok(svc:_submit_event({ kind = 'context_admitted', listener_id = 'l1', context_id = 'c1', generation = 1 }))
+		ok(svc:_submit_event({ kind = 'context_transferred', listener_id = 'l1', context_id = 'c1', generation = 1 }))
+		ok(svc:_submit_event({ kind = 'listener_terminated', handle_id = 'l1', generation = 1, reason = 'listener_closed' }))
+		yield_many(8)
+		local snap = svc:stats()
+		eq(snap.active_listeners, 0)
+		eq(snap.active_contexts, 1, 'transferred context should remain active after listener termination')
+		ok(svc:_submit_event({ kind = 'context_terminated', listener_id = 'l1', context_id = 'c1', generation = 1, reason = 'request_done' }))
+		yield_many(4)
+		eq(svc:stats().active_contexts, 0)
+		svc:terminate('done')
+	end)
+end
+
+local function fake_polling_driver()
+	local cond = require 'fibers.cond'
+	local changed = cond.new()
+	local drv = {
+		started = false,
+		terminated = nil,
+	}
+	function drv:start() self.started = true; return true end
+	function drv:terminate(reason)
+		self.terminated = reason or true
+		changed:signal()
+		return true
+	end
+	function drv:run_op(_, fn) return fibers.guard(function () return fibers.always(fn()) end) end
+	function drv:pollable_step_op()
+		return changed:wait_op():wrap(function ()
+			if self.terminated then return nil, self.terminated end
+			return true
+		end)
+	end
+	function drv:poke() changed:signal(); return true end
+	return drv
+end
+
+local function fake_headers(status)
+	return {
+		get = function (_, name) if name == ':status' then return tostring(status or 200) end end,
+		each = function ()
+			local rows = { { ':status', tostring(status or 200) }, { 'content-type', 'text/plain' } }
+			local i = 0
+			return function ()
+				i = i + 1
+				local row = rows[i]
+				if row then return row[1], row[2] end
+			end
+		end,
+	}
+end
+
+local function request_module(body_text, counters)
+	counters = counters or {}
+	return {
+		new_from_uri = function (uri)
+			counters.request_new_from_uri = (counters.request_new_from_uri or 0) + 1
+			return {
+				uri = uri,
+				headers = {
+					set = {},
+					upsert = function (self, k, v) self.set[k] = v end,
+					append = function (self, k, v) self.set[k] = v end,
+				},
+				go = function (self)
+					local chunks = { body_text or ('body for ' .. self.uri) }
+					local i = 0
+					return fake_headers(204), {
+						get_next_chunk = function () i = i + 1; return chunks[i] end,
+						shutdown = function () return true end,
+					}
+				end,
+			}
+		end,
+	}
+end
+
+local function websocket_module(counters)
+	counters = counters or {}
+	return {
+		new_from_uri = function (uri)
+			counters.websocket_new_from_uri = (counters.websocket_new_from_uri or 0) + 1
+			return {
+				uri = uri,
+				connect = function (self) self.connected = true; return true end,
+				send = function () return true end,
+				receive = function () return nil, 'closed' end,
+				close = function () return true end,
+			}
+		end,
+	}
+end
+
+local function http_server_success(counters)
+	counters = counters or {}
+	return {
+		listen = function (opts)
+			counters.server_listen_constructed = (counters.server_listen_constructed or 0) + 1
+			return {
+				_opts = opts,
+				listen = function (self)
+					self.listen_called = true
+					counters.server_listen_called = (counters.server_listen_called or 0) + 1
+					return true
+				end,
+				step = function () return true end,
+				close = function (self)
+					self.closed = true
+					counters.server_closed = (counters.server_closed or 0) + 1
+					return true
+				end,
+				localname = function () return '127.0.0.1', 12345 end,
+			}
+		end,
+	}
+end
+
+
+local function fake_stream_for_context()
+	return {
+		terminated = false,
+		calls = {},
+		shutdown = function (self) self.terminated = true; return true end,
+		get_headers = function () return { ':method', 'GET' } end,
+		get_next_chunk = function () return nil end,
+		write_headers = function () return true end,
+		write_chunk = function () return true end,
+	}
+end
+
+local function event_seen(events, kind, pred)
+	for _, ev in ipairs(events or {}) do
+		if ev.kind == kind and (not pred or pred(ev)) then return ev end
+	end
+	return nil
+end
+
+function M.test_backend_failure_terminates_service_owned_handles()
+	fibers.run(function ()
+		local b = bus.new()
+		local root = b:connect({ origin_base = { kind = 'local' } })
+		local svc = ok(http_service.start(root, { driver = fake_driver(), id = 'main' }))
+		yield_many(4)
+
+		local terminated = {}
+		local function handle(name)
+			return {
+				terminate = function (_, reason)
+					terminated[name] = reason or true
+					return true
+				end,
+				close_op = function () error('graceful close_op must not be used by registry termination', 0) end,
+			}
+		end
+
+		svc._registry:register('listener', handle('listener'), { id = 'l1', generation = svc._generation })
+		svc._registry:register('exchange', handle('exchange'), { id = 'e1', generation = svc._generation })
+		svc._registry:register('websocket', handle('websocket'), { id = 'w1', generation = svc._generation })
+		yield_many(8)
+		local before = svc:stats()
+		eq(before.active_listeners, 1)
+		eq(before.active_exchanges, 1)
+		eq(before.active_websockets, 1)
+
+		ok(svc:_submit_event({ kind = 'backend_failed', reason = 'backend_boom', generation = svc._generation }))
+		yield_many(12)
+		local after = svc:stats()
+		eq(after.backend, 'failed')
+		eq(after.ready, false)
+		eq(after.last_error, 'backend_boom')
+		eq(after.active_listeners, 0)
+		eq(after.active_exchanges, 0)
+		eq(after.active_websockets, 0)
+		eq(terminated.listener, 'backend_boom')
+		eq(terminated.exchange, 'backend_boom')
+		eq(terminated.websocket, 'backend_boom')
+		svc:terminate('done')
+	end)
+end
+
+function M.test_listener_setup_failure_leaves_no_live_ownership()
+	fibers.run(function ()
+		local counters = {}
+		local failing_server = {
+			listen = function ()
+				counters.constructed = (counters.constructed or 0) + 1
+				return {
+					listen = function () counters.listen_called = (counters.listen_called or 0) + 1; return nil, 'listen_failed' end,
+					close = function () counters.closed = (counters.closed or 0) + 1; return true end,
+					step = function () return true end,
+				}
+			end,
+		}
+		local b = bus.new()
+		local root = b:connect({ origin_base = { kind = 'local' } })
+		local svc = ok(http_service.start(root, { driver = fake_polling_driver(), id = 'main', http_server = failing_server }))
+		local user = b:connect({ origin_base = { kind = 'local' } })
+		local ref = sdk_mod.new_ref(user, 'main')
+
+		local reply, err = fibers.perform(ref:listen_op({ host = '127.0.0.1', port = 0 }))
+		eq(reply, nil)
+		eq(err, 'listen_failed')
+		yield_many(12)
+		eq(counters.constructed, 1)
+		eq(counters.listen_called, 1)
+		eq(counters.closed, 1)
+		eq(svc:stats().active_listeners, 0)
+		eq(next(svc._registry:snapshot()), nil, 'failed listener setup must leave no active registry record')
+		svc:terminate('done')
+	end)
+end
+
+function M.test_handle_returning_rpcs_return_public_wrappers()
+	fibers.run(function ()
+		local counters = {}
+		local b = bus.new()
+		local root = b:connect({ origin_base = { kind = 'local' } })
+		local svc = ok(http_service.start(root, {
+			driver = fake_polling_driver(),
+			id = 'main',
+			http_server = http_server_success(counters),
+			request_module = request_module('body', counters),
+			websocket_module = websocket_module(counters),
+		}))
+		local user = b:connect({ origin_base = { kind = 'local' } })
+		local ref = sdk_mod.new_ref(user, 'main')
+
+		local listen_reply = ok(fibers.perform(ref:listen_op({ host = '127.0.0.1', port = 0 })))
+		local exchange_reply = ok(fibers.perform(ref:open_exchange_op({ uri = 'http://example.test/', method = 'GET' })))
+		local websocket_reply = ok(fibers.perform(ref:connect_ws_op({ uri = 'ws://example.test/ws' })))
+
+		local listener_mod = require 'services.http.listener'
+		local exchange_mod = require 'services.http.exchange'
+		local websocket_mod = require 'services.http.websocket'
+		eq(getmetatable(listen_reply.listener), listener_mod.HttpListener, 'listen should return public HttpListener wrapper')
+		eq(getmetatable(exchange_reply.exchange), exchange_mod.HttpExchange, 'open_exchange should return public HttpExchange wrapper')
+		eq(getmetatable(websocket_reply.websocket), websocket_mod.ClientWebSocket, 'connect_ws should return public ClientWebSocket wrapper')
+		ok(not tostring(getmetatable(listen_reply.listener)):match('transport'), 'listener wrapper should not expose transport type')
+		ok(not tostring(getmetatable(exchange_reply.exchange)):match('transport'), 'exchange wrapper should not expose transport type')
+		ok(not tostring(getmetatable(websocket_reply.websocket)):match('transport'), 'websocket wrapper should not expose transport type')
+		svc:terminate('done')
+	end)
+end
+
+function M.test_each_local_handle_rpc_rejects_non_local_before_backend_admission()
+	fibers.run(function ()
+		local counters = {}
+		local b = bus.new()
+		local root = b:connect({ origin_base = { kind = 'local' } })
+		local svc = ok(http_service.start(root, {
+			driver = fake_polling_driver(),
+			id = 'main',
+			http_server = http_server_success(counters),
+			request_module = request_module('body', counters),
+			websocket_module = websocket_module(counters),
+		}))
+		local remote = b:connect({ origin_base = { kind = 'local', link_id = 'fabric-link' } })
+		local ref = sdk_mod.new_ref(remote, 'main')
+
+		local listen_reply, listen_err = fibers.perform(ref:listen_op({ host = '127.0.0.1', port = 0 }))
+		local exchange_reply, exchange_err = fibers.perform(ref:open_exchange_op({ uri = 'http://example.test/', method = 'GET' }))
+		local ws_reply, ws_err = fibers.perform(ref:connect_ws_op({ uri = 'ws://example.test/ws' }))
+		eq(listen_reply, nil)
+		eq(exchange_reply, nil)
+		eq(ws_reply, nil)
+		eq(listen_err, 'not_local')
+		eq(exchange_err, 'not_local')
+		eq(ws_err, 'not_local')
+		eq(counters.server_listen_constructed or 0, 0, 'non-local listen must reject before backend admission')
+		eq(counters.request_new_from_uri or 0, 0, 'non-local open_exchange must reject before request construction')
+		eq(counters.websocket_new_from_uri or 0, 0, 'non-local connect_ws must reject before websocket construction')
+		eq(svc:stats().rejected_requests, 3)
+		svc:terminate('done')
+	end)
+end
+
+
+function M.test_initial_retained_status_is_not_available_before_backend_ready_event_is_reduced()
+	fibers.run(function ()
+		local topics = require 'services.http.topics'
+		local b = bus.new()
+		local root = b:connect({ origin_base = { kind = 'local' } })
+		local svc = ok(http_service.start(root, { driver = fake_driver(), id = 'main' }))
+
+		local view = root:retained_view(topics.status('main'))
+		local msg = ok(view:get(topics.status('main')), 'status should be retained immediately')
+		eq(msg.payload.available, false, 'cap status must not advertise availability before backend_ready is reduced')
+		eq(msg.payload.state, 'starting')
+		svc:terminate('done')
+	end)
+end
+
+function M.test_listener_owner_reports_identity_completion_when_listener_runtime_ends()
+	fibers.run(function ()
+		local counters = {}
+		local b = bus.new()
+		local root = b:connect({ origin_base = { kind = 'local' } })
+		local svc = ok(http_service.start(root, {
+			driver = fake_polling_driver(),
+			id = 'main',
+			http_server = http_server_success(counters),
+		}))
+		local user = b:connect({ origin_base = { kind = 'local' } })
+		local ref = sdk_mod.new_ref(user, 'main')
+
+		local rep = ok(fibers.perform(ref:listen_op({ host = '127.0.0.1', port = 0 })))
+		local listener = ok(rep.listener)
+		local handle_id = ok(rep.handle_id)
+		listener:terminate('listener_done_for_test')
+		yield_many(12)
+
+		local saw_done = false
+		for _, ev in ipairs(svc:events()) do
+			if ev.kind == 'listener_done' and ev.handle_id == handle_id then
+				saw_done = true
+				eq(ev.generation, svc._generation)
+				eq(ev.status, 'ok')
+			end
+		end
+		ok(saw_done, 'listener owner scope should report an identity-bearing completion')
+		svc:terminate('done')
+	end)
+end
+
+
+function M.test_onstream_context_admission_emits_service_event_without_reducing_in_callback()
+	fibers.run(function ()
+		local counters = {}
+		local b = bus.new()
+		local root = b:connect({ origin_base = { kind = 'local' } })
+		local svc = ok(http_service.start(root, {
+			driver = fake_polling_driver(),
+			id = 'main',
+			http_server = http_server_success(counters),
+		}))
+		local user = b:connect({ origin_base = { kind = 'local' } })
+		local ref = sdk_mod.new_ref(user, 'main')
+		local rep = ok(fibers.perform(ref:listen_op({ host = '127.0.0.1', port = 0 })))
+		local listener = ok(rep.listener)
+		local raw_listener = ok(listener:_raw_listener())
+		local raw_ctx = lua_http._new_context_for_test(raw_listener, raw_listener:_raw_server_for_test(), fake_stream_for_context())
+
+		local admitted, err = raw_listener:_admit_context(raw_ctx)
+		eq(admitted, true)
+		eq(err, nil)
+		eq(svc:stats().active_contexts, 0, 'onstream admission must enqueue, not run the service reducer synchronously')
+
+		yield_many(8)
+		eq(svc:stats().active_contexts, 1, 'queued, unaccepted context should be counted as listener-owned after coordinator observes admission')
+		ok(event_seen(svc:events(), 'context_admitted', function (ev)
+			return ev.listener_id == rep.handle_id and ev.context_id == raw_ctx:id()
+		end), 'context_admitted event should carry listener/context identity')
+		ok(not event_seen(svc:events(), 'context_transferred', function (ev)
+			return ev.context_id == raw_ctx:id()
+		end), 'onstream admission must not imply caller ownership transfer')
+		svc:terminate('done')
+	end)
+end
+
+function M.test_unaccepted_context_is_listener_owned_until_accept()
+	fibers.run(function ()
+		local b = bus.new()
+		local root = b:connect({ origin_base = { kind = 'local' } })
+		local svc = ok(http_service.start(root, {
+			driver = fake_polling_driver(),
+			id = 'main',
+			http_server = http_server_success({}),
+		}))
+		local user = b:connect({ origin_base = { kind = 'local' } })
+		local rep = ok(fibers.perform(sdk_mod.new_ref(user, 'main'):listen_op({ host = '127.0.0.1', port = 0 })))
+		local raw_listener = rep.listener:_raw_listener()
+		local raw_ctx = lua_http._new_context_for_test(raw_listener, raw_listener:_raw_server_for_test(), fake_stream_for_context())
+		ok(raw_listener:_admit_context(raw_ctx))
+		yield_many(8)
+
+		local snap = svc:stats()
+		eq(snap.active_contexts, 1)
+		local rec = snap.handles['ctx' .. tostring(raw_ctx:id())]
+		ok(rec, 'unaccepted context should have a registry record')
+		eq(rec.kind, 'context')
+		eq(rec.owner, 'listener')
+		eq(rec.state, 'registered')
+
+		local accepted = ok(fibers.perform(rep.listener:accept_op()))
+		eq(accepted:id(), raw_ctx:id())
+		yield_many(8)
+		local after = svc:stats().handles['ctx' .. tostring(raw_ctx:id())]
+		ok(after, 'accepted context should remain registered as a service shutdown backstop')
+		eq(after.owner, 'caller_after_handoff')
+		eq(after.state, 'transferred')
+		svc:terminate('done')
+	end)
+end
+
+function M.test_listener_termination_terminates_unaccepted_context_and_emits_context_terminated()
+	fibers.run(function ()
+		local terminated_reason
+		local b = bus.new()
+		local root = b:connect({ origin_base = { kind = 'local' } })
+		local svc = ok(http_service.start(root, {
+			driver = fake_polling_driver(),
+			id = 'main',
+			http_server = http_server_success({}),
+			context_terminator = function (_, reason) terminated_reason = reason end,
+		}))
+		local user = b:connect({ origin_base = { kind = 'local' } })
+		local rep = ok(fibers.perform(sdk_mod.new_ref(user, 'main'):listen_op({ host = '127.0.0.1', port = 0 })))
+		local raw_listener = rep.listener:_raw_listener()
+		local raw_ctx = lua_http._new_context_for_test(raw_listener, raw_listener:_raw_server_for_test(), fake_stream_for_context())
+		ok(raw_listener:_admit_context(raw_ctx))
+		yield_many(8)
+
+		rep.listener:terminate('listener_closed')
+		yield_many(12)
+		ok(raw_ctx:is_closed(), 'unaccepted context should be terminated with its listener')
+		eq(terminated_reason, 'listener_closed')
+		ok(event_seen(svc:events(), 'context_terminated', function (ev)
+			return ev.context_id == raw_ctx:id() and ev.reason == 'listener_closed'
+		end), 'listener-owned context termination should emit context_terminated')
+		eq(svc:stats().active_contexts, 0)
+		svc:terminate('done')
+	end)
+end
+
+function M.test_accepted_context_survives_listener_termination_until_context_terminates()
+	fibers.run(function ()
+		local b = bus.new()
+		local root = b:connect({ origin_base = { kind = 'local' } })
+		local svc = ok(http_service.start(root, {
+			driver = fake_polling_driver(),
+			id = 'main',
+			http_server = http_server_success({}),
+		}))
+		local user = b:connect({ origin_base = { kind = 'local' } })
+		local rep = ok(fibers.perform(sdk_mod.new_ref(user, 'main'):listen_op({ host = '127.0.0.1', port = 0 })))
+		local raw_listener = rep.listener:_raw_listener()
+		local raw_ctx = lua_http._new_context_for_test(raw_listener, raw_listener:_raw_server_for_test(), fake_stream_for_context())
+		ok(raw_listener:_admit_context(raw_ctx))
+		local ctx = ok(fibers.perform(rep.listener:accept_op()))
+		yield_many(8)
+
+		rep.listener:terminate('listener_closed')
+		yield_many(8)
+		ok(not ctx:is_closed(), 'accepted context should be owned by caller/request scope after accept')
+		eq(svc:stats().active_contexts, 1)
+		ctx:terminate('request_done')
+		yield_many(8)
+		eq(svc:stats().active_contexts, 0)
+		svc:terminate('done')
+	end)
+end
+
+function M.test_cancel_listen_start_while_waiting_for_ready_cleans_up_setup_listener()
+	fibers.run(function (scope)
+		local closed_reason
+		local server = {
+			listen = function () return true end,
+			close = function (_, reason) closed_reason = reason or true; return true end,
+			step = function () return true end,
+		}
+		local drv = fake_driver()
+		drv.run_op = function () return fibers.never() end
+		local lifetime = ok(scope:child())
+		local caller = ok(scope:child())
+		local result, err
+		ok(caller:spawn(function ()
+			result, err = listener_owner.start({
+				lifetime_scope = lifetime,
+				listen_opts = { driver = drv, server = server },
+				handle_id = 'listener-pending',
+				generation = 1,
+			})
+		end))
+		yield_many(8)
+		caller:cancel('caller_cancelled')
+		yield_many(12)
+		eq(result, nil)
+		ok(closed_reason ~= nil, 'cancelled listen setup should terminate the unreturned listener immediately')
+		lifetime:cancel('done')
+	end)
+end
+
+function M.test_server_side_websocket_upgrade_registers_and_deregisters_service_websocket_record()
+	fibers.run(function (scope)
+		local b = bus.new()
+		local root = b:connect({ origin_base = { kind = 'local' } })
+		local svc = ok(http_service.start(root, {
+			driver = fake_polling_driver(),
+			id = 'main',
+			http_server = http_server_success({}),
+		}))
+		local user = b:connect({ origin_base = { kind = 'local' } })
+		local rep = ok(fibers.perform(sdk_mod.new_ref(user, 'main'):listen_op({ host = '127.0.0.1', port = 0 })))
+		local raw_listener = rep.listener:_raw_listener()
+		local raw_ctx = lua_http._new_context_for_test(raw_listener, raw_listener:_raw_server_for_test(), fake_stream_for_context())
+		ok(raw_listener:_admit_context(raw_ctx))
+		local ctx = ok(fibers.perform(rep.listener:accept_op()))
+		local fake_raw_ws = {
+			accept = function () return true end,
+			receive = function () return nil, 'closed' end,
+			send = function () return true end,
+			close = function () return true end,
+		}
+		local module = { new_from_stream = function () return fake_raw_ws end }
+		local ws, werr
+		ok(scope:spawn(function ()
+			ws, werr = fibers.perform(public_ws.from_context_op(ctx, {}, { websocket_module = module }))
+		end))
+		yield_many(3)
+		ok(raw_ctx:_drain_one_for_test())
+		yield_many(8)
+		ok(ws, werr or 'server websocket should be returned')
+		eq(svc:stats().active_websockets, 1, 'server-side websocket upgrade should be visible in service summary')
+		ws:terminate('ws_done')
+		yield_many(8)
+		eq(svc:stats().active_websockets, 0)
+		svc:terminate('done')
+	end)
+end
+
+function M.test_service_shutdown_terminates_server_side_upgraded_websocket()
+	fibers.run(function (scope)
+		local b = bus.new()
+		local root = b:connect({ origin_base = { kind = 'local' } })
+		local svc = ok(http_service.start(root, {
+			driver = fake_polling_driver(),
+			id = 'main',
+			http_server = http_server_success({}),
+		}))
+		local user = b:connect({ origin_base = { kind = 'local' } })
+		local rep = ok(fibers.perform(sdk_mod.new_ref(user, 'main'):listen_op({ host = '127.0.0.1', port = 0 })))
+		local raw_listener = rep.listener:_raw_listener()
+		local raw_ctx = lua_http._new_context_for_test(raw_listener, raw_listener:_raw_server_for_test(), fake_stream_for_context())
+		ok(raw_listener:_admit_context(raw_ctx))
+		local ctx = ok(fibers.perform(rep.listener:accept_op()))
+		local fake_raw_ws = { close = function () return true end, receive = function () return nil, 'closed' end, send = function () return true end }
+		local module = { new_from_stream = function () return fake_raw_ws end }
+		local ws
+		ok(scope:spawn(function () ws = fibers.perform(public_ws.from_context_op(ctx, {}, { websocket_module = module })) end))
+		yield_many(3)
+		ok(raw_ctx:_drain_one_for_test())
+		yield_many(8)
+		ok(ws)
+		svc:terminate('service_shutdown')
+		yield_many(4)
+		ok(ws:is_closed(), 'service shutdown should terminate registered server-side websocket transport handles')
+		eq(ws:why(), 'service_shutdown')
+	end)
+end
+
+
+function M.test_public_context_read_cancellation_terminates_context_and_service_record()
+	fibers.run(function (scope)
+		local b = bus.new()
+		local root = b:connect({ origin_base = { kind = 'local' } })
+		local svc = ok(http_service.start(root, {
+			driver = fake_polling_driver(),
+			id = 'main',
+			http_server = http_server_success({}),
+		}))
+		local user = b:connect({ origin_base = { kind = 'local' } })
+		local rep = ok(fibers.perform(sdk_mod.new_ref(user, 'main'):listen_op({ host = '127.0.0.1', port = 0 })))
+		local raw_listener = rep.listener:_raw_listener()
+		local stream = fake_stream_for_context()
+		local read_active = false
+		stream.get_next_chunk = function (self)
+			read_active = true
+			while not self.terminated do runtime.yield() end
+			return nil, 'closed'
+		end
+		local raw_ctx = lua_http._new_context_for_test(raw_listener, raw_listener:_raw_server_for_test(), stream)
+		ok(raw_listener:_admit_context(raw_ctx))
+		local ctx = ok(fibers.perform(rep.listener:accept_op()))
+		yield_many(8)
+		eq(svc:stats().active_contexts, 1)
+
+		local waiter = ok(scope:child())
+		ok(waiter:spawn(function () fibers.perform(ctx:read_chunk_op(1024)) end))
+		local runner = ok(scope:child())
+		ok(runner:spawn(function () raw_ctx:_drain_one_for_test() end))
+		yield_until(function () return read_active end, 'public context read should be active')
+
+		waiter:cancel('caller_cancelled')
+		fibers.perform(waiter:join_op())
+		yield_until(function () return svc:stats().active_contexts == 0 end,
+			'context termination should be reported through service-owned events')
+		ok(ctx:is_closed(), 'cancelling a public context read should terminate the context owner')
+		eq(ctx:why(), 'aborted')
+		runner:cancel('done')
+		fibers.perform(runner:join_op())
+		svc:terminate('done')
+	end)
+end
+
+function M.test_public_server_websocket_receive_cancellation_terminates_websocket_and_registry_record()
+	fibers.run(function (scope)
+		local b = bus.new()
+		local root = b:connect({ origin_base = { kind = 'local' } })
+		local svc = ok(http_service.start(root, {
+			driver = fake_polling_driver(),
+			id = 'main',
+			http_server = http_server_success({}),
+		}))
+		local user = b:connect({ origin_base = { kind = 'local' } })
+		local rep = ok(fibers.perform(sdk_mod.new_ref(user, 'main'):listen_op({ host = '127.0.0.1', port = 0 })))
+		local raw_listener = rep.listener:_raw_listener()
+		local raw_ctx = lua_http._new_context_for_test(raw_listener, raw_listener:_raw_server_for_test(), fake_stream_for_context())
+		ok(raw_listener:_admit_context(raw_ctx))
+		local ctx = ok(fibers.perform(rep.listener:accept_op()))
+
+		local receive_active = false
+		local fake_raw_ws = {
+			accept = function () return true end,
+			receive = function ()
+				receive_active = true
+				while not raw_ctx:is_closed() do runtime.yield() end
+				return nil, 'closed'
+			end,
+			send = function () return true end,
+			close = function (self, _code, reason) self.closed_reason = reason or true; return true end,
+		}
+		local module = { new_from_stream = function () return fake_raw_ws end }
+		local ws
+		ok(scope:spawn(function () ws = fibers.perform(public_ws.from_context_op(ctx, {}, { websocket_module = module })) end))
+		yield_many(3)
+		ok(raw_ctx:_drain_one_for_test())
+		yield_many(8)
+		ok(ws, 'server websocket should be returned before receive test')
+		eq(svc:stats().active_websockets, 1)
+
+		local waiter = ok(scope:child())
+		ok(waiter:spawn(function () fibers.perform(ws:receive_op()) end))
+		local runner = ok(scope:child())
+		ok(runner:spawn(function () raw_ctx:_drain_one_for_test() end))
+		yield_until(function () return receive_active end, 'public websocket receive should be active')
+
+		waiter:cancel('caller_cancelled')
+		fibers.perform(waiter:join_op())
+		yield_until(function () return svc:stats().active_websockets == 0 end,
+			'websocket termination should deregister the service record')
+		ok(ws:is_closed(), 'cancelling a public websocket receive should terminate the websocket')
+		eq(ws:why(), 'aborted')
+		runner:cancel('done')
+		fibers.perform(runner:join_op())
+		svc:terminate('done')
+	end)
+end
+
+function M.test_public_open_exchange_handle_read_cancellation_keeps_service_backend_usable()
+	local ctl = fake_controller()
+	local drv = assert(driver_mod.new { controller = ctl })
+	local first_stream
+	local first_read_active = false
+	local request_mod = {
+		new_from_uri = function (uri)
+			return {
+				uri = uri,
+				headers = {
+					upsert = function () end,
+					append = function () end,
+				},
+				go = function (self)
+					local headers = fake_headers(200)
+					if tostring(self.uri):match('slow') then
+						first_stream = {
+							terminated = false,
+							get_next_chunk = function (stream)
+								first_read_active = true
+								while not stream.terminated do runtime.yield() end
+								return nil, 'closed'
+							end,
+							shutdown = function (stream) stream.terminated = true; return true end,
+						}
+						return headers, first_stream
+					end
+					local chunks = { 'ok' }
+					local i = 0
+					return headers, {
+						get_next_chunk = function () i = i + 1; return chunks[i] end,
+						shutdown = function () return true end,
+					}
+				end,
+				shutdown = function () return true end,
+			}
+		end,
+	}
+
+	fibers.run(function (scope)
+		local b = bus.new()
+		local root = b:connect({ origin_base = { kind = 'local' } })
+		local svc = ok(http_service.start(root, {
+			driver = drv,
+			id = 'main',
+			request_module = request_mod,
+		}))
+		local user = b:connect({ origin_base = { kind = 'local' } })
+		local ref = sdk_mod.new_ref(user, 'main')
+
+		local rep = ok(fibers.perform(ref:open_exchange_op({ uri = 'http://example.test/slow', method = 'GET' })))
+		local ex = ok(rep.exchange)
+		yield_many(8)
+		eq(svc:stats().active_exchanges, 1)
+
+		local waiter = ok(scope:child())
+		ok(waiter:spawn(function () fibers.perform(ex:read_chunk_op(1024)) end))
+		yield_until(function () return first_read_active end, 'slow exchange read should be active')
+		-- The driver pump runs the active read job.  Once the caller loses interest,
+		-- the public exchange handle should terminate that stream, not the backend.
+		waiter:cancel('caller_cancelled')
+		fibers.perform(waiter:join_op())
+		yield_until(function () return svc:stats().active_exchanges == 0 end,
+			'exchange termination should deregister the service record')
+
+		ok(first_stream.terminated, 'public exchange read cancellation should terminate the exchange stream')
+		ok(ex:is_closed(), 'public exchange handle should be closed after active read abort')
+		ok(not drv:is_closed(), 'the exchange is the narrow owner; the HTTP backend should stay usable')
+
+		local second = ok(fibers.perform(ref:exchange_op({ uri = 'http://example.test/fast', method = 'GET' })))
+		eq(second.result.status, '200')
+		eq(svc:stats().completed_exchanges, 1, 'a subsequent public exchange should complete after active read cancellation')
+		svc:terminate('done')
+	end)
+end
+
+function M.test_retained_http_config_updates_policy_generation_and_policy()
+	fibers.run(function ()
+		local b = bus.new()
+		local root = b:connect({ origin_base = { kind = 'local' } })
+		root:retain({ 'cfg', 'http' }, {
+			rev = 7,
+			data = {
+				schema = require('services.http.config').SCHEMA,
+				policy = { allow_loopback = false, allowed_schemes = { https = true } },
+			},
+		})
+		local svc = ok(http_service.start(root, { driver = fake_driver(), id = 'main' }))
+		yield_until(function () return svc:stats().policy_generation == 7 end, 'retained cfg/http was not applied')
+		eq(svc._opts.policy.allow_loopback, false)
+		eq(svc._opts.policy.allowed_schemes.https, true)
+		eq(svc._opts.policy.allowed_schemes.http, nil)
+		svc:terminate('done')
+	end)
+end
+
+function M.test_invalid_retained_http_config_marks_service_degraded_without_replacing_policy()
+	fibers.run(function ()
+		local b = bus.new()
+		local root = b:connect({ origin_base = { kind = 'local' } })
+		root:retain({ 'cfg', 'http' }, { rev = 3, data = { schema = 'wrong' } })
+		local svc = ok(http_service.start(root, { driver = fake_driver(), id = 'main' }))
+		yield_until(function () return svc:stats().last_error ~= nil end, 'invalid cfg/http was not reported')
+		ok(tostring(svc:stats().last_error):find('schema', 1, true))
+		eq(svc:stats().policy_generation, 1, 'invalid config must not advance policy generation')
+		svc:terminate('done')
+	end)
+end
+
+return M

--- a/tests/unit/http/test_service_architecture.lua
+++ b/tests/unit/http/test_service_architecture.lua
@@ -1,0 +1,143 @@
+local fibers = require 'fibers'
+local runtime = require 'fibers.runtime'
+local bus    = require 'bus'
+
+local http_service = require 'services.http.service'
+local sdk_mod      = require 'services.http.sdk'
+local body         = require 'services.http.body'
+
+local M = {}
+
+local function eq(a, b, msg)
+	if a ~= b then error((msg or 'assertion failed') .. ': expected ' .. tostring(b) .. ', got ' .. tostring(a), 2) end
+end
+local function ok(v, msg) if not v then error(msg or 'assertion failed', 2) end return v end
+
+local function yield_many(n)
+	for _ = 1, n do runtime.yield() end
+end
+
+local function fake_driver()
+	return {
+		started = false,
+		terminated = nil,
+		start = function (self) self.started = true; return true end,
+		terminate = function (self, reason) self.terminated = reason or true; return true end,
+		run_op = function (_, _, fn) return fibers.guard(function () return fibers.always(fn()) end) end,
+	}
+end
+
+local function failing_run_driver()
+	return {
+		terminated = nil,
+		run = function () return nil, 'backend_boom' end,
+		terminate = function (self, reason) self.terminated = reason or true; return true end,
+		run_op = function (_, _, fn) return fibers.guard(function () return fibers.always(fn()) end) end,
+	}
+end
+
+local function fake_headers(status)
+	return {
+		get = function (_, name) if name == ':status' then return tostring(status or 200) end end,
+		each = function ()
+			local rows = { { ':status', tostring(status or 200) }, { 'content-type', 'text/plain' } }
+			local i = 0
+			return function ()
+				i = i + 1
+				local row = rows[i]
+				if row then return row[1], row[2] end
+			end
+		end,
+	}
+end
+
+local function request_module(body)
+	return {
+		new_from_uri = function (uri)
+			return {
+				uri = uri,
+				headers = {
+					set = {},
+					upsert = function (self, k, v) self.set[k] = v end,
+					append = function (self, k, v) self.set[k] = v end,
+				},
+				go = function ()
+					local chunks = { body or 'ok' }
+					local i = 0
+					return fake_headers(200), {
+						get_next_chunk = function () i = i + 1; return chunks[i] end,
+						shutdown = function () return true end,
+					}
+				end,
+			}
+		end,
+	}
+end
+
+function M.test_backend_run_is_named_component_with_identity_completion()
+	fibers.run(function ()
+		local b = bus.new()
+		local root = b:connect({ origin_base = { kind = 'local' } })
+		local drv = failing_run_driver()
+		local svc = ok(http_service.start(root, { driver = drv, id = 'main' }))
+		yield_many(10)
+		local done
+		for _, ev in ipairs(svc:events()) do
+			if ev.kind == 'backend_done' then done = ev end
+		end
+		ok(done, 'backend_done completion should exist')
+		eq(done.component, 'backend')
+		eq(done.component_id, 'http_backend')
+		eq(done.status, 'failed')
+		eq(done.primary, 'backend_boom')
+		local snap = svc:stats()
+		eq(snap.backend, 'failed')
+		eq(snap.last_error, 'backend_boom')
+		svc:terminate('done')
+	end)
+end
+
+function M.test_exchange_is_named_scoped_work_with_identity_completion_and_event_driven_summary()
+	fibers.run(function ()
+		local b = bus.new()
+		local root = b:connect({ origin_base = { kind = 'local' } })
+		local written = {}
+		local registry = body.new_registry()
+		registry:register_resolver('unit_sink', function ()
+			return {
+				write_chunk_op = function (_, chunk) written[#written + 1] = chunk; return fibers.always(true) end,
+				finish_op = function () return fibers.always(true) end,
+				terminate = function () return true end,
+			}
+		end)
+		local svc = ok(http_service.start(root, {
+			driver = fake_driver(),
+			id = 'main',
+			request_module = request_module('hello'),
+			body_registry = registry,
+		}))
+		local user = b:connect({ origin_base = { kind = 'local' } })
+		local ref = sdk_mod.new_ref(user, 'main')
+		local rep = ok(fibers.perform(ref:exchange_op({ uri = 'http://example.test/', method = 'GET', response_sink = { kind = 'unit_sink' } })))
+		eq(rep.result.status, '200')
+		eq(rep.result.body, nil)
+		eq(rep.result.response_sink.bytes, 5)
+		eq(table.concat(written), 'hello')
+		yield_many(8)
+		local events = svc:events()
+		local started, done
+		for _, ev in ipairs(events) do
+			if ev.kind == 'operation_started' and ev.operation == 'exchange' then started = ev end
+			if ev.kind == 'http_operation_done' and ev.operation == 'exchange' then done = ev end
+		end
+		ok(started, 'operation_started event should exist')
+		ok(done, 'identity-bearing completion should exist')
+		eq(done.operation_id, started.operation_id)
+		eq(done.status, 'ok')
+		local status = ok(fibers.perform(ref:status_op()))
+		eq(status.status.completed_exchanges, 1)
+		svc:terminate('done')
+	end)
+end
+
+return M

--- a/tests/unit/http/test_structure.lua
+++ b/tests/unit/http/test_structure.lua
@@ -1,0 +1,94 @@
+local M = {}
+
+local function ok(v, msg)
+	if not v then error(msg or 'assertion failed', 2) end
+end
+
+local function read_file(path)
+	local f = assert(io.open(path, 'r'))
+	local s = f:read('*a')
+	f:close()
+	return s
+end
+
+function M.test_only_http_transport_requires_lua_http_or_cqueues()
+	local p = io.popen("find ../src/services/http -name '*.lua' | sort")
+	for file in p:lines() do
+		local s = read_file(file)
+		local has_backend_require = s:find("require 'cqueues", 1, true)
+			or s:find("require 'http.", 1, true)
+			or s:find("pcall(require, 'cqueues", 1, true)
+			or s:find("pcall(require, 'http.", 1, true)
+		if has_backend_require then
+			ok(file:find('/transport/', 1, true), 'backend require outside transport: ' .. file)
+		end
+	end
+	p:close()
+end
+
+
+function M.test_http_sources_use_termination_vocabulary()
+	local cmd = [[find ../src/services/http ../src/services/ui \( -name '*.lua' -o -name '*.md' \) | sort]]
+	local p = assert(io.popen(cmd))
+
+	for file in p:lines() do
+		local s = read_file(file)
+		local old_terminate = 'terminate' .. '_now'
+		local old_close = 'close' .. '_now'
+
+		ok(not s:find(old_terminate, 1, true), old_terminate .. ' used in ' .. file)
+		ok(not s:find(old_close, 1, true), old_close .. ' used in ' .. file)
+	end
+
+	p:close()
+end
+
+
+function M.test_http_service_wires_components_with_service_event_ports()
+	local service = read_file('../src/services/http/service.lua')
+	ok(service:find('devicecode.support.service_events', 1, true), 'http service does not use service event helper')
+	ok(service:find('_event_port', 1, true), 'http service lacks event-port helper')
+	ok(service:find('events_port = self:_event_port', 1, true), 'http backend/registry are not wired through event ports')
+
+	local ops = read_file('../src/services/http/operations.lua')
+	ok(ops:find('events_port = service_events.port', 1, true), 'http listener operation does not pass event port')
+	ok(not ops:find('on_context_admitted = function', 1, true), 'http operation still passes context admission callback')
+	ok(not ops:find('on_context_transferred = function', 1, true), 'http operation still passes context transfer callback')
+	ok(not ops:find('on_server_websocket = function', 1, true), 'http operation still passes server websocket callback')
+end
+
+function M.test_http_service_code_does_not_use_perform_raw()
+	local p = io.popen("find ../src/services/http -name '*.lua' | sort")
+	for file in p:lines() do
+		local s = read_file(file)
+		ok(not s:find('perform_raw', 1, true), 'perform_raw used in ' .. file)
+	end
+	p:close()
+end
+
+
+function M.test_http_service_and_support_do_not_use_private_op_internals()
+	local files = {}
+	local p1 = io.popen("find ../src/services/http -name '*.lua' | sort")
+	for file in p1:lines() do
+		if not file:find('/transport/', 1, true) then files[#files + 1] = file end
+	end
+	p1:close()
+	files[#files + 1] = '../src/devicecode/support/queue.lua'
+	files[#files + 1] = '../src/devicecode/support/priority_event.lua'
+
+	local forbidden = {
+		'try_fn',
+		'wait_fn',
+		'new_primitive',
+	}
+
+	for _, file in ipairs(files) do
+		local s = read_file(file)
+		for _, needle in ipairs(forbidden) do
+			ok(not s:find(needle, 1, true), ('private Op internals %s used in %s'):format(needle, file))
+		end
+	end
+end
+
+return M

--- a/tests/unit/http/test_websocket_client.lua
+++ b/tests/unit/http/test_websocket_client.lua
@@ -1,0 +1,79 @@
+local fibers = require 'fibers'
+local websocket = require 'services.http.websocket'
+
+local M = {}
+
+local function eq(a, b, msg)
+	if a ~= b then error((msg or 'assertion failed') .. ': expected ' .. tostring(b) .. ', got ' .. tostring(a), 2) end
+end
+local function ok(v, msg) if not v then error(msg or 'assertion failed', 2) end return v end
+
+local function fake_driver()
+	return {
+		run_op = function (_, _, fn)
+			return fibers.guard(function () return fibers.always(fn()) end)
+		end,
+	}
+end
+
+function M.test_client_connect_and_send_are_driver_jobs()
+	fibers.run(function ()
+		local raw = {
+			connected = false,
+			sent = nil,
+			connect = function (self) self.connected = true; return true end,
+			send = function (self, data, opcode) self.sent = { data, opcode }; return true end,
+			receive = function () return 'reply', 'text' end,
+			close = function () return true end,
+		}
+		local module = {
+			new_from_uri = function (uri)
+				eq(uri, 'ws://example.test/ws')
+				return raw
+			end,
+		}
+		local ws = ok(fibers.perform(websocket.connect_op(fake_driver(), {
+			uri = 'ws://example.test/ws',
+		}, { websocket_module = module })))
+		ok(raw.connected, 'connect should run')
+		ok(fibers.perform(ws:send_op('hello', 'text')))
+		eq(raw.sent[1], 'hello')
+		eq(raw.sent[2], 'text')
+		local data, opcode = fibers.perform(ws:receive_op())
+		eq(data, 'reply')
+		eq(opcode, 'text')
+	end)
+end
+
+
+function M.test_client_connect_applies_validated_headers_before_connect()
+	fibers.run(function ()
+		local raw = {
+			headers = {
+				values = {},
+				upsert = function (self, k, v) self.values[k] = v end,
+				append = function (self, k, v) self.values[k] = v end,
+			},
+			connect = function (self)
+				eq(self.headers.values['x-auth'], 'token', 'headers must be applied before websocket connect')
+				return true
+			end,
+			send = function () return true end,
+			receive = function () return nil, 'closed' end,
+			close = function () return true end,
+		}
+		local module = {
+			new_from_uri = function (uri)
+				eq(uri, 'ws://example.test/ws')
+				return raw
+			end,
+		}
+		local ws = ok(fibers.perform(websocket.connect_op(fake_driver(), {
+			uri = 'ws://example.test/ws',
+			headers = { ['x-auth'] = 'token' },
+		}, { websocket_module = module })))
+		ok(ws)
+	end)
+end
+
+return M

--- a/tests/unit/http/transport/test_cqueues_driver.lua
+++ b/tests/unit/http/transport/test_cqueues_driver.lua
@@ -1,0 +1,362 @@
+local fibers = require 'fibers'
+local sleep  = require 'fibers.sleep'
+local runtime = require 'fibers.runtime'
+local driver_mod = require 'services.http.transport.cqueues_driver'
+
+local M = {}
+
+local function eq(a, b, msg)
+	if a ~= b then error((msg or 'assertion failed') .. ': expected ' .. tostring(b) .. ', got ' .. tostring(a), 2) end
+end
+
+local function ok(v, msg)
+	if not v then error(msg or 'assertion failed', 2) end
+end
+
+local function yield_once()
+	runtime.yield()
+end
+
+local function yield_many(n)
+	for _ = 1, n do yield_once() end
+end
+
+local function yield_until(pred, msg)
+	for _ = 1, 50 do
+		if pred() then return true end
+		yield_once()
+	end
+	error(msg or 'condition was not reached', 2)
+end
+
+local function fake_controller()
+	local q = {}
+	return {
+		wraps = 0,
+		steps = 0,
+		closed = false,
+		wrap = function (self, fn)
+			self.wraps = self.wraps + 1
+			q[#q + 1] = fn
+			return self
+		end,
+		step = function (self, timeout)
+			eq(timeout, 0, 'driver must step with timeout 0')
+			self.steps = self.steps + 1
+			local fn = table.remove(q, 1)
+			if fn then fn() end
+			return true
+		end,
+		pollfd = function () return nil end,
+		events = function () return '' end,
+		timeout = function () return nil end,
+		queued = function () return #q end,
+	}
+end
+
+function M.test_event_wants_maps_cqueues_event_strings()
+	local rd, wr = driver_mod.event_wants('r')
+	ok(rd, 'r should want read')
+	ok(not wr, 'r should not want write')
+
+	rd, wr = driver_mod.event_wants('w')
+	ok(not rd, 'w should not want read')
+	ok(wr, 'w should want write')
+
+	rd, wr = driver_mod.event_wants('p')
+	ok(rd, 'priority event should map to read-side wake')
+	ok(not wr, 'p should not want write')
+
+	rd, wr = driver_mod.event_wants('rw')
+	ok(rd and wr, 'rw should want both directions')
+end
+
+function M.test_pollable_ready_op_uses_poke_as_step_hint()
+	local drv = assert(driver_mod.new { create_controller = false })
+	local pollable = {
+		pollfd = function () return nil end,
+		events = function () return '' end,
+		timeout = function () return nil end,
+	}
+
+	fibers.run(function (scope)
+		local reason, err
+		assert(scope:spawn(function ()
+			reason, err = fibers.perform(drv:pollable_ready_op(pollable))
+		end))
+		yield_many(3)
+		drv:poke()
+		yield_many(3)
+		eq(reason, 'poke')
+		eq(err, nil)
+		drv:terminate('done')
+	end)
+end
+
+function M.test_pollable_ready_op_reports_due_timeout_immediately()
+	local drv = assert(driver_mod.new { create_controller = false })
+	local pollable = { timeout = function () return 0 end }
+
+	fibers.run(function ()
+		local reason, err = fibers.perform(drv:pollable_ready_op(pollable))
+		eq(reason, 'timeout')
+		eq(err, nil)
+		drv:terminate('done')
+	end)
+end
+
+function M.test_pollable_step_op_treats_spurious_timeout_step_as_nonfatal()
+	local drv = assert(driver_mod.new { create_controller = false })
+	local pollable = {
+		timeout = function () return 0 end,
+		step = function (_, timeout)
+			eq(timeout, 0)
+			return nil, 'timeout'
+		end,
+	}
+
+	fibers.run(function ()
+		local ok1, err = fibers.perform(drv:pollable_step_op(pollable))
+		eq(ok1, true)
+		eq(err, nil)
+		drv:terminate('done')
+	end)
+end
+
+function M.test_run_op_completes_inside_driver_pump()
+	local ctl = fake_controller()
+	local drv = assert(driver_mod.new { controller = ctl })
+
+	fibers.run(function (scope)
+		assert(drv:start(scope))
+		local a, b = fibers.perform(drv:run_op('unit.job', function ()
+			return 'done', 42
+		end))
+		eq(a, 'done')
+		eq(b, 42)
+		ok(ctl.wraps >= 1, 'controller.wrap should be used')
+		ok(ctl.steps >= 1, 'controller.step should be used')
+		drv:terminate('test complete')
+	end)
+end
+
+function M.test_run_op_reports_lua_errors_as_failed_results()
+	local ctl = fake_controller()
+	local drv = assert(driver_mod.new { controller = ctl })
+
+	fibers.run(function (scope)
+		assert(drv:start(scope))
+		local v, err = fibers.perform(drv:run_op('unit.error', function ()
+			error('boom', 0)
+		end))
+		eq(v, nil)
+		ok(tostring(err):find('boom', 1, true) ~= nil, 'error should be reported')
+		drv:terminate('test complete')
+	end)
+end
+
+function M.test_losing_run_op_aborts_without_running_job()
+	local ctl = fake_controller()
+	local drv = assert(driver_mod.new { controller = ctl })
+	local aborted = false
+	local ran = false
+
+	fibers.run(function (scope)
+		assert(drv:start(scope))
+
+		local which = fibers.perform(fibers.named_choice {
+			winner = fibers.always('now'),
+			job = drv:run_op('unit.loser', function ()
+				ran = true
+				return 'late'
+			end, {
+				on_abort = function () aborted = true end,
+			}),
+		})
+
+		eq(which, 'winner')
+		ok(aborted, 'losing job should be abandoned')
+		ctl:step(0)
+		ok(not ran, 'abandoned job body must not run')
+		drv:terminate('test complete')
+	end)
+end
+
+function M.test_losing_active_run_op_calls_active_abort_without_closing_driver()
+	local ctl = fake_controller()
+	local drv = assert(driver_mod.new { controller = ctl })
+	local active = false
+	local release = false
+	local active_abort
+
+	fibers.run(function (scope)
+		assert(drv:start(scope))
+
+		local waiter = assert(scope:child())
+		local result, err
+		assert(waiter:spawn(function ()
+			result, err = fibers.perform(drv:run_op('unit.active_loser', function ()
+				active = true
+				while not release do runtime.yield() end
+				return 'late'
+			end, {
+				on_active_abort = function (reason)
+					active_abort = reason
+					release = true
+				end,
+			}))
+		end))
+
+		yield_until(function () return active end, 'job should become active')
+		waiter:cancel('stop_waiting')
+		fibers.perform(waiter:join_op())
+		eq(active_abort, 'aborted')
+		ok(not drv:is_closed(), 'active abort with a narrow owner must not close the driver')
+		release = true
+		yield_many(3)
+		eq(result, nil)
+		eq(err, nil)
+		drv:terminate('done')
+	end)
+end
+
+function M.test_losing_active_run_op_without_owner_terminates_driver()
+	local ctl = fake_controller()
+	local drv = assert(driver_mod.new { controller = ctl })
+	local active = false
+
+	fibers.run(function (scope)
+		assert(drv:start(scope))
+
+		local waiter = assert(scope:child())
+		assert(waiter:spawn(function ()
+			fibers.perform(drv:run_op('unit.active_loser_no_owner', function ()
+				active = true
+				while not drv:is_closed() do runtime.yield() end
+				return 'late'
+			end))
+		end))
+
+		yield_until(function () return active end, 'job should become active')
+		waiter:cancel('stop_waiting')
+		fibers.perform(waiter:join_op())
+		ok(drv:is_closed(), 'active abort with no narrower owner should close the driver')
+		eq(drv:why(), 'aborted')
+	end)
+end
+
+function M.test_active_aborted_job_late_completion_is_ignored()
+	local ctl = fake_controller()
+	local drv = assert(driver_mod.new { controller = ctl })
+	local active = false
+	local release = false
+	local active_abort = 0
+
+	fibers.run(function (scope)
+		assert(drv:start(scope))
+
+		local waiter = assert(scope:child())
+		local result, err
+		assert(waiter:spawn(function ()
+			result, err = fibers.perform(drv:run_op('unit.active_late_completion', function ()
+				active = true
+				while not release do runtime.yield() end
+				return 'late_result'
+			end, {
+				on_active_abort = function ()
+					active_abort = active_abort + 1
+				end,
+			}))
+		end))
+
+		yield_until(function () return active end, 'job should become active')
+		waiter:cancel('stop_waiting')
+		fibers.perform(waiter:join_op())
+		eq(active_abort, 1)
+		release = true
+		yield_many(5)
+		eq(result, nil)
+		eq(err, nil)
+		ok(not drv:is_closed(), 'owned active abort should not close driver')
+		drv:terminate('done')
+	end)
+end
+
+function M.test_terminate_wakes_pending_run_op_without_pump()
+	local ctl = fake_controller()
+	local drv = assert(driver_mod.new { controller = ctl })
+
+	fibers.run(function (scope)
+		local result, err
+		assert(scope:spawn(function ()
+			result, err = fibers.perform(drv:run_op('unit.never', function ()
+				return 'should not matter'
+			end))
+		end))
+
+		yield_many(3)
+		drv:terminate('stopping')
+		yield_many(3)
+
+		eq(result, nil)
+		eq(err, 'stopping')
+	end)
+end
+
+function M.test_multiple_concurrent_run_ops_are_completed_by_one_pump()
+	local ctl = fake_controller()
+	local drv = assert(driver_mod.new { controller = ctl })
+
+	fibers.run(function (scope)
+		local a, b
+		assert(drv:start(scope))
+		assert(scope:spawn(function () a = fibers.perform(drv:run_op('a', function () return 'A' end)) end))
+		assert(scope:spawn(function () b = fibers.perform(drv:run_op('b', function () return 'B' end)) end))
+
+		for _ = 1, 5 do yield_once() end
+		eq(a, 'A')
+		eq(b, 'B')
+		ok(ctl.steps >= 2, 'pump should step enough to complete queued jobs')
+		drv:terminate('done')
+	end)
+end
+
+function M.test_driver_scope_finaliser_terminates_driver_after_scope_cancel()
+	local ctl = fake_controller()
+	local drv = assert(driver_mod.new { controller = ctl })
+
+	fibers.run(function (scope)
+		local child = assert(scope:child())
+		assert(child:spawn(function (s)
+			assert(drv:start(s))
+			-- Keep the component scope alive until cancellation.
+			fibers.perform(sleep.sleep_op(60))
+		end))
+		yield_once()
+		child:cancel('stop')
+		fibers.perform(child:join_op())
+		ok(drv:is_closed(), 'driver should be closed by scope finaliser')
+	end)
+end
+
+
+function M.test_driver_start_can_target_started_parent_scope_from_child_scope()
+	local ctl = fake_controller()
+	local drv = assert(driver_mod.new { controller = ctl })
+
+	fibers.run(function (parent)
+		local child = assert(parent:child())
+		local started, start_err
+
+		assert(child:spawn(function ()
+			started, start_err = drv:start(parent)
+		end))
+
+		yield_many(3)
+		eq(started, true)
+		eq(start_err, nil)
+		drv:terminate('done')
+	end)
+end
+
+return M

--- a/tests/unit/http/transport/test_lua_http.lua
+++ b/tests/unit/http/transport/test_lua_http.lua
@@ -1,0 +1,385 @@
+local fibers = require 'fibers'
+local sleep  = require 'fibers.sleep'
+local runtime = require 'fibers.runtime'
+local driver_mod = require 'services.http.transport.cqueues_driver'
+local lua_http = require 'services.http.transport.lua_http'
+
+local M = {}
+
+local function eq(a, b, msg)
+	if a ~= b then error((msg or 'assertion failed') .. ': expected ' .. tostring(b) .. ', got ' .. tostring(a), 2) end
+end
+
+local function ok(v, msg)
+	if not v then error(msg or 'assertion failed', 2) end
+end
+
+local function yield_once()
+	runtime.yield()
+end
+
+local function yield_many(n)
+	for _ = 1, n do yield_once() end
+end
+
+local function yield_until(pred, msg)
+	for _ = 1, 50 do
+		if pred() then return true end
+		yield_once()
+	end
+	error(msg or 'condition was not reached', 2)
+end
+
+local function fake_condition()
+	return {
+		signals = 0,
+		waits = 0,
+		signal = function (self) self.signals = self.signals + 1; return true end,
+		wait = function (self) self.waits = self.waits + 1; return true end,
+	}
+end
+
+local function fake_server()
+	return {
+		steps = 0,
+		closed = false,
+		listened = false,
+		pollfd = function () return nil end,
+		events = function () return '' end,
+		timeout = function () return nil end,
+		step = function (self, timeout)
+			eq(timeout, 0)
+			self.steps = self.steps + 1
+			return true
+		end,
+		listen = function (self, timeout)
+			self.listened = timeout or true
+			return true
+		end,
+		close = function (self)
+			self.closed = true
+			return true
+		end,
+		pause = function (self) self.paused = true; return true end,
+		resume = function (self) self.resumed = true; return true end,
+	}
+end
+
+local function fake_stream()
+	return {
+		terminated = false,
+		calls = {},
+		shutdown = function (self) self.terminated = true; return true end,
+		get_headers = function (self, timeout) self.calls[#self.calls+1] = {'headers', timeout}; return { ':method', 'GET' } end,
+		get_next_chunk = function (self, timeout) self.calls[#self.calls+1] = {'chunk', timeout}; return 'chunk', false end,
+		get_body_chars = function (self, n, timeout) self.calls[#self.calls+1] = {'chars', n, timeout}; return string.rep('x', n) end,
+		get_body_as_string = function (self, timeout) self.calls[#self.calls+1] = {'body', timeout}; return 'body' end,
+		write_headers = function (self, headers, end_stream, timeout) self.calls[#self.calls+1] = {'write_headers', headers, end_stream, timeout}; return true end,
+		write_chunk = function (self, chunk, end_stream, timeout) self.calls[#self.calls+1] = {'write_chunk', chunk, end_stream, timeout}; return true end,
+		write_body_from_string = function (self, body, timeout) self.calls[#self.calls+1] = {'write_body', body, timeout}; return true end,
+	}
+end
+
+local function listener_with(opts)
+	opts = opts or {}
+	local drv = opts.driver or assert(driver_mod.new { create_controller = false })
+	return assert(lua_http.listen {
+		server = opts.server or fake_server(),
+		driver = drv,
+		max_accept_queue = opts.max_accept_queue,
+		condition_factory = function () return fake_condition() end,
+		context_terminator = opts.context_terminator,
+		on_context = opts.on_context,
+	})
+end
+
+function M.test_listener_admits_context_and_accept_op_returns_it()
+	local listener = listener_with()
+	local ctx = lua_http._new_context_for_test(listener, listener:_raw_server_for_test(), fake_stream())
+
+	fibers.run(function ()
+		assert(listener:_admit_context(ctx))
+		local got, err = fibers.perform(listener:accept_op())
+		eq(got, ctx)
+		eq(err, nil)
+		listener:terminate('done')
+	end)
+end
+
+function M.test_listener_accept_queue_overflow_terminates_context()
+	local terminated_reason
+	local listener = listener_with {
+		max_accept_queue = 0,
+		context_terminator = function (_, reason) terminated_reason = reason end,
+	}
+	local ctx = lua_http._new_context_for_test(listener, listener:_raw_server_for_test(), fake_stream())
+	local ok1, err = listener:_admit_context(ctx)
+	eq(ok1, nil)
+	eq(err, 'accept_queue_full')
+	eq(terminated_reason, 'accept_queue_full')
+	listener:terminate('done')
+end
+
+function M.test_listener_terminate_wakes_accept_waiter()
+	local listener = listener_with()
+
+	fibers.run(function (scope)
+		local got, err
+		assert(scope:spawn(function ()
+			got, err = fibers.perform(listener:accept_op())
+		end))
+		yield_many(3)
+		listener:terminate('closed')
+		yield_many(3)
+		eq(got, nil)
+		eq(err, 'closed')
+	end)
+end
+
+function M.test_http_context_stream_ops_run_on_command_loop()
+	local listener = listener_with()
+	local stream = fake_stream()
+	local ctx = lua_http._new_context_for_test(listener, listener:_raw_server_for_test(), stream)
+
+	fibers.run(function (scope)
+		local ok_write, err
+		assert(scope:spawn(function ()
+			ok_write, err = fibers.perform(ctx:write_chunk_op('abc', true))
+		end))
+		yield_many(3)
+		ok(ctx:_drain_one_for_test(), 'command should be queued')
+		yield_many(3)
+		eq(ok_write, true)
+		eq(err, nil)
+		eq(stream.calls[1][1], 'write_chunk')
+		eq(stream.calls[1][2], 'abc')
+		eq(stream.calls[1][3], true)
+		eq(stream.calls[1][4], nil)
+		ctx:terminate('done')
+		listener:terminate('done')
+	end)
+end
+
+function M.test_http_context_read_helpers_preserve_http_semantics()
+	local listener = listener_with()
+	local stream = fake_stream()
+	local ctx = lua_http._new_context_for_test(listener, listener:_raw_server_for_test(), stream)
+
+	fibers.run(function (scope)
+		local body
+		assert(scope:spawn(function ()
+			body = fibers.perform(ctx:read_body_as_string_op())
+		end))
+		yield_many(3)
+		ok(ctx:_drain_one_for_test())
+		yield_many(3)
+		eq(body, 'body')
+		eq(stream.calls[1][1], 'body')
+		eq(stream.calls[1][2], nil)
+		ctx:terminate('done')
+		listener:terminate('done')
+	end)
+end
+
+function M.test_losing_stream_command_is_abandoned_and_not_run()
+	local listener = listener_with()
+	local stream = fake_stream()
+	local ctx = lua_http._new_context_for_test(listener, listener:_raw_server_for_test(), stream)
+	local ran = false
+	local aborted = false
+
+	fibers.run(function ()
+		local which = fibers.perform(fibers.named_choice {
+			winner = fibers.always('now'),
+			cmd = ctx:run_stream_op('loser', function () ran = true; return true end, {
+				on_abort = function () aborted = true end,
+			}),
+		})
+		eq(which, 'winner')
+		ok(aborted, 'abort hook should run')
+		ctx:_drain_one_for_test()
+		ok(not ran, 'abandoned command should not run')
+		ctx:terminate('done')
+		listener:terminate('done')
+	end)
+end
+
+function M.test_losing_active_stream_command_terminates_context()
+	local terminated_reason
+	local listener = listener_with {
+		context_terminator = function (_, reason) terminated_reason = reason end,
+	}
+	local ctx = lua_http._new_context_for_test(listener, listener:_raw_server_for_test(), fake_stream())
+	local active = false
+	local release = false
+
+	fibers.run(function (scope)
+		local waiter = assert(scope:child())
+		assert(waiter:spawn(function ()
+			fibers.perform(ctx:run_stream_op('active_loser', function ()
+				active = true
+				while not release do runtime.yield() end
+				return true
+			end))
+		end))
+
+		assert(scope:spawn(function () ctx:_drain_one_for_test() end))
+		yield_until(function () return active end, 'stream command should become active')
+		waiter:cancel('stop_waiting')
+		fibers.perform(waiter:join_op())
+		eq(terminated_reason, 'aborted')
+		ok(ctx:is_closed(), 'active command abort should close the context')
+		release = true
+		listener:terminate('done')
+	end)
+end
+
+function M.test_losing_active_write_command_terminates_context()
+	local terminated_reason
+	local stream = fake_stream()
+	stream.write_chunk = function ()
+		stream.write_active = true
+		while not stream.terminated do runtime.yield() end
+		return true
+	end
+	local listener = listener_with {
+		context_terminator = function (s, reason)
+			terminated_reason = reason
+			s.terminated = true
+		end,
+	}
+	local ctx = lua_http._new_context_for_test(listener, listener:_raw_server_for_test(), stream)
+
+	fibers.run(function (scope)
+		local waiter = assert(scope:child())
+		assert(waiter:spawn(function ()
+			fibers.perform(ctx:write_chunk_op('payload', false))
+		end))
+
+		assert(scope:spawn(function () ctx:_drain_one_for_test() end))
+		yield_until(function () return stream.write_active end, 'write command should become active')
+		waiter:cancel('stop_waiting')
+		fibers.perform(waiter:join_op())
+		eq(terminated_reason, 'aborted')
+		ok(ctx:is_closed(), 'active write abort should close the context')
+		listener:terminate('done')
+	end)
+end
+
+function M.test_context_terminate_wakes_pending_stream_command()
+	local listener = listener_with()
+	local ctx = lua_http._new_context_for_test(listener, listener:_raw_server_for_test(), fake_stream())
+
+	fibers.run(function (scope)
+		local result, err
+		assert(scope:spawn(function ()
+			result, err = fibers.perform(ctx:run_stream_op('pending', function () return 'late' end))
+		end))
+		yield_many(3)
+		ctx:terminate('gone')
+		yield_many(3)
+		eq(result, nil)
+		eq(err, 'gone')
+		listener:terminate('done')
+	end)
+end
+
+function M.test_listener_terminate_terminates_open_contexts_and_server()
+	local server = fake_server()
+	local terminated = 0
+	local listener = listener_with {
+		server = server,
+		context_terminator = function () terminated = terminated + 1 end,
+	}
+	local ctx = lua_http._new_context_for_test(listener, server, fake_stream())
+	assert(listener:_admit_context(ctx))
+	listener:terminate('service_down')
+	ok(server.closed, 'server close should be called')
+	eq(terminated, 1)
+	ok(ctx:is_closed(), 'context should be closed')
+end
+
+
+function M.test_listener_terminate_does_not_terminate_accepted_context_after_transfer()
+	local server = fake_server()
+	local terminated = 0
+	local listener = listener_with {
+		server = server,
+		context_terminator = function () terminated = terminated + 1 end,
+	}
+	local ctx = lua_http._new_context_for_test(listener, server, fake_stream())
+
+	fibers.run(function ()
+		assert(listener:_admit_context(ctx))
+		local got = fibers.perform(listener:accept_op())
+		eq(got, ctx)
+
+		listener:terminate('listener_down')
+		ok(server.closed, 'server close should be called')
+		eq(terminated, 0)
+		ok(not ctx:is_closed(), 'accepted context should be owned by the caller after accept')
+		ctx:terminate('request_done')
+	end)
+end
+
+function M.test_listener_listen_op_runs_via_driver()
+	local server = fake_server()
+	local ctl = {
+		q = {},
+		wrap = function (self, fn) self.q[#self.q+1] = fn end,
+		step = function (self) local fn = table.remove(self.q, 1); if fn then fn() end; return true end,
+		pollfd = function () return nil end,
+		events = function () return '' end,
+		timeout = function () return nil end,
+	}
+	local drv = assert(driver_mod.new { controller = ctl })
+	local listener = listener_with { server = server, driver = drv }
+
+	fibers.run(function (scope)
+		assert(drv:start(scope))
+		local ok_listen = fibers.perform(listener:listen_op())
+		eq(ok_listen, true)
+		eq(server.listened, true)
+		listener:terminate('done')
+		drv:terminate('done')
+	end)
+end
+
+
+function M.test_listener_start_can_target_started_parent_scope_from_child_scope()
+	local listener = listener_with()
+
+	fibers.run(function (parent)
+		local child = assert(parent:child())
+		local started, start_err
+
+		assert(child:spawn(function ()
+			started, start_err = listener:start(parent)
+		end))
+
+		yield_many(3)
+		eq(started, true)
+		eq(start_err, nil)
+		listener:terminate('done')
+	end)
+end
+
+
+function M.test_onstream_admission_does_not_call_service_hook_synchronously()
+	local called = 0
+	local listener = listener_with {
+		on_context = function ()
+			called = called + 1
+			error('service hook must not run from the backend onstream path', 0)
+		end,
+	}
+	local ctx = lua_http._new_context_for_test(listener, listener:_raw_server_for_test(), fake_stream())
+
+	local admitted, err = listener:_admit_context(ctx)
+	eq(admitted, true)
+	eq(err, nil)
+	eq(called, 0, 'backend context admission must only wake a Fibers-owned event source')
+	listener:terminate('done')
+end
+
+return M

--- a/tests/unit/http/transport/test_terminate.lua
+++ b/tests/unit/http/transport/test_terminate.lua
@@ -1,0 +1,53 @@
+local terminate = require 'services.http.transport.terminate'
+
+local M = {}
+
+local function eq(a, b, msg)
+	if a ~= b then error((msg or 'assertion failed') .. ': expected ' .. tostring(b) .. ', got ' .. tostring(a), 2) end
+end
+local function ok(v, msg) if not v then error(msg or 'assertion failed', 2) end return v end
+
+function M.test_terminate_stream_prefers_shutdown_and_is_idempotent_shape()
+	local calls = {}
+	local stream = {
+		shutdown = function () calls[#calls + 1] = 'shutdown'; return true end,
+		close = function () calls[#calls + 1] = 'close'; return true end,
+	}
+	ok(terminate.terminate_stream(stream, 'done'))
+	eq(calls[1], 'shutdown')
+	eq(calls[2], nil)
+end
+
+function M.test_terminate_server_uses_immediate_termination()
+	local closed
+	ok(terminate.terminate_server({ close = function () closed = true; return true end }, 'down'))
+	eq(closed, true)
+end
+
+function M.test_terminate_websocket_uses_abnormal_immediate_termination()
+	local code, reason, timeout
+	ok(terminate.terminate_websocket({ close = function (_, c, r, t) code, reason, timeout = c, r, t; return true end }, 'drop'))
+	eq(code, 1006)
+	eq(reason, 'drop')
+	eq(timeout, 0)
+end
+
+function M.test_terminate_request_prefers_immediate_shutdown()
+	local calls = {}
+	ok(terminate.terminate_request({
+		shutdown = function () calls[#calls + 1] = 'shutdown'; return true end,
+		close = function () calls[#calls + 1] = 'close'; return true end,
+	}, 'drop'))
+	eq(calls[1], 'shutdown')
+	eq(calls[2], nil)
+end
+
+function M.test_terminate_request_falls_back_to_cancel_with_reason()
+	local cancel_reason
+	ok(terminate.terminate_request({
+		cancel = function (_, reason) cancel_reason = reason; return true end,
+	}, 'drop'))
+	eq(cancel_reason, 'drop')
+end
+
+return M

--- a/tests/unit/http/transport/test_websocket.lua
+++ b/tests/unit/http/transport/test_websocket.lua
@@ -1,0 +1,287 @@
+local fibers = require 'fibers'
+local sleep  = require 'fibers.sleep'
+local runtime = require 'fibers.runtime'
+local driver_mod = require 'services.http.transport.cqueues_driver'
+local lua_http = require 'services.http.transport.lua_http'
+local websocket = require 'services.http.transport.websocket'
+
+local M = {}
+
+local function eq(a, b, msg)
+	if a ~= b then error((msg or 'assertion failed') .. ': expected ' .. tostring(b) .. ', got ' .. tostring(a), 2) end
+end
+
+local function ok(v, msg)
+	if not v then error(msg or 'assertion failed', 2) end
+end
+
+local function yield_once()
+	runtime.yield()
+end
+
+local function yield_many(n)
+	for _ = 1, n do yield_once() end
+end
+
+local function yield_until(pred, msg)
+	for _ = 1, 50 do
+		if pred() then return true end
+		yield_once()
+	end
+	error(msg or 'condition was not reached', 2)
+end
+
+local function fake_controller()
+	local q = {}
+	return {
+		wrap = function (self, fn) q[#q + 1] = fn; return self end,
+		step = function () local fn = table.remove(q, 1); if fn then fn() end; return true end,
+		pollfd = function () return nil end,
+		events = function () return '' end,
+		timeout = function () return nil end,
+	}
+end
+
+local function fake_condition()
+	return {
+		signal = function () return true end,
+		wait = function () return true end,
+	}
+end
+
+local function fake_server()
+	return {
+		pollfd = function () return nil end,
+		events = function () return '' end,
+		timeout = function () return nil end,
+		step = function () return true end,
+		close = function () return true end,
+	}
+end
+
+local function listener_with(term)
+	return assert(lua_http.listen {
+		server = fake_server(),
+		driver = assert(driver_mod.new { create_controller = false }),
+		condition_factory = function () return fake_condition() end,
+		context_terminator = term,
+	})
+end
+
+local function fake_ws()
+	return {
+		calls = {},
+		accept = function (self, options, timeout)
+			self.calls[#self.calls+1] = {'accept', options, timeout}
+			return true
+		end,
+		receive = function (self, timeout)
+			self.calls[#self.calls+1] = {'receive', timeout}
+			return 'hello', 'text'
+		end,
+		send = function (self, data, opcode, timeout)
+			self.calls[#self.calls+1] = {'send', data, opcode, timeout}
+			return true
+		end,
+		send_ping = function (self, data, timeout)
+			self.calls[#self.calls+1] = {'ping', data, timeout}
+			return true
+		end,
+		send_pong = function (self, data, timeout)
+			self.calls[#self.calls+1] = {'pong', data, timeout}
+			return true
+		end,
+		close = function (self, code, reason, timeout)
+			self.calls[#self.calls+1] = {'close', code, reason, timeout}
+			return true
+		end,
+	}
+end
+
+function M.test_from_context_op_constructs_websocket_inside_context()
+	local listener = listener_with()
+	local stream = { id = 'stream' }
+	local ctx = lua_http._new_context_for_test(listener, listener:_raw_server_for_test(), stream)
+	local raw = fake_ws()
+	local module = {
+		new_from_stream = function (s, headers)
+			eq(s, stream)
+			eq(headers.token, 'h')
+			return raw
+		end,
+	}
+
+	fibers.run(function (scope)
+		local ws, err
+		assert(scope:spawn(function ()
+			ws, err = fibers.perform(websocket.from_context_op(ctx, { token = 'h' }, {
+				websocket_module = module,
+			}))
+		end))
+		yield_many(3)
+		ok(ctx:_drain_one_for_test())
+		yield_many(3)
+		ok(ws, 'websocket should be returned')
+		eq(err, nil)
+		eq(ws:_raw_websocket_for_test(), raw)
+		ws:terminate('done')
+		listener:terminate('done')
+	end)
+end
+
+function M.test_websocket_receive_and_send_are_context_commands()
+	local listener = listener_with()
+	local ctx = lua_http._new_context_for_test(listener, listener:_raw_server_for_test(), {})
+	local raw = fake_ws()
+	local ws = websocket.WebSocket and setmetatable({ _ctx = ctx, _ws = raw }, websocket.WebSocket) or nil
+	-- Avoid reaching through the metatable from production callers; this is a unit seam.
+	if not ws then error('missing WebSocket class') end
+
+	fibers.run(function (scope)
+		local data, opcode, sent
+		assert(scope:spawn(function () data, opcode = fibers.perform(ws:receive_op()) end))
+		yield_many(3)
+		ok(ctx:_drain_one_for_test())
+		yield_many(3)
+		eq(data, 'hello')
+		eq(opcode, 'text')
+
+		assert(scope:spawn(function () sent = fibers.perform(ws:send_op('payload', 'text')) end))
+		yield_many(3)
+		ok(ctx:_drain_one_for_test())
+		yield_many(3)
+		eq(sent, true)
+		eq(raw.calls[2][1], 'send')
+		eq(raw.calls[2][2], 'payload')
+		eq(raw.calls[2][3], 'text')
+		eq(raw.calls[2][4], nil)
+
+		ws:terminate('done')
+		listener:terminate('done')
+	end)
+end
+
+function M.test_websocket_close_op_marks_wrapper_closed()
+	local listener = listener_with()
+	local ctx = lua_http._new_context_for_test(listener, listener:_raw_server_for_test(), {})
+	local raw = fake_ws()
+	local ws = setmetatable({ _ctx = ctx, _ws = raw }, websocket.WebSocket)
+
+	fibers.run(function (scope)
+		local closed_ok
+		assert(scope:spawn(function () closed_ok = fibers.perform(ws:close_op(1000, 'bye')) end))
+		yield_many(3)
+		ok(ctx:_drain_one_for_test())
+		yield_many(3)
+		eq(closed_ok, true)
+		ok(ws:is_closed(), 'wrapper should be closed after close_op')
+		eq(ws:why(), 'bye')
+		eq(raw.calls[1][1], 'close')
+		eq(raw.calls[1][2], 1000)
+		eq(raw.calls[1][3], 'bye')
+		listener:terminate('done')
+	end)
+end
+
+function M.test_websocket_terminate_terminates_context_without_protocol_close()
+	local terminated
+	local listener = listener_with(function (_, reason) terminated = reason end)
+	local ctx = lua_http._new_context_for_test(listener, listener:_raw_server_for_test(), {})
+	local raw = fake_ws()
+	local ws = setmetatable({ _ctx = ctx, _ws = raw }, websocket.WebSocket)
+
+	ws:terminate('drop')
+	ok(ws:is_closed(), 'websocket should be marked closed')
+	eq(terminated, 'drop')
+	eq(#raw.calls, 0, 'terminate must not perform graceful websocket close_op')
+	listener:terminate('done')
+end
+
+function M.test_server_websocket_active_receive_abort_terminates_context_and_wrapper()
+	local terminated_reason
+	local listener = listener_with(function (_, reason) terminated_reason = reason end)
+	local ctx = lua_http._new_context_for_test(listener, listener:_raw_server_for_test(), {})
+	local raw = fake_ws()
+	raw.receive = function (self)
+		self.receive_active = true
+		while terminated_reason == nil do runtime.yield() end
+		return nil, 'closed'
+	end
+	local ws = setmetatable({ _ctx = ctx, _ws = raw }, websocket.WebSocket)
+	ctx._http_transport_websocket = ws
+
+	fibers.run(function (scope)
+		local waiter = assert(scope:child())
+		assert(waiter:spawn(function () fibers.perform(ws:receive_op()) end))
+		assert(scope:spawn(function () ctx:_drain_one_for_test() end))
+		yield_until(function () return raw.receive_active end, 'server websocket receive should become active')
+		waiter:cancel('stop_waiting')
+		fibers.perform(waiter:join_op())
+		eq(terminated_reason, 'aborted')
+		ok(ctx:is_closed(), 'active server websocket abort should close context')
+		ok(ws:is_closed(), 'transport websocket wrapper should be marked closed')
+		listener:terminate('done')
+	end)
+end
+
+function M.test_client_websocket_active_receive_abort_terminates_websocket()
+	local ctl = fake_controller()
+	local drv = assert(driver_mod.new { controller = ctl })
+	local raw = fake_ws()
+	raw.receive = function (self)
+		self.receive_active = true
+		while not self.closed do runtime.yield() end
+		return nil, 'closed'
+	end
+	raw.close = function (self, code, reason, timeout)
+		self.closed = true
+		self.calls[#self.calls+1] = {'close', code, reason, timeout}
+		return true
+	end
+	local ws = setmetatable({ _driver = drv, _ws = raw }, websocket.ClientWebSocket)
+
+	fibers.run(function (scope)
+		assert(drv:start(scope))
+		local waiter = assert(scope:child())
+		assert(waiter:spawn(function () fibers.perform(ws:receive_op()) end))
+		yield_until(function () return raw.receive_active end, 'client websocket receive should become active')
+		waiter:cancel('stop_waiting')
+		fibers.perform(waiter:join_op())
+		ok(raw.closed, 'active client websocket abort should close raw websocket')
+		ok(ws:is_closed(), 'client websocket wrapper should be marked closed')
+		ok(not drv:is_closed(), 'websocket is the narrow owner; driver should survive')
+		drv:terminate('done')
+	end)
+end
+
+function M.test_client_websocket_active_send_abort_terminates_websocket()
+	local ctl = fake_controller()
+	local drv = assert(driver_mod.new { controller = ctl })
+	local raw = fake_ws()
+	raw.send = function (self)
+		self.send_active = true
+		while not self.closed do runtime.yield() end
+		return true
+	end
+	raw.close = function (self, code, reason, timeout)
+		self.closed = true
+		self.calls[#self.calls+1] = {'close', code, reason, timeout}
+		return true
+	end
+	local ws = setmetatable({ _driver = drv, _ws = raw }, websocket.ClientWebSocket)
+
+	fibers.run(function (scope)
+		assert(drv:start(scope))
+		local waiter = assert(scope:child())
+		assert(waiter:spawn(function () fibers.perform(ws:send_op('payload', 'text')) end))
+		yield_until(function () return raw.send_active end, 'client websocket send should become active')
+		waiter:cancel('stop_waiting')
+		fibers.perform(waiter:join_op())
+		ok(raw.closed, 'active client websocket send abort should close raw websocket')
+		ok(ws:is_closed(), 'client websocket wrapper should be marked closed')
+		ok(not drv:is_closed(), 'websocket is the narrow owner; driver should survive')
+		drv:terminate('done')
+	end)
+end
+
+return M


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] 🍕 Feature
- [x] 📝 Documentation Update
- [x] 🧑‍💻 Code Refactor
- [x] ✅ Test

## Description

This PR implements **http**, which provides the controlled HTTP and WebSocket capability boundary for other services. It owns the underlying transport integration, listener and request lifetimes, context and WebSocket handles, and exposes public HTTP operations through stable `cap/http/...` interfaces without leaking transport internals into service code. This service is described in `/docs/specs/http.md`, which should be read in conjunction with `docs/service-architecture.md`.

Changes include:

  - Adds HTTP design documentation:
    - `docs/specs/http.md`
  - Adds the public `services.http` entrypoint.
  - Adds HTTP service components for:
    - configuration normalisation
    - backend construction
    - capability surface binding
    - listener ownership
    - request context ownership
    - operation ownership and completion reporting
    - registry/model tracking
    - public SDK helpers
    - request/response body descriptors
    - headers, TLS and URI policy
    - exchange/client operations
    - WebSocket operations
  - Adds an Op-only transport layer over `cqueues` and `lua-http`, including:
    - cqueues driver integration
    - lua-http listener/context wrappers
    - request body streaming
    - client exchange support
    - WebSocket wrapping
    - immediate termination helpers
  - Exposes local HTTP capabilities under canonical `cap/http/...` surfaces.
  - Keeps raw transport/backend details at the edge so higher services interact with Fibers-native Ops and public handles rather than `cqueues` or raw `lua-http` objects.
  - Adds real devhost integration coverage for:
    - HTTP transport request/response round-trips
    - concurrent transport operations
    - WebSocket echo round-trips
    - HTTP service listen and shutdown behaviour
    - capability-driven client exchange
    - capability-driven WebSocket connect/send/receive/close
    - ownership transfer between listener and accepted contexts
  - Adds unit coverage for:
    - request and response body contracts
    - client exchange ownership and cancellation
    - config normalisation
    - header conversion
    - locality and payload policy
    - registry behaviour
    - service lifecycle and capability routing
    - static architecture rules
    - WebSocket client operations
    - cqueues driver semantics
    - lua-http wrapper semantics
    - immediate termination helpers
    - WebSocket transport wrappers
  - Updates the test runner to include HTTP unit and integration coverage.

## Related Issues, Tickets & Documents

Relevant design context:

  - Disciplined `fibers` service guide
  - Canonical bus naming and capability namespace guide
  - HTTP specification added in this PR
  - HTTP architecture note added in this PR

## Screenshots/Recordings

Not applicable. This PR has no visual changes.

## Manual test
- [x] 👍 yes

## Manual test description

Ran the Lua test suite locally:

```sh
cd tests
lua run.lua
````

Result:

```text
615 tests, 0 failed, 0 skipped
```

## Added tests?

* [x] 👍 yes

## Added to documentation?

* [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?

No deployment task is required for this PR.

Follow-up work should connect UI to the HTTP capability service, so UI owns routes, sessions and read-model semantics while HTTP continues to own transport, request contexts and WebSocket handles.
