### PR TITLE
main: add exit grace period before service cancellation

### DIFF
--- a/src/devicecode/main.lua
+++ b/src/devicecode/main.lua
@@ -10,6 +10,8 @@ local busmod = require 'bus'
 
 local safe   = require 'coxpcall'
 
+local EXIT_GRACE_PERIOD = 60.0
+
 local M      = {}
 
 local function require_env(name)
@@ -285,6 +287,8 @@ function M.run(scope, params)
             status  = jst,
             primary = tostring(jprimary),
         })
+
+        sleep.sleep(EXIT_GRACE_PERIOD)
 
 		scope:cancel(('service_not_ok:%s'):format(tostring(svc)))
     end)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description
Instead of any service's failure bringing down all services immediately devicecode now gives a grace period before closing. This grace period means any failure that could happen early on in execution will not stop the core services (HAL, net, gsm) from making their initial configs such that bigbox could still achieve backhaul and build a network. Without a network we and the user would be locked out of the box.

## Manual test
<!-- Have you manually tested this code and confirmed it is working? -->
- [x] 👍 yes
- [ ] 🙅 no

## Manual test description
add into the gsm start method 
```lua
sleep.sleep(5)
error("failed")
```
Then run the code, gsm should fail (monitor will log this) and then the code will run a bit further before exiting

## Added tests?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?
- [ ] 📜 README.md
- [x] 🙅 no documentation needed


