### PR TITLE
Add OpenWrt VM integration test lane for HAL networking work

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,8 @@
 	"remoteUser": "vscode",
 	"postCreateCommand": "bash .devcontainer/postCreateCommand.sh",
 	"forwardPorts": [
-		8081
+		8081,
+		2222
 	],
 	"customizations": {
 		"vscode": {

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,19 +1,44 @@
-#!/bin/sh
+#!/usr/bin/env sh
+set -eu
 
-cd /tmp
-git clone https://github.com/jangala-dev/lua-fibers
-cd lua-fibers
-git checkout v0.4
-sudo cp -r src/* /workspaces/lua-bus/src/
-cd ..
-rm -rf lua-fibers
+echo "[devcontainer] preparing OpenWrt VM test tools"
 
-cd /tmp
-git clone https://github.com/jangala-dev/lua-trie
-cd lua-trie
-git checkout v0.2
-sudo mv src/trie.lua /workspaces/lua-bus/src/
-cd ..
-rm -rf lua-trie
+if command -v apt-get >/dev/null 2>&1; then
+	sudo apt-get update
+	sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
+		curl \
+		ca-certificates \
+		gzip \
+		openssh-client \
+		rsync \
+		socat \
+		qemu-system-x86 \
+		qemu-system-arm \
+		qemu-utils \
+		ovmf \
+		qemu-efi-aarch64 \
+		make
+elif command -v apk >/dev/null 2>&1; then
+	sudo apk add --no-cache \
+		curl \
+		ca-certificates \
+		gzip \
+		openssh-client \
+		rsync \
+		socat \
+		qemu-system-x86_64 \
+		qemu-system-aarch64 \
+		qemu-img \
+		ovmf \
+		edk2-aarch64 \
+		make
+else
+	echo "[devcontainer] unsupported base image: no apt-get or apk found" >&2
+	exit 1
+fi
+
+mkdir -p tests/integration/openwrt_vm/{images,work,scripts,tests}
+
+echo "[devcontainer] OpenWrt VM tools ready"
 
 exit 0

--- a/tests/integration/openwrt_vm/.gitignore
+++ b/tests/integration/openwrt_vm/.gitignore
@@ -1,0 +1,4 @@
+images/*
+work/*
+!images/.gitkeep
+!work/.gitkeep

--- a/tests/integration/openwrt_vm/.gitignore
+++ b/tests/integration/openwrt_vm/.gitignore
@@ -1,4 +1,0 @@
-images/*
-work/*
-!images/.gitkeep
-!work/.gitkeep

--- a/tests/integration/openwrt_vm/Makefile
+++ b/tests/integration/openwrt_vm/Makefile
@@ -1,13 +1,31 @@
-.PHONY: fetch reset run stop ssh smoke logs
+.PHONY: \
+	preflight fetch verify reset run wait provision provision-force \
+	stop ssh smoke logs baseline test-baseline test-tc-veth test \
+	openwrt-vm-test clean
+
+preflight:
+	./scripts/preflight
 
 fetch:
 	./scripts/fetch-image
+
+verify:
+	./scripts/verify-image
 
 reset:
 	./scripts/reset-disk
 
 run:
 	./scripts/run-vm
+
+wait:
+	./scripts/wait-ssh
+
+provision:
+	./scripts/provision
+
+provision-force:
+	OPENWRT_PROVISION_FORCE=1 ./scripts/provision
 
 stop:
 	./scripts/stop-vm
@@ -22,9 +40,30 @@ smoke:
 logs:
 	tail -n 200 work/qemu.log
 
-provision:
-	./scripts/provision
+baseline: test-baseline
 
 test-baseline:
 	./scripts/wait-ssh
 	./tests/test_openwrt_baseline.sh
+
+test-tc-veth:
+	./scripts/wait-ssh
+	./tests/test_tc_veth_baseline.sh
+
+test-scp:
+	./scripts/wait-ssh
+	tmp="$$(mktemp)"; \
+	echo "devicecode-openwrt-vm" > "$$tmp"; \
+	./scripts/scp-to "$$tmp" /tmp/devicecode-scp-test; \
+	./scripts/ssh 'grep -q devicecode-openwrt-vm /tmp/devicecode-scp-test'; \
+	./scripts/scp-from /tmp/devicecode-scp-test "$$tmp.out"; \
+	grep -q devicecode-openwrt-vm "$$tmp.out"; \
+	rm -f "$$tmp" "$$tmp.out"
+
+test: test-baseline test-tc-veth test-scp
+
+openwrt-vm-test: preflight fetch verify reset run wait provision test
+
+clean:
+	./scripts/stop-vm
+	rm -rf work

--- a/tests/integration/openwrt_vm/Makefile
+++ b/tests/integration/openwrt_vm/Makefile
@@ -1,0 +1,30 @@
+.PHONY: fetch reset run stop ssh smoke logs
+
+fetch:
+	./scripts/fetch-image
+
+reset:
+	./scripts/reset-disk
+
+run:
+	./scripts/run-vm
+
+stop:
+	./scripts/stop-vm
+
+ssh:
+	./scripts/ssh
+
+smoke:
+	./scripts/wait-ssh
+	./scripts/ssh 'uname -a; uci show system | head; ip link; for x in uci ip nft tc; do printf "%s: " "$$x"; command -v "$$x" || echo missing; done'
+
+logs:
+	tail -n 200 work/qemu.log
+
+provision:
+	./scripts/provision
+
+test-baseline:
+	./scripts/wait-ssh
+	./tests/test_openwrt_baseline.sh

--- a/tests/integration/openwrt_vm/env.sh
+++ b/tests/integration/openwrt_vm/env.sh
@@ -1,9 +1,25 @@
 #!/usr/bin/env sh
+# Shared environment for the OpenWrt VM integration test lane.
+#
+# Scripts normally set VM_DIR before sourcing this file. When sourced directly,
+# fall back to the directory containing this file if the caller has cd'd here.
+
+if [ -z "${VM_DIR:-}" ]; then
+	VM_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+fi
 
 OPENWRT_VERSION="${OPENWRT_VERSION:-24.10.4}"
 OPENWRT_SSH_PORT="${OPENWRT_SSH_PORT:-2222}"
+OPENWRT_SSH_WAIT_S="${OPENWRT_SSH_WAIT_S:-90}"
 OPENWRT_VM_MEM="${OPENWRT_VM_MEM:-512M}"
 OPENWRT_VM_CPUS="${OPENWRT_VM_CPUS:-2}"
+OPENWRT_KVM="${OPENWRT_KVM:-auto}"
+
+# Optional host tap devices for dataplane tests. These are deliberately separate
+# from the QEMU user-mode management NIC. Leave empty for the default self-contained
+# VM tests, which create veth/ifb devices inside OpenWrt.
+# Example: OPENWRT_TAP_IFACES="tap-dc0 tap-dc1"
+OPENWRT_TAP_IFACES="${OPENWRT_TAP_IFACES:-}"
 
 case "$(uname -m)" in
 	x86_64|amd64)
@@ -11,14 +27,14 @@ case "$(uname -m)" in
 		OPENWRT_TARGET_PATH="x86/64"
 		OPENWRT_PREFIX="openwrt-${OPENWRT_VERSION}-x86-64"
 		OPENWRT_IMAGE_NAME="${OPENWRT_PREFIX}-generic-ext4-combined.img.gz"
-		OPENWRT_QEMU="qemu-system-x86_64"
+		OPENWRT_QEMU="${OPENWRT_QEMU:-qemu-system-x86_64}"
 		;;
 	aarch64|arm64)
 		OPENWRT_ARCH="aarch64"
 		OPENWRT_TARGET_PATH="armsr/armv8"
 		OPENWRT_PREFIX="openwrt-${OPENWRT_VERSION}-armsr-armv8"
 		OPENWRT_IMAGE_NAME="${OPENWRT_PREFIX}-generic-ext4-combined-efi.img.gz"
-		OPENWRT_QEMU="qemu-system-aarch64"
+		OPENWRT_QEMU="${OPENWRT_QEMU:-qemu-system-aarch64}"
 		;;
 	*)
 		echo "unsupported host architecture: $(uname -m)" >&2
@@ -28,9 +44,16 @@ esac
 
 OPENWRT_BASE_URL="https://downloads.openwrt.org/releases/${OPENWRT_VERSION}/targets/${OPENWRT_TARGET_PATH}"
 
-OPENWRT_DIR="${VM_DIR:-$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)}"
-OPENWRT_IMAGE_GZ="${OPENWRT_DIR}/images/${OPENWRT_IMAGE_NAME}"
-OPENWRT_IMAGE_RAW="${OPENWRT_DIR}/images/${OPENWRT_IMAGE_NAME%.gz}"
-OPENWRT_WORK_DISK="${OPENWRT_DIR}/work/openwrt-${OPENWRT_ARCH}.qcow2"
-OPENWRT_PID="${OPENWRT_DIR}/work/qemu.pid"
-OPENWRT_LOG="${OPENWRT_DIR}/work/qemu.log"
+OPENWRT_DIR="${VM_DIR}"
+OPENWRT_IMAGE_DIR="${OPENWRT_DIR}/images"
+OPENWRT_WORK_DIR="${OPENWRT_DIR}/work"
+OPENWRT_IMAGE_GZ="${OPENWRT_IMAGE_DIR}/${OPENWRT_IMAGE_NAME}"
+OPENWRT_IMAGE_RAW="${OPENWRT_IMAGE_DIR}/${OPENWRT_IMAGE_NAME%.gz}"
+OPENWRT_SHA256SUMS_NAME="sha256sums"
+OPENWRT_SHA256SUMS="${OPENWRT_IMAGE_DIR}/sha256sums-${OPENWRT_VERSION}-${OPENWRT_ARCH}"
+OPENWRT_WORK_DISK="${OPENWRT_WORK_DIR}/openwrt-${OPENWRT_ARCH}.qcow2"
+OPENWRT_PID="${OPENWRT_WORK_DIR}/qemu.pid"
+OPENWRT_LOG="${OPENWRT_WORK_DIR}/qemu.log"
+
+OPENWRT_PROVISION_MARKER="${OPENWRT_PROVISION_MARKER:-/etc/devicecode-vm-provisioned}"
+OPENWRT_PROVISION_FORCE="${OPENWRT_PROVISION_FORCE:-0}"

--- a/tests/integration/openwrt_vm/env.sh
+++ b/tests/integration/openwrt_vm/env.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env sh
+
+OPENWRT_VERSION="${OPENWRT_VERSION:-24.10.4}"
+OPENWRT_SSH_PORT="${OPENWRT_SSH_PORT:-2222}"
+OPENWRT_VM_MEM="${OPENWRT_VM_MEM:-512M}"
+OPENWRT_VM_CPUS="${OPENWRT_VM_CPUS:-2}"
+
+case "$(uname -m)" in
+	x86_64|amd64)
+		OPENWRT_ARCH="x86_64"
+		OPENWRT_TARGET_PATH="x86/64"
+		OPENWRT_PREFIX="openwrt-${OPENWRT_VERSION}-x86-64"
+		OPENWRT_IMAGE_NAME="${OPENWRT_PREFIX}-generic-ext4-combined.img.gz"
+		OPENWRT_QEMU="qemu-system-x86_64"
+		;;
+	aarch64|arm64)
+		OPENWRT_ARCH="aarch64"
+		OPENWRT_TARGET_PATH="armsr/armv8"
+		OPENWRT_PREFIX="openwrt-${OPENWRT_VERSION}-armsr-armv8"
+		OPENWRT_IMAGE_NAME="${OPENWRT_PREFIX}-generic-ext4-combined-efi.img.gz"
+		OPENWRT_QEMU="qemu-system-aarch64"
+		;;
+	*)
+		echo "unsupported host architecture: $(uname -m)" >&2
+		exit 1
+		;;
+esac
+
+OPENWRT_BASE_URL="https://downloads.openwrt.org/releases/${OPENWRT_VERSION}/targets/${OPENWRT_TARGET_PATH}"
+
+OPENWRT_DIR="${VM_DIR:-$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)}"
+OPENWRT_IMAGE_GZ="${OPENWRT_DIR}/images/${OPENWRT_IMAGE_NAME}"
+OPENWRT_IMAGE_RAW="${OPENWRT_DIR}/images/${OPENWRT_IMAGE_NAME%.gz}"
+OPENWRT_WORK_DISK="${OPENWRT_DIR}/work/openwrt-${OPENWRT_ARCH}.qcow2"
+OPENWRT_PID="${OPENWRT_DIR}/work/qemu.pid"
+OPENWRT_LOG="${OPENWRT_DIR}/work/qemu.log"

--- a/tests/integration/openwrt_vm/images/.gitignore
+++ b/tests/integration/openwrt_vm/images/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/integration/openwrt_vm/readme.md
+++ b/tests/integration/openwrt_vm/readme.md
@@ -1,0 +1,133 @@
+# OpenWrt VM integration tests
+
+This directory provides an opt-in OpenWrt VM test lane for Devicecode integration work.
+
+It is intended for HAL and networking tests that need a real OpenWrt userspace and kernel networking stack, including UCI, `fw4`/nftables, `tc`, IFB and veth devices. It is not part of the normal unit test path.
+
+## Layout
+
+```text
+tests/integration/openwrt_vm
+  env.sh
+  Makefile
+  scripts/
+  tests/
+````
+
+The VM uses QEMU. A QEMU user-mode NIC is used for SSH and provisioning. Optional tap NICs may be added separately for dataplane tests.
+
+## Requirements
+
+On the host:
+
+```text
+qemu-system-x86_64 or qemu-system-aarch64
+qemu-img
+curl
+gzip
+ssh
+scp
+sha256sum or shasum
+```
+
+On AArch64 hosts, QEMU EFI firmware is also required.
+
+Check the local setup with:
+
+```sh
+make preflight
+```
+
+## Basic workflow
+
+From this directory:
+
+```sh
+make fetch
+make reset
+make run
+make provision
+make test
+```
+
+Or run the full lane:
+
+```sh
+make openwrt-vm-test
+```
+
+The default test target currently checks:
+
+```text
+OpenWrt baseline tools and state
+veth, IFB, HTB, fq_codel and ingress qdisc support
+SCP copy to and from the VM
+```
+
+## Common commands
+
+```sh
+make run          # start the VM
+make wait         # wait until SSH is ready
+make ssh          # open a root SSH session
+make smoke        # show basic VM state
+make provision    # install packages needed by the tests
+make test         # run current VM tests
+make logs         # show recent serial log output
+make stop         # stop the VM
+make clean        # stop and remove the work disk
+```
+
+Force package provisioning to run again:
+
+```sh
+OPENWRT_PROVISION_FORCE=1 make provision
+```
+
+Use a shorter SSH wait while iterating:
+
+```sh
+OPENWRT_SSH_WAIT_S=30 make smoke
+```
+
+## Image and disk handling
+
+Images are downloaded into:
+
+```text
+images/
+```
+
+The downloaded image is verified against OpenWrt `sha256sums` before use.
+
+The writable VM disk is a qcow2 overlay in:
+
+```text
+work/
+```
+
+Reset it with:
+
+```sh
+make reset
+```
+
+This discards changes made inside the VM.
+
+## Dataplane testing
+
+The default tests create veth and IFB devices inside the VM. This is enough for many kernel traffic-control tests.
+
+For tests requiring host-side dataplane interfaces, provide tap devices explicitly:
+
+```sh
+OPENWRT_TAP_IFACES="tap-dc0 tap-dc1" make run
+```
+
+The management SSH NIC remains separate from any tap dataplane NICs.
+
+## Notes
+
+This lane is intentionally separate from the normal unit suite. It is for tests where container-based execution is not representative, especially OpenWrt HAL work involving UCI, networking reloads, nftables, traffic control, IFB, veth and future shaping or bandwidth-estimation tests.
+
+Keep service logic tests outside this lane where possible. Use this VM lane for behaviour that depends on OpenWrt or kernel networking semantics.

--- a/tests/integration/openwrt_vm/scripts/fetch-image
+++ b/tests/integration/openwrt_vm/scripts/fetch-image
@@ -7,12 +7,14 @@ VM_DIR="$(dirname "$SCRIPT_DIR")"
 # shellcheck disable=SC1091
 . "$VM_DIR/env.sh"
 
-mkdir -p "${OPENWRT_DIR}/images"
+mkdir -p "${OPENWRT_IMAGE_DIR}"
 
 if [ ! -f "${OPENWRT_IMAGE_GZ}" ]; then
 	echo "[openwrt-vm] fetching ${OPENWRT_IMAGE_NAME}"
 	curl -fL "${OPENWRT_BASE_URL}/${OPENWRT_IMAGE_NAME}" -o "${OPENWRT_IMAGE_GZ}"
 fi
+
+"$SCRIPT_DIR/verify-image"
 
 if [ ! -f "${OPENWRT_IMAGE_RAW}" ]; then
 	echo "[openwrt-vm] decompressing ${OPENWRT_IMAGE_NAME}"

--- a/tests/integration/openwrt_vm/scripts/fetch-image
+++ b/tests/integration/openwrt_vm/scripts/fetch-image
@@ -1,0 +1,46 @@
+#!/usr/bin/env sh
+set -eu
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+VM_DIR="$(dirname "$SCRIPT_DIR")"
+
+# shellcheck disable=SC1091
+. "$VM_DIR/env.sh"
+
+mkdir -p "${OPENWRT_DIR}/images"
+
+if [ ! -f "${OPENWRT_IMAGE_GZ}" ]; then
+	echo "[openwrt-vm] fetching ${OPENWRT_IMAGE_NAME}"
+	curl -fL "${OPENWRT_BASE_URL}/${OPENWRT_IMAGE_NAME}" -o "${OPENWRT_IMAGE_GZ}"
+fi
+
+if [ ! -f "${OPENWRT_IMAGE_RAW}" ]; then
+	echo "[openwrt-vm] decompressing ${OPENWRT_IMAGE_NAME}"
+	tmp="${OPENWRT_IMAGE_RAW}.tmp"
+	rm -f "$tmp"
+
+	set +e
+	gzip -dc "${OPENWRT_IMAGE_GZ}" > "$tmp"
+	rc=$?
+	set -e
+
+	if [ "$rc" -ne 0 ] && [ "$rc" -ne 2 ]; then
+		rm -f "$tmp"
+		echo "[openwrt-vm] gzip failed with exit code $rc" >&2
+		exit "$rc"
+	fi
+
+	if [ ! -s "$tmp" ]; then
+		rm -f "$tmp"
+		echo "[openwrt-vm] decompressed image is empty" >&2
+		exit 1
+	fi
+
+	if [ "$rc" -eq 2 ]; then
+		echo "[openwrt-vm] gzip reported trailing data; using decompressed image anyway" >&2
+	fi
+
+	mv "$tmp" "${OPENWRT_IMAGE_RAW}"
+fi
+
+echo "[openwrt-vm] image ready: ${OPENWRT_IMAGE_RAW}"

--- a/tests/integration/openwrt_vm/scripts/preflight
+++ b/tests/integration/openwrt_vm/scripts/preflight
@@ -1,0 +1,78 @@
+#!/usr/bin/env sh
+set -eu
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+VM_DIR="$(dirname "$SCRIPT_DIR")"
+
+# shellcheck disable=SC1091
+. "$VM_DIR/env.sh"
+
+missing=0
+
+need_cmd() {
+	if ! command -v "$1" >/dev/null 2>&1; then
+		echo "[openwrt-vm] missing required command: $1" >&2
+		missing=1
+	fi
+}
+
+need_cmd "$OPENWRT_QEMU"
+need_cmd qemu-img
+need_cmd curl
+need_cmd gzip
+need_cmd ssh
+need_cmd scp
+
+if ! command -v sha256sum >/dev/null 2>&1 && ! command -v shasum >/dev/null 2>&1; then
+	echo "[openwrt-vm] missing required checksum tool: sha256sum or shasum" >&2
+	missing=1
+fi
+
+if [ "$OPENWRT_ARCH" = "aarch64" ]; then
+	found=""
+	for p in \
+		/usr/share/AAVMF/AAVMF_CODE.fd \
+		/usr/share/qemu-efi-aarch64/QEMU_EFI.fd \
+		/usr/share/edk2/aarch64/QEMU_EFI.fd
+	do
+		if [ -f "$p" ]; then
+			found="$p"
+			break
+		fi
+	done
+	if [ -z "$found" ]; then
+		echo "[openwrt-vm] missing AArch64 EFI firmware" >&2
+		missing=1
+	else
+		echo "[openwrt-vm] AArch64 EFI firmware: $found"
+	fi
+fi
+
+if [ "$OPENWRT_KVM" = "auto" ] || [ "$OPENWRT_KVM" = "1" ]; then
+	if [ -e /dev/kvm ]; then
+		if [ -r /dev/kvm ] && [ -w /dev/kvm ]; then
+			echo "[openwrt-vm] KVM available"
+		else
+			echo "[openwrt-vm] /dev/kvm exists but is not accessible to this user" >&2
+			if [ "$OPENWRT_KVM" = "1" ]; then missing=1; fi
+		fi
+	else
+		echo "[openwrt-vm] KVM not available; QEMU will use emulation"
+		if [ "$OPENWRT_KVM" = "1" ]; then missing=1; fi
+	fi
+fi
+
+if [ -n "${OPENWRT_TAP_IFACES:-}" ]; then
+	for tap in $OPENWRT_TAP_IFACES; do
+		if ! ip link show "$tap" >/dev/null 2>&1; then
+			echo "[openwrt-vm] configured tap device not present: $tap" >&2
+			missing=1
+		fi
+	done
+fi
+
+if [ "$missing" -ne 0 ]; then
+	exit 1
+fi
+
+echo "[openwrt-vm] preflight ok"

--- a/tests/integration/openwrt_vm/scripts/provision
+++ b/tests/integration/openwrt_vm/scripts/provision
@@ -1,0 +1,37 @@
+#!/usr/bin/env sh
+set -eu
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+VM_DIR="$(dirname "$SCRIPT_DIR")"
+
+# shellcheck disable=SC1091
+. "$VM_DIR/env.sh"
+
+"$SCRIPT_DIR/wait-ssh"
+
+echo "[openwrt-vm] provisioning base packages"
+
+"$SCRIPT_DIR/ssh" '
+	set -eu
+
+	echo "[openwrt-vm] configuring temporary outbound route"
+
+	ip route replace default via 192.168.1.2 dev br-lan || true
+
+	mkdir -p /tmp/resolv.conf.d
+	printf "nameserver 192.168.1.3\nnameserver 1.1.1.1\n" > /tmp/resolv.conf.d/resolv.conf.auto
+	printf "nameserver 192.168.1.3\nnameserver 1.1.1.1\n" > /tmp/resolv.conf
+
+	echo "[openwrt-vm] checking connectivity"
+	ping -c 1 -W 3 192.168.1.2 >/dev/null || {
+		echo "cannot reach QEMU user-network gateway 192.168.1.2" >&2
+		ip addr >&2
+		ip route >&2
+		exit 1
+	}
+
+	opkg update
+	opkg install tc-full kmod-sched kmod-sched-core kmod-ifb kmod-veth ip-full
+'
+
+echo "[openwrt-vm] provision complete"

--- a/tests/integration/openwrt_vm/scripts/provision
+++ b/tests/integration/openwrt_vm/scripts/provision
@@ -9,22 +9,28 @@ VM_DIR="$(dirname "$SCRIPT_DIR")"
 
 "$SCRIPT_DIR/wait-ssh"
 
+if [ "${OPENWRT_PROVISION_FORCE}" != "1" ]; then
+	if "$SCRIPT_DIR/ssh" "test -f '${OPENWRT_PROVISION_MARKER}'" >/dev/null 2>&1; then
+		echo "[openwrt-vm] provision already complete; set OPENWRT_PROVISION_FORCE=1 to run again"
+		exit 0
+	fi
+fi
+
 echo "[openwrt-vm] provisioning base packages"
 
-"$SCRIPT_DIR/ssh" '
+"$SCRIPT_DIR/ssh" "
 	set -eu
 
-	echo "[openwrt-vm] configuring temporary outbound route"
-
+	echo '[openwrt-vm] configuring temporary outbound route'
 	ip route replace default via 192.168.1.2 dev br-lan || true
 
 	mkdir -p /tmp/resolv.conf.d
-	printf "nameserver 192.168.1.3\nnameserver 1.1.1.1\n" > /tmp/resolv.conf.d/resolv.conf.auto
-	printf "nameserver 192.168.1.3\nnameserver 1.1.1.1\n" > /tmp/resolv.conf
+	printf 'nameserver 192.168.1.3\nnameserver 1.1.1.1\n' > /tmp/resolv.conf.d/resolv.conf.auto
+	printf 'nameserver 192.168.1.3\nnameserver 1.1.1.1\n' > /tmp/resolv.conf
 
-	echo "[openwrt-vm] checking connectivity"
+	echo '[openwrt-vm] checking connectivity'
 	ping -c 1 -W 3 192.168.1.2 >/dev/null || {
-		echo "cannot reach QEMU user-network gateway 192.168.1.2" >&2
+		echo 'cannot reach QEMU user-network gateway 192.168.1.2' >&2
 		ip addr >&2
 		ip route >&2
 		exit 1
@@ -32,6 +38,12 @@ echo "[openwrt-vm] provisioning base packages"
 
 	opkg update
 	opkg install tc-full kmod-sched kmod-sched-core kmod-ifb kmod-veth ip-full
-'
+
+	# Optional but useful for performance tests. Do not fail provisioning if unavailable
+	# on a given target/release.
+	opkg install iperf3 || true
+
+	touch '${OPENWRT_PROVISION_MARKER}'
+"
 
 echo "[openwrt-vm] provision complete"

--- a/tests/integration/openwrt_vm/scripts/reset-disk
+++ b/tests/integration/openwrt_vm/scripts/reset-disk
@@ -9,7 +9,7 @@ VM_DIR="$(dirname "$SCRIPT_DIR")"
 
 "$SCRIPT_DIR/fetch-image"
 
-mkdir -p "${OPENWRT_DIR}/work"
+mkdir -p "${OPENWRT_WORK_DIR}"
 rm -f "${OPENWRT_WORK_DISK}"
 
 qemu-img create \

--- a/tests/integration/openwrt_vm/scripts/reset-disk
+++ b/tests/integration/openwrt_vm/scripts/reset-disk
@@ -1,0 +1,21 @@
+#!/usr/bin/env sh
+set -eu
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+VM_DIR="$(dirname "$SCRIPT_DIR")"
+
+# shellcheck disable=SC1091
+. "$VM_DIR/env.sh"
+
+"$SCRIPT_DIR/fetch-image"
+
+mkdir -p "${OPENWRT_DIR}/work"
+rm -f "${OPENWRT_WORK_DISK}"
+
+qemu-img create \
+	-f qcow2 \
+	-F raw \
+	-b "${OPENWRT_IMAGE_RAW}" \
+	"${OPENWRT_WORK_DISK}"
+
+echo "[openwrt-vm] reset disk: ${OPENWRT_WORK_DISK}"

--- a/tests/integration/openwrt_vm/scripts/run-vm
+++ b/tests/integration/openwrt_vm/scripts/run-vm
@@ -1,0 +1,69 @@
+#!/usr/bin/env sh
+set -eu
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+VM_DIR="$(dirname "$SCRIPT_DIR")"
+
+# shellcheck disable=SC1091
+. "$VM_DIR/env.sh"
+
+if [ -f "${OPENWRT_PID}" ] && kill -0 "$(cat "${OPENWRT_PID}")" 2>/dev/null; then
+	echo "[openwrt-vm] already running with pid $(cat "${OPENWRT_PID}")"
+	exit 0
+fi
+
+if [ ! -f "${OPENWRT_WORK_DISK}" ]; then
+	tests/integration/openwrt_vm/scripts/reset-disk
+fi
+
+mkdir -p "${OPENWRT_DIR}/work"
+rm -f "${OPENWRT_LOG}" "${OPENWRT_PID}"
+
+NETDEV="user,id=net0,net=192.168.1.0/24,hostfwd=tcp::${OPENWRT_SSH_PORT}-192.168.1.1:22"
+
+if [ "${OPENWRT_ARCH}" = "x86_64" ]; then
+	exec "${OPENWRT_QEMU}" \
+		-m "${OPENWRT_VM_MEM}" \
+		-smp "${OPENWRT_VM_CPUS}" \
+		-drive "file=${OPENWRT_WORK_DISK},format=qcow2,if=virtio" \
+		-netdev "${NETDEV}" \
+		-device virtio-net-pci,netdev=net0 \
+		-display none \
+		-monitor none \
+		-daemonize \
+		-pidfile "${OPENWRT_PID}" \
+		-serial "file:${OPENWRT_LOG}"
+fi
+
+# aarch64 / arm64
+AAVMF_CODE=""
+for p in \
+	/usr/share/AAVMF/AAVMF_CODE.fd \
+	/usr/share/qemu-efi-aarch64/QEMU_EFI.fd \
+	/usr/share/edk2/aarch64/QEMU_EFI.fd
+do
+	if [ -f "$p" ]; then
+		AAVMF_CODE="$p"
+		break
+	fi
+done
+
+if [ -z "${AAVMF_CODE}" ]; then
+	echo "could not find AArch64 EFI firmware" >&2
+	exit 1
+fi
+
+exec "${OPENWRT_QEMU}" \
+	-machine virt \
+	-cpu cortex-a72 \
+	-m "${OPENWRT_VM_MEM}" \
+	-smp "${OPENWRT_VM_CPUS}" \
+	-bios "${AAVMF_CODE}" \
+	-drive "file=${OPENWRT_WORK_DISK},format=qcow2,if=virtio" \
+	-netdev "${NETDEV}" \
+	-device virtio-net-pci,netdev=net0 \
+	-display none \
+	-monitor none \
+	-daemonize \
+	-pidfile "${OPENWRT_PID}" \
+	-serial "file:${OPENWRT_LOG}"

--- a/tests/integration/openwrt_vm/scripts/run-vm
+++ b/tests/integration/openwrt_vm/scripts/run-vm
@@ -13,29 +13,56 @@ if [ -f "${OPENWRT_PID}" ] && kill -0 "$(cat "${OPENWRT_PID}")" 2>/dev/null; the
 fi
 
 if [ ! -f "${OPENWRT_WORK_DISK}" ]; then
-	tests/integration/openwrt_vm/scripts/reset-disk
+	"$SCRIPT_DIR/reset-disk"
 fi
 
-mkdir -p "${OPENWRT_DIR}/work"
+mkdir -p "${OPENWRT_WORK_DIR}"
 rm -f "${OPENWRT_LOG}" "${OPENWRT_PID}"
 
-NETDEV="user,id=net0,net=192.168.1.0/24,hostfwd=tcp::${OPENWRT_SSH_PORT}-192.168.1.1:22"
+NETDEV="user,id=mgmt0,net=192.168.1.0/24,hostfwd=tcp::${OPENWRT_SSH_PORT}-192.168.1.1:22"
 
-if [ "${OPENWRT_ARCH}" = "x86_64" ]; then
-	exec "${OPENWRT_QEMU}" \
+add_common_args() {
+	set -- \
 		-m "${OPENWRT_VM_MEM}" \
 		-smp "${OPENWRT_VM_CPUS}" \
 		-drive "file=${OPENWRT_WORK_DISK},format=qcow2,if=virtio" \
 		-netdev "${NETDEV}" \
-		-device virtio-net-pci,netdev=net0 \
+		-device virtio-net-pci,netdev=mgmt0 \
 		-display none \
 		-monitor none \
 		-daemonize \
 		-pidfile "${OPENWRT_PID}" \
 		-serial "file:${OPENWRT_LOG}"
+
+	idx=0
+	for tap in ${OPENWRT_TAP_IFACES:-}; do
+		idx=$((idx + 1))
+		mac="$(printf '02:dc:bb:00:00:%02x' "$idx")"
+		set -- "$@" \
+			-netdev "tap,id=data${idx},ifname=${tap},script=no,downscript=no" \
+			-device "virtio-net-pci,netdev=data${idx},mac=${mac}"
+	done
+
+	if [ "$OPENWRT_ARCH" = "x86_64" ]; then
+		case "$OPENWRT_KVM" in
+			1)
+				set -- -enable-kvm "$@"
+				;;
+			auto)
+				if [ -r /dev/kvm ] && [ -w /dev/kvm ]; then
+					set -- -enable-kvm "$@"
+				fi
+				;;
+		esac
+	fi
+
+	exec "$OPENWRT_QEMU" "$@"
+}
+
+if [ "${OPENWRT_ARCH}" = "x86_64" ]; then
+	add_common_args
 fi
 
-# aarch64 / arm64
 AAVMF_CODE=""
 for p in \
 	/usr/share/AAVMF/AAVMF_CODE.fd \
@@ -53,17 +80,31 @@ if [ -z "${AAVMF_CODE}" ]; then
 	exit 1
 fi
 
-exec "${OPENWRT_QEMU}" \
+set -- \
 	-machine virt \
 	-cpu cortex-a72 \
+	-bios "${AAVMF_CODE}"
+
+# Rebuild the common tail after the AArch64 machine-specific prefix.
+set -- "$@" \
 	-m "${OPENWRT_VM_MEM}" \
 	-smp "${OPENWRT_VM_CPUS}" \
-	-bios "${AAVMF_CODE}" \
 	-drive "file=${OPENWRT_WORK_DISK},format=qcow2,if=virtio" \
 	-netdev "${NETDEV}" \
-	-device virtio-net-pci,netdev=net0 \
+	-device virtio-net-pci,netdev=mgmt0 \
 	-display none \
 	-monitor none \
 	-daemonize \
 	-pidfile "${OPENWRT_PID}" \
 	-serial "file:${OPENWRT_LOG}"
+
+idx=0
+for tap in ${OPENWRT_TAP_IFACES:-}; do
+	idx=$((idx + 1))
+	mac="$(printf '02:dc:bb:00:00:%02x' "$idx")"
+	set -- "$@" \
+		-netdev "tap,id=data${idx},ifname=${tap},script=no,downscript=no" \
+		-device "virtio-net-pci,netdev=data${idx},mac=${mac}"
+done
+
+exec "${OPENWRT_QEMU}" "$@"

--- a/tests/integration/openwrt_vm/scripts/scp-from
+++ b/tests/integration/openwrt_vm/scripts/scp-from
@@ -1,0 +1,22 @@
+#!/usr/bin/env sh
+set -eu
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+VM_DIR="$(dirname "$SCRIPT_DIR")"
+
+# shellcheck disable=SC1091
+. "$VM_DIR/env.sh"
+
+if [ "$#" -ne 2 ]; then
+	echo "usage: $0 REMOTE_PATH LOCAL_PATH" >&2
+	exit 2
+fi
+
+exec scp \
+	-O \
+	-o StrictHostKeyChecking=no \
+	-o UserKnownHostsFile=/dev/null \
+	-o LogLevel=ERROR \
+	-P "${OPENWRT_SSH_PORT}" \
+	-r \
+	"root@127.0.0.1:$1" "$2"

--- a/tests/integration/openwrt_vm/scripts/scp-to
+++ b/tests/integration/openwrt_vm/scripts/scp-to
@@ -1,0 +1,22 @@
+#!/usr/bin/env sh
+set -eu
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+VM_DIR="$(dirname "$SCRIPT_DIR")"
+
+# shellcheck disable=SC1091
+. "$VM_DIR/env.sh"
+
+if [ "$#" -ne 2 ]; then
+	echo "usage: $0 LOCAL_PATH REMOTE_PATH" >&2
+	exit 2
+fi
+
+exec scp \
+	-O \
+	-o StrictHostKeyChecking=no \
+	-o UserKnownHostsFile=/dev/null \
+	-o LogLevel=ERROR \
+	-P "${OPENWRT_SSH_PORT}" \
+	-r \
+	"$1" "root@127.0.0.1:$2"

--- a/tests/integration/openwrt_vm/scripts/ssh
+++ b/tests/integration/openwrt_vm/scripts/ssh
@@ -1,0 +1,18 @@
+#!/usr/bin/env sh
+set -eu
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+VM_DIR="$(dirname "$SCRIPT_DIR")"
+
+# shellcheck disable=SC1091
+. "$VM_DIR/env.sh"
+
+exec ssh \
+	-o StrictHostKeyChecking=no \
+	-o UserKnownHostsFile=/dev/null \
+	-o LogLevel=ERROR \
+	-o ConnectTimeout=3 \
+	-o ConnectionAttempts=1 \
+	-p "${OPENWRT_SSH_PORT}" \
+	root@127.0.0.1 \
+	"$@"

--- a/tests/integration/openwrt_vm/scripts/stop-vm
+++ b/tests/integration/openwrt_vm/scripts/stop-vm
@@ -1,0 +1,21 @@
+#!/usr/bin/env sh
+set -eu
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+VM_DIR="$(dirname "$SCRIPT_DIR")"
+
+# shellcheck disable=SC1091
+. "$VM_DIR/env.sh"
+
+if [ -f "${OPENWRT_PID}" ]; then
+	pid="$(cat "${OPENWRT_PID}")"
+	if kill -0 "$pid" 2>/dev/null; then
+		echo "[openwrt-vm] stopping pid ${pid}"
+		kill "$pid" || true
+		sleep 1
+		if kill -0 "$pid" 2>/dev/null; then
+			kill -9 "$pid" || true
+		fi
+	fi
+	rm -f "${OPENWRT_PID}"
+fi

--- a/tests/integration/openwrt_vm/scripts/verify-image
+++ b/tests/integration/openwrt_vm/scripts/verify-image
@@ -1,0 +1,49 @@
+#!/usr/bin/env sh
+set -eu
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+VM_DIR="$(dirname "$SCRIPT_DIR")"
+
+# shellcheck disable=SC1091
+. "$VM_DIR/env.sh"
+
+mkdir -p "${OPENWRT_IMAGE_DIR}"
+
+if [ ! -f "${OPENWRT_SHA256SUMS}" ]; then
+	echo "[openwrt-vm] fetching ${OPENWRT_SHA256SUMS_NAME}"
+	curl -fL "${OPENWRT_BASE_URL}/${OPENWRT_SHA256SUMS_NAME}" -o "${OPENWRT_SHA256SUMS}"
+fi
+
+if [ ! -f "${OPENWRT_IMAGE_GZ}" ]; then
+	echo "[openwrt-vm] image is missing: ${OPENWRT_IMAGE_GZ}" >&2
+	exit 1
+fi
+
+expected="$(awk -v name="${OPENWRT_IMAGE_NAME}" '
+	{
+		file=$2
+		sub(/^\*/, "", file)
+		if (file == name) { print $1; found=1; exit }
+	}
+	END { if (!found) exit 1 }
+' "${OPENWRT_SHA256SUMS}" 2>/dev/null || true)"
+
+if [ -z "$expected" ]; then
+	echo "[openwrt-vm] ${OPENWRT_IMAGE_NAME} not found in ${OPENWRT_SHA256SUMS}" >&2
+	exit 1
+fi
+
+if command -v sha256sum >/dev/null 2>&1; then
+	actual="$(sha256sum "${OPENWRT_IMAGE_GZ}" | awk '{ print $1 }')"
+else
+	actual="$(shasum -a 256 "${OPENWRT_IMAGE_GZ}" | awk '{ print $1 }')"
+fi
+
+if [ "$actual" != "$expected" ]; then
+	echo "[openwrt-vm] checksum mismatch for ${OPENWRT_IMAGE_NAME}" >&2
+	echo "[openwrt-vm] expected: $expected" >&2
+	echo "[openwrt-vm] actual:   $actual" >&2
+	exit 1
+fi
+
+echo "[openwrt-vm] checksum ok: ${OPENWRT_IMAGE_NAME}"

--- a/tests/integration/openwrt_vm/scripts/wait-ssh
+++ b/tests/integration/openwrt_vm/scripts/wait-ssh
@@ -1,0 +1,30 @@
+#!/usr/bin/env sh
+set -eu
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+VM_DIR="$(dirname "$SCRIPT_DIR")"
+
+# shellcheck disable=SC1091
+. "$VM_DIR/env.sh"
+
+deadline="${OPENWRT_SSH_WAIT_S:-90}"
+start="$(date +%s)"
+
+echo "[openwrt-vm] waiting for SSH on 127.0.0.1:${OPENWRT_SSH_PORT}"
+
+while true; do
+	if "$SCRIPT_DIR/ssh" 'true' >/dev/null 2>&1; then
+		echo "[openwrt-vm] SSH ready"
+		exit 0
+	fi
+
+	now="$(date +%s)"
+	if [ $((now - start)) -ge "$deadline" ]; then
+		echo "[openwrt-vm] SSH did not become ready within ${deadline}s" >&2
+		echo "[openwrt-vm] last serial log lines:" >&2
+		tail -n 80 "${OPENWRT_LOG}" >&2 || true
+		exit 1
+	fi
+
+	sleep 2
+done

--- a/tests/integration/openwrt_vm/scripts/wait-ssh
+++ b/tests/integration/openwrt_vm/scripts/wait-ssh
@@ -7,7 +7,7 @@ VM_DIR="$(dirname "$SCRIPT_DIR")"
 # shellcheck disable=SC1091
 . "$VM_DIR/env.sh"
 
