### PR TITLE
http: propagate bus request cancellation into admitted scoped work

### DIFF
--- a/src/devicecode/support/request_owner.lua
+++ b/src/devicecode/support/request_owner.lua
@@ -95,6 +95,24 @@ function RequestOwner:abandon_unresolved(_reason)
 	return true, nil
 end
 
+
+function RequestOwner:caller_cancel_op()
+	local req = self._request
+	if type(req) ~= 'table' or type(req.done_op) ~= 'function' then
+		return nil, 'request has no done_op'
+	end
+
+	return req:done_op():wrap(function (status, _value, err)
+		if status == 'abandoned' and not self:done() then
+			local reason = err or 'caller_abandoned'
+			self:abandon_unresolved(reason)
+			return reason
+		end
+
+		return false
+	end)
+end
+
 M.RequestOwner = RequestOwner
 
 return M

--- a/src/devicecode/support/scoped_work.lua
+++ b/src/devicecode/support/scoped_work.lua
@@ -115,6 +115,9 @@ end
 ---                         setup-owned resources such as request owners
 ---   report(ev)          : immediate reporter callback; should not yield
 ---   copy_result(result) : optional body-end snapshot hook for successful result
+---   cancel_op           : optional Op, or function(child, setup_result) -> Op;
+---                         if it wins before body-ended and returns neither nil
+---                         nor false, child scope is cancelled with that reason
 ---
 ---@param spec table
 ---@return table|nil handle
@@ -172,6 +175,10 @@ local function start_impl(spec, opts)
 		return nil, 'copy_result must be a function when provided'
 	end
 
+	if spec.cancel_op ~= nil and type(spec.cancel_op) ~= 'table' and type(spec.cancel_op) ~= 'function' then
+		return nil, 'cancel_op must be an Op or function when provided'
+	end
+
 	local identity = copy_table(spec.identity)
 	local copy_result = spec.copy_result or copy_value
 
@@ -203,6 +210,20 @@ local function start_impl(spec, opts)
 
 	local function outcome_snapshot()
 		return copy_completion(outcome)
+	end
+
+	local function cancel_child_now(reason)
+		reason = reason or 'cancelled'
+
+		if setup_result and type(setup_result.cancel_owned_now) == 'function' then
+			local ok, err = setup_result.cancel_owned_now(reason)
+			if ok == false or ok == nil then
+				return nil, err or 'scoped_work_cancel_owned_failed'
+			end
+		end
+
+		child:cancel(reason)
+		return true, nil
 	end
 
 	local function outcome_op()
@@ -283,6 +304,39 @@ local function start_impl(spec, opts)
 		return nil, reaper_spawn_err or 'reaper_spawn_failed'
 	end
 
+	if spec.cancel_op ~= nil then
+		local cancel_op = spec.cancel_op
+		if type(cancel_op) == 'function' then
+			local ok_cancel_op, cop_or_err = safe.pcall(function ()
+				return cancel_op(child, setup_result)
+			end)
+			if not ok_cancel_op then
+				cancel_start_failure(cop_or_err or 'cancel_op_setup_failed')
+				return nil, tostring(cop_or_err or 'cancel_op_setup_failed')
+			end
+			cancel_op = cop_or_err
+		end
+
+		if cancel_op ~= nil then
+			local ok_cancel, cancel_spawn_err = reaper_scope:spawn(function ()
+				local which, reason = fibers.perform(op.named_choice({
+					cancel = cancel_op,
+					body_done = body_done:wait_op(),
+				}))
+
+				if which == 'cancel' and reason ~= nil and reason ~= false then
+					local ok, cerr = cancel_child_now(reason)
+					if ok ~= true then error(cerr or 'scoped_work_cancel_failed', 0) end
+				end
+			end)
+
+			if ok_cancel ~= true then
+				cancel_start_failure(cancel_spawn_err or 'cancel_watcher_spawn_failed')
+				return nil, cancel_spawn_err or 'cancel_watcher_spawn_failed'
+			end
+		end
+	end
+
 	if spec.report then
 		local ok_reporter, reporter_spawn_err = report_scope:spawn(function ()
 			-- Reporter is ordinary observing-scope code. If its scope is
@@ -341,21 +395,7 @@ local function start_impl(spec, opts)
 	}
 
 	function handle:cancel(reason)
-		reason = reason or 'cancelled'
-
-		-- Setup may have transferred ownership of immediate, caller-visible
-		-- resources into this scoped work before the worker body has started.
-		-- Give those resources a non-yielding cancellation path now; finalisers
-		-- remain the structural fallback and must be idempotent.
-		if setup_result and type(setup_result.cancel_owned_now) == 'function' then
-			local ok, err = setup_result.cancel_owned_now(reason)
-			if ok == false or ok == nil then
-				return nil, err or 'scoped_work_cancel_owned_failed'
-			end
-		end
-
-		child:cancel(reason)
-		return true
+		return cancel_child_now(reason or 'cancelled')
 	end
 
 	function handle:outcome_op()

