### PR TITLE
ui: prevents spurious lifecycle publishing

### DIFF
--- a/src/services/ui/service.lua
+++ b/src/services/ui/service.lua
@@ -563,11 +563,11 @@ local function reduce_event(state, ev)
 		return { publish = true }
 	elseif ev.kind == 'read_model_changed' then
 		state.model_seen = ev.version or state.model_seen
-		return { publish = true }
+		return {}
 	elseif ev.kind == 'session_changed' then
 		state.sessions_seen = ev.version or state.sessions_seen
 		state.last_session_event = ev.last_event or ev
-		return { publish = true }
+		return {}
 	elseif is_session_event(ev) then
 		state.last_session_event = ev
 		return { publish = true }

--- a/tests/unit/ui/test_service.lua
+++ b/tests/unit/ui/test_service.lua
@@ -147,6 +147,41 @@ function tests.test_stale_http_listener_request_events_are_ignored()
 	assert_eq(state.active_requests, 1)
 end
 
+function tests.test_read_model_changed_updates_seen_without_lifecycle_publish()
+	local state = base_state()
+	state.model_seen = 4
+
+	local decision = service._test.reduce_event(state, {
+		kind = 'read_model_changed',
+		version = 5,
+		snapshot = { services = {} },
+	})
+
+	assert_eq(state.model_seen, 5)
+	assert_eq(next(decision), nil)
+end
+
+function tests.test_session_changed_updates_seen_without_lifecycle_publish()
+	local state = base_state()
+	state.sessions_seen = 2
+	state.last_session_event = nil
+
+	local ev = {
+		kind = 'session_changed',
+		version = 3,
+		last_event = {
+			kind = 'session_count_changed',
+			count = 1,
+		},
+	}
+
+	local decision = service._test.reduce_event(state, ev)
+
+	assert_eq(state.sessions_seen, 3)
+	assert_eq(state.last_session_event, ev.last_event)
+	assert_eq(next(decision), nil)
+end
+
 function tests.test_cleanup_error_recording_is_explicit_and_non_throwing()
 	local state = base_state()
 	local rec = service._test.record_cleanup_error(state, 'ui_cleanup_failed', 'cleanup_failed')


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

* [x] 🐛 Bug Fix
* [x] ✅ Test

## Description

Stops UI read-model and session observer churn from republishing UI lifecycle status.

* Excludes `read_model_changed` from triggering lifecycle/status publication
* Excludes aggregate `session_changed` notifications from triggering lifecycle/status publication
* Keeps coordinator bookkeeping for read-model and session versions
* Preserves publication for first-class session events
* Adds regression coverage for both no-publish paths

## Manual test

* [x] 👍 yes

## Manual test description

Ran the firmware on target after excluding UI-owned retained lifecycle topics. Confirmed the previous tight loop of repeated `obs/v1/ui/metric/status` messages stopped. Remaining UI status messages now follow ordinary boot-time state changes rather than self-ingestion churn.

Also ran the test suite:

```text
887 tests, 0 failed, 0 skipped
```

## Added tests?

* [x] 👍 yes

## Added to documentation?

* [x] 🙅 no documentation needed