### PR TITLE
main: make root path an unconditional package path

### DIFF
--- a/src/main.lua
+++ b/src/main.lua
@@ -15,9 +15,9 @@ end
 
 local env = os.getenv('DEVICECODE_ENV') or 'dev'
 add_path('/usr/lib/lua/')
+add_path('./')
 if env == 'prod' then
 	add_path('./lib/')
-	add_path('./')
 else
 	add_path('../vendor/lua-fibers/src/')
 	add_path('../vendor/lua-bus/src/')


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description
This change was done before but was overwritten so placing it back now. Both dev and prod (and any env name) need devicecode its self as a package path for .init auto importing in backend systems

## Manual test
<!-- Have you manually tested this code and confirmed it is working? -->
- [x] 👍 yes
- [ ] 🙅 no

## Manual test description
Run devicecode in both the dev env (don't make build for this, just copy over src and vendor) and run in prod env (make build)

## Added tests?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?
- [ ] 📜 README.md
- [x] 🙅 no documentation needed