-deadline="${OPENWRT_SSH_WAIT_S:-90}"
+deadline="${OPENWRT_SSH_WAIT_S}"
 start="$(date +%s)"
 
 echo "[openwrt-vm] waiting for SSH on 127.0.0.1:${OPENWRT_SSH_PORT}"

--- a/tests/integration/openwrt_vm/tests/test_openwrt_baseline.sh
+++ b/tests/integration/openwrt_vm/tests/test_openwrt_baseline.sh
@@ -15,4 +15,23 @@ SSH="$VM_DIR/scripts/ssh"
 "$SSH" 'tc qdisc show >/dev/null'
 "$SSH" 'nft list ruleset >/dev/null'
 
+"$SSH" '
+	set -eu
+	ip link del dc_base_a 2>/dev/null || true
+	ip link del dc_base_ifb 2>/dev/null || true
+	trap "ip link del dc_base_a 2>/dev/null || true; ip link del dc_base_ifb 2>/dev/null || true" EXIT
+
+	ip link add dc_base_a type veth peer name dc_base_b
+	ip link set dc_base_a up
+	ip link set dc_base_b up
+	ip link add dc_base_ifb type ifb
+	ip link set dc_base_ifb up
+
+	tc qdisc add dev dc_base_a root handle 1: htb default 10
+	tc class add dev dc_base_a parent 1: classid 1:10 htb rate 10mbit ceil 10mbit
+	tc qdisc add dev dc_base_a parent 1:10 fq_codel
+	tc qdisc show dev dc_base_a | grep -q htb
+	tc class show dev dc_base_a | grep -q "1:10"
+'
+
 echo "openwrt baseline: ok"