--- a/src/services/http/operation_owner.lua
+++ b/src/services/http/operation_owner.lua
@@ -37,7 +37,9 @@ function M.operation_setup(service, owner)
 			owner = owner,
 			reserved_handles = {},
 			cancel_owned_now = function (reason)
-				owner:finalise_unresolved(reason or 'scoped_work_start_failed')
+				if not owner:done() then
+					owner:finalise_unresolved(reason or 'scoped_work_start_failed')
+				end
 				return true
 			end,
 		}
@@ -79,6 +81,8 @@ function M.start(service, verb, req, request_id, owner, run)
 	local report_event = events_port and service_events.reporter(events_port, 'http_operation_done_report_failed')
 		or function (ev) return service:_submit_event(ev, 'http_operation_done_report_failed', { fatal = true }) end
 
+	local cancel_op = owner.caller_cancel_op and owner:caller_cancel_op() or nil
+
 	local handle, err = scoped_work.start({
 		lifetime_scope = service._scope,
 		reaper_scope = service._scope,
@@ -87,6 +91,7 @@ function M.start(service, verb, req, request_id, owner, run)
 		setup = setup_fn,
 		run = run,
 		report = report_event,
+		cancel_op = cancel_op,
 	})
 	if not handle then
 		local rec = service._state.operations[identity.operation_id]

--- a/src/services/http/sdk.lua
+++ b/src/services/http/sdk.lua
@@ -11,8 +11,17 @@ function M.new_ref(conn, id)
 	return setmetatable({ conn = conn, id = id or 'main' }, Ref)
 end
 
+local function call_opts(opts)
+	local out = {}
+	for k, v in pairs(opts or {}) do out[k] = v end
+	if out.timeout == nil and out.deadline == nil then
+		out.timeout = false
+	end
+	return out
+end
+
 function Ref:call_op(verb, args, opts)
-	return self.conn:call_op(topics.rpc(self.id, verb), args or {}, opts)
+	return self.conn:call_op(topics.rpc(self.id, verb), args or {}, call_opts(opts))
 end
 
 function Ref:status_op(opts) return self:call_op('status', {}, opts) end

--- a/tests/unit/http/test_service.lua
+++ b/tests/unit/http/test_service.lua
@@ -1,5 +1,6 @@
 local fibers = require 'fibers'
 local runtime = require 'fibers.runtime'
+local sleep   = require 'fibers.sleep'
 local mailbox = require 'fibers.mailbox'
 local bus    = require 'bus'
 
@@ -9,6 +10,7 @@ local listener_owner = require 'services.http.listener_owner'
 local lua_http      = require 'services.http.transport.lua_http'
 local public_ws     = require 'services.http.websocket'
 local driver_mod    = require 'services.http.transport.cqueues_driver'
+local operation_owner = require 'services.http.operation_owner'
 
 local M = {}
 
@@ -210,6 +212,77 @@ function M.test_event_queue_overflow_for_completion_fails_observing_service()
 		eq(st, 'failed')
 		ok(tostring(primary):match('http_operation_done_report_failed'))
 	end)
+end
+
+
+function M.test_bus_request_abandonment_cancels_admitted_http_operation()
+	fibers.run(function ()
+		local b = bus.new()
+		local root = b:connect({ origin_base = { kind = 'local' } })
+		local svc = ok(http_service.open_handle(root, { driver = fake_driver(), id = 'main' }))
+		yield_many(4)
+
+		local done_tx, done_rx = mailbox.new(1, { full = 'reject_newest' })
+		local req = {
+			payload = { method = 'GET', url = 'http://example.invalid/' },
+			origin = { kind = 'local' },
+			reply = function () error('abandoned request must not be replied to', 0) end,
+			fail = function () error('abandoned request must not be failed visibly', 0) end,
+			done_op = function ()
+				return done_rx:recv_op():wrap(function (ev)
+					return ev.status, ev.value, ev.err
+				end)
+			end,
+		}
+		local request_id, owner = svc:_next_request_identity('exchange', req)
+		svc._state.requests[request_id] = { request_id = request_id, verb = 'exchange', owner = owner, state = 'received', generation = svc._generation }
+
+		ok(operation_owner.start(svc, 'exchange', req, request_id, owner, function ()
+			fibers.perform(sleep.sleep_op(10.0))
+			return { ok = true }
+		end))
+
+		local operation_id
+		for id, rec in pairs(svc._state.operations) do
+			if rec.request_id == request_id then operation_id = id end
+		end
+		ok(operation_id, 'expected operation identity')
+
+		ok(done_tx:send({ status = 'abandoned', err = 'caller_timeout' }))
+		yield_until(function ()
+			local rec = svc._state.operations[operation_id]
+			return rec and rec.state == 'completed'
+		end, 'operation should complete after caller abandonment')
+
+		local rec = svc._state.operations[operation_id]
+		eq(rec.status, 'cancelled')
+		eq(rec.primary, 'caller_timeout')
+		local reqrec = svc._state.requests[request_id]
+		eq(reqrec.state, 'cancelled')
+		eq(reqrec.reason, 'caller_timeout')
+		eq(svc._owned_requests[request_id], nil)
+		ok(owner:done(), 'owner should be locally abandoned')
+
+		svc:terminate('done')
+	end)
+end
+
+function M.test_http_sdk_uses_compositional_timeout_by_default()
+	local seen_opts
+	local ref = sdk_mod.new_ref({
+		call_op = function (_, _topic, _args, opts)
+			seen_opts = opts
+			return fibers.always('ok')
+		end,
+	}, 'main')
+
+	fibers.run(function ()
+		local v = fibers.perform(ref:exchange_op({ method = 'GET', url = 'http://example.invalid/' }))
+		eq(v, 'ok')
+	end)
+
+	ok(seen_opts, 'expected SDK to pass call opts')
+	eq(seen_opts.timeout, false)
 end
 
 function M.test_service_shutdown_terminates_registry_handles_and_finalises_unresolved_requests()

