### PR TITLE
config: adds tests, docs

### DIFF
--- a/docs/service-architecture.md
+++ b/docs/service-architecture.md
@@ -541,6 +541,28 @@ The shared support modules encode service discipline. Prefer them over service-l
 
 Use the shared helper unless the service has a clear reason not to.
 
+### Retained service configuration
+
+Modern service shells consume intended configuration through
+`devicecode.support.config_watch`.
+
+The helper opens a normal `lua-bus` subscription to `cfg/<service>`.  In
+`lua-bus`, subscription creation replays matching retained messages before
+subsequent live publications.  That retained replay is the bootstrap mechanism:
+a service which starts after its configuration has already been retained must
+observe that configuration as a normal `config_changed` event.
+
+Do not build service-specific retained configuration paths using an independent
+retained view plus a live subscription.  That split can reintroduce the timing
+race retained configuration was introduced to remove.  Service code should own
+validation and generation policy, but the subscription/replay mechanics belong
+in the shared helper.
+
+Direct `cfg/<service>` subscriptions in modern services are architecture debt.
+Bridge code may still subscribe to arbitrary bus topics supplied by Fabric
+routing rules, but service shell configuration should go through
+`config_watch.open`.
+
 ## Request ownership
 
 Every request-like object needs one owner.

--- a/src/devicecode/support/config_watch.lua
+++ b/src/devicecode/support/config_watch.lua
@@ -5,6 +5,12 @@
 -- The helper owns only the local retained subscription and event-shaping
 -- mechanics.  Service modules still own validation, normalisation, generation
 -- policy and effects.
+--
+-- lua-bus Subscription creation replays matching retained messages before live
+-- publications.  That replay is the service bootstrap mechanism: a service that
+-- starts after cfg/<service> was retained must still see the current config as
+-- its first config_changed event.  Do not replace this in service shells with a
+-- retained-view plus subscription pair; that would reintroduce ordering races.
 
 local bus_cleanup = require 'devicecode.support.bus_cleanup'
 
@@ -64,6 +70,8 @@ function M.open(conn, service, opts)
 	end
 
 	local topic = opts.topic or cfg_topic(service)
