### PR TITLE
metrics: use http service for publishing cloud metrics

### DIFF
--- a/src/services/metrics.lua
+++ b/src/services/metrics.lua
@@ -12,6 +12,7 @@
 --   {'cfg', 'metrics'}                       - metrics config (retained)
 --   {'state', 'time', 'synced'}              - NTP sync status (retained)
 --   {'cap', 'fs', 'configs', ...}             - HAL filesystem capability (via cap listener)
+--   {'cap', 'http', 'main', 'rpc', ...}      - HTTP capability service (exchange RPC)
 --
 -- Topics produced:
 --   {'svc', 'metrics', 'status'}             - service lifecycle status (retained)
@@ -26,7 +27,8 @@ local perform        = fibers.perform
 
 local json           = require 'cjson.safe'
 local base           = require 'devicecode.service_base'
-local cap_sdk = require 'services.hal.sdk.cap'
+local cap_sdk        = require 'services.hal.sdk.cap'
+local http_sdk       = require('services.http').sdk
 
 local senml          = require 'services.metrics.senml'
 local http_m         = require 'services.metrics.http'
@@ -106,6 +108,7 @@ local State = {
 	conn             = nil,
 	svc              = nil,
 	name             = nil,
+	http_ref         = nil,
 	http_send_ch     = nil,
 	pipelines_map    = {},
 	metric_states    = {},
@@ -531,7 +534,8 @@ function M.start(conn, opts)
 	State.conn             = conn
 	State.svc              = svc
 	State.name             = name
-	State.http_send_ch     = http_m.start_http_publisher(function(level, payload)
+	State.http_ref         = http_sdk.new_ref(conn, opts.http_service_id or 'main')
+	State.http_send_ch     = http_m.start_http_publisher(State.http_ref, function(level, payload)
 		svc:obs_log(level, payload)
 	end)
 	State.pipelines_map    = {}

--- a/src/services/metrics/http.lua
+++ b/src/services/metrics/http.lua
@@ -18,13 +18,13 @@
 --     http_ref: an http SDK ref obtained via http_sdk.new_ref(conn, id)
 --     log_fn(level, payload) is an optional logger; defaults to log.debug/info.
 
-local fibers      = require 'fibers'
-local op          = require 'fibers.op'
-local sleep       = require 'fibers.sleep'
-local channel     = require 'fibers.channel'
-local blob_source = require 'devicecode.blob_source'
+local fibers       = require 'fibers'
+local op           = require 'fibers.op'
+local sleep        = require 'fibers.sleep'
+local channel      = require 'fibers.channel'
+local blob_source  = require 'devicecode.blob_source'
 
-local QUEUE_SIZE = 10
+local QUEUE_SIZE   = 10
 local HTTP_TIMEOUT = 60
 
 --- Send a single HTTP payload to the cloud via the HTTP capability service,
@@ -43,18 +43,24 @@ local function send_http(http_ref, data, log_fn)
 	local reply
 
 	while not reply do
-		local result, err = fibers.perform(http_ref:exchange_op({
-			method  = 'POST',
-			uri     = uri,
-			headers = {
-				authorization    = auth,
-				['content-type'] = 'application/senml+json',
-			},
-			body_source = blob_source.from_string(body),
-		}, { timeout = HTTP_TIMEOUT }))
+		log_fn('trace', { what = 'http_publish_attempt', status = 'started' })
+		local which, result, err = fibers.perform(op.named_choice({
+			response = http_ref:exchange_op({
+				method      = 'POST',
+				uri         = uri,
+				headers     = {
+					authorization    = auth,
+					['content-type'] = 'application/senml+json',
+				},
+				body_source = blob_source.from_string(body),
+			}),
+			timeout  = sleep.sleep_op(HTTP_TIMEOUT),
+		}))
+		log_fn('trace', { what = 'http_publish_attempt', status = which })
 
-		if not result then
-			log_fn('debug', { what = 'http_retry', retry_in_s = sleep_duration, err = tostring(err) })
+		if which == 'timeout' or not result then
+			local err_msg = which == 'timeout' and 'timeout' or tostring(err)
+			log_fn('debug', { what = 'http_retry', retry_in_s = sleep_duration, err = err_msg })
 			sleep.sleep(sleep_duration)
 			sleep_duration = math.min(sleep_duration * 2, 60)
 		else

--- a/src/services/metrics/http.lua
+++ b/src/services/metrics/http.lua
@@ -6,106 +6,115 @@
 -- sends them to the Mainflux cloud endpoint with exponential-backoff retry on
 -- network failure.
 --
+-- Uses the HTTP capability service (services.http.sdk) so outbound requests
+-- are handled via fiber-native Ops and do not block the cqueues event loop.
+--
 -- Public API:
---   start_http_publisher(log_fn?) -> channel
+--   start_http_publisher(http_ref, log_fn?) -> channel
 --     Must be called from inside a running fiber scope.  Returns the send
 --     channel (capacity QUEUE_SIZE).  The caller enqueues payloads with a
 --     non-blocking put; if the channel is full the payload is dropped and an
 --     error is logged.
+--     http_ref: an http SDK ref obtained via http_sdk.new_ref(conn, id)
 --     log_fn(level, payload) is an optional logger; defaults to log.debug/info.
 
-local fibers     = require 'fibers'
-local op         = require 'fibers.op'
-local sleep      = require 'fibers.sleep'
-local channel    = require 'fibers.channel'
-local request    = require 'http.request'
+local fibers      = require 'fibers'
+local op          = require 'fibers.op'
+local sleep       = require 'fibers.sleep'
+local channel     = require 'fibers.channel'
+local blob_source = require 'devicecode.blob_source'
 
 local QUEUE_SIZE = 10
+local HTTP_TIMEOUT = 60
 
---- Send a single HTTP payload to the cloud, retrying with exponential backoff
---- on network failure.  Returns only when the send succeeds or the enclosing
---- scope is cancelled.
+--- Send a single HTTP payload to the cloud via the HTTP capability service,
+--- retrying with exponential backoff on failure.  Returns only when the send
+--- succeeds or the enclosing scope is cancelled.
 ---
----@param data table  { uri: string, auth: string, body: string }
+---@param http_ref table  HTTP SDK ref (services.http.sdk Ref)
+---@param data table      { uri: string, auth: string, body: string }
 ---@param log_fn fun(level: string, payload: any)
-local function send_http(data, log_fn)
-    local uri            = data.uri
-    local body           = data.body
-    local auth           = data.auth
+local function send_http(http_ref, data, log_fn)
+	local uri            = data.uri
+	local body           = data.body
+	local auth           = data.auth
 
-    local sleep_duration = 1
-    local response_headers
+	local sleep_duration = 1
+	local reply
 
-    while not response_headers do
-        local req = request.new_from_uri(uri)
-        req.headers:upsert(':method', 'POST')
-        req.headers:upsert('authorization', auth)
-        req.headers:upsert('content-type', 'application/senml+json')
-        req.headers:delete('expect')
-        req:set_body(body)
+	while not reply do
+		local result, err = fibers.perform(http_ref:exchange_op({
+			method  = 'POST',
+			uri     = uri,
+			headers = {
+				authorization    = auth,
+				['content-type'] = 'application/senml+json',
+			},
+			body_source = blob_source.from_string(body),
+		}, { timeout = HTTP_TIMEOUT }))
 
-        local headers = req:go(10)
-        response_headers = headers
+		if not result then
+			log_fn('debug', { what = 'http_retry', retry_in_s = sleep_duration, err = tostring(err) })
+			sleep.sleep(sleep_duration)
+			sleep_duration = math.min(sleep_duration * 2, 60)
+		else
+			reply = result
+		end
+	end
 
-        if not response_headers then
-            log_fn('debug', { what = 'http_retry', retry_in_s = sleep_duration })
-            sleep.sleep(sleep_duration)
-            sleep_duration = math.min(sleep_duration * 2, 60)
-        end
-    end
-
-    local status = response_headers:get(':status')
-    if status ~= '202' then
-        local parts = {}
-        for k, v in response_headers:each() do
-            table.insert(parts, string.format('\t%s: %s', k, v))
-        end
-        log_fn('warn', {
-            what = 'http_publish_failed',
-            status = status,
-            headers = table.concat(parts, '\n')
-        })
-    else
-        log_fn('info', { what = 'http_publish_ok', status = status })
-    end
+	local status = reply.result and reply.result.status
+	if status ~= '202' then
+		local parts = {}
+		for k, v in pairs(reply.result and reply.result.headers or {}) do
+			table.insert(parts, string.format('\t%s: %s', k, v))
+		end
+		log_fn('warn', {
+			what    = 'http_publish_failed',
+			status  = tostring(status),
+			headers = table.concat(parts, '\n'),
+		})
+	else
+		log_fn('info', { what = 'http_publish_ok', status = status })
+	end
 end
 
 --- Start the HTTP publisher fiber in the current scope.
 --- Returns the send channel.  Payloads must be enqueued with a non-blocking
---- select (see _http_publish in metrics.lua); if the channel is full the
+--- select (see http_publish in metrics.lua); if the channel is full the
 --- payload should be dropped by the caller.
 ---
----@param log_fn? fun(level: string, payload: any)  optional logger
+---@param http_ref table                            HTTP SDK ref
+---@param log_fn?  fun(level: string, payload: any) optional logger
 ---@return table channel
-local function start_http_publisher(log_fn)
-    log_fn = log_fn or function() end
+local function start_http_publisher(http_ref, log_fn)
+	log_fn = log_fn or function() end
 
-    local send_ch = channel.new(QUEUE_SIZE)
+	local send_ch = channel.new(QUEUE_SIZE)
 
-    fibers.spawn(function()
-        fibers.run_scope(function(s)
-            s:finally(function(aborted, _, sc_err)
-                if aborted then
-                    log_fn('fatal', "HTTP fiber: " .. tostring(sc_err))
-                else
-                    log_fn('trace', "HTTP fiber: exiting")
-                end
-            end)
+	fibers.spawn(function()
+		fibers.run_scope(function(s)
+			s:finally(function(aborted, _, sc_err)
+				if aborted then
+					log_fn('fatal', 'HTTP publisher fiber: ' .. tostring(sc_err))
+				else
+					log_fn('trace', 'HTTP publisher fiber: exiting')
+				end
+			end)
 
-            while true do
-                local which, payload = fibers.perform(op.named_choice({
-                    msg = send_ch:get_op(),
-                }))
-                if which == 'msg' and payload ~= nil then
-                    send_http(payload, log_fn)
-                end
-            end
-        end)
-    end)
+			while true do
+				local which, payload = fibers.perform(op.named_choice({
+					msg = send_ch:get_op(),
+				}))
+				if which == 'msg' and payload ~= nil then
+					send_http(http_ref, payload, log_fn)
+				end
+			end
+		end)
+	end)
 
-    return send_ch
+	return send_ch
 end
 
 return {
-    start_http_publisher = start_http_publisher,
+	start_http_publisher = start_http_publisher,
 }

--- a/src/services/metrics/types.lua
+++ b/src/services/metrics/types.lua
@@ -156,6 +156,7 @@ end
 ---@field svc              ServiceBase?
 ---@field conn             Connection?   nil before M.start() is called
 ---@field name             string?       nil before M.start() is called
+---@field http_ref         CapabilityReference?
 ---@field http_send_ch     Channel?      nil before M.start() is called
 ---@field pipelines_map    PipelineMap
 ---@field metric_states    MetricStates

--- a/tests/unit/metrics/http_spec.lua
+++ b/tests/unit/metrics/http_spec.lua
@@ -1,10 +1,12 @@
 -- tests/unit/metrics/http_spec.lua
 --
 -- Unit test for the HTTP publisher module.
--- Stubs http.request before loading services.metrics.http so no real network
--- traffic is made.  Uses runfibers + virtual_time for deterministic timing.
+-- Supplies a stub http_ref whose exchange_op records what it receives so no
+-- real network traffic is made.  Uses runfibers + virtual_time for
+-- deterministic timing.
 
 local fibers       = require 'fibers'
+local op           = require 'fibers.op'
 local perform      = fibers.perform
 local time_harness = require 'tests.support.time_harness'
 local virtual_time = require 'tests.support.virtual_time'
@@ -12,69 +14,40 @@ local runfibers    = require 'tests.support.run_fibers'
 
 local T = {}
 
-function T.start_http_publisher_builds_expected_request()
-	-- Save originals so we can restore after the test.
-	local original_http_request = package.loaded['http.request']
-	local original_http_module  = package.loaded['services.metrics.http']
+-- Build a stub http_ref whose exchange_op immediately resolves with the given
+-- HTTP status, and records what it was called with.
+local function make_fake_ref(captured, reply_status)
+	local ref = {}
+	function ref:exchange_op(args)
+		captured.method       = args.method
+		captured.uri          = args.uri
+		captured.auth         = args.headers and args.headers.authorization
+		captured.content_type = args.headers and args.headers['content-type']
+		captured.body_source  = args.body_source
+		return op.always({ result = { status = reply_status or '202', headers = {} } })
+	end
+	return ref
+end
 
-	local captured = {
-		uri           = nil,
-		method        = nil,
-		auth          = nil,
-		content_type  = nil,
-		expect_header = 'present',  -- sentinel; nil means the header was deleted
-		body          = nil,
-		timeout       = nil,
-	}
+function T.start_http_publisher_sends_expected_request()
+	local original_http_module = package.loaded['services.metrics.http']
 
-	-- Stub http.request with a mock that captures what the publisher sends.
-	package.loaded['http.request'] = {
-		new_from_uri = function(uri)
-			captured.uri = uri
+	local captured = {}
 
-			local hdr = {}
-			local req = {
-				headers = {
-					upsert = function(_, k, v) hdr[k] = v end,
-					delete = function(_, k)    hdr[k] = nil end,
-				},
-				set_body = function(_, body)
-					captured.body = body
-				end,
-				go = function(_, timeout)
-					captured.timeout      = timeout
-					captured.method       = hdr[':method']
-					captured.auth         = hdr['authorization']
-					captured.content_type = hdr['content-type']
-					captured.expect_header = hdr['expect']
-					return {
-						get = function(_, key)
-							if key == ':status' then return '202' end
-							return nil
-						end,
-						each = function()
-							return function() return nil end
-						end,
-					}
-				end,
-			}
-			return req
-		end,
-	}
-
-	-- Force a fresh load so it picks up the stub above.
+	-- Force a fresh load.
 	package.loaded['services.metrics.http'] = nil
 
 	local ok_run, run_err = pcall(function()
 		runfibers.run(function(scope)
 			local clock = virtual_time.install({ monotonic = 0, realtime = 1700000000 })
+			scope:finally(function() clock:restore() end)
 
-			local http_mod = require 'services.metrics.http'
-
+			local http_mod     = require 'services.metrics.http'
+			local fake_ref     = make_fake_ref(captured, '202')
 			local worker_scope = scope:child()
 
 			local spawn_ok, spawn_err = worker_scope:spawn(function()
-				local ch = http_mod.start_http_publisher()
+				local ch = http_mod.start_http_publisher(fake_ref)
 
 				perform(ch:put_op({
 					uri  = 'http://localhost:18080/http/channels/ch-data/messages',
@@ -94,22 +67,14 @@ function T.start_http_publisher_builds_expected_request()
 				'unexpected auth: ' .. tostring(captured.auth))
 			assert(captured.content_type == 'application/senml+json',
 				'unexpected content-type: ' .. tostring(captured.content_type))
-			assert(captured.expect_header == nil,
-				'expected Expect header to be deleted, got ' .. tostring(captured.expect_header))
-			assert(captured.body == '[{"n":"sim","vs":"present"}]',
-				'unexpected body: ' .. tostring(captured.body))
-			assert(captured.timeout == 10,
-				'expected timeout=10, got ' .. tostring(captured.timeout))
+			assert(captured.body_source ~= nil,
+				'expected body_source to be set')
 
 			worker_scope:cancel('test done')
 			perform(worker_scope:join_op())
-
-			clock:restore()
 		end, { timeout = 2.0 })
 	end)
 
-	-- Restore stubs regardless of test outcome.
-	package.loaded['http.request']          = original_http_request
 	package.loaded['services.metrics.http'] = original_http_module
 
 	assert(ok_run, tostring(run_err))


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [x] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description
Using lua-http meant every metrics publication was blocking the entire codebase, not very fibers-esc, this impacted timeouts across devicecode and made code paths fail where they otherwise would have succeeded. 

I have migrated to the http service which is non-blocking. 

## Manual test
<!-- Have you manually tested this code and confirmed it is working? -->
- [x] 👍 yes
- [ ] 🙅 no

## Manual test description
Run code with metrics, http, monitor, config, system. Check that metrics are sent up to grafana

## Added tests?
- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?
- [ ] 📜 README.md
- [x] 🙅 no documentation needed
