### PR TITLE
cleans up http entry + lifecycle publication, ui lifecycle publicatio…

### DIFF
--- a/docs/service-architecture.md
+++ b/docs/service-architecture.md
@@ -993,4 +993,3 @@ a test that depends on private coordinator tables for an integration behaviour
 ```
 
 Any one of these may be justified in a narrow case. Several together usually mean the service boundary is losing shape.
-````

--- a/docs/service-architecture.md
+++ b/docs/service-architecture.md
@@ -1,5 +1,27 @@
 # Devicecode service architecture guide
 
+> **Basis of this note**
+>
+> This architecture follows the `fibers` doctrine.
+>
+> It relies on the observed runtime contracts that:
+>
+> * `fibers.perform` is scope-aware;
+> * `fibers.spawn` spawns into the current scope;
+> * `perform_raw` bypasses scope-aware cancellation and belongs to infrastructure;
+> * scope cancellation is downward only;
+> * scope cancellation is cooperative;
+> * finalisers cannot yield, only `perform` with an `:or_else()` immediate fallback is permitted;
+> * parentage is the structural ownership mechanism;
+> * attached child scopes are joined by their parent’s join/finalisation path;
+> * `join_op()` is active finalisation, not passive observation;
+> * non-parent joining must be an explicit service discipline;
+> * `run_scope_op` is useful for deliberate whole-operation waits, but not for strict coordinator branches;
+> * `named_choice`, `choice`, and `first_ready` select readiness, not semantic priority;
+> * Lua table order must not be used as a priority mechanism;
+> * where semantic priority is **genuinely** required, Device uses `devicecode/support/priority_event.lua`;
+> * finalisers must release owned resources without waiting.
+
 ## Purpose
 
 This guide is the canonical architecture guide for Devicecode services built on `fibers` and `bus`.

--- a/docs/service-architecture.md
+++ b/docs/service-architecture.md
@@ -99,6 +99,30 @@ ownership transfer
 
 A fibre runs code. A scope owns lifetime.
 
+## Service entry contract
+
+A service launched by `main.lua` has a foreground entry point:
+
+```text
+start(conn, opts)
+  creates service lifecycle state
+  enters the long-lived service coordinator
+  must not return while the service is healthy
+```
+
+The lower-level coordinator body is:
+
+```text
+run(scope, params)
+  owns the service event loop
+  normally blocks until cancellation or failure
+```
+
+A helper that returns a local handle must use an explicit name such as
+`open_handle`, `new_handle`, or `open_component`. It must not be called
+`start`. If `start()` or `run()` returns in a healthy path, the service should
+publish a stopped/failed lifecycle state and raise an error.
+
 ## Programming style
 
 Devicecode service code should be direct, explicit and state-machine shaped.

--- a/docs/specs/http.md
+++ b/docs/specs/http.md
@@ -18,7 +18,7 @@ HTTP capability publication
 transport observability
 ```
 
-HTTP is an infrastructure service. UI and other services consume it through public HTTP capability handles.
+HTTP is an infrastructure service. UI and other services consume it through public HTTP capability handles. Its `start(conn, opts)` entry is a foreground service body for `main.lua` and must not return while healthy. Tests and embedded compositions that need the in-process service handle use `services.http.service.open_handle(conn, opts)`.
 
 ## Lifetime shape
 
@@ -27,6 +27,7 @@ flowchart TD
   HttpScope["http service scope"] --> Coordinator["coordinator"]
   HttpScope --> Registry["handle registry"]
   HttpScope --> Backend["transport driver scope"]
+  HttpScope --> Lifecycle["svc/http lifecycle"]
   HttpScope --> Publisher["cap/http publisher"]
 
   Coordinator --> Listener["listener scopes"]

--- a/src/services/http.lua
+++ b/src/services/http.lua
@@ -1,11 +1,8 @@
 -- services/http.lua
 -- Public entry point for the HTTP capability service.
 
