### PR TITLE
Makefile replace constants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ scratchpad
 src/services/modem-*
 docs/
 build/
+.env.secret

--- a/Makefile
+++ b/Makefile
@@ -29,9 +29,25 @@ build-vendor:
 	@cp -r $(VENDOR_DIR)/lua-bus/src/. $(BUILD_DIR)/lib/
 	@echo "Vendor build complete."
 
-# Build-All: Build source and vendor libs
+# Build-All: Build source and vendor libs, then substitute secrets
 .PHONY: build-all
-build-all: build build-vendor
+build-all: build build-vendor substitute-secrets
+
+# Substitute-Secrets: Replace $VAR placeholders in build configs using .env.secret
+.PHONY: substitute-secrets
+substitute-secrets:
+	@echo "Substituting secrets in build configs..."
+	@if [ ! -f .env.secret ]; then \
+		echo "WARNING: .env.secret not found — \$$VAR placeholders in build configs will not be replaced."; \
+	else \
+		while IFS='=' read -r key value; do \
+			[ -z "$$key" ] && continue; \
+			find $(BUILD_DIR)/configs -name "*.json" | while read -r f; do \
+				sed -i 's|\$$'"$$key"'|'"$$value"'|g' "$$f"; \
+			done; \
+		done < .env.secret; \
+	fi
+	@echo "Secret substitution complete."
 
 # Env: Pin each vendor submodule to the revision specified in .env
 .PHONY: env
@@ -94,7 +110,8 @@ help:
 	@echo "Targets:"
 	@echo "  build         Copy source files into $(BUILD_DIR)/"
 	@echo "  build-vendor  Copy vendor library sources into $(BUILD_DIR)/lib/"
-	@echo "  build-all     Run both build and build-vendor (default)"
+	@echo "  substitute-secrets  Replace \$$VAR placeholders in $(BUILD_DIR)/configs/ using .env.secret"
+	@echo "  build-all     Run build, build-vendor, and substitute-secrets (default)"
 	@echo "  env           Pin vendor submodules to revisions in .env"
 	@echo "  test          Run the devicecode test suite"
 	@echo "  test-all      Run devicecode and all vendor test suites"

--- a/README.md
+++ b/README.md
@@ -31,6 +31,25 @@ DEVICECODE_CONFIG_DIR=/path/to/config/dir \
 CONFIG_TARGET=config \
 luajit main.lua
 ```
+## Build
+
+Run `make build-all` to copy sources into `build/` and inject secrets into config files.
+
+### Secret substitution
+
+Config files under `src/configs/` may contain `$VAR` placeholders for sensitive values (credentials, URLs, etc.). During `make build-all`, these are replaced in the **build output only** — `src/` is never modified.
+
+Create `.env.secret` in the repository root with the following keys:
+
+```
+SWITCH_USERNAME=
+SWITCH_PASSWORD=
+UNIFI_ADDRESS=
+CLOUD_URL=
+```
+
+`.env.secret` is listed in `.gitignore` and must never be committed. If the file is absent, `make build-all` will print a warning and leave placeholders unreplaced.
+
 ## Vendor Versions
 
 `lua-fibers`: v0.8.1

--- a/src/configs/bigbox-v1-cm-2.json
+++ b/src/configs/bigbox-v1-cm-2.json
@@ -312,6 +312,13 @@
           }
         },
         "records": {
+          "unifi": {
+            "name": "unifi",
+            "address": "$UNIFI_ADDRESS",
+            "segments": [
+              "int"
+            ]
+          },
           "config.bigbox.home": {
             "name": "config.bigbox.home",
             "address": "172.28.8.1"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [x] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description
The makefile has been changed to make subsitutions of the $ constants in config files. This means we will no longer need to edit the files ourselves for every test.

## Related Issues, Tickets & Documents

#100

## Manual test
<!-- Have you manually tested this code and confirmed it is working? -->
- [ ] 👍 yes
- [ ] 🙅 no

## Manual test description
Create a .env.secret file as mentioned in the readme and run `make build-all` and check the config in the build directory has replaced the strings

## Added tests?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?
- [x] 📜 README.md
- [ ] 🙅 no documentation needed