--- a/tests/unit/support/test_request_owner.lua
+++ b/tests/unit/support/test_request_owner.lua
@@ -1,6 +1,8 @@
 -- tests/unit/support/test_request_owner.lua
 
 local request_owner = require 'devicecode.support.request_owner'
+local fibers = require 'fibers'
+local op = require 'fibers.op'
 
 local tests = {}
 
@@ -93,6 +95,49 @@ function tests.test_abandon_unresolved_resolves_without_reply_or_fail()
 
 	assert_eq(req.fails, nil)
 	assert_eq(req.replies, nil)
+end
+
+
+function tests.test_caller_cancel_op_abandons_on_bus_request_abandoned()
+	fibers.run(function ()
+		local req = new_request()
+		function req:done_op()
+			return op.always('abandoned', nil, 'timeout')
+		end
+
+		local owner = request_owner.new(req)
+		local reason = fibers.perform(owner:caller_cancel_op())
+
+		assert_eq(reason, 'timeout')
+		assert_true(owner:done())
+		assert_false(owner:reply_once('late'))
+		assert_eq(req.replies, nil)
+		assert_eq(req.fails, nil)
+	end)
+end
+
+function tests.test_caller_cancel_op_ignores_non_abandoned_done_status()
+	fibers.run(function ()
+		local req = new_request()
+		function req:done_op()
+			return op.always('replied', 'ok', nil)
+		end
+
+		local owner = request_owner.new(req)
+		local reason = fibers.perform(owner:caller_cancel_op())
+
+		assert_false(reason)
+		assert_false(owner:done())
+		assert_true(owner:reply_once('late'))
+		assert_eq(req.replies, 1)
+	end)
+end
+
+function tests.test_caller_cancel_op_requires_request_done_op()
+	local owner = request_owner.new(new_request())
+	local cancel_op, err = owner:caller_cancel_op()
+	assert_eq(cancel_op, nil)
+	assert_eq(err, 'request has no done_op')
 end
 
 return tests

--- a/tests/unit/support/test_scoped_work.lua
+++ b/tests/unit/support/test_scoped_work.lua
@@ -789,4 +789,97 @@ function tests.test_post_setup_start_failure_runs_cancel_owned_now()
 	end)
 end
 