-local service = require 'services.http.service'
-
-return {
-	start = service.start,
-	service = service,
+local M = {
+	service = require 'services.http.service',
 	sdk = require 'services.http.sdk',
 	headers = require 'services.http.headers',
 	config = require 'services.http.config',
@@ -17,3 +14,13 @@ return {
 	body = require 'services.http.body',
 	topics = require 'services.http.topics',
 }
+
+function M.start(conn, opts)
+	M.service.start(conn, opts)
+end
+
+function M.run(scope, params)
+	return M.service.run(scope, params)
+end
+
+return M

--- a/src/services/http/service.lua
+++ b/src/services/http/service.lua
@@ -17,6 +17,7 @@ local queue = require 'devicecode.support.queue'
 local config_watch = require 'devicecode.support.config_watch'
 local config_mod = require 'services.http.config'
 local service_events = require 'devicecode.support.service_events'
+local service_base = require 'devicecode.service_base'
 
 local M = {}
 local perform = fibers.perform
@@ -675,10 +676,10 @@ function HttpService:events()
 	return out
 end
 
-function M.start(conn, opts)
+function M.open_handle(conn, opts)
 	opts = opts or {}
 	local scope = fibers.current_scope()
-	if not scope then return nil, 'http service must start inside a scope' end
+	if not scope then return nil, 'http.open_handle must be called inside a scope' end
 
 	local initial_config, config_err = normalise_initial_config(opts)
 	if not initial_config then return nil, config_err or 'invalid_http_config' end
@@ -779,6 +780,50 @@ function M.start(conn, opts)
 	end
 
 	return self
+end
+
+function M.run(scope, params)
+	params = params or {}
+	local conn = params.conn
+	if conn == nil then error('http.run: conn required', 2) end
+	if scope == nil then error('http.run: scope required', 2) end
+
+	local svc, err = M.open_handle(conn, params)
+	if not svc then error(err or 'http service start failed', 0) end
+
+	local lifecycle = params.lifecycle
+	if lifecycle and type(lifecycle.running) == 'function' then
+		lifecycle:running({ ready = true, http_id = params.id or 'main' })
+	end
+
+	fibers.perform(fibers.never())
+	svc:terminate('returned')
+	return nil, 'http service returned unexpectedly'
+end
+
+function M.start(conn, opts)
+	opts = opts or {}
+	if conn == nil then error('http.start: conn required', 2) end
+	local scope = fibers.current_scope()
+	if not scope then error('http.start must be called inside a fiber', 2) end
+
+	local svc = service_base.new(conn, {
+		name = opts.name or 'http',
+		env = opts.env,
+		meta = opts.meta,
+		announce = opts.announce,
+	})
+	svc:starting({ ready = false })
+
+	local params = copy(opts)
+	params.conn = conn
+	params.name = opts.name or 'http'
+	params.lifecycle = svc
+
+	M.run(scope, params)
+
+	svc:stopped({ reason = 'returned' })
+	error('http service returned unexpectedly', 0)
 end
 
 M.HttpService = HttpService

--- a/src/services/ui/service.lua
+++ b/src/services/ui/service.lua
@@ -535,6 +535,9 @@ function M.run(scope, params)
 	state.service_status = 'running'
 
 	publish_summary(state)
+	if params.lifecycle and type(params.lifecycle.running) == 'function' then
+		params.lifecycle:running({ ready = true })
+	end
 
 	while true do
 		local ev = fibers.perform(next_event_op(state))
@@ -559,9 +562,11 @@ function M.start(conn, opts)
 	})
 	svc:starting({ ready = false })
 
+	svc:running({ ready = false })
+
 	local params = shallow_copy(opts)
 	params.conn = conn
-	svc:running({ ready = true })
+	params.lifecycle = svc
 	return M.run(scope, params)
 end
 

--- a/src/services/update.lua
+++ b/src/services/update.lua
@@ -1,36 +1,28 @@
 -- services/update.lua
---
 -- Public update service entry point.
 
