### PR TITLE
hal: add validation for UCI section types to support hyphens

### DIFF
--- a/src/configs/bigbox-v1-cm-2.json
+++ b/src/configs/bigbox-v1-cm-2.json
@@ -9,6 +9,10 @@
           "root": "/data/devicecode/configs"
         },
         {
+          "name": "credentials",
+          "root": "/data/configs"
+        },
+        {
           "name": "state",
           "root": "/tmp/devicecode-state"
         }

--- a/src/services/hal/backends/openwrt/uci_manager.lua
+++ b/src/services/hal/backends/openwrt/uci_manager.lua
@@ -121,8 +121,9 @@ local function is_uci_identifier(s)
 	return type(s) == 'string' and s ~= '' and s:match('^[A-Za-z0-9_]+$') ~= nil
 end
 
+-- UCI section types (e.g. wifi-device, wifi-iface) may contain hyphens.
 local function is_uci_section_type(s)
-	return type(s) == 'string' and s ~= '' and s:match('^[A-Za-z0-9_-]+$') ~= nil
+	return type(s) == 'string' and s ~= '' and s:match('^[A-Za-z0-9_%-]+$') ~= nil
 end
 
 local function validate_pkg(s, label)
@@ -197,7 +198,7 @@ local function validate_change(record, ch, i)
 		end
 		if ch.value == nil then
 			if not is_uci_section_type(ch.option) then
-				return nil, 'change ' .. i .. ' named section type must be a valid UCI section type'
+				return nil, 'change ' .. i .. ' named section type must be a UCI identifier'
 			end
 		else
 			local _, verr = to_uci_value(ch.value)

--- a/src/services/metrics.lua
+++ b/src/services/metrics.lua
@@ -556,7 +556,7 @@ function M.start(conn, opts)
 	end)
 
 	svc:obs_log('info', 'waiting for filesystem capability')
-	local fs_listener = cap_sdk.new_cap_listener(conn, 'fs', 'configs')
+	local fs_listener = cap_sdk.new_cap_listener(conn, 'fs', 'credentials')
 	local fs_cap, cap_err = fs_listener:wait_for_cap()
 	fs_listener:close()
 	if not fs_cap then

--- a/src/services/wifi.lua
+++ b/src/services/wifi.lua
@@ -757,7 +757,7 @@ local function on_fs_cap(ctx, msg)
     local state = msg.payload
     if state == 'added' then
         ctx.svc:obs_log('info', { what = 'fs_configs_cap_added' })
-        ctx.fs_configs_cap = cap_sdk.new_cap_ref(ctx.conn, 'fs', 'configs')
+        ctx.fs_configs_cap = cap_sdk.new_cap_ref(ctx.conn, 'fs', 'credentials')
         reapply_all_radios(ctx)
     elseif state == 'removed' then
         ctx.svc:obs_log('info', { what = 'fs_configs_cap_removed' })
@@ -810,7 +810,7 @@ function WifiService.start(conn, opts)
     -- Subscribe to cap state notifications (radio, band, fs/configs)
     local radio_cap_listener = cap_sdk.new_cap_listener(conn, 'radio', '+')
     local band_cap_listener  = cap_sdk.new_cap_listener(conn, 'band', '1')
-    local fs_cap_listener    = cap_sdk.new_cap_listener(conn, 'fs', 'configs')
+    local fs_cap_listener    = cap_sdk.new_cap_listener(conn, 'fs', 'credentials')
 
     svc:status('running')
     svc:obs_log('info', 'service running')


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description
Previously section names were given the same validation as uci identifiers, this was causing issues as section were using hypens in their names which is valid with uci usage but being flagged as invalid. I have made a seperate validation path for sections.

Also config and configs were two similarly named but very different filesystem capabilities that I have changed to config and credentials. I have refactored wifi and metrics for this. 

## Manual test
<!-- Have you manually tested this code and confirmed it is working? -->
- [x] 👍 yes
- [ ] 🙅 no

## Manual test description
Ran code and verified an empty /etc/config/wireless file was correctly populated

## Added tests?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?
- [ ] 📜 README.md
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?