--- a/tests/integration/openwrt_vm/tests/test_openwrt_baseline.sh
+++ b/tests/integration/openwrt_vm/tests/test_openwrt_baseline.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env sh
+set -eu
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+VM_DIR="$(dirname "$SCRIPT_DIR")"
+SSH="$VM_DIR/scripts/ssh"
+
+"$SSH" 'command -v uci >/dev/null'
+"$SSH" 'command -v ip >/dev/null'
+"$SSH" 'command -v nft >/dev/null'
+"$SSH" 'command -v tc >/dev/null'
+
+"$SSH" 'uci show network >/dev/null'
+"$SSH" 'ip link show br-lan >/dev/null'
+"$SSH" 'tc qdisc show >/dev/null'
+"$SSH" 'nft list ruleset >/dev/null'
+
+echo "openwrt baseline: ok"

--- a/tests/integration/openwrt_vm/tests/test_tc_veth_baseline.sh
+++ b/tests/integration/openwrt_vm/tests/test_tc_veth_baseline.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env sh
+set -eu
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+VM_DIR="$(dirname "$SCRIPT_DIR")"
+SSH="$VM_DIR/scripts/ssh"
+
+run() {
+	"$SSH" "$@"
+}
+
+run '
+	set -eu
+
+	cleanup() {
+		ip link del dc-veth-a 2>/dev/null || true
+		ip link del dc-ifb0 2>/dev/null || true
+	}
+	trap cleanup EXIT
+	cleanup
+
+	echo "[openwrt-vm] checking kernel modules"
+	modprobe veth 2>/dev/null || true
+	modprobe ifb 2>/dev/null || true
+	modprobe sch_htb 2>/dev/null || true
+	modprobe sch_ingress 2>/dev/null || true
+	modprobe sch_fq_codel 2>/dev/null || true
+	modprobe cls_u32 2>/dev/null || true
+	modprobe act_mirred 2>/dev/null || true
+
+	echo "[openwrt-vm] creating veth"
+	ip link add dc-veth-a type veth peer name dc-veth-b
+	ip link set dc-veth-a up
+	ip link set dc-veth-b up
+
+	echo "[openwrt-vm] adding root htb"
+	tc qdisc add dev dc-veth-a root handle 1: htb default 10
+
+	echo "[openwrt-vm] adding htb class"
+	tc class add dev dc-veth-a parent 1: classid 1:10 htb rate 10mbit ceil 10mbit
+
+	echo "[openwrt-vm] adding fq_codel"
+	tc qdisc add dev dc-veth-a parent 1:10 fq_codel
+
+	echo "[openwrt-vm] adding ifb"
+	ip link add dc-ifb0 type ifb
+	ip link set dc-ifb0 up
+
+	echo "[openwrt-vm] adding ingress"
+	tc qdisc add dev dc-veth-b ingress
+
+	echo "[openwrt-vm] tc state"
+	tc qdisc show dev dc-veth-a
+	tc class show dev dc-veth-a
+	tc qdisc show dev dc-veth-b
+
+	echo "openwrt tc/veth baseline: ok"
+'