+
+-------------------------------------------------------------------------------
+-- 16. cancel_op cancels admitted child work and immediate owned resources
+-------------------------------------------------------------------------------
+
+function tests.test_cancel_op_cancels_child_and_setup_owned_resources()
+	fibers.run(function (scope)
+		local cancel_tx, cancel_rx = mailbox.new(1, { full = 'reject_newest' })
+		local cancel_reason
+		local worker_started = false
+
+		local handle = start_required {
+			lifetime_scope = scope,
+
+			identity = {
+				kind = 'cancel_op_test',
+				id = 'work-16',
+			},
+
+			setup = function ()
+				return {
+					cancel_owned_now = function (reason)
+						cancel_reason = reason
+						return true
+					end,
+				}
+			end,
+
+			cancel_op = cancel_rx:recv_op(),
+
+			run = function ()
+				worker_started = true
+				fibers.perform(sleep.sleep_op(10.0))
+				return { ok = true }
+			end,
+		}
+
+		assert_true(cancel_tx:send('caller_aborted'))
+		local ev = fibers.perform(handle:outcome_op())
+
+		-- The cancellation watcher may win before the worker body first runs;
+		-- the important contract is that admitted scoped work is cancelled and
+		-- setup-owned resources receive their immediate cancellation path.
+		assert_eq(cancel_reason, 'caller_aborted')
+		assert_eq(ev.kind, 'cancel_op_test')
+		assert_eq(ev.status, 'cancelled')
+		assert_eq(ev.primary, 'caller_aborted')
+	end)
+end
+
+-------------------------------------------------------------------------------
+-- 17. cancel_op losing to body_done must not rewrite successful completion
+-------------------------------------------------------------------------------
+
+function tests.test_cancel_op_loses_to_body_done()
+	fibers.run(function (scope)
+		local cancel_tx, cancel_rx = mailbox.new(1, { full = 'reject_newest' })
+		local cancel_reason
+
+		local handle = start_required {
+			lifetime_scope = scope,
+
+			identity = {
+				kind = 'cancel_op_loses_test',
+				id = 'work-17',
+			},
+
+			setup = function ()
+				return {
+					cancel_owned_now = function (reason)
+						cancel_reason = reason
+						return true
+					end,
+				}
+			end,
+
+			cancel_op = cancel_rx:recv_op(),
+
+			run = function ()
+				return { ok = true, value = 17 }
+			end,
+		}
+
+		local ev = fibers.perform(handle:outcome_op())
+		assert_eq(ev.status, 'ok')
+		assert_eq(ev.result.value, 17)
+
+		assert_true(cancel_tx:send('late_cancel'))
+		fibers.perform(sleep.sleep_op(0.001))
+		assert_eq(cancel_reason, nil)
+	end)
+end
+
 return tests


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

* [x] 🍕 Feature
* [x] 🐛 Bug Fix
* [x] 🧑‍💻 Code Refactor
* [x] ✅ Test

## Description

Implements compositional cancellation propagation across bus-backed service operations.

Previously, an SDK operation losing a `fibers.choice` could abandon the caller-side bus request, but service-side work already admitted by the receiving service could continue running until it later attempted to reply. This was especially visible for HTTP operations: caller timeouts bounded the caller’s wait, but did not necessarily cancel admitted HTTP transport work promptly.

This change makes bus request abandonment observable by services and wires that lifecycle into `request_owner` and `scoped_work`, so admitted service work can be cancelled when the caller no longer wants the result.

Changes included:

* Adds explicit lifecycle status to `lua-bus` requests: `pending`, `replied`, `failed`, and `abandoned`.
* Adds `Request:status()` and `Request:done_op()` to observe request lifecycle without conflating caller abandonment with service failure.
* Adds `timeout = false` / `deadline = false` support to `bus:call_op`, allowing SDKs to avoid hidden default request deadlines.
* Adds `RequestOwner:caller_cancel_op()` for converting bus request abandonment into a service-side cancellation signal.
* Adds `cancel_op` support to `devicecode.support.scoped_work`, allowing owned child work to be cancelled when an external lifecycle Op fires.
* Wires HTTP admitted operations to pass `owner:caller_cancel_op()` into `scoped_work`.
* Updates the HTTP SDK so calls are compositional by default: callers can use ordinary `fibers.choice`/`named_choice` with `sleep_op(...)` for timeouts.
* Preserves existing request-owner at-most-once reply/fail/abandon semantics.
* Adds tests covering request lifecycle, caller abandonment, scoped-work cancellation and HTTP bus-boundary cancellation.

The intended public usage is now:

```lua
local which, result, err = fibers.perform(fibers.named_choice {
  http = http_ref:exchange_op(args),
  timeout = sleep.sleep_op(5):wrap(function ()
    return nil, "timeout"
  end),
})
```

If `timeout` wins, the HTTP SDK Op loses the choice, the bus request is abandoned, and admitted service-side HTTP work is cancelled through its scoped-work owner.

## Related Issues, Tickets & Documents

N/A

## Screenshots/Recordings

N/A

## Manual test

* [x] 👍 yes

## Manual test description

Ran the relevant Lua test slice locally with `luajit run.lua`.

Results:

```text
37 tests, 0 failed, 0 skipped
```

The passing tests included:

* `unit.support.test_request_owner`
* `unit.http.test_service`

Notable covered cases:

* bus request abandonment is observed by `RequestOwner:caller_cancel_op()`;
* non-abandoned request completion is ignored by `caller_cancel_op`;
* admitted HTTP operations are cancelled when the caller abandons the bus request;
* HTTP SDK calls use compositional timeout behaviour by default;
* service shutdown still finalises unresolved request owners;
* public HTTP handle cancellation remains safe.

## Added tests?

* [x] 👍 yes

## Added to documentation?

* [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?

Audit other bus-backed services that admit scoped work and apply the same pattern where appropriate:

```lua
cancel_op = owner:caller_cancel_op()
```

Likely candidates include device actions, update operations, fabric transfers, long-running HAL capability calls and UI commands.