-local service    = require 'services.update.service'
-local generation = require 'services.update.generation'
-local events     = require 'services.update.events'
-local model      = require 'services.update.model'
-local projection = require 'services.update.projection'
-local publisher  = require 'services.update.publisher'
-local topics     = require 'services.update.topics'
-local config     = require 'services.update.config'
-local job_repository = require 'services.update.job_repository'
-local job_store_cap = require 'services.update.job_store_cap'
-local manager_requests = require 'services.update.manager_requests'
-local active_runtime = require 'services.update.active_runtime'
-local active_job = require 'services.update.active_job'
-
-return {
-	start = service.start,
-	run   = service.run,
-
-	service    = service,
-	generation = generation,
-	events     = events,
-	model      = model,
-	projection = projection,
-	publisher  = publisher,
-	topics     = topics,
-	config     = config,
-	job_repository = job_repository,
-	job_store_cap = job_store_cap,
-	manager_requests = manager_requests,
-	active_runtime = active_runtime,
-	active_job = active_job,
+local M = {
+	service    = require 'services.update.service',
+	generation = require 'services.update.generation',
+	events     = require 'services.update.events',
+	model      = require 'services.update.model',
+	projection = require 'services.update.projection',
+	publisher  = require 'services.update.publisher',
+	topics     = require 'services.update.topics',
+	config     = require 'services.update.config',
+	job_repository = require 'services.update.job_repository',
+	job_store_cap = require 'services.update.job_store_cap',
+	manager_requests = require 'services.update.manager_requests',
+	active_runtime = require 'services.update.active_runtime',
+	active_job = require 'services.update.active_job',
 }
+
+function M.start(conn, opts)
+	M.service.start(conn, opts)
+end
+
+function M.run(scope, params)
+	return M.service.run(scope, params)
+end
+
+return M

--- a/tests/integration/devhost/test_http_service_real.lua
+++ b/tests/integration/devhost/test_http_service_real.lua
@@ -90,7 +90,7 @@ local function start_cap_service(opts)
 	local memory_sinks = opts.memory_sinks or {}
 	local b = bus.new()
 	local svc_conn = b:connect({ origin_base = { kind = 'local' } })
-	local svc = ok(http_service.start(svc_conn, {
+	local svc = ok(http_service.open_handle(svc_conn, {
 		id = opts.id or 'main',
 		backend_timeout = opts.backend_timeout or 2,
 		connection_setup_timeout = opts.connection_setup_timeout or 2,

--- a/tests/unit/http/test_service.lua
+++ b/tests/unit/http/test_service.lua
@@ -60,7 +60,7 @@ function M.test_service_retains_capability_metadata_and_status()
 		local b = bus.new()
 		local root = b:connect({ origin_base = { kind = 'local' } })
 		local drv = fake_driver()
-		local svc = ok(http_service.start(root, { driver = drv, id = 'main' }))
+		local svc = ok(http_service.open_handle(root, { driver = drv, id = 'main' }))
 		local user = b:connect({ origin_base = { kind = 'local' } })
 		local ref = sdk_mod.new_ref(user, 'main')
 		local rep = ok(fibers.perform(ref:status_op()))
@@ -75,7 +75,7 @@ function M.test_non_local_handle_returning_call_is_rejected_before_backend_work(
 		local b = bus.new()
 		local root = b:connect({ origin_base = { kind = 'local' } })
 		local drv = fake_driver()
-		local svc = ok(http_service.start(root, { driver = drv, id = 'main' }))
+		local svc = ok(http_service.open_handle(root, { driver = drv, id = 'main' }))
 		local remote = b:connect({ origin_base = { kind = 'local', link_id = 'fabric-link' } })
 		local ref = sdk_mod.new_ref(remote, 'main')
 		local reply, err = fibers.perform(ref:listen_op({ host = '127.0.0.1', port = 0 }))
@@ -90,7 +90,7 @@ function M.test_registry_callbacks_do_not_mutate_model_until_coordinator_receive
 	fibers.run(function ()
 		local b = bus.new()
 		local root = b:connect({ origin_base = { kind = 'local' } })
-		local svc = ok(http_service.start(root, { driver = fake_driver(), id = 'main' }))
+		local svc = ok(http_service.open_handle(root, { driver = fake_driver(), id = 'main' }))
 		yield_many(4)
 		eq(svc:stats().active_listeners, 0)
 		eq(svc._emit, nil, 'legacy direct reducer ingress should not exist')
@@ -121,7 +121,7 @@ function M.test_model_fields_are_recomputed_from_identity_records_and_duplicate_
 	fibers.run(function ()
 		local b = bus.new()
 		local root = b:connect({ origin_base = { kind = 'local' } })
-		local svc = ok(http_service.start(root, { driver = fake_driver(), id = 'main' }))
+		local svc = ok(http_service.open_handle(root, { driver = fake_driver(), id = 'main' }))
 		yield_many(4)
 
 		ok(svc:_submit_event({ kind = 'listener_registered', handle_id = 'l1', generation = 1 }))
@@ -148,7 +148,7 @@ function M.test_stale_generation_events_are_ignored()
 	fibers.run(function ()
 		local b = bus.new()
 		local root = b:connect({ origin_base = { kind = 'local' } })
-		local svc = ok(http_service.start(root, { driver = fake_driver(), id = 'main' }))
+		local svc = ok(http_service.open_handle(root, { driver = fake_driver(), id = 'main' }))
 		yield_many(4)
 
 		ok(svc:_submit_event({ kind = 'listener_registered', handle_id = 'l1', generation = 1 }))
@@ -170,7 +170,7 @@ function M.test_cap_request_received_then_service_shutdown_finalises_request_own
 	fibers.run(function ()
 		local b = bus.new()
 		local root = b:connect({ origin_base = { kind = 'local' } })
-		local svc = ok(http_service.start(root, { driver = fake_driver(), id = 'main' }))
+		local svc = ok(http_service.open_handle(root, { driver = fake_driver(), id = 'main' }))
 		local failed
 		local req = {
 			payload = {},
@@ -192,7 +192,7 @@ function M.test_event_queue_overflow_for_completion_fails_observing_service()
 		ok(child:spawn(function ()
 			local b = bus.new()
 			local root = b:connect({ origin_base = { kind = 'local' } })
-			local svc = ok(http_service.start(root, { driver = fake_driver(), id = 'main', event_queue_len = 1 }))
+			local svc = ok(http_service.open_handle(root, { driver = fake_driver(), id = 'main', event_queue_len = 1 }))
 			return fibers.perform(tx:send_op(svc))
 		end))
 		local svc = ok(fibers.perform(rx:recv_op()))
@@ -216,7 +216,7 @@ function M.test_service_shutdown_terminates_registry_handles_and_finalises_unres
 	fibers.run(function ()
 		local b = bus.new()
 		local root = b:connect({ origin_base = { kind = 'local' } })
-		local svc = ok(http_service.start(root, { driver = fake_driver(), id = 'main' }))
+		local svc = ok(http_service.open_handle(root, { driver = fake_driver(), id = 'main' }))
 		local terminated
 		local id = ok(svc._registry:register('exchange', { terminate = function (_, reason) terminated = reason; return true end }, { generation = svc._generation }))
 		yield_many(4)
@@ -236,7 +236,7 @@ function M.test_context_transfer_keeps_context_active_after_listener_termination
 	fibers.run(function ()
 		local b = bus.new()
 		local root = b:connect({ origin_base = { kind = 'local' } })
-		local svc = ok(http_service.start(root, { driver = fake_driver(), id = 'main' }))
+		local svc = ok(http_service.open_handle(root, { driver = fake_driver(), id = 'main' }))
 		yield_many(4)
 		ok(svc:_submit_event({ kind = 'listener_registered', handle_id = 'l1', generation = 1 }))
 		ok(svc:_submit_event({ kind = 'context_admitted', listener_id = 'l1', context_id = 'c1', generation = 1 }))
@@ -381,7 +381,7 @@ function M.test_backend_failure_terminates_service_owned_handles()
 	fibers.run(function ()
 		local b = bus.new()
 		local root = b:connect({ origin_base = { kind = 'local' } })
-		local svc = ok(http_service.start(root, { driver = fake_driver(), id = 'main' }))
+		local svc = ok(http_service.open_handle(root, { driver = fake_driver(), id = 'main' }))
 		yield_many(4)
 
 		local terminated = {}
@@ -435,7 +435,7 @@ function M.test_listener_setup_failure_leaves_no_live_ownership()
 		}
 		local b = bus.new()
 		local root = b:connect({ origin_base = { kind = 'local' } })
-		local svc = ok(http_service.start(root, { driver = fake_polling_driver(), id = 'main', http_server = failing_server }))
+		local svc = ok(http_service.open_handle(root, { driver = fake_polling_driver(), id = 'main', http_server = failing_server }))
 		local user = b:connect({ origin_base = { kind = 'local' } })
 		local ref = sdk_mod.new_ref(user, 'main')
 
@@ -457,7 +457,7 @@ function M.test_handle_returning_rpcs_return_public_wrappers()
 		local counters = {}
 		local b = bus.new()
 		local root = b:connect({ origin_base = { kind = 'local' } })
-		local svc = ok(http_service.start(root, {
+		local svc = ok(http_service.open_handle(root, {
 			driver = fake_polling_driver(),
 			id = 'main',
 			http_server = http_server_success(counters),
@@ -489,7 +489,7 @@ function M.test_each_local_handle_rpc_rejects_non_local_before_backend_admission
 		local counters = {}
 		local b = bus.new()
 		local root = b:connect({ origin_base = { kind = 'local' } })
-		local svc = ok(http_service.start(root, {
+		local svc = ok(http_service.open_handle(root, {
 			driver = fake_polling_driver(),
 			id = 'main',
 			http_server = http_server_success(counters),
@@ -522,7 +522,7 @@ function M.test_initial_retained_status_is_not_available_before_backend_ready_ev
 		local topics = require 'services.http.topics'
 		local b = bus.new()
 		local root = b:connect({ origin_base = { kind = 'local' } })
-		local svc = ok(http_service.start(root, { driver = fake_driver(), id = 'main' }))
+		local svc = ok(http_service.open_handle(root, { driver = fake_driver(), id = 'main' }))
 
 		local view = root:retained_view(topics.status('main'))
 		local msg = ok(view:get(topics.status('main')), 'status should be retained immediately')
@@ -537,7 +537,7 @@ function M.test_listener_owner_reports_identity_completion_when_listener_runtime
 		local counters = {}
 		local b = bus.new()
 		local root = b:connect({ origin_base = { kind = 'local' } })
-		local svc = ok(http_service.start(root, {
+		local svc = ok(http_service.open_handle(root, {
 			driver = fake_polling_driver(),
 			id = 'main',
 			http_server = http_server_success(counters),
@@ -570,7 +570,7 @@ function M.test_onstream_context_admission_emits_service_event_without_reducing_
 		local counters = {}
 		local b = bus.new()
 		local root = b:connect({ origin_base = { kind = 'local' } })
-		local svc = ok(http_service.start(root, {
+		local svc = ok(http_service.open_handle(root, {
 			driver = fake_polling_driver(),
 			id = 'main',
 			http_server = http_server_success(counters),
@@ -603,7 +603,7 @@ function M.test_unaccepted_context_is_listener_owned_until_accept()
 	fibers.run(function ()
 		local b = bus.new()
 		local root = b:connect({ origin_base = { kind = 'local' } })
-		local svc = ok(http_service.start(root, {
+		local svc = ok(http_service.open_handle(root, {
 			driver = fake_polling_driver(),
 			id = 'main',
 			http_server = http_server_success({}),
@@ -639,7 +639,7 @@ function M.test_listener_termination_terminates_unaccepted_context_and_emits_con
 		local terminated_reason
 		local b = bus.new()
 		local root = b:connect({ origin_base = { kind = 'local' } })
-		local svc = ok(http_service.start(root, {
+		local svc = ok(http_service.open_handle(root, {
 			driver = fake_polling_driver(),
 			id = 'main',
 			http_server = http_server_success({}),
@@ -668,7 +668,7 @@ function M.test_accepted_context_survives_listener_termination_until_context_ter
 	fibers.run(function ()
 		local b = bus.new()
 		local root = b:connect({ origin_base = { kind = 'local' } })
-		local svc = ok(http_service.start(root, {
+		local svc = ok(http_service.open_handle(root, {
 			driver = fake_polling_driver(),
 			id = 'main',
 			http_server = http_server_success({}),
@@ -726,7 +726,7 @@ function M.test_server_side_websocket_upgrade_registers_and_deregisters_service_
 	fibers.run(function (scope)
 		local b = bus.new()
 		local root = b:connect({ origin_base = { kind = 'local' } })
-		local svc = ok(http_service.start(root, {
+		local svc = ok(http_service.open_handle(root, {
 			driver = fake_polling_driver(),
 			id = 'main',
 			http_server = http_server_success({}),
@@ -764,7 +764,7 @@ function M.test_service_shutdown_terminates_server_side_upgraded_websocket()
 	fibers.run(function (scope)
 		local b = bus.new()
 		local root = b:connect({ origin_base = { kind = 'local' } })
-		local svc = ok(http_service.start(root, {
+		local svc = ok(http_service.open_handle(root, {
 			driver = fake_polling_driver(),
 			id = 'main',
 			http_server = http_server_success({}),
@@ -795,7 +795,7 @@ function M.test_public_context_read_cancellation_terminates_context_and_service_
 	fibers.run(function (scope)
 		local b = bus.new()
 		local root = b:connect({ origin_base = { kind = 'local' } })
-		local svc = ok(http_service.start(root, {
+		local svc = ok(http_service.open_handle(root, {
 			driver = fake_polling_driver(),
 			id = 'main',
 			http_server = http_server_success({}),
@@ -838,7 +838,7 @@ function M.test_public_server_websocket_receive_cancellation_terminates_websocke
 	fibers.run(function (scope)
 		local b = bus.new()
 		local root = b:connect({ origin_base = { kind = 'local' } })
-		local svc = ok(http_service.start(root, {
+		local svc = ok(http_service.open_handle(root, {
 			driver = fake_polling_driver(),
 			id = 'main',
 			http_server = http_server_success({}),
@@ -930,7 +930,7 @@ function M.test_public_open_exchange_handle_read_cancellation_keeps_service_back
 	fibers.run(function (scope)
 		local b = bus.new()
 		local root = b:connect({ origin_base = { kind = 'local' } })
-		local svc = ok(http_service.start(root, {
+		local svc = ok(http_service.open_handle(root, {
 			driver = drv,
 			id = 'main',
 			request_module = request_mod,
@@ -975,7 +975,7 @@ function M.test_retained_http_config_updates_policy_generation_and_policy()
 				policy = { allow_loopback = false, allowed_schemes = { https = true } },
 			},
 		})
-		local svc = ok(http_service.start(root, { driver = fake_driver(), id = 'main' }))
+		local svc = ok(http_service.open_handle(root, { driver = fake_driver(), id = 'main' }))
 		yield_until(function () return svc:stats().policy_generation == 7 end, 'retained cfg/http was not applied')
 		eq(svc._opts.policy.allow_loopback, false)
 		eq(svc._opts.policy.allowed_schemes.https, true)
@@ -989,7 +989,7 @@ function M.test_invalid_retained_http_config_marks_service_degraded_without_repl
 		local b = bus.new()
 		local root = b:connect({ origin_base = { kind = 'local' } })
 		root:retain({ 'cfg', 'http' }, { rev = 3, data = { schema = 'wrong' } })
-		local svc = ok(http_service.start(root, { driver = fake_driver(), id = 'main' }))
+		local svc = ok(http_service.open_handle(root, { driver = fake_driver(), id = 'main' }))
 		yield_until(function () return svc:stats().last_error ~= nil end, 'invalid cfg/http was not reported')
 		ok(tostring(svc:stats().last_error):find('schema', 1, true))
 		eq(svc:stats().policy_generation, 1, 'invalid config must not advance policy generation')

--- a/tests/unit/http/test_service_architecture.lua
+++ b/tests/unit/http/test_service_architecture.lua
@@ -79,7 +79,7 @@ function M.test_backend_run_is_named_component_with_identity_completion()
 		local b = bus.new()
 		local root = b:connect({ origin_base = { kind = 'local' } })
 		local drv = failing_run_driver()
-		local svc = ok(http_service.start(root, { driver = drv, id = 'main' }))
+		local svc = ok(http_service.open_handle(root, { driver = drv, id = 'main' }))
 		yield_many(10)
 		local done
 		for _, ev in ipairs(svc:events()) do
@@ -102,7 +102,7 @@ function M.test_exchange_is_named_scoped_work_with_identity_completion_and_event
 		local b = bus.new()
 		local root = b:connect({ origin_base = { kind = 'local' } })
 		local sink = blob.to_memory()
-		local svc = ok(http_service.start(root, {
+		local svc = ok(http_service.open_handle(root, {
 			driver = fake_driver(),
 			id = 'main',
 			request_module = request_module('hello'),

--- a/tests/unit/http/test_structure.lua
+++ b/tests/unit/http/test_structure.lua
@@ -91,4 +91,26 @@ function M.test_http_service_and_support_do_not_use_private_op_internals()
 	end
 end
 
+
+function M.test_http_service_start_is_foreground_entry_not_handle_constructor()
+	local service = read_file('../src/services/http/service.lua')
+	ok(service:find('function M.run%(scope, params%)'), 'http service does not expose run(scope, params)')
+	ok(service:find('function M.start%(conn, opts%)'), 'http service does not expose start(conn, opts)')
+	ok(service:find("require 'devicecode.service_base'", 1, true), 'http start does not use service_base lifecycle')
+	ok(service:find('function M.open_handle%(conn, opts%)'), 'http handle-returning helper is not explicit')
+	ok(not service:find('function M.start%(conn, opts%)[%s%S]-return self[%s%S]-end'), 'http start returns a service handle')
+	ok(service:find('http service returned unexpectedly', 1, true), 'http start does not fail if run returns')
+end
+
+function M.test_http_unit_tests_use_explicit_handle_helper()
+	local needle = 'http_service.' .. 'start'
+	local cmd = "find ../tests/unit/http ../tests/integration/devhost -name '*.lua' | sort"
+	local p = assert(io.popen(cmd))
+	for file in p:lines() do
+		local s = read_file(file)
+		ok(not s:find(needle, 1, true), 'http tests still use start as a handle constructor: ' .. file)
+	end
+	p:close()
+end
+
 return M


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

* [x] 🐛 Bug Fix
* [x] 📝 Documentation Update
* [x] 🧑‍💻 Code Refactor
* [x] ✅ Test

## Description

Aligns service entry semantics across the new Fabric, Device, Update, HTTP and UI services.

* Makes HTTP `start(conn, opts)` a long-lived main service entry rather than a handle-returning constructor.
* Adds HTTP `run(scope, params)` as the foreground coordinator path.
* Renames the HTTP handle-returning path to `open_handle(conn, opts)`.
* Adds HTTP `service_base` lifecycle publication.
* Updates HTTP tests to use `open_handle(...)` when they need an in-process service handle.
* Standardises `http.lua` and `update.lua` public entry module shape.
* Adjusts UI readiness so it starts as `ready=false` and marks ready after initial setup.
* Adds architecture tests to prevent service `start()` from returning while healthy.
* Updates service architecture and HTTP documentation.

## Manual test

* [x] 👍 yes

## Manual test description

Ran the full Lua test suite.

```text
701 tests, 0 failed, 0 skipped
```

## Added tests?

* [x] 👍 yes

## Added to documentation?

* [x] 📜 README.md