+	-- conn:subscribe() replays retained cfg messages.  Keep this as the single
+	-- bootstrap path used by modern service shells.
 	local sub, err = bus_cleanup.subscribe(conn, topic, {
 		queue_len = opts.queue_len or opts.config_queue_len or 4,
 		full = opts.full or 'reject_newest',

--- a/tests/run.lua
+++ b/tests/run.lua
@@ -102,6 +102,7 @@ local files = {
 	'unit.support.test_resource',
 	'unit.support.test_bus_cleanup',
 	'unit.support.test_config_watch',
+	'unit.support.test_config_watch_architecture',
 	'unit.support.test_service_events',
 	'unit.http.transport.test_cqueues_driver',
 	'unit.http.transport.test_lua_http',

--- a/tests/unit/support/test_config_watch.lua
+++ b/tests/unit/support/test_config_watch.lua
@@ -1,9 +1,17 @@
+local fibers = require 'fibers'
+local bus = require 'bus'
+
 local config_watch = require 'devicecode.support.config_watch'
 
 local M = {}
 
 local function eq(a, b, msg)
 	if a ~= b then error((msg or 'assertion failed') .. ': expected ' .. tostring(b) .. ', got ' .. tostring(a), 2) end
+end
+
+local function ok(v, msg)
+	if not v then error(msg or 'assertion failed', 2) end
+	return v
 end
 
 function M.test_extracts_data_from_retained_config_record()
@@ -22,6 +30,82 @@ function M.test_standard_cfg_topic_shape()
 	local topic = config_watch.topic('ui')
 	eq(topic[1], 'cfg')
 	eq(topic[2], 'ui')
+end
+
+function M.test_open_replays_retained_cfg_record_published_before_watch_creation()
+	fibers.run(function ()
+		local b = bus.new()
+		local conn = b:connect({ origin_base = { kind = 'test' } })
+		ok(conn:retain({ 'cfg', 'update' }, {
+			rev = 42,
+			data = { schema = 'devicecode.config/update/1', enabled = true },
+		}))
+
+		local watch, err = config_watch.open(conn, 'update', { queue_len = 2 })
+		ok(watch, err)
+
+		local ev, recv_err = fibers.perform(watch:recv_op())
+		ok(ev, recv_err)
+		eq(ev.kind, 'config_changed')
+		eq(ev.service, 'update')
+		eq(ev.generation, 42)
+		eq(ev.rev, 42)
+		eq(ev.raw.enabled, true)
+		eq(ev.record.rev, 42)
+		eq(ev.msg.topic[1], 'cfg')
+		eq(ev.msg.topic[2], 'update')
+
+		ok(watch:close())
+	end)
+end
+
+function M.test_try_recv_now_can_consume_bootstrap_replay_without_waiting()
+	fibers.run(function ()
+		local b = bus.new()
+		local conn = b:connect({ origin_base = { kind = 'test' } })
+		ok(conn:retain({ 'cfg', 'net' }, {
+			rev = 3,
+			data = { schema = 'devicecode.config/net/1' },
+		}))
+
+		local watch, err = config_watch.open(conn, 'net', { queue_len = 1 })
+		ok(watch, err)
+
+		local ev = watch:try_recv_now()
+		ok(ev, 'retained cfg/net replay should be immediately ready after open')
+		eq(ev.kind, 'config_changed')
+		eq(ev.service, 'net')
+		eq(ev.generation, 3)
+		eq(ev.raw.schema, 'devicecode.config/net/1')
+
+		local none, why = watch:try_recv_now()
+		eq(none, nil)
+		eq(why, nil)
+
+		ok(watch:close())
+	end)
+end
+
+function M.test_watch_receives_live_cfg_after_retained_bootstrap()
+	fibers.run(function ()
+		local b = bus.new()
+		local conn = b:connect({ origin_base = { kind = 'test' } })
+		ok(conn:retain({ 'cfg', 'ui' }, { rev = 1, data = { enabled = false } }))
+
+		local watch, err = config_watch.open(conn, 'ui', { queue_len = 3 })
+		ok(watch, err)
+		local boot = ok(fibers.perform(watch:recv_op()))
+		eq(boot.generation, 1)
+		eq(boot.raw.enabled, false)
+
+		ok(conn:retain({ 'cfg', 'ui' }, { rev = 2, data = { enabled = true } }))
+		local live = ok(fibers.perform(watch:recv_op()))
+		eq(live.kind, 'config_changed')
+		eq(live.generation, 2)
+		eq(live.raw.enabled, true)
+
+		ok(watch:close())
+	end)
 end
 
 return M

--- a/tests/unit/support/test_config_watch_architecture.lua
+++ b/tests/unit/support/test_config_watch_architecture.lua
@@ -1,0 +1,127 @@
+-- tests/unit/support/test_config_watch_architecture.lua
+--
+-- Guardrails for the retained cfg/<service> bootstrap path used by modern
+-- Devicecode services.  Service code should consume configuration through
+-- devicecode.support.config_watch, which relies on lua-bus subscription replay
+-- for retained cfg bootstrap.
+
+local tests = {}
+
+local modern_services = {
+	fabric = '../src/services/fabric/service.lua',
+	device = '../src/services/device/service.lua',
+	update = '../src/services/update/service.lua',
+	http   = '../src/services/http/service.lua',
+	ui     = '../src/services/ui/service.lua',
+	net    = '../src/services/net/service.lua',
+	wired  = '../src/services/wired/service.lua',
+}
+
+local modern_roots = {
+	'../src/services/fabric',
+	'../src/services/device',
+	'../src/services/update',
+	'../src/services/http',
+	'../src/services/ui',
+	'../src/services/net',
+	'../src/services/wired',
+}
+
+local function fail(msg) error(msg or 'assertion failed', 2) end
+
+local function read_file(path)
+	local f = assert(io.open(path, 'r'))
+	local s = f:read('*a')
+	f:close()
+	return s
+end
+
+local function scan_files(root)
+	local p = assert(io.popen(('find %s -type f -name "*.lua" | sort'):format(root)))
+	local out = {}
+	for line in p:lines() do out[#out + 1] = line end
+	p:close()
+	return out
+end
+
+local function split_lines(s)
+	local lines = {}
+	for line in (s .. '\n'):gmatch('([^\n]*)\n') do
+		lines[#lines + 1] = line
+	end
+	return lines
+end
+
+local function line_window(lines, i, before, after)
+	local out = {}
+	local first = math.max(1, i - before)
+	local last = math.min(#lines, i + after)
+	for n = first, last do out[#out + 1] = lines[n] end
+	return table.concat(out, '\n')
+end
+
+local function looks_like_service_cfg_reference(window)
+	local needles = {
+		"{ 'cfg'",
+		'{ "cfg"',
+		"'cfg'",
+		'"cfg"',
+		'topics.config()',
+		'topics.cfg()',
+		"config_topic",
+		"cfg_topic",
+	}
+	for _, needle in ipairs(needles) do
+		if window:find(needle, 1, true) then return true end
+	end
+	return false
+end
+
+function tests.test_modern_service_shells_use_shared_config_watch_helper()
+	for service, path in pairs(modern_services) do
+		local s = read_file(path)
+		if not s:find("devicecode.support.config_watch", 1, true) then
+			fail(service .. ' service shell does not require devicecode.support.config_watch')
+		end
+		if not s:find('config_watch.open', 1, true) then
+			fail(service .. ' service shell does not open configuration through config_watch.open')
+		end
+	end
+end
+
+function tests.test_modern_service_shells_do_not_subscribe_to_cfg_directly()
+	for service, path in pairs(modern_services) do
+		local s = read_file(path)
+		if s:find('conn:subscribe', 1, true) or s:find('bus_cleanup.subscribe', 1, true) then
+			fail(service .. ' service shell subscribes directly instead of using config_watch')
+		end
+	end
+end
+
+function tests.test_modern_services_do_not_add_direct_cfg_subscription_regressions()
+	for _, root in ipairs(modern_roots) do
+		for _, path in ipairs(scan_files(root)) do
+			local lines = split_lines(read_file(path))
+			for i, line in ipairs(lines) do
+				if line:find(':subscribe%s*%(') or line:find('bus_cleanup%.subscribe%s*%(') then
+					local window = line_window(lines, i, 4, 6)
+					if looks_like_service_cfg_reference(window) then
+						fail(path .. ':' .. tostring(i) .. ' appears to subscribe to cfg directly; use config_watch.open')
+					end
+				end
+			end
+		end
+	end
+end
+
+function tests.test_config_watch_helper_is_the_only_shared_helper_that_subscribes_to_cfg_service_directly()
+	local helper = read_file('../src/devicecode/support/config_watch.lua')
+	if not helper:find('bus_cleanup.subscribe', 1, true) then
+		fail('config_watch helper should own the local bus subscription')
+	end
+	if not helper:find("{ 'cfg', service }", 1, true) then
+		fail('config_watch helper should own cfg/<service> topic construction')
+	end
+end
+
+return tests


### PR DESCRIPTION
## What type of PR is this?

* [x] 📝 Documentation Update
* [x] ✅ Test

## Description

Documents and tests retained config bootstrap behaviour for modern services.

* Clarifies that `conn:subscribe()` retained replay is the bootstrap mechanism used by `config_watch`.
* Adds tests proving retained config published before watch creation is delivered.
* Adds guardrail tests so modern service shells keep using `config_watch` and do not regress to ad hoc config subscription patterns.
* Updates service architecture docs.

## Added tests?

* [x] 👍 yes

## Added to documentation?

* [x] 📜 service architecture docs
