### PR TITLE
ui: projection-boundary fix

### DIFF
--- a/src/services/ui/read_model.lua
+++ b/src/services/ui/read_model.lua
@@ -17,6 +17,32 @@ local topics      = require 'services.ui.topics'
 
 local M = {}
 
+
+local function event_topic(ev)
+	if type(ev) ~= 'table' then return nil end
+	return ev.topic
+end
+
+local function topic_is_excluded(topic, excluded_patterns, opts)
+	opts = opts or {}
+	if type(topic) ~= 'table' then return false end
+	for _, pattern in ipairs(excluded_patterns or {}) do
+		if store_mod.match_topic(pattern, topic, opts.s_wild or '+', opts.m_wild or '#') then
+			return true
+		end
+	end
+	return false
+end
+
+local function should_ingest_event(ev, opts)
+	opts = opts or {}
+	if type(ev) ~= 'table' then return true end
+	if ev.op == 'replay_done' then return true end
+	local topic = event_topic(ev)
+	local excluded = opts.exclude_patterns or opts.excluded_patterns or topics.default_excluded_retained_patterns()
+	return not topic_is_excluded(topic, excluded, opts)
+end
+
 local function start_feed_owner(scope, target, conn, pattern, opts)
 	local watch, err = bus_cleanup.watch_retained(conn, pattern, {
 		replay = true,
@@ -37,9 +63,11 @@ local function start_feed_owner(scope, target, conn, pattern, opts)
 			if ev == nil then
 				error(recv_err or 'read model retained feed closed', 0)
 			end
-			local changed, _msg, _op_name, ingest_err = target:ingest(ev)
-			if changed == nil then
-				error(ingest_err or 'read model ingest failed', 0)
+			if should_ingest_event(ev, opts) then
+				local changed, _msg, _op_name, ingest_err = target:ingest(ev)
+				if changed == nil then
+					error(ingest_err or 'read model ingest failed', 0)
+				end
 			end
 		end
 	end)
@@ -99,5 +127,9 @@ M.Store = store_mod.Store
 M.WatchOwner = watches_mod.WatchOwner
 M.Watch = watches_mod.Watch
 M.match_topic = store_mod.match_topic
+M._test = {
+	should_ingest_event = should_ingest_event,
+	topic_is_excluded = topic_is_excluded,
+}
 
 return M

--- a/src/services/ui/service.lua
+++ b/src/services/ui/service.lua
@@ -10,7 +10,6 @@ local service_base = require 'devicecode.service_base'
 local scoped_work  = require 'devicecode.support.scoped_work'
 local sleep        = require 'fibers.sleep'
 local queue        = require 'devicecode.support.queue'
-local bus_cleanup  = require 'devicecode.support.bus_cleanup'
 local read_model   = require 'services.ui.read_model'
 local queries      = require 'services.ui.queries'
 local sessions_mod = require 'services.ui.sessions'
@@ -38,32 +37,9 @@ local function component_summary(components)
 	return out
 end
 
-local function read_model_payload(state, snapshot)
-	local count = 0
-	for _ in pairs((snapshot and snapshot.items) or {}) do count = count + 1 end
-	return {
-		kind = 'ui.read-model',
-		version = snapshot and snapshot.version or 0,
-		items = count,
-		closed = snapshot and snapshot.closed or false,
-		reason = snapshot and snapshot.reason or nil,
-		status = state.read_model_status,
-	}
-end
-
-local function sessions_payload(state)
-	local snap = (state.sessions and type(state.sessions.snapshot) == 'function') and state.sessions:snapshot() or nil
-	return {
-		kind = 'ui.sessions',
-		version = snap and snap.version or 0,
-		count = snap and snap.count or 0,
-		last_event = snap and snap.last_event or nil,
-	}
-end
-
-local function publish_summary(state)
+local function build_summary(state)
 	local model_snapshot = state.model and state.model:snapshot() or nil
-	local payload = queries.summary(model_snapshot,
+	return queries.summary(model_snapshot,
 		state.sessions and state.sessions:count() or 0,
 		{
 			active_requests = state.active_requests,
@@ -78,15 +54,14 @@ local function publish_summary(state)
 			last_error = state.last_error,
 		}
 	)
-	local ok, err = bus_cleanup.retain(state.conn, topics.summary(), payload)
-	if ok ~= true then error(err or 'ui summary publication failed', 0) end
-	ok, err = bus_cleanup.retain(state.conn, topics.read_model_status(), read_model_payload(state, model_snapshot))
-	if ok ~= true then error(err or 'ui read-model publication failed', 0) end
-	ok, err = bus_cleanup.retain(state.conn, topics.session_count(), sessions_payload(state))
-	if ok ~= true then error(err or 'ui sessions publication failed', 0) end
-	return payload
 end
 
+local function publish_summary(state)
+	-- UI summaries are presentation projections. They are intentionally not
+	-- retained back to the bus because the read model consumes retained state/#.
+	-- Publishing derived UI state there creates a self-ingesting projection loop.
+	return build_summary(state)
+end
 local function record_cleanup_error(state, kind, err)
 	local rec = {
 		kind = kind or 'cleanup_error',
@@ -543,20 +518,6 @@ function M.run(scope, params)
 		if not read_model_owns_model then
 			watch_owner:terminate(reason)
 			model:terminate(reason)
-		end
-		local ok, err = bus_cleanup.unretain(conn, topics.summary())
-		if ok ~= true then
-			record_cleanup_error(state, 'ui_summary_unretain_failed', err)
-		end
-
-		ok, err = bus_cleanup.unretain(conn, topics.read_model_status())
-		if ok ~= true then
-			record_cleanup_error(state, 'ui_read_model_unretain_failed', err)
-		end
-
-		ok, err = bus_cleanup.unretain(conn, topics.session_count())
-		if ok ~= true then
-			record_cleanup_error(state, 'ui_sessions_unretain_failed', err)
 		end
 	end)
 

--- a/src/services/ui/topics.lua
+++ b/src/services/ui/topics.lua
@@ -17,18 +17,6 @@ function M.svc_meta()
 end
 
 
-function M.summary()
-	return t('state', 'ui', 'summary')
-end
-
-function M.read_model_status()
-	return t('state', 'ui', 'read-model')
-end
-
-function M.session_count()
-	return t('state', 'ui', 'sessions')
-end
-
 function M.default_retained_patterns()
 	return {
 		t('cfg', '#'),
@@ -36,6 +24,14 @@ function M.default_retained_patterns()
 		t('state', '#'),
 		t('cap', '#'),
 		t('raw', '#'),
+	}
+end
+
+
+function M.default_excluded_retained_patterns()
+	return {
+		t('state', 'ui', '#'),
+		t('obs', 'v1', 'ui', '#'),
 	}
 end
 

--- a/tests/unit/ui/test_architecture.lua
+++ b/tests/unit/ui/test_architecture.lua
@@ -228,11 +228,21 @@ function tests.test_response_headers_op_does_not_mutate_in_guard_path()
 	if not body:find('acquire_start_token_op', 1, true) then fail('write_headers_op does not use the choice-safe start token op') end
 end
 
-function tests.test_ui_summary_unretain_cleanup_is_explicitly_recorded()
+function tests.test_ui_service_does_not_retain_ui_projection_state()
 	local service = read_file('../src/services/ui/service.lua')
-	if not service:find("record_cleanup_error(state, 'ui_summary_unretain_failed'", 1, true) then
-		fail('ui summary unretain failure is not explicitly recorded')
+	for _, needle in ipairs({ 'topics.summary()', 'topics.read_model_status()', 'topics.session_count()', "'state', 'ui'" }) do
+		if service:find(needle, 1, true) then fail('ui service retains or unretains UI projection state: ' .. needle) end
 	end
+	if not service:find('self%-ingesting projection loop') then fail('ui service does not document projection feedback boundary') end
+end
+
+function tests.test_read_model_declares_self_ingestion_exclusions()
+	local topics = read_file('../src/services/ui/topics.lua')
+	local read_model = read_file('../src/services/ui/read_model.lua')
+	if not topics:find('default_excluded_retained_patterns', 1, true) then fail('ui topics do not declare retained-input exclusions') end
+	if not topics:find("t('state', 'ui', '#')", 1, true) then fail('state/ui/# is not excluded') end
+	if not topics:find("t('obs', 'v1', 'ui', '#')", 1, true) then fail('obs/v1/ui/# is not excluded') end
+	if not read_model:find('should_ingest_event', 1, true) then fail('read model has no retained-feed exclusion check') end
 end
 
 return tests

--- a/tests/unit/ui/test_read_model.lua
+++ b/tests/unit/ui/test_read_model.lua
@@ -13,6 +13,17 @@ local function assert_eq(a, b, msg) if a ~= b then fail(msg or ('expected '..tos
 local function assert_nil(v, msg) if v ~= nil then fail(msg or ('expected nil, got '..tostring(v))) end end
 local function assert_not_nil(v, msg) if v == nil then fail(msg or 'expected non-nil') end end
 
+
+function tests.test_read_model_default_exclusions_prevent_self_ingesting_ui_state()
+	local should = read_model._test.should_ingest_event
+	assert_eq(should({ op = 'retain', topic = { 'state', 'device', 'summary' }, payload = {} }, {}), true)
+	assert_eq(should({ op = 'retain', topic = { 'state', 'ui', 'summary' }, payload = {} }, {}), false)
+	assert_eq(should({ op = 'retain', topic = { 'state', 'ui', 'read-model' }, payload = {} }, {}), false)
+	assert_eq(should({ op = 'unretain', topic = { 'state', 'ui', 'sessions' } }, {}), false)
+	assert_eq(should({ op = 'retain', topic = { 'obs', 'v1', 'ui', 'metric', 'requests' }, payload = {} }, {}), false)
+	assert_eq(should({ op = 'replay_done' }, {}), true)
+end
+
 function tests.test_store_snapshot_changed_op_and_material_change()
 	run_fibers.run(function ()
 		local model = read_model.new()

--- a/tests/unit/ui/test_service.lua
+++ b/tests/unit/ui/test_service.lua
@@ -81,23 +81,21 @@ end
 
 
 
-function tests.test_publish_summary_fails_on_retain_failure()
+function tests.test_publish_summary_is_local_projection_not_retained_state()
+	local retain_calls = 0
 	local state = base_state()
 	state.conn = {
-		retain = function () return nil, 'retain_failed' end,
+		retain = function () retain_calls = retain_calls + 1; return nil, 'retain_failed' end,
 	}
 	state.sessions = { count = function () return 0 end }
 	state.active_requests = 0
 	state.rejected_requests = 0
 
-	local ok, err = pcall(function ()
-		service._test.publish_summary(state)
-	end)
-
-	if ok then fail('expected publish_summary to fail') end
-	if not tostring(err):find('retain_failed', 1, true) then
-		fail('expected retain failure, got ' .. tostring(err))
-	end
+	local payload = service._test.publish_summary(state)
+	assert_eq(payload.service_status, 'running')
+	assert_eq(payload.read_model_status, 'running')
+	assert_eq(payload.listener_status, 'running')
+	assert_eq(retain_calls, 0)
 end
 
 function tests.test_session_events_are_first_class_service_events()
@@ -151,9 +149,9 @@ end
 
 function tests.test_cleanup_error_recording_is_explicit_and_non_throwing()
 	local state = base_state()
-	local rec = service._test.record_cleanup_error(state, 'ui_summary_unretain_failed', 'unretain_failed')
-	assert_eq(rec.kind, 'ui_summary_unretain_failed')
-	assert_eq(rec.err, 'unretain_failed')
+	local rec = service._test.record_cleanup_error(state, 'ui_cleanup_failed', 'cleanup_failed')
+	assert_eq(rec.kind, 'ui_cleanup_failed')
+	assert_eq(rec.err, 'cleanup_failed')
 	assert_eq(state.last_cleanup_error, rec)
 end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

* [x] 🐛 Bug Fix
* [x] ✅ Test

## Description

Prevents the UI read model from ingesting its own derived retained output.

* Removes retained publication of UI-derived projection records under `state/ui/...`.
* Keeps UI summary/read-model/session data as local presentation state only.
* Adds explicit read-model exclusions for `state/ui/#` and `obs/v1/ui/#`.
* Adds regression tests for the projection boundary and self-ingestion exclusion.

## Related Issues, Tickets & Documents

Fixes UI read-model retained-state feedback loop.

## Manual test

* [x] 👍 yes

## Manual test description

Ran the full Lua test suite:

```text
699 tests, 0 failed, 0 skipped
```

## Added tests?

* [x] 👍 yes

## Added to documentation?

* [x] 🙅 no documentation needed
