### PR TITLE
Setup shared path for lua http and .init at root

### DIFF
--- a/src/main.lua
+++ b/src/main.lua
@@ -15,14 +15,13 @@ end
 
 local env = os.getenv('DEVICECODE_ENV') or 'dev'
 add_path('/usr/lib/lua/')
+add_path('./')
 if env == 'prod' then
 	add_path('./lib/')
 else
 	add_path('../vendor/lua-fibers/src/')
 	add_path('../vendor/lua-bus/src/')
 	add_path('../vendor/lua-trie/src/')
-	add_path('./')
-	add_path('/usr/lib/lua/')
 end
 
 local fibers = require 'fibers'


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description
Before we were applying a path for lua-http twice, now only once in a shared spot (any env will apply this path). Also sharing a path to the project root so .init modules will work (fixes radio backend)

## Manual test
<!-- Have you manually tested this code and confirmed it is working? -->
- [x] 👍 yes
- [ ] 🙅 no

## Manual test description
Run the code, radio and band no longer crash and http require works

## Added tests?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?
- [ ] 📜 README.md
- [x] 🙅 no documentation needed
