### PR TITLE
http: removes the premature request and response registry

### DIFF
--- a/docs/specs/http.md
+++ b/docs/specs/http.md
@@ -58,6 +58,7 @@ cap/http/main/meta
 cap/http/main/status
 cap/http/main/rpc/listen
 cap/http/main/rpc/open-exchange
+cap/http/main/rpc/exchange
 cap/http/main/rpc/connect-ws
 cap/http/main/state/stats
 
@@ -83,6 +84,63 @@ local listener = reply.listener
 ```
 
 The consumer owns accepted contexts after handoff. HTTP owns unaccepted contexts and transport handles until ownership transfer.
+
+
+## Body object capabilities
+
+HTTP follows the local bus object-capability style used by HAL/UART. Request
+and response bodies are passed as Lua objects with explicit Op-shaped methods;
+they are not described by remote references and are not resolved through an HTTP
+body registry.
+
+An outgoing request body is supplied as:
+
+```lua
+{
+  uri = 'https://example.test/api',
+  method = 'POST',
+  headers = { ['content-type'] = 'application/json' },
+  body_source = blob_source.from_string('{"ok":true}'),
+}
+```
+
+`body_source` must provide:
+
+```text
+read_chunk_op(max_bytes)
+terminate(reason)
+```
+
+`response_sink`, when supplied, must provide:
+
+```text
+write_chunk_op(chunk)
+terminate(reason)
+finish_op() or commit_op()   optional success finalisation
+```
+
+Inline control-plane bytes remain invalid:
+
+```text
+body
+body_string
+body_chunks
+data
+chunk
+chunks
+bytes
+```
+
+The rule is:
+
+```text
+The bus may carry local Lua object capabilities.
+It must not carry raw bulk bytes in control-plane fields.
+```
+
+If a future Fabric boundary needs to carry HTTP bodies between nodes, Fabric
+should adapt known interfaces such as BlobSource and BlobSink into protocol
+operations. HTTP should still see the local object shape.
 
 ## Op-only boundary
 

--- a/src/services/http/body.lua
+++ b/src/services/http/body.lua
@@ -1,106 +1,49 @@
 -- services/http/body.lua
--- Descriptor validation and service-owned source/sink lease registries. Bytes do
--- not travel over the bus; descriptors are resolved to local leases inside
--- operation scopes.
+-- Shared HTTP body object-capability helpers.  The bus may carry local Lua
+-- capabilities with the right shape.  It must not carry inline bulk bytes in
+-- control-plane fields.
 
 local fibers = require 'fibers'
-local op     = require 'fibers.op'
 
 local M = {}
-local Registry = {}
-Registry.__index = Registry
 
-local function copy(t)
-	local out = {}
-	for k, v in pairs(t or {}) do out[k] = v end
-	return out
+local function has_method(obj, name)
+	return type(obj) == 'table' and type(obj[name]) == 'function'
 end
 
-local function is_descriptor(desc)
-	return type(desc) == 'table' and type(desc.kind) == 'string' and desc.kind ~= ''
-end
-
-function M.validate_descriptor(desc, direction)
-	if desc == nil then return nil, nil end
-	if type(desc) ~= 'table' then return nil, 'invalid_args' end
-	if type(desc.kind) ~= 'string' or desc.kind == '' then return nil, 'invalid_args' end
-	-- Keep raw bytes, hidden iterators and handles off the bus/control plane.
-	if desc.data ~= nil or desc.chunk ~= nil or desc.chunks ~= nil or desc.body ~= nil then return nil, 'invalid_args' end
-	if desc.handle ~= nil or desc.object ~= nil or desc.iterator ~= nil or desc.file ~= nil then return nil, 'invalid_args' end
-	if desc.bytes ~= nil and (type(desc.bytes) ~= 'number' or desc.bytes < 0) then return nil, 'invalid_args' end
-	if desc.direction ~= nil and direction ~= nil and desc.direction ~= direction then return nil, 'invalid_args' end
-	local out = copy(desc)
-	out.direction = direction or out.direction
-	return out, nil
-end
-
-function M.validate_exchange_descriptors(args)
+local function reject_inline_bytes(args)
 	args = args or {}
-	if args.body ~= nil or args.body_chunks ~= nil or args.response_body ~= nil or args.body_string ~= nil then
-		return nil, 'invalid_args'
-	end
-	local source, serr = M.validate_descriptor(args.body_source or args.source, 'source')
+	if args.body ~= nil or args.body_string ~= nil or args.body_chunks ~= nil or args.response_body ~= nil then return nil, 'invalid_args' end
+	if args.data ~= nil or args.chunk ~= nil or args.chunks ~= nil or args.bytes ~= nil then return nil, 'invalid_args' end
+	return true, nil
+end
+
+function M.validate_source(source)
+	if source == nil then return nil, nil end
+	if not has_method(source, 'read_chunk_op') then return nil, 'invalid_args' end
+	if not has_method(source, 'terminate') then return nil, 'invalid_args' end
+	return source, nil
+end
+
+function M.validate_sink(sink)
+	if sink == nil then return nil, nil end
+	if not has_method(sink, 'write_chunk_op') then return nil, 'invalid_args' end
+	if not has_method(sink, 'terminate') then return nil, 'invalid_args' end
+	if sink.finish_op ~= nil and type(sink.finish_op) ~= 'function' then return nil, 'invalid_args' end
+	if sink.commit_op ~= nil and type(sink.commit_op) ~= 'function' then return nil, 'invalid_args' end
+	return sink, nil
+end
+
+function M.validate_exchange_bodies(args)
+	args = args or {}
+	local ok, berr = reject_inline_bytes(args)
+	if not ok then return nil, berr end
+	local source, serr = M.validate_source(args.body_source)
 	if serr then return nil, serr end
-	local sink, skerr = M.validate_descriptor(args.response_sink or args.sink, 'sink')
+	local sink, skerr = M.validate_sink(args.response_sink)
 	if skerr then return nil, skerr end
 	return { source = source, sink = sink }, nil
 end
-
-local function normalise_resolver_result(value, err)
-	if value == nil then return nil, err or 'invalid_args' end
-	if type(value) ~= 'table' then return nil, 'invalid_args' end
-	return value, nil
-end
-
-function M.new_registry(opts)
-	opts = opts or {}
-	local self = setmetatable({ _resolvers = {} }, Registry)
-	for kind, resolver in pairs(opts.resolvers or opts or {}) do
-		if type(kind) == 'string' and type(resolver) == 'function' then
-			self:register_resolver(kind, resolver)
-		end
-	end
-	return self
-end
-
-function Registry:register_resolver(kind, resolver)
-	if type(kind) ~= 'string' or kind == '' then return nil, 'invalid_args' end
-	if type(resolver) ~= 'function' then return nil, 'invalid_args' end
-	self._resolvers[kind] = resolver
-	return true
-end
-
-function Registry:resolve_op(desc, ctx)
-	return op.guard(function ()
-		if desc == nil then return op.always(nil, nil) end
-		local checked, err = M.validate_descriptor(desc, ctx and ctx.direction)
-		if not checked then return op.always(nil, err) end
-
-		local resolver = self._resolvers[checked.kind]
-		if not resolver then return op.always(nil, 'invalid_args') end
-
-		local ok, result, rerr = pcall(function ()
-			return resolver(checked, ctx or {})
-		end)
-		if not ok then
-			return op.always(nil, 'invalid_args')
-		end
-
-		if type(result) == 'table' and type(result.wrap) == 'function' then
-			return result:wrap(normalise_resolver_result)
-		end
-
-		return op.always(normalise_resolver_result(result, rerr))
-	end)
-end
-
-local default_registry = M.new_registry()
-
--- Compatibility only for direct unit construction. Services should use their
--- own registry instance so authority and provider state are service-owned.
-function M.register_resolver(kind, resolver) return default_registry:register_resolver(kind, resolver) end
-function M.clear_resolvers_for_test() default_registry = M.new_registry(); return true end
-function M.resolve_op(desc, ctx) return default_registry:resolve_op(desc, ctx) end
 
 local function terminate(obj, reason)
 	if obj and type(obj.terminate) == 'function' then return obj:terminate(reason) end
@@ -181,7 +124,7 @@ function M.copy_source_to_sink_op(source, sink, opts)
 				break
 			end
 			copied = copied + #chunk
-			if copied > limit then return nil, opts.too_large_error or 'response_body_too_large' end
+			if copied > limit then return nil, opts.too_large_error or 'request_body_too_large' end
 			local ok, werr = fibers.perform(sink:write_chunk_op(chunk))
 			if not ok then return nil, werr end
 		end
@@ -196,6 +139,4 @@ function M.copy_source_to_sink_op(source, sink, opts)
 	end))
 end
 
-M.is_descriptor = is_descriptor
-M.Registry = Registry
 return M

--- a/src/services/http/client.lua
+++ b/src/services/http/client.lua
@@ -1,7 +1,7 @@
 -- services/http/client.lua
 -- Policy-facing outgoing HTTP client operations. lua-http request machinery is
--- confined to services.http.transport.client; descriptor leases and response
--- copying are owned here by operation scopes.
+-- confined to services.http.transport.client; request/response body object
+-- capabilities are owned here by operation scopes.
 
 local fibers = require 'fibers'
 local op = require 'fibers.op'
@@ -38,21 +38,11 @@ local function unwrap(scope_op)
 	end)
 end
 
-local function resolve_registry(opts)
-	return opts.body_registry or body.new_registry(opts.body_resolvers or {})
-end
 
-local function install_request_source(scope, checked, registry, opts)
+local function install_request_source(scope, checked, opts)
 	if not checked.body_source then return checked, nil end
 
-	local source, serr = fibers.perform(registry:resolve_op(checked.body_source, {
-		direction = 'source',
-		principal = opts.principal,
-		origin = opts.origin,
-		policy = opts.policy or opts,
-	}))
-	if not source then return nil, serr or 'invalid_args' end
-
+	local source = checked.body_source
 	local source_owned = true
 	scope:finally(function (_, status, primary)
 		if source_owned then body.terminate(source, primary or status or 'exchange_source_finalised') end
@@ -113,9 +103,8 @@ local function install_request_source(scope, checked, registry, opts)
 end
 
 local function open_exchange_result_op(driver, checked, opts)
-	local registry = resolve_registry(opts)
 	return unwrap(fibers.run_scope_op(function (scope)
-		local prepared, req_body = install_request_source(scope, checked, registry, opts)
+		local prepared, req_body = install_request_source(scope, checked, opts)
 		if not prepared then return nil, req_body end
 
 		local response_headers, stream_or_err = fibers.perform(transport_client.open_exchange_op(driver, prepared, opts))
@@ -145,21 +134,13 @@ function M.exchange_op(driver, args, opts)
 	return op.guard(function ()
 		local checked, perr = checked_args(args, { driver = driver, policy = opts.policy or opts })
 		if not checked then return op.always(nil, perr) end
-		local registry = resolve_registry(opts)
-
 		return unwrap(fibers.run_scope_op(function (scope)
 			local sink, ex
 			local sink_owned, ex_owned = false, false
 			local sink_final_reason, ex_final_reason = 'exchange_sink_finalised', 'exchange_finalised'
 
 			if checked.response_sink then
-				sink = fibers.perform(registry:resolve_op(checked.response_sink, {
-					direction = 'sink',
-					principal = opts.principal,
-					origin = opts.origin,
-					policy = opts.policy or opts,
-				}))
-				if not sink then return nil, 'invalid_args' end
+				sink = checked.response_sink
 				sink_owned = true
 				scope:finally(function (_, status, primary)
 					if sink_owned then body.terminate(sink, sink_final_reason or primary or status or 'exchange_sink_finalised') end

--- a/src/services/http/operations.lua
+++ b/src/services/http/operations.lua
@@ -144,7 +144,6 @@ local function run_open_exchange(service, scope, req, setup)
 	for k, v in pairs(opts.policy or {}) do opts[k] = v end
 	opts.origin = req.origin
 	opts.principal = req.origin and req.origin.principal
-	opts.body_registry = service._body_registry
 	opts.on_terminate = function (_, reason)
 		service:_remove_handle(handle_id, reason or 'exchange_terminated')
 	end
@@ -164,7 +163,6 @@ local function run_exchange(service, _scope, req, _setup)
 	for k, v in pairs(opts.policy or {}) do opts[k] = v end
 	opts.origin = req.origin
 	opts.principal = req.origin and req.origin.principal
-	opts.body_registry = service._body_registry
 	local result, err = perform(client.exchange_op(service._driver, req.payload or {}, opts))
 	if not result then error(err or 'exchange_failed', 0) end
 	return { result = result }

--- a/src/services/http/policy.lua
+++ b/src/services/http/policy.lua
@@ -126,7 +126,7 @@ end
 function M.validate_exchange_args(args, opts)
 	opts = opts or {}
 	if type(args) ~= 'table' then return nil, 'invalid_args' end
-	local ok, ferr = require_only_fields(args, { uri = true, method = true, headers = true, body_source = true, source = true, response_sink = true, sink = true })
+	local ok, ferr = require_only_fields(args, { uri = true, method = true, headers = true, body_source = true, response_sink = true })
 	if not ok then return nil, ferr end
 	local uri, uerr = M.validate_uri(args.uri, opts)
 	if not uri then return nil, uerr end
@@ -137,16 +137,16 @@ function M.validate_exchange_args(args, opts)
 	local headers, herr = copy_headers(args.headers)
 	if herr then return nil, herr end
 
-	local descriptors, derr = body.validate_exchange_descriptors(args)
-	if not descriptors then return nil, derr end
+	local bodies, derr = body.validate_exchange_bodies(args)
+	if not bodies then return nil, derr end
 
 	return {
 		uri = uri.uri,
 		method = method,
 		headers = headers,
 		_uri = uri,
-		body_source = descriptors.source,
-		response_sink = descriptors.sink,
+		body_source = bodies.source,
+		response_sink = bodies.sink,
 	}, nil
 end
 

--- a/src/services/http/service.lua
+++ b/src/services/http/service.lua
@@ -13,7 +13,6 @@ local cap_surface = require 'services.http.cap_surface'
 local registry_mod = require 'services.http.registry'
 local operations = require 'services.http.operations'
 local operation_owner = require 'services.http.operation_owner'
-local body = require 'services.http.body'
 local queue = require 'devicecode.support.queue'
 local config_watch = require 'devicecode.support.config_watch'
 local config_mod = require 'services.http.config'
@@ -694,7 +693,6 @@ function M.start(conn, opts)
 		_opts = opts,
 		_driver = driver,
 		_backend = nil,
-		_body_registry = opts.body_registry or body.new_registry(opts.body_resolvers or {}),
 		_model = model,
 		_event_tx = event_tx,
 		_event_rx = event_rx,

--- a/tests/integration/devhost/test_http_service_real.lua
+++ b/tests/integration/devhost/test_http_service_real.lua
@@ -20,7 +20,6 @@ local sdk_mod      = require 'services.http.sdk'
 local driver_mod   = require 'services.http.transport.cqueues_driver'
 local lua_http     = require 'services.http.transport.lua_http'
 local ws_wrap      = require 'services.http.transport.websocket'
-local body_mod     = require 'services.http.body'
 
 local M = {}
 
@@ -62,35 +61,33 @@ local function ws_uri(port, path)
 	return ('ws://127.0.0.1:%d%s'):format(port, path or '/ws')
 end
 
+local function memory_sink(sinks, key)
+	sinks[key] = sinks[key] or { chunks = {} }
+	local rec = sinks[key]
+	return {
+		write_chunk_op = function (_, chunk) rec.chunks[#rec.chunks + 1] = chunk; return fibers.always(true) end,
+		finish_op = function () rec.finished = true; return fibers.always(true) end,
+		terminate = function (_, reason) rec.terminated = reason or true; return true end,
+	}
+end
+
+local function memory_source(sources, key)
+	local chunks = sources[key] or {}
+	local i = 0
+	return {
+		read_chunk_op = function ()
+			return fibers.guard(function ()
+				i = i + 1
+				return fibers.always(chunks[i], nil)
+			end)
+		end,
+		terminate = function (_, reason) sources[key .. '_terminated'] = reason or true; return true end,
+	}
+end
+
 local function start_cap_service(opts)
 	opts = opts or {}
 	local memory_sinks = opts.memory_sinks or {}
-	local memory_sources = opts.memory_sources or {}
-	local registry = opts.body_registry or body_mod.new_registry()
-	registry:register_resolver('memory_sink', function (desc)
-		local key = desc.ref or 'default'
-		memory_sinks[key] = memory_sinks[key] or { chunks = {} }
-		local rec = memory_sinks[key]
-		return {
-			write_chunk_op = function (_, chunk) rec.chunks[#rec.chunks + 1] = chunk; return fibers.always(true) end,
-			finish_op = function () rec.finished = true; return fibers.always(true) end,
-			terminate = function (_, reason) rec.terminated = reason or true; return true end,
-		}
-	end)
-	registry:register_resolver('memory_source', function (desc)
-		local key = desc.ref or 'default'
-		local chunks = memory_sources[key] or {}
-		local i = 0
-		return {
-			read_chunk_op = function ()
-				return fibers.guard(function ()
-					i = i + 1
-					return fibers.always(chunks[i], nil)
-				end)
-			end,
-			terminate = function (_, reason) memory_sources[key .. '_terminated'] = reason or true; return true end,
-		}
-	end)
 	local b = bus.new()
 	local svc_conn = b:connect({ origin_base = { kind = 'local' } })
 	local svc = ok(http_service.start(svc_conn, {
@@ -99,7 +96,6 @@ local function start_cap_service(opts)
 		connection_setup_timeout = opts.connection_setup_timeout or 2,
 		intra_stream_timeout = opts.intra_stream_timeout or 2,
 		max_accept_queue = opts.max_accept_queue or 32,
-		body_registry = registry,
 	}))
 
 	local user_conn = b:connect({ origin_base = { kind = 'local' } })
@@ -244,9 +240,8 @@ end
 function M.test_real_cap_exchange_get_and_post_round_trip_to_local_server()
 	fibers.run(function (scope)
 		local listener, driver, port = start_backend_listener(scope, { label = 'http-service-real-exchange-backend' })
-		local _, svc, ref, sinks = start_cap_service({
-			memory_sources = { post = { 'upload-', 'payload' } },
-		})
+		local sources = { post = { 'upload-', 'payload' } }
+		local _, svc, ref, sinks = start_cap_service()
 		local handled = 0
 
 		for _ = 1, 2 do
@@ -269,7 +264,7 @@ function M.test_real_cap_exchange_get_and_post_round_trip_to_local_server()
 			uri = http_uri(port, '/out-get'),
 			method = 'GET',
 			headers = { ['x-test'] = 'get' },
-			response_sink = { kind = 'memory_sink', ref = 'get' },
+			response_sink = memory_sink(sinks, 'get'),
 		}, { timeout = 3 })))
 		eq(get_rep.result.status, '200')
 		eq(table.concat(sinks.get.chunks), 'GET:/out-get')
@@ -278,8 +273,8 @@ function M.test_real_cap_exchange_get_and_post_round_trip_to_local_server()
 			uri = http_uri(port, '/out-post'),
 			method = 'POST',
 			headers = { ['x-test'] = 'post' },
-			body_source = { kind = 'memory_source', ref = 'post' },
-			response_sink = { kind = 'memory_sink', ref = 'post' },
+			body_source = memory_source(sources, 'post'),
+			response_sink = memory_sink(sinks, 'post'),
 		}, { timeout = 3 })))
 		eq(post_rep.result.status, '200')
 		eq(table.concat(sinks.post.chunks), 'POST:/out-post:upload-payload')

--- a/tests/unit/http/test_body.lua
+++ b/tests/unit/http/test_body.lua
@@ -1,5 +1,6 @@
 local fibers = require 'fibers'
 local body = require 'services.http.body'
+local blob = require 'devicecode.blob_source'
 
 local M = {}
 
@@ -8,56 +9,39 @@ local function eq(a, b, msg)
 end
 local function ok(v, msg) if not v then error(msg or 'assertion failed', 2) end return v end
 
-function M.test_descriptor_rejects_inline_bytes()
-	local desc, err = body.validate_descriptor({ kind = 'x', data = 'bytes' }, 'source')
-	eq(desc, nil)
+function M.test_rejects_inline_bytes()
+	local bodies, err = body.validate_exchange_bodies({ body = 'bytes' })
+	eq(bodies, nil)
+	eq(err, 'invalid_args')
+	bodies, err = body.validate_exchange_bodies({ data = 'bytes' })
+	eq(bodies, nil)
 	eq(err, 'invalid_args')
 end
 
-function M.test_source_and_sink_leases_copy_inside_ops()
-	fibers.run(function ()
-		body.clear_resolvers_for_test()
-		body.register_resolver('unit_source', function ()
-			local chunks = { 'ab', 'cd' }
-			local i = 0
-			return {
-				terminated = false,
-				read_chunk_op = function ()
-					return fibers.guard(function ()
-						i = i + 1
-						return fibers.always(chunks[i], nil)
-					end)
-				end,
-				terminate = function (self, reason) self.terminated = reason or true; return true end,
-			}
-		end)
-		local written = {}
-		body.register_resolver('unit_sink', function ()
-			return {
-				write_chunk_op = function (_, chunk) return fibers.always((table.insert(written, chunk) and true) or true) end,
-				finish_op = function () return fibers.always(true) end,
-				terminate = function () return true end,
-			}
-		end)
-
-		local source = ok(fibers.perform(body.resolve_op({ kind = 'unit_source' }, { direction = 'source' })))
-		local sink = ok(fibers.perform(body.resolve_op({ kind = 'unit_sink' }, { direction = 'sink' })))
-		local rep = ok(fibers.perform(body.copy_source_to_sink_op(source, sink, { max_bytes = 16 })))
-		eq(rep.bytes, 4)
-		eq(table.concat(written), 'abcd')
-	end)
+function M.test_accepts_lua_body_source_and_response_sink_capabilities()
+	local source = blob.from_string('abcd')
+	local sink = blob.to_memory()
+	local bodies = ok(body.validate_exchange_bodies({ body_source = source, response_sink = sink }))
+	eq(bodies.source, source)
+	eq(bodies.sink, sink)
 end
 
-function M.test_resolver_registries_are_service_owned()
+function M.test_rejects_bad_body_source_and_sink_shapes()
+	local bodies, err = body.validate_exchange_bodies({ body_source = { terminate = function () return true end } })
+	eq(bodies, nil)
+	eq(err, 'invalid_args')
+	bodies, err = body.validate_exchange_bodies({ response_sink = { write_chunk_op = function () end } })
+	eq(bodies, nil)
+	eq(err, 'invalid_args')
+end
+
+function M.test_source_and_sink_capabilities_copy_inside_ops()
 	fibers.run(function ()
-		local r1 = body.new_registry()
-		local r2 = body.new_registry()
-		r1:register_resolver('x', function () return { marker = 'r1' } end)
-		r2:register_resolver('x', function () return { marker = 'r2' } end)
-		local a = ok(fibers.perform(r1:resolve_op({ kind = 'x' }, { direction = 'source' })))
-		local b = ok(fibers.perform(r2:resolve_op({ kind = 'x' }, { direction = 'source' })))
-		eq(a.marker, 'r1')
-		eq(b.marker, 'r2')
+		local source = blob.from_string('abcd')
+		local sink = blob.to_memory()
+		local rep = ok(fibers.perform(body.copy_source_to_sink_op(source, sink, { max_bytes = 16 })))
+		eq(rep.bytes, 4)
+		eq(sink:result(), 'abcd')
 	end)
 end
 
@@ -83,34 +67,6 @@ function M.test_request_body_pipe_is_a_bounded_fibers_sink_and_lua_http_iterator
 		eq(iter(), 'ab')
 		eq(iter(), 'cd')
 		eq(iter(), nil)
-	end)
-end
-
-
-function M.test_resolver_is_called_when_resolve_op_is_performed_not_constructed()
-	fibers.run(function ()
-		local registry = body.new_registry()
-		local calls = 0
-		registry:register_resolver('late_source', function ()
-			calls = calls + 1
-			return { terminate = function () return true end }
-		end)
-
-		local resolve = registry:resolve_op({ kind = 'late_source' }, { direction = 'source' })
-		eq(calls, 0, 'resolver must not run at Op construction time')
-		local lease = ok(fibers.perform(resolve))
-		eq(calls, 1)
-		ok(lease)
-	end)
-end
-
-function M.test_resolver_errors_are_caught_and_normalised()
-	fibers.run(function ()
-		local registry = body.new_registry()
-		registry:register_resolver('boom', function () error('backend exploded', 0) end)
-		local lease, err = fibers.perform(registry:resolve_op({ kind = 'boom' }, { direction = 'source' }))
-		eq(lease, nil)
-		eq(err, 'invalid_args', 'resolver exceptions should become a stable public error')
 	end)
 end
 

--- a/tests/unit/http/test_client.lua
+++ b/tests/unit/http/test_client.lua
@@ -2,7 +2,7 @@ local fibers = require 'fibers'
 local runtime = require 'fibers.runtime'
 local driver_mod = require 'services.http.transport.cqueues_driver'
 local client = require 'services.http.client'
-local body = require 'services.http.body'
+local blob = require 'devicecode.blob_source'
 
 local M = {}
 
@@ -92,25 +92,17 @@ end
 
 function M.test_exchange_op_streams_response_to_sink_without_returning_body()
 	fibers.run(function ()
-		local written = {}
-		local registry = body.new_registry()
-		registry:register_resolver('unit_sink', function ()
-			return {
-				write_chunk_op = function (_, chunk) written[#written + 1] = chunk; return fibers.always(true) end,
-				finish_op = function () return fibers.always(true) end,
-				terminate = function () return true end,
-			}
-		end)
+		local sink = blob.to_memory()
 		local result = ok(fibers.perform(client.exchange_op(fake_driver(), {
 			uri = 'http://example.test/path',
 			method = 'GET',
 			headers = { ['x-test'] = 'yes' },
-			response_sink = { kind = 'unit_sink' },
-		}, { request_module = request_module('hello'), body_registry = registry })))
+			response_sink = sink,
+		}, { request_module = request_module('hello') })))
 		eq(result.status, '202')
 		eq(result.body, nil)
 		eq(result.response_sink.bytes, 5)
-		eq(table.concat(written), 'hello')
+		eq(sink:result(), 'hello')
 		eq(result.headers['content-type'], 'text/plain')
 	end)
 end
@@ -163,25 +155,10 @@ function M.test_request_source_streams_through_fibers_native_body_pipe()
 
 	fibers.run(function (scope)
 		assert(drv:start(scope))
-		local registry = body.new_registry()
-		registry:register_resolver('op_source_only', function ()
-			local chunks = { 'ab', 'cd' }
-			local i = 0
-			return {
-				read_chunk_op = function ()
-					return fibers.guard(function ()
-						i = i + 1
-						return fibers.always(chunks[i], nil)
-					end)
-				end,
-				terminate = function () return true end,
-			}
-		end)
 		local result = ok(fibers.perform(client.exchange_op(drv, {
-			uri = 'http://example.test/', method = 'POST', body_source = { kind = 'op_source_only' },
+			uri = 'http://example.test/', method = 'POST', body_source = blob.from_string('abcd'),
 		}, {
 			request_module = request_mod,
-			body_registry = registry,
 			request_body_condition_factory = fake_condition_factory,
 		})))
 		eq(result.status, '201')
@@ -195,20 +172,17 @@ function M.test_exchange_op_does_not_terminate_committed_response_sink_after_suc
 	fibers.run(function ()
 		local committed = false
 		local terminated = nil
-		local registry = body.new_registry()
-		registry:register_resolver('committing_sink', function ()
-			return {
-				write_chunk_op = function () return fibers.always(true) end,
-				commit_op = function () committed = true; return fibers.always(true) end,
-				terminate = function (_, reason) terminated = reason or true; return true end,
-			}
-		end)
+		local sink = {
+			write_chunk_op = function () return fibers.always(true) end,
+			commit_op = function () committed = true; return fibers.always(true) end,
+			terminate = function (_, reason) terminated = reason or true; return true end,
+		}
 
 		local result = ok(fibers.perform(client.exchange_op(fake_driver(), {
 			uri = 'http://example.test/path',
 			method = 'GET',
-			response_sink = { kind = 'committing_sink' },
-		}, { request_module = request_module('hello'), body_registry = registry })))
+			response_sink = sink,
+		}, { request_module = request_module('hello') })))
 		eq(result.response_sink.bytes, 5)
 		eq(committed, true, 'sink commit must run')
 		eq(terminated, nil, 'committed sink ownership must not be reclaimed by the exchange finaliser')
@@ -218,20 +192,17 @@ end
 function M.test_exchange_op_terminates_uncommitted_response_sink_on_copy_failure()
 	fibers.run(function ()
 		local terminated = nil
-		local registry = body.new_registry()
-		registry:register_resolver('failing_sink', function ()
-			return {
-				write_chunk_op = function () return fibers.always(nil, 'sink_failed') end,
-				commit_op = function () error('commit must not run after write failure', 0) end,
-				terminate = function (_, reason) terminated = reason or true; return true end,
-			}
-		end)
+		local sink = {
+			write_chunk_op = function () return fibers.always(nil, 'sink_failed') end,
+			commit_op = function () error('commit must not run after write failure', 0) end,
+			terminate = function (_, reason) terminated = reason or true; return true end,
+		}
 
 		local result, err = fibers.perform(client.exchange_op(fake_driver(), {
 			uri = 'http://example.test/path',
 			method = 'GET',
-			response_sink = { kind = 'failing_sink' },
-		}, { request_module = request_module('hello'), body_registry = registry }))
+			response_sink = sink,
+		}, { request_module = request_module('hello') }))
 		eq(result, nil)
 		eq(err, 'sink_failed')
 		eq(terminated, 'failed', 'uncommitted sink must be terminated by the operation scope')
@@ -241,19 +212,15 @@ end
 
 function M.test_request_body_source_without_read_op_rejects_before_request_construction()
 	fibers.run(function ()
-		local registry = body.new_registry()
 		local constructed = 0
-		registry:register_resolver('bad_source', function ()
-			return { terminate = function () return true end }
-		end)
 		local request_mod = {
 			new_from_uri = function () constructed = constructed + 1; return request_module().new_from_uri('http://example.test/') end,
 		}
 		local result, err = fibers.perform(client.exchange_op(fake_driver(), {
-			uri = 'http://example.test/', method = 'POST', body_source = { kind = 'bad_source' },
-		}, { request_module = request_mod, body_registry = registry }))
+			uri = 'http://example.test/', method = 'POST', body_source = { terminate = function () return true end },
+		}, { request_module = request_mod }))
 		eq(result, nil)
-		eq(err, 'request_body_source_invalid')
+		eq(err, 'invalid_args')
 		eq(constructed, 0, 'invalid request source must reject before lua-http request construction')
 	end)
 end

--- a/tests/unit/http/test_policy.lua
+++ b/tests/unit/http/test_policy.lua
@@ -46,6 +46,24 @@ function M.test_validate_exchange_rejects_raw_body_bytes_over_control_plane()
 	local bad, err = policy.validate_exchange_args { uri = 'http://example.test/', method = 'POST', body = 'bytes' }
 	eq(bad, nil)
 	eq(err, 'invalid_args')
+	bad, err = policy.validate_exchange_args { uri = 'http://example.test/', method = 'POST', data = 'bytes' }
+	eq(bad, nil)
+	eq(err, 'invalid_args')
+end
+
+function M.test_validate_exchange_accepts_body_object_capabilities_and_rejects_remote_reference_tables()
+	local source = { read_chunk_op = function () end, terminate = function () return true end }
+	local sink = { write_chunk_op = function () end, terminate = function () return true end }
+	local checked = ok(policy.validate_exchange_args { uri = 'http://example.test/', method = 'POST', body_source = source, response_sink = sink })
+	eq(checked.body_source, source)
+	eq(checked.response_sink, sink)
+
+	local bad, err = policy.validate_exchange_args { uri = 'http://example.test/', method = 'POST', body_source = { kind = 'remote-ref' } }
+	eq(bad, nil)
+	eq(err, 'invalid_args')
+	bad, err = policy.validate_exchange_args { uri = 'http://example.test/', method = 'POST', source = source }
+	eq(bad, nil)
+	eq(err, 'invalid_args')
 end
 
 function M.test_validate_listen_defaults_loopback_ephemeral_port()

--- a/tests/unit/http/test_service_architecture.lua
+++ b/tests/unit/http/test_service_architecture.lua
@@ -4,7 +4,7 @@ local bus    = require 'bus'
 
 local http_service = require 'services.http.service'
 local sdk_mod      = require 'services.http.sdk'
-local body         = require 'services.http.body'
+local blob         = require 'devicecode.blob_source'
 
 local M = {}
 
@@ -101,28 +101,19 @@ function M.test_exchange_is_named_scoped_work_with_identity_completion_and_event
 	fibers.run(function ()
 		local b = bus.new()
 		local root = b:connect({ origin_base = { kind = 'local' } })
-		local written = {}
-		local registry = body.new_registry()
-		registry:register_resolver('unit_sink', function ()
-			return {
-				write_chunk_op = function (_, chunk) written[#written + 1] = chunk; return fibers.always(true) end,
-				finish_op = function () return fibers.always(true) end,
-				terminate = function () return true end,
-			}
-		end)
+		local sink = blob.to_memory()
 		local svc = ok(http_service.start(root, {
 			driver = fake_driver(),
 			id = 'main',
 			request_module = request_module('hello'),
-			body_registry = registry,
 		}))
 		local user = b:connect({ origin_base = { kind = 'local' } })
 		local ref = sdk_mod.new_ref(user, 'main')
-		local rep = ok(fibers.perform(ref:exchange_op({ uri = 'http://example.test/', method = 'GET', response_sink = { kind = 'unit_sink' } })))
+		local rep = ok(fibers.perform(ref:exchange_op({ uri = 'http://example.test/', method = 'GET', response_sink = sink })))
 		eq(rep.result.status, '200')
 		eq(rep.result.body, nil)
 		eq(rep.result.response_sink.bytes, 5)
-		eq(table.concat(written), 'hello')
+		eq(sink:result(), 'hello')
 		yield_many(8)
 		local events = svc:events()
 		local started, done


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

* [x] 🧑‍💻 Code Refactor
* [x] ✅ Test
* [x] 📝 Documentation Update

## Description

Simplifies HTTP request and response body handling to use local Lua object capabilities, matching the HAL/UART capability style.

* Removes the HTTP body descriptor/registry/resolver system.
* Accepts shaped body objects directly:

  * `body_source.read_chunk_op(max_bytes)`
  * `body_source.terminate(reason)`
  * `response_sink.write_chunk_op(chunk)`
  * `response_sink.terminate(reason)`
  * optional `response_sink.finish_op()` or `response_sink.commit_op()`
* Keeps control-plane guardrails rejecting inline body bytes.
* Updates HTTP unit/integration tests and documentation for the new object-capability API.

## Manual test

* [x] 👍 yes

## Manual test description

Ran the full Lua test suite:

```text
699 tests, 0 failed, 0 skipped
```

## Added tests?

* [x] 👍 yes

## Added to documentation?

* [x] 📜 README.md