--- a/tests/integration/openwrt_vm/work/.gitignore
+++ b/tests/integration/openwrt_vm/work/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature
- [x] Documentation Update
- [x] Test

## Description

Adds an opt-in OpenWrt VM integration test lane for HAL and network development.

This provides a QEMU-based OpenWrt environment for testing behaviours that are not well represented in containers, including UCI, nftables, `tc`, IFB and veth-based traffic-control work.

Changes include:

- Adds OpenWrt VM orchestration scripts for image fetch, checksum verification, disk reset, VM start/stop, SSH wait, SSH access and SCP transfer.
- Adds idempotent VM provisioning for required networking tools, including `tc-full`, `ip-full`, veth/IFB support and optional `iperf3`.
- Adds baseline OpenWrt integration tests for UCI, IP, nftables and traffic-control availability.
- Adds a veth/IFB/HTB/fq_codel traffic-control baseline test.
- Adds Makefile targets for preflight, fetch, reset, run, provision, smoke, test and cleanup workflows.
- Adds README documentation for the OpenWrt VM test lane.

## Manual test

- [x] yes

## Manual test description

Manually tested the OpenWrt VM workflow from `tests/integration/openwrt_vm`.

Confirmed that:

- the VM boots and SSH becomes available;
- provisioning installs `tc`;
- `make smoke` reports UCI, IP, nftables and `tc`;
- `make test` passes the OpenWrt baseline test;
- `make test` passes the veth/IFB/HTB/fq_codel traffic-control baseline test;
- SCP copy to and from the VM works.

## Added tests?

- [x] yes

Added:

- `tests/test_openwrt_baseline.sh`
- `tests/test_tc_veth_baseline.sh`
- SCP round-trip coverage through the Makefile test target

## Added to documentation?

- [x] README.md