### PR TITLE
tests: stabilises scheduler-sensitive service tests

### DIFF
--- a/tests/integration/devhost/dependency_uniformity_spec.lua
+++ b/tests/integration/devhost/dependency_uniformity_spec.lua
@@ -199,7 +199,9 @@ function T.ui_waits_for_http_capability_before_starting_listener()
 			local p = msg and msg.payload
 			return p and p.ready == true and p.listener_status == 'running'
 		end, { timeout = 0.8, interval = 0.01 }), 'ui should start listener after HTTP appears')
-		assert_eq(#calls, 1)
+		assert_true(probe.wait_until(function ()
+			return #calls == 1
+		end, { timeout = 0.8, interval = 0.01 }), 'expected HTTP listen to be called after HTTP appears')
 
 		child:cancel('test complete')
 		cap_scope:cancel('test complete')
@@ -250,7 +252,9 @@ function T.fabric_waits_for_raw_transport_and_recovers_after_route_missing()
 			local p = msg and msg.payload
 			return p and p.state == 'running' and p.ready == true
 		end, { timeout = 0.8, interval = 0.01 }), 'fabric should retry after transport route returns')
-		assert_true(#calls >= 2, 'expected transport open to be retried')
+		assert_true(probe.wait_until(function ()
+			return #calls >= 2
+		end, { timeout = 0.8, interval = 0.01 }), 'expected transport open to be retried')
 
 		child:cancel('test complete')
 		cap_scope:cancel('test complete')

--- a/tests/unit/update/test_service.lua
+++ b/tests/unit/update/test_service.lua
@@ -99,7 +99,11 @@ function tests.test_config_change_replaces_generation()
 		end)
 		assert_true(ok, err)
 
-		fibers.perform(sleep.sleep_op(0.02))
+		local status_ready = probe.wait_until(function ()
+			local reply = caller:call(topics.update_manager_rpc('status'), {}, { timeout = 0.1 })
+			return reply and reply.ok == true and reply.snapshot and reply.snapshot.service == 'update'
+		end, { timeout = 1.0, interval = 0.01 })
+		assert_true(status_ready, 'expected update status endpoint to be ready before changing config')
 
 		cfg_conn:retain(topics.config(), {
 			rev = 2,
@@ -114,9 +118,9 @@ function tests.test_config_change_replaces_generation()
 
 		local reply
 		local ok_wait = probe.wait_until(function ()
-			reply = caller:call(topics.update_manager_rpc('status'), {}, { timeout = 0.03 })
+			reply = caller:call(topics.update_manager_rpc('status'), {}, { timeout = 0.1 })
 			return reply and reply.snapshot and reply.snapshot.config and reply.snapshot.config.namespace == 'new-ns'
-		end, { timeout = 0.4, interval = 0.01 })
+		end, { timeout = 1.0, interval = 0.01 })
 
 		assert_true(ok_wait, 'expected config replacement to be visible')
 		assert_eq(reply.snapshot.config.component_count, 1)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Test

## Description

Makes a minimal set of test-only changes to reduce occasional scheduler-related flakiness.

The affected tests were asserting immediately after service readiness or config-change events, even though the side effect being checked is performed by another fiber and may happen on a later scheduler turn.

Changes include:

- Updates `integration.devhost.dependency_uniformity_spec` to wait for mocked capability calls to become visible before asserting.
- Fixes the Fabric raw-transport retry test so it waits for the retry side effect instead of assuming it has already occurred.
- Fixes the UI HTTP listener dependency test so it waits for the listener call after the HTTP capability becomes available.
- Updates `unit.update.test_service` so config replacement waits for the update manager status endpoint to be available before asserting replacement visibility.
- Slightly relaxes the replacement-status polling window to avoid racing the service fiber.

No production code changes.

## Manual test

- [X] yes

## Manual test description

20 test runs no flakiness detected

## Added tests?

- [x] yes

Updated existing tests to wait for observable side effects instead of relying on immediate scheduler ordering.