### PR TITLE
terminates abandoned http object immediately

### DIFF
--- a/src/services/http/exchange.lua
+++ b/src/services/http/exchange.lua
@@ -15,6 +15,7 @@ local function make(driver, response_headers, stream, opts)
 		_driver = driver,
 		_headers = response_headers,
 		_stream = stream,
+		_opts = opts or {},
 		_closed = false,
 		_close_reason = nil,
 		_id = opts and opts.id,
@@ -42,30 +43,48 @@ function HttpExchange:why()
 	return self._close_reason
 end
 
+local function stream_timeout(self)
+	return self._opts and self._opts.intra_stream_timeout or nil
+end
+
+function HttpExchange:_mark_closed(reason)
+	if self._closed then return false end
+	self._closed = true
+	self._close_reason = reason or 'closed'
+	local hook = self._on_terminate
+	self._on_terminate = nil
+	if hook then pcall(hook, self, self._close_reason) end
+	return true
+end
+
 function HttpExchange:_stream_op(label, fn)
 	if self._closed then return op.always(nil, self._close_reason or 'closed') end
 	return self._driver:run_op(label, fn, {
-		on_active_abort = function (reason)
-			self:terminate(reason or 'exchange_op_aborted')
+		detach_on_abort = true,
+		on_detach = function (reason)
+			self:_mark_closed(reason or 'exchange_op_aborted')
+		end,
+		on_detached_complete = function (reason)
+			terminate.terminate_stream(self._stream, reason or 'exchange_op_aborted')
 		end,
 	})
 end
 
 function HttpExchange:read_chunk_op(_max)
 	return self:_stream_op('http.exchange.read_chunk', function ()
-		return self._stream:get_next_chunk()
+		return self._stream:get_next_chunk(stream_timeout(self))
 	end)
 end
 
 function HttpExchange:read_chars_op(n)
 	return self:_stream_op('http.exchange.read_chars', function ()
-		return self._stream:get_body_chars(n)
+		return self._stream:get_body_chars(n, stream_timeout(self))
 	end)
 end
 
 function HttpExchange:read_body_as_string_op()
 	return self:_stream_op('http.exchange.read_body_as_string', function ()
-		return self._stream:get_body_as_string()
+		return self._stream:get_body_as_string(stream_timeout(self))
 	end)
 end
 
@@ -74,23 +93,15 @@ function HttpExchange:shutdown_op()
 		if type(self._stream.shutdown) == 'function' then return self._stream:shutdown() end
 		return true
 	end):wrap(function (ok, err)
-		self._closed = true
-		self._close_reason = err or 'closed'
-		local hook = self._on_terminate
-		self._on_terminate = nil
-		if hook then pcall(hook, self, self._close_reason) end
+		self:_mark_closed(err or 'closed')
 		return ok, err
 	end)
 end
 
 function HttpExchange:terminate(reason)
 	if self._closed then return true end
-	self._closed = true
-	self._close_reason = reason or 'closed'
-	local hook = self._on_terminate
-	self._on_terminate = nil
+	self:_mark_closed(reason or 'closed')
 	terminate.terminate_stream(self._stream, self._close_reason)
-	if hook then pcall(hook, self, self._close_reason) end
 	return true
 end
 

--- a/src/services/http/transport/client.lua
+++ b/src/services/http/transport/client.lua
@@ -108,14 +108,13 @@ function M.open_exchange_op(driver, checked_args, opts)
 			active.stream = stream
 			return response_headers, stream
 		end, {
-			on_active_abort = function (reason)
+			detach_on_abort = true,
+			on_detached_complete = function (reason)
 				local why = reason or 'open_exchange_aborted'
 				if active.stream then
 					terminate.terminate_stream(active.stream, why)
 				elseif active.request then
 					terminate.terminate_request(active.request, why)
-				elseif driver and driver.terminate then
-					driver:terminate(why)
 				end
 			end,
 		})

--- a/src/services/http/transport/cqueues_driver.lua
+++ b/src/services/http/transport/cqueues_driver.lua
@@ -353,14 +353,49 @@ function Driver:_complete_job(job, ok, results_or_err)
 	self:_signal_changed()
 end
 
+function Driver:_finish_detached_job(job, ok, results_or_err)
+	if job.done then return end
+
+	job.done = true
+	job.phase = 'detached_done'
+	job.ok = ok
+	if ok then job.results = results_or_err or pack() else job.err = results_or_err end
+
+	local cleanup = job.on_detached_complete
+	if cleanup then safe.pcall(cleanup, job.abort_reason or 'aborted', ok, results_or_err, job) end
+
+	self._jobs[job] = nil
+	notify_waitset(self._job_waiters, job)
+	self:_signal_changed()
+end
+
 function Driver:_abandon_job(job, reason)
 	if job.done or job.abandoned then return end
 
 	local abort_reason = reason or 'aborted'
 	local phase = job.phase or 'queued'
 
+	-- Ownership invariant: once a cqueues/lua-http job has become active, the
+	-- descriptor-owning coroutine remains the only place that may clean up
+	-- cqueues-owned request, stream, connection, or socket state.  A Fibers
+	-- caller losing interest is therefore detached from the result; it must not
+	-- synchronously close or cancel descriptors that may still be installed in
+	-- the cqueues controller.  on_detached_complete is run after the cqueues
+	-- coroutine returns, when that ownership boundary is safe again.
+
 	job.abandoned = true
 	job.abort_reason = abort_reason
+
+	if phase == 'active' and job.detach_on_abort then
+		job.detached = true
+		job.phase = 'detached'
+		local on_detach = job.on_detach
+		if on_detach then safe.pcall(on_detach, abort_reason, job) end
+		notify_waitset(self._job_waiters, job)
+		self:_signal_changed()
+		return
+	end
+
 	job.phase = 'abandoned'
 	self._jobs[job] = nil
 
@@ -400,9 +435,13 @@ function Driver:_start_job(label, fn, opts)
 		results = nil,
 		err = nil,
 		abandoned = false,
+		detached = false,
 		abort_reason = nil,
+		detach_on_abort = opts.detach_on_abort,
 		on_abort = opts.on_abort,
 		on_active_abort = opts.on_active_abort,
+		on_detach = opts.on_detach,
+		on_detached_complete = opts.on_detached_complete,
 	}
 
 	self._jobs[job] = true
@@ -416,8 +455,10 @@ function Driver:_start_job(label, fn, opts)
 			return tb or tostring_error(e)
 		end)
 
-		if job.abandoned then return end
-
+		if job.abandoned then
+			self:_finish_detached_job(job, ok, result or 'cqueues job failed')
+			return
+		end
 		if ok then
 			self:_complete_job(job, true, result)
 		else
@@ -442,6 +483,8 @@ end
 
 function Driver:_job_outcome_op(job)
 	local function step()
+		if job.abandoned then return true, nil, job.abort_reason or 'aborted' end
+
 		if job.done then
 			if job.ok then
 				local r = job.results or pack()
@@ -449,8 +492,6 @@ function Driver:_job_outcome_op(job)
 			end
 			return true, nil, job.err or 'cqueues job failed'
 		end
-
-		if job.abandoned then return true, nil, job.abort_reason or 'aborted' end
 		if self._closed then return true, nil, self._close_reason or 'closed' end
 
 		return false

--- a/src/services/http/transport/lua_http.lua
+++ b/src/services/http/transport/lua_http.lua
@@ -117,6 +117,7 @@ local function new_context(listener, server, stream)
 		_active_cmd       = nil,
 		_commands_started = 0,
 		_commands_done    = 0,
+		_stream_timeout   = listener._intra_stream_timeout,
 	}, HttpContext)
 end
 
@@ -309,45 +310,49 @@ end
 
 -- HTTP stream-shaped Ops ------------------------------------------------------
 
+local function context_stream_timeout(ctx)
+	return ctx._stream_timeout
+end
+
 function HttpContext:get_headers_op()
 	return self:run_stream_op('http.get_headers', function (stream)
-		return stream:get_headers()
+		return stream:get_headers(context_stream_timeout(self))
 	end)
 end
 
 function HttpContext:read_chunk_op(_max)
 	return self:run_stream_op('http.get_next_chunk', function (stream)
-		return stream:get_next_chunk()
+		return stream:get_next_chunk(context_stream_timeout(self))
 	end)
 end
 
 function HttpContext:read_chars_op(n)
 	return self:run_stream_op('http.get_body_chars', function (stream)
-		return stream:get_body_chars(n)
+		return stream:get_body_chars(n, context_stream_timeout(self))
 	end)
 end
 
 function HttpContext:read_body_as_string_op()
 	return self:run_stream_op('http.get_body_as_string', function (stream)
-		return stream:get_body_as_string()
+		return stream:get_body_as_string(context_stream_timeout(self))
 	end)
 end
 
 function HttpContext:write_headers_op(headers, end_stream)
 	return self:run_stream_op('http.write_headers', function (stream)
-		return stream:write_headers(headers, not not end_stream)
+		return stream:write_headers(headers, not not end_stream, context_stream_timeout(self))
 	end)
 end
 
 function HttpContext:write_chunk_op(chunk, end_stream)
 	return self:run_stream_op('http.write_chunk', function (stream)
-		return stream:write_chunk(chunk, not not end_stream)
+		return stream:write_chunk(chunk, not not end_stream, context_stream_timeout(self))
 	end)
 end
 
 function HttpContext:write_body_from_string_op(str)
 	return self:run_stream_op('http.write_body_from_string', function (stream)
-		return stream:write_body_from_string(str)
+		return stream:write_body_from_string(str, context_stream_timeout(self))
 	end)
 end
 
@@ -473,6 +478,7 @@ function M.listen(opts)
 		_condition_factory  = opts.condition_factory,
 		_context_terminator = opts.context_terminator,
 		_backend_timeout    = opts.backend_timeout,
+		_intra_stream_timeout = opts.intra_stream_timeout,
 	}, Listener)
 
 	local server_opts = copy_table(opts)
@@ -491,6 +497,7 @@ function M.listen(opts)
 	server_opts.on_terminate = nil
 	server_opts.driver_options = nil
 	server_opts.backend_timeout = nil
+	server_opts.intra_stream_timeout = nil
 
 	local server, err = make_server(server_opts)
 	if not server then return nil, err end

--- a/src/services/http/transport/terminate.lua
+++ b/src/services/http/transport/terminate.lua
@@ -17,41 +17,87 @@ local function call(method, obj, ...)
 	return false, 'method_missing'
 end
 
+local function get_field(obj, key)
+	if obj == nil then return nil end
+	local ok, value = safe.pcall(function () return obj[key] end)
+	if ok then return value end
+	return nil
+end
+
+local function take_and_close_socket_from_connection(conn)
+	if conn == nil or type(conn.take_socket) ~= 'function' then
+		return false, 'take_socket_unavailable'
+	end
+
+	local ok, sock = safe.pcall(function () return conn:take_socket() end)
+	if not ok or sock == nil then return false, sock or 'take_socket_failed' end
+
+	-- This is the abort boundary for daurnimator/lua-http HTTP/1 streams.  Do
+	-- not call stream:shutdown(), connection:shutdown(), or connection:close()
+	-- here: those are graceful protocol operations and may wait in cqueues.
+	-- Once the socket is taken, direct socket close is the immediate fd teardown
+	-- primitive.
+	call('close', sock)
+	return true, nil
+end
+
+local function take_and_close_socket(obj)
+	local conn = get_field(obj, 'connection')
+	local ok, err = take_and_close_socket_from_connection(conn)
+	if ok then return true, nil end
+
+	if obj and type(obj.connection) == 'function' then
+		local cok, c = safe.pcall(function () return obj:connection() end)
+		if cok and c then
+			ok, err = take_and_close_socket_from_connection(c)
+			if ok then return true, nil end
+		end
+	end
+
+	return false, err or 'connection_socket_unavailable'
+end
+
 function M.terminate_stream(stream, reason)
 	if not stream then return true end
-	local ok = call('shutdown', stream)
+	local ok = call('terminate', stream, reason or 'terminated')
 	if ok then return true end
-	ok = call('close', stream)
-	if ok then return true end
+	-- Real lua-http response streams expose stream.connection.  Abort/finaliser
+	-- paths must tear down that transport, not fall back to graceful stream close.
+	take_and_close_socket(stream)
 	return true
 end
 
 function M.terminate_server(server, reason)
 	if not server then return true end
-	local ok = call('close', server)
+	local ok = call('terminate', server, reason or 'terminated')
 	if ok then return true end
+	-- lua-http server objects expose close() as their listener teardown primitive.
+	-- This is not a stream/connection graceful close_op path.
+	call('close', server)
 	return true
 end
 
 function M.terminate_websocket(ws, reason)
 	if not ws then return true end
-	-- This is deliberately not graceful. It gives lua-http/cqueues a bounded
-	-- immediate wake/close path for finalisers and service shutdown.
-	local ok = call('close', ws, 1006, reason or 'terminated', 0)
+	local ok = call('terminate', ws, reason or 'terminated')
 	if ok then return true end
-	ok = call('shutdown', ws)
+	ok = take_and_close_socket(ws)
 	if ok then return true end
+	-- If the websocket object does not expose its connection, use an abnormal
+	-- close with zero timeout as the narrow transport-level teardown primitive.
+	call('close', ws, 1006, reason or 'terminated', 0)
 	return true
 end
 
 function M.terminate_request(req, reason)
 	if not req then return true end
-	local ok = call('shutdown', req)
+	local ok = call('terminate', req, reason or 'terminated')
 	if ok then return true end
-	ok = call('close', req)
+	ok = take_and_close_socket(req)
 	if ok then return true end
-	ok = call('cancel', req, reason or 'terminated')
-	if ok then return true end
+	-- lua-http requests do not always expose a connection before req:go() has
+	-- produced a stream.  cancel(), when present, is the request-level abort hook.
+	call('cancel', req, reason or 'terminated')
 	return true
 end
 

--- a/src/services/http/transport/terminate.lua
+++ b/src/services/http/transport/terminate.lua
@@ -18,86 +18,76 @@ local function call(method, obj, ...)
 end
 
 local function get_field(obj, key)
-	if obj == nil then return nil end
+	if not obj then return nil end
 	local ok, value = safe.pcall(function () return obj[key] end)
 	if ok then return value end
 	return nil
 end
 
-local function take_and_close_socket_from_connection(conn)
-	if conn == nil or type(conn.take_socket) ~= 'function' then
-		return false, 'take_socket_unavailable'
-	end
-
-	local ok, sock = safe.pcall(function () return conn:take_socket() end)
-	if not ok or sock == nil then return false, sock or 'take_socket_failed' end
-
-	-- This is the abort boundary for daurnimator/lua-http HTTP/1 streams.  Do
-	-- not call stream:shutdown(), connection:shutdown(), or connection:close()
-	-- here: those are graceful protocol operations and may wait in cqueues.
-	-- Once the socket is taken, direct socket close is the immediate fd teardown
-	-- primitive.
-	call('close', sock)
-	return true, nil
-end
-
-local function take_and_close_socket(obj)
+local function take_and_close_connection_socket(obj)
 	local conn = get_field(obj, 'connection')
-	local ok, err = take_and_close_socket_from_connection(conn)
-	if ok then return true, nil end
+	if not conn then return false, 'connection_missing' end
 
-	if obj and type(obj.connection) == 'function' then
-		local cok, c = safe.pcall(function () return obj:connection() end)
-		if cok and c then
-			ok, err = take_and_close_socket_from_connection(c)
-			if ok then return true, nil end
+	-- lua-http exposes h1 stream.connection and h1_connection:take_socket().  In
+	-- cancellation cleanup we need a transport boundary, not a graceful protocol
+	-- shutdown.  Taking the cqueues socket and closing that socket lets cqueues
+	-- cancel its descriptor before close, which is the ordering cqueues requires.
+	if type(conn.take_socket) == 'function' then
+		local ok, sock = safe.pcall(function () return conn:take_socket() end)
+		if ok and sock then
+			local closed = call('close', sock)
+			if closed then return true end
 		end
 	end
 
-	return false, err or 'connection_socket_unavailable'
+	return false, 'take_socket_unavailable'
 end
 
 function M.terminate_stream(stream, reason)
 	if not stream then return true end
-	local ok = call('terminate', stream, reason or 'terminated')
+	local ok = take_and_close_connection_socket(stream)
 	if ok then return true end
-	-- Real lua-http response streams expose stream.connection.  Abort/finaliser
-	-- paths must tear down that transport, not fall back to graceful stream close.
-	take_and_close_socket(stream)
+	ok = call('terminate', stream, reason or 'terminated')
+	if ok then return true end
+	ok = call('close', stream)
+	if ok then return true end
+	-- Last resort only.  lua-http shutdown can be graceful and should not be the
+	-- first action on timeout/finaliser cleanup.
+	ok = call('shutdown', stream)
+	if ok then return true end
 	return true
 end
 
 function M.terminate_server(server, reason)
 	if not server then return true end
-	local ok = call('terminate', server, reason or 'terminated')
+	local ok = call('close', server)
 	if ok then return true end
-	-- lua-http server objects expose close() as their listener teardown primitive.
-	-- This is not a stream/connection graceful close_op path.
-	call('close', server)
 	return true
 end
 
 function M.terminate_websocket(ws, reason)
 	if not ws then return true end
-	local ok = call('terminate', ws, reason or 'terminated')
+	-- This is deliberately not graceful. It gives lua-http/cqueues a bounded
+	-- immediate wake/close path for finalisers and service shutdown.
+	local ok = call('close', ws, 1006, reason or 'terminated', 0)
 	if ok then return true end
-	ok = take_and_close_socket(ws)
+	ok = call('shutdown', ws)
 	if ok then return true end
-	-- If the websocket object does not expose its connection, use an abnormal
-	-- close with zero timeout as the narrow transport-level teardown primitive.
-	call('close', ws, 1006, reason or 'terminated', 0)
 	return true
 end
 
 function M.terminate_request(req, reason)
 	if not req then return true end
-	local ok = call('terminate', req, reason or 'terminated')
+	local ok = take_and_close_connection_socket(req)
 	if ok then return true end
-	ok = take_and_close_socket(req)
+	ok = call('terminate', req, reason or 'terminated')
 	if ok then return true end
-	-- lua-http requests do not always expose a connection before req:go() has
-	-- produced a stream.  cancel(), when present, is the request-level abort hook.
-	call('cancel', req, reason or 'terminated')
+	ok = call('cancel', req, reason or 'terminated')
+	if ok then return true end
+	ok = call('close', req)
+	if ok then return true end
+	ok = call('shutdown', req)
+	if ok then return true end
 	return true
 end
 

--- a/tests/integration/devhost/support/http_hostile_tcp_child.lua
+++ b/tests/integration/devhost/support/http_hostile_tcp_child.lua
@@ -1,0 +1,309 @@
+-- tests/integration/devhost/support/http_hostile_tcp_child.lua
+-- Child-process payload for the hostile HTTP regression. It deliberately uses a
+-- raw TCP upstream so cap/http/main's lua-http client sees incomplete and hostile
+-- responses while a service-owned listener remains active in the same backend.
+
+local function add_path(prefix)
+	package.path = prefix .. '?.lua;' .. prefix .. '?/init.lua;' .. package.path
+end
+
+package.path = '../src/?.lua;' .. package.path
+package.path = '../?.lua;../?/init.lua;./?.lua;./?/init.lua;' .. package.path
+add_path('../vendor/lua-fibers/src/')
+add_path('../vendor/lua-bus/src/')
+add_path('../vendor/lua-trie/src/')
+add_path('./')
+
+local stdlib_ok, stdlib = pcall(require, 'posix.stdlib')
+if stdlib_ok and stdlib and stdlib.setenv then
+	stdlib.setenv('CONFIG_TARGET', 'services', true)
+end
+
+local fibers = require 'fibers'
+local op     = require 'fibers.op'
+local sleep  = require 'fibers.sleep'
+local socket = require 'fibers.io.socket'
+local bus    = require 'bus'
+
+local http_headers = require 'http.headers'
+local http_service = require 'services.http.service'
+local sdk_mod      = require 'services.http.sdk'
+local blob_source  = require 'devicecode.blob_source'
+
+local LOG = os.getenv('HTTP_HOSTILE_CHILD_LOG') or '/tmp/devicecode-http-hostile-child.log'
+local T0 = os.clock()
+
+local function log(msg)
+	local f = io.open(LOG, 'a')
+	if f then
+		f:write(('[%.6f] %s\n'):format(os.clock() - T0, tostring(msg)))
+		f:close()
+	end
+end
+
+local function fail(msg)
+	log('child:fail ' .. tostring(msg))
+	error(msg, 0)
+end
+local function ok(v, msg) if not v then fail(msg or 'assertion failed') end return v end
+local function eq(a, b, msg) if a ~= b then fail((msg or 'assertion failed') .. ': expected ' .. tostring(b) .. ', got ' .. tostring(a)) end end
+
+local function env_num(name, default)
+	local v = tonumber(os.getenv(name) or '')
+	if v == nil then return default end
+	return v
+end
+
+local function parse_modes()
+	local s = os.getenv('HTTP_METRICS_TIMEOUT_HOSTILE_MODES') or 'stall_no_response,partial_status,partial_headers,partial_body'
+	local modes = {}
+	for part in s:gmatch('[^,]+') do
+		part = part:gsub('^%s+', ''):gsub('%s+$', '')
+		if part ~= '' then modes[#modes + 1] = part end
+	end
+	if #modes == 0 then modes[1] = 'partial_body' end
+	return modes
+end
+
+local function response_headers(status, content_type)
+	local h = http_headers.new()
+	h:append(':status', tostring(status or 200))
+	if content_type then h:append('content-type', content_type) end
+	return h
+end
+
+local function wait_until(predicate, timeout_s, label)
+	local deadline = os.clock() + (timeout_s or 2.0)
+	while true do
+		local v = predicate()
+		if v then return v end
+		if os.clock() >= deadline then fail('timed out waiting for ' .. (label or 'condition')) end
+		fibers.perform(sleep.sleep_op(0.005))
+	end
+end
+
+local function write_all_op(stream, data)
+	return fibers.run_scope_op(function ()
+		local off = 1
+		while off <= #data do
+			local n, err = fibers.perform(stream:write_op(data:sub(off)))
+			if n == nil then return nil, err or 'write_failed' end
+			if n <= 0 then return nil, 'zero_length_write' end
+			off = off + n
+		end
+		return true, nil
+	end):wrap(function (st, _rep, okv, err)
+		if st == 'ok' then return okv, err end
+		return nil, okv or st
+	end)
+end
+
+local function perform_with_timeout(label, operation, timeout_s)
+	local which, a, b = fibers.perform(op.named_choice({
+		value = operation,
+		timeout = sleep.sleep_op(timeout_s or 1.0),
+	}))
+	if which == 'timeout' then return nil, label .. '_timeout' end
+	return a, b
+end
+
+local function bind_inet_with_retry()
+	local base = env_num('HTTP_METRICS_TIMEOUT_HOSTILE_PORT_BASE', 39000 + (os.time() % 20000))
+	for i = 0, 200 do
+		local port = base + i
+		if port > 65000 then port = 39000 + (i % 20000) end
+		local s = socket.listen_inet('127.0.0.1', port)
+		if s then return s, port end
+	end
+	return nil, 'no_free_port'
+end
+
+local function read_request_head(stream)
+	local buf = ''
+	while not buf:find('\r\n\r\n', 1, true) and #buf < 32768 do
+		local chunk, err = perform_with_timeout('read_request_head', stream:read_some_op(512), 1.0)
+		if chunk == nil then return nil, err or 'closed' end
+		buf = buf .. chunk
+	end
+	return buf, nil
+end
+
+local function parse_path(req)
+	return req and req:match('^[A-Z]+%s+([^%s]+)') or '/'
+end
+
+local function parse_index(path)
+	return tonumber(tostring(path or ''):match('(%d+)$'))
+end
+
+local function start_hostile_server(scope, records, auto_release_s)
+	local server, port = bind_inet_with_retry()
+	ok(server, port or 'bind_failed')
+	ok(scope:spawn(function ()
+		while true do
+			local stream = fibers.perform(server:accept_op())
+			if not stream then return end
+			ok(scope:spawn(function ()
+				local req = read_request_head(stream)
+				local path = parse_path(req)
+				local idx = parse_index(path)
+				local rec = idx and records[idx] or nil
+				if rec then
+					rec.path = path
+					rec.seen = true
+				end
+				local mode = rec and rec.mode or 'success'
+				if mode == 'partial_status' then
+					fibers.perform(write_all_op(stream, 'HTTP/1.1 202'))
+				elseif mode == 'partial_headers' then
+					fibers.perform(write_all_op(stream, 'HTTP/1.1 202 Accepted\r\nContent-Length: 100'))
+				elseif mode == 'partial_body' then
+					fibers.perform(write_all_op(stream, 'HTTP/1.1 202 Accepted\r\nContent-Length: 100\r\nConnection: close\r\n\r\nshort'))
+				elseif mode == 'success' then
+					fibers.perform(write_all_op(stream, 'HTTP/1.1 202 Accepted\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok'))
+				else
+					-- stall_no_response: the server has seen the request and intentionally
+					-- gives the client no response bytes.
+				end
+				fibers.perform(sleep.sleep_op(auto_release_s or 0.1))
+				if rec then rec.auto_released = true end
+				if stream and type(stream.terminate) == 'function' then stream:terminate('hostile_done') end
+			end))
+		end
+	end))
+	return server, port
+end
+
+local function start_cap_service(opts)
+	opts = opts or {}
+	local b = bus.new()
+	local svc_conn = b:connect({ origin_base = { kind = 'local' } })
+	local svc = ok(http_service.open_handle(svc_conn, {
+		id = 'main',
+		backend_timeout = opts.backend_timeout or 2,
+		connection_setup_timeout = opts.connection_setup_timeout or 2,
+		intra_stream_timeout = opts.intra_stream_timeout or 2,
+		max_accept_queue = 32,
+	}))
+	local user_conn = b:connect({ origin_base = { kind = 'local' } })
+	return b, svc, sdk_mod.new_ref(user_conn, 'main')
+end
+
+local function http_uri(port, path)
+	return ('http://127.0.0.1:%d%s'):format(port, path or '/')
+end
+
+local function run_ui_raw_probe(scope, listener, port, i)
+	log(('iter:%03d ui_probe_spawn_handler'):format(i))
+	local handled = { accepted = false, wrote_body = false }
+	ok(scope:spawn(function ()
+		log(('iter:%03d ui_handler_accept_wait'):format(i))
+		local ctx, aerr = fibers.perform(listener:accept_op())
+		if not ctx then fail('ui accept failed: ' .. tostring(aerr)) end
+		handled.accepted = true
+		log(('iter:%03d ui_handler_accept_done'):format(i))
+		local req_headers = ok(fibers.perform(ctx:get_headers_op()))
+		log(('iter:%03d ui_handler_headers_done path=%s'):format(i, tostring(req_headers:get(':path'))))
+		ok(fibers.perform(ctx:write_headers_op(response_headers(200, 'text/plain'))))
+		log(('iter:%03d ui_handler_write_headers_done'):format(i))
+		ok(fibers.perform(ctx:write_body_from_string_op(('listener-still-alive-hostile-%d'):format(i))))
+		handled.wrote_body = true
+		log(('iter:%03d ui_handler_write_body_done'):format(i))
+	end))
+
+	log(('iter:%03d ui_raw_client_begin'):format(i))
+	local stream = ok(socket.connect_inet('127.0.0.1', port), 'raw UI client connect failed')
+	local request = ('GET /ui-hostile/%03d HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n'):format(i)
+	ok(fibers.perform(write_all_op(stream, request)), 'raw UI client write failed')
+	local buf = ''
+	while not buf:find('\r\n\r\n', 1, true) and #buf < 8192 do
+		local chunk, err = perform_with_timeout('ui_raw_read', stream:read_some_op(512), 1.0)
+		if chunk == nil then fail('raw UI client read failed: ' .. tostring(err)) end
+		buf = buf .. chunk
+	end
+	if stream and type(stream.terminate) == 'function' then stream:terminate('ui_probe_done') end
+	local status = buf:match('^HTTP/%d%.%d%s+(%d+)')
+	log(('iter:%03d ui_raw_client_done status=%s body_len=%d'):format(i, tostring(status), math.max(0, #buf - (buf:find('\r\n\r\n', 1, true) or #buf))))
+	eq(status, '200', 'UI raw probe status')
+	wait_until(function () return handled.accepted and handled.wrote_body end, 1.0, 'UI handler completion')
+end
+
+local M = {}
+
+local function run_child()
+	log('child:start')
+	local iterations = math.floor(env_num('HTTP_METRICS_TIMEOUT_HOSTILE_ITERATIONS', 4))
+	local attempts_timeout = env_num('HTTP_METRICS_TIMEOUT_HOSTILE_TIMEOUT_S', 0.05)
+	local backend_timeout = env_num('HTTP_METRICS_TIMEOUT_HOSTILE_BACKEND_TIMEOUT_S', 0.10)
+	local intra_stream_timeout = env_num('HTTP_METRICS_TIMEOUT_HOSTILE_INTRA_STREAM_TIMEOUT_S', 0.10)
+	local auto_release_s = env_num('HTTP_METRICS_TIMEOUT_HOSTILE_AUTO_RELEASE_S', 0.10)
+	local ui_every = math.floor(env_num('HTTP_METRICS_TIMEOUT_HOSTILE_UI_EVERY', 3))
+	local modes = parse_modes()
+
+	fibers.run(function (scope)
+		local records = {}
+		local hostile_server, hostile_port = start_hostile_server(scope, records, auto_release_s)
+		local _, svc, ref = start_cap_service({ backend_timeout = backend_timeout, intra_stream_timeout = intra_stream_timeout })
+		local rep = ok(fibers.perform(ref:listen_op({ host = '127.0.0.1', port = 0, tls = false }, { timeout = 3 })))
+		local ui_listener = ok(rep.listener)
+		local _, _, ui_port = ui_listener:localname()
+		log(('child:configured iterations=%d caller_timeout_s=%s backend_timeout_s=%s intra_stream_timeout_s=%s auto_release_s=%s ui_every=%d modes=%s hostile_port=%d ui_port=%d'):format(
+			iterations, tostring(attempts_timeout), tostring(backend_timeout), tostring(intra_stream_timeout), tostring(auto_release_s), ui_every, table.concat(modes, ','), hostile_port, ui_port))
+
+		for i = 1, iterations do
+			local mode = modes[((i - 1) % #modes) + 1]
+			records[i] = { mode = mode }
+			log(('iter:%03d begin mode=%s'):format(i, mode))
+			log(('iter:%03d before_exchange_op_build'):format(i))
+			local response_op = ref:exchange_op({
+				uri = http_uri(hostile_port, ('/mainflux-hostile/%03d'):format(i)),
+				method = 'POST',
+				headers = {
+					['content-type'] = 'application/senml+json',
+					['authorization'] = 'Bearer hostile-regression',
+				},
+				body_source = blob_source.from_string('[{"n":"x","v":1}]'),
+			})
+			log(('iter:%03d response_op_built'):format(i))
+			log(('iter:%03d before_exchange_choice_perform'):format(i))
+			local which, result, err = fibers.perform(op.named_choice({
+				response = response_op,
+				timeout = sleep.sleep_op(attempts_timeout),
+			}))
+			log(('iter:%03d exchange_choice_returned which=%s result=%s err=%s'):format(i, tostring(which), tostring(result), tostring(err)))
+			eq(which, 'timeout', 'caller timeout should win for hostile exchange')
+			log(('iter:%03d wait_rec_seen'):format(i))
+			wait_until(function () return records[i].seen end, 1.0, 'hostile peer to see request ' .. tostring(i))
+			log(('iter:%03d rec_seen path=%s'):format(i, tostring(records[i].path)))
+			records[i].released = true
+			log(('iter:%03d rec_released done=%s auto_released=%s'):format(i, tostring(records[i].done), tostring(records[i].auto_released)))
+
+			if ui_every > 0 and (i % ui_every) == 0 then
+				log(('iter:%03d ui_probe_begin client=raw'):format(i))
+				run_ui_raw_probe(scope, ui_listener, ui_port, i)
+			end
+		end
+
+		log('child:post_loop_checks')
+		local final_i = iterations + 1
+		records[final_i] = { mode = 'success' }
+		log('child:final_retry_begin')
+		local final = ok(fibers.perform(ref:exchange_op({
+			uri = http_uri(hostile_port, ('/mainflux-hostile/%03d'):format(final_i)),
+			method = 'POST',
+			headers = { ['content-type'] = 'application/senml+json' },
+			body_source = blob_source.from_string('[{"n":"final","v":1}]'),
+		})))
+		eq(final.result.status, '202', 'final retry status')
+		log('child:success')
+		io.stdout:flush()
+		io.stderr:flush()
+		os.exit(0)
+	end)
+end
+
+function M.run()
+	return run_child()
+end
+
+return M

--- a/tests/integration/devhost/support/http_hostile_tcp_child.lua
+++ b/tests/integration/devhost/support/http_hostile_tcp_child.lua
@@ -55,7 +55,7 @@ local function env_num(name, default)
 end
 
 local function parse_modes()
-	local s = os.getenv('HTTP_METRICS_TIMEOUT_HOSTILE_MODES') or 'stall_no_response,partial_status,partial_headers,partial_body'
+	local s = os.getenv('HTTP_METRICS_TIMEOUT_HOSTILE_MODES') or 'partial_body,stall_no_response'
 	local modes = {}
 	for part in s:gmatch('[^,]+') do
 		part = part:gsub('^%s+', ''):gsub('%s+$', '')
@@ -193,6 +193,17 @@ local function http_uri(port, path)
 	return ('http://127.0.0.1:%d%s'):format(port, path or '/')
 end
 
+local function assert_http_backend_ready(svc, label)
+	local st = svc:stats()
+	if st.backend ~= 'ready' then
+		fail((label or 'http backend check') .. ': backend=' .. tostring(st.backend) .. ' last_error=' .. tostring(st.last_error or st.reason))
+	end
+	if tostring(st.last_error or ''):find('Bad file descriptor', 1, true) then
+		fail((label or 'http backend check') .. ': EBADF reported: ' .. tostring(st.last_error))
+	end
+	return st
+end
+
 local function run_ui_raw_probe(scope, listener, port, i)
 	log(('iter:%03d ui_probe_spawn_handler'):format(i))
 	local handled = { accepted = false, wrote_body = false }
@@ -277,14 +288,17 @@ local function run_child()
 			log(('iter:%03d rec_seen path=%s'):format(i, tostring(records[i].path)))
 			records[i].released = true
 			log(('iter:%03d rec_released done=%s auto_released=%s'):format(i, tostring(records[i].done), tostring(records[i].auto_released)))
+			assert_http_backend_ready(svc, ('iter:%03d post_exchange_backend_ready'):format(i))
 
 			if ui_every > 0 and (i % ui_every) == 0 then
 				log(('iter:%03d ui_probe_begin client=raw'):format(i))
 				run_ui_raw_probe(scope, ui_listener, ui_port, i)
+				assert_http_backend_ready(svc, ('iter:%03d post_ui_probe_backend_ready'):format(i))
 			end
 		end
 
 		log('child:post_loop_checks')
+		assert_http_backend_ready(svc, 'post_loop_backend_ready')
 		local final_i = iterations + 1
 		records[final_i] = { mode = 'success' }
 		log('child:final_retry_begin')
@@ -295,6 +309,8 @@ local function run_child()
 			body_source = blob_source.from_string('[{"n":"final","v":1}]'),
 		})))
 		eq(final.result.status, '202', 'final retry status')
+		assert_http_backend_ready(svc, 'after_final_retry_backend_ready')
+		wait_until(function () return (svc:stats().active_exchanges or 0) == 0 end, 1.0, 'active exchanges to drain')
 		log('child:success')
 		io.stdout:flush()
 		io.stderr:flush()
@@ -304,6 +320,10 @@ end
 
 function M.run()
 	return run_child()
+end
+
+if ... == nil then
+	return M.run()
 end
 
 return M

--- a/tests/integration/devhost/test_http_service_real.lua
+++ b/tests/integration/devhost/test_http_service_real.lua
@@ -368,4 +368,97 @@ function M.test_real_cap_connect_ws_send_receive_and_close_round_trip()
 	end)
 end
 
+
+local function shquote(s)
+	s = tostring(s or '')
+	return "'" .. s:gsub("'", "'\\''") .. "'"
+end
+
+local function append_file(path, text)
+	local f = assert(io.open(path, 'a'))
+	f:write(text)
+	f:close()
+end
+
+local function read_file(path)
+	local f = io.open(path, 'r')
+	if not f then return '' end
+	local data = f:read('*a') or ''
+	f:close()
+	return data
+end
+
+local function tail_lines(text, n)
+	n = tonumber(n) or 80
+	local lines = {}
+	for line in tostring(text or ''):gmatch('([^\n]*)\n?') do
+		if line ~= '' then lines[#lines + 1] = line end
+	end
+	local first = math.max(1, #lines - n + 1)
+	local out = {}
+	for i = first, #lines do out[#out + 1] = lines[i] end
+	return table.concat(out, '\n')
+end
+
+local function shell_exit_status(a, b, c)
+	if type(a) == 'number' then
+		if a >= 256 then return math.floor(a / 256) end
+		return a
+	end
+	if a == true then return 0 end
+	if type(c) == 'number' then return c end
+	if b == 'exit' and type(c) == 'number' then return c end
+	return 1
+end
+
+function M.test_real_metrics_style_exchange_timeout_hostile_tcp_keeps_backend_and_listener_ready()
+	local log_path = os.getenv('HTTP_METRICS_TIMEOUT_HOSTILE_LOG') or '/tmp/devicecode-http-hostile-child.log'
+	local attempts = tonumber(os.getenv('HTTP_METRICS_TIMEOUT_HOSTILE_CHILD_ATTEMPTS') or '') or 1
+	local timeout_s = tonumber(os.getenv('HTTP_METRICS_TIMEOUT_HOSTILE_PARENT_TIMEOUT_S') or '') or 8
+	local tail_n = tonumber(os.getenv('HTTP_METRICS_TIMEOUT_HOSTILE_TAIL_LINES') or '') or 120
+	os.remove(log_path)
+
+	local env_names = {
+		'HTTP_METRICS_TIMEOUT_HOSTILE_MODES',
+		'HTTP_METRICS_TIMEOUT_HOSTILE_ITERATIONS',
+		'HTTP_METRICS_TIMEOUT_HOSTILE_TIMEOUT_S',
+		'HTTP_METRICS_TIMEOUT_HOSTILE_BACKEND_TIMEOUT_S',
+		'HTTP_METRICS_TIMEOUT_HOSTILE_INTRA_STREAM_TIMEOUT_S',
+		'HTTP_METRICS_TIMEOUT_HOSTILE_AUTO_RELEASE_S',
+		'HTTP_METRICS_TIMEOUT_HOSTILE_UI_EVERY',
+		'HTTP_METRICS_TIMEOUT_HOSTILE_PORT_BASE',
+	}
+
+	for attempt = 1, attempts do
+		append_file(log_path, ('[parent %.6f] attempt:%03d begin timeout_s=%s\n'):format(os.clock(), attempt, tostring(timeout_s)))
+		local env_parts = {
+			'HTTP_HOSTILE_CHILD_LOG=' .. shquote(log_path),
+			'HTTP_METRICS_TIMEOUT_HOSTILE_CHILD=1',
+			'TEST_FILTER=http_hostile_tcp_child_payload',
+		}
+		for _, name in ipairs(env_names) do
+			local value = os.getenv(name)
+			if value ~= nil then env_parts[#env_parts + 1] = name .. '=' .. shquote(value) end
+		end
+		local lua = os.getenv('LUAJIT') or 'luajit'
+		local cmd = ('timeout %s env %s %s run.lua >> %s 2>&1'):format(
+			tostring(timeout_s), table.concat(env_parts, ' '), shquote(lua), shquote(log_path))
+		local exit = shell_exit_status(os.execute(cmd))
+		append_file(log_path, ('[parent %.6f] attempt:%03d exit=%s\n'):format(os.clock(), attempt, tostring(exit)))
+		if exit ~= 0 then
+			local tail = tail_lines(read_file(log_path), tail_n)
+			error(('hostile TCP child failed or timed out: attempt=%d/%d exit=%s timeout_s=%s log=%s\n%s'):format(
+				attempt, attempts, tostring(exit), tostring(timeout_s), log_path, tail), 0)
+		end
+	end
+end
+
+function M.http_hostile_tcp_child_payload()
+	if os.getenv('HTTP_METRICS_TIMEOUT_HOSTILE_CHILD') ~= '1' then return end
+	require('integration.devhost.support.http_hostile_tcp_child').run()
+	io.stdout:flush()
+	io.stderr:flush()
+	os.exit(0)
+end
+
 return M

--- a/tests/integration/devhost/test_http_service_real.lua
+++ b/tests/integration/devhost/test_http_service_real.lua
@@ -369,18 +369,18 @@ function M.test_real_cap_connect_ws_send_receive_and_close_round_trip()
 end
 
 
-local function shquote(s)
+local function hostile_shquote(s)
 	s = tostring(s or '')
 	return "'" .. s:gsub("'", "'\\''") .. "'"
 end
 
-local function append_file(path, text)
+local function hostile_append_file(path, text)
 	local f = assert(io.open(path, 'a'))
 	f:write(text)
 	f:close()
 end
 
-local function read_file(path)
+local function hostile_read_file(path)
 	local f = io.open(path, 'r')
 	if not f then return '' end
 	local data = f:read('*a') or ''
@@ -388,77 +388,63 @@ local function read_file(path)
 	return data
 end
 
-local function tail_lines(text, n)
-	n = tonumber(n) or 80
+local function hostile_tail_lines(text, n)
+	n = tonumber(n) or 120
 	local lines = {}
-	for line in tostring(text or ''):gmatch('([^\n]*)\n?') do
-		if line ~= '' then lines[#lines + 1] = line end
-	end
+	for line in tostring(text or ''):gmatch('[^\n]+') do lines[#lines + 1] = line end
 	local first = math.max(1, #lines - n + 1)
 	local out = {}
 	for i = first, #lines do out[#out + 1] = lines[i] end
 	return table.concat(out, '\n')
 end
 
-local function shell_exit_status(a, b, c)
+local function hostile_shell_exit_status(a, b, c)
 	if type(a) == 'number' then
 		if a >= 256 then return math.floor(a / 256) end
 		return a
 	end
 	if a == true then return 0 end
-	if type(c) == 'number' then return c end
 	if b == 'exit' and type(c) == 'number' then return c end
+	if type(c) == 'number' then return c end
 	return 1
 end
 
-function M.test_real_metrics_style_exchange_timeout_hostile_tcp_keeps_backend_and_listener_ready()
+function M.test_real_metrics_style_exchange_timeout_regression_hostile_tcp_keeps_backend_and_listener_ready()
 	local log_path = os.getenv('HTTP_METRICS_TIMEOUT_HOSTILE_LOG') or '/tmp/devicecode-http-hostile-child.log'
-	local attempts = tonumber(os.getenv('HTTP_METRICS_TIMEOUT_HOSTILE_CHILD_ATTEMPTS') or '') or 1
+	local attempts = tonumber(os.getenv('HTTP_METRICS_TIMEOUT_HOSTILE_CHILD_ATTEMPTS') or '') or 3
 	local timeout_s = tonumber(os.getenv('HTTP_METRICS_TIMEOUT_HOSTILE_PARENT_TIMEOUT_S') or '') or 8
 	local tail_n = tonumber(os.getenv('HTTP_METRICS_TIMEOUT_HOSTILE_TAIL_LINES') or '') or 120
 	os.remove(log_path)
 
-	local env_names = {
-		'HTTP_METRICS_TIMEOUT_HOSTILE_MODES',
-		'HTTP_METRICS_TIMEOUT_HOSTILE_ITERATIONS',
-		'HTTP_METRICS_TIMEOUT_HOSTILE_TIMEOUT_S',
-		'HTTP_METRICS_TIMEOUT_HOSTILE_BACKEND_TIMEOUT_S',
-		'HTTP_METRICS_TIMEOUT_HOSTILE_INTRA_STREAM_TIMEOUT_S',
-		'HTTP_METRICS_TIMEOUT_HOSTILE_AUTO_RELEASE_S',
-		'HTTP_METRICS_TIMEOUT_HOSTILE_UI_EVERY',
-		'HTTP_METRICS_TIMEOUT_HOSTILE_PORT_BASE',
+	local env = {
+		HTTP_HOSTILE_CHILD_LOG = log_path,
+		HTTP_METRICS_TIMEOUT_HOSTILE_MODES = os.getenv('HTTP_METRICS_TIMEOUT_HOSTILE_MODES') or 'partial_body,stall_no_response',
+		HTTP_METRICS_TIMEOUT_HOSTILE_ITERATIONS = os.getenv('HTTP_METRICS_TIMEOUT_HOSTILE_ITERATIONS') or '4',
+		HTTP_METRICS_TIMEOUT_HOSTILE_TIMEOUT_S = os.getenv('HTTP_METRICS_TIMEOUT_HOSTILE_TIMEOUT_S') or '0.05',
+		HTTP_METRICS_TIMEOUT_HOSTILE_BACKEND_TIMEOUT_S = os.getenv('HTTP_METRICS_TIMEOUT_HOSTILE_BACKEND_TIMEOUT_S') or '0.10',
+		HTTP_METRICS_TIMEOUT_HOSTILE_INTRA_STREAM_TIMEOUT_S = os.getenv('HTTP_METRICS_TIMEOUT_HOSTILE_INTRA_STREAM_TIMEOUT_S') or '0.10',
+		HTTP_METRICS_TIMEOUT_HOSTILE_AUTO_RELEASE_S = os.getenv('HTTP_METRICS_TIMEOUT_HOSTILE_AUTO_RELEASE_S') or '0.10',
+		HTTP_METRICS_TIMEOUT_HOSTILE_UI_EVERY = os.getenv('HTTP_METRICS_TIMEOUT_HOSTILE_UI_EVERY') or '3',
 	}
+	if os.getenv('HTTP_METRICS_TIMEOUT_HOSTILE_PORT_BASE') then
+		env.HTTP_METRICS_TIMEOUT_HOSTILE_PORT_BASE = os.getenv('HTTP_METRICS_TIMEOUT_HOSTILE_PORT_BASE')
+	end
 
 	for attempt = 1, attempts do
-		append_file(log_path, ('[parent %.6f] attempt:%03d begin timeout_s=%s\n'):format(os.clock(), attempt, tostring(timeout_s)))
-		local env_parts = {
-			'HTTP_HOSTILE_CHILD_LOG=' .. shquote(log_path),
-			'HTTP_METRICS_TIMEOUT_HOSTILE_CHILD=1',
-			'TEST_FILTER=http_hostile_tcp_child_payload',
-		}
-		for _, name in ipairs(env_names) do
-			local value = os.getenv(name)
-			if value ~= nil then env_parts[#env_parts + 1] = name .. '=' .. shquote(value) end
-		end
-		local lua = os.getenv('LUAJIT') or 'luajit'
-		local cmd = ('timeout %s env %s %s run.lua >> %s 2>&1'):format(
-			tostring(timeout_s), table.concat(env_parts, ' '), shquote(lua), shquote(log_path))
-		local exit = shell_exit_status(os.execute(cmd))
-		append_file(log_path, ('[parent %.6f] attempt:%03d exit=%s\n'):format(os.clock(), attempt, tostring(exit)))
-		if exit ~= 0 then
-			local tail = tail_lines(read_file(log_path), tail_n)
+		hostile_append_file(log_path, ('[parent %.6f] attempt:%03d begin timeout_s=%s\n'):format(os.clock(), attempt, tostring(timeout_s)))
+		local env_parts = {}
+		for k, v in pairs(env) do env_parts[#env_parts + 1] = k .. '=' .. hostile_shquote(v) end
+		table.sort(env_parts)
+		local cmd = ('timeout %s env %s luajit integration/devhost/support/http_hostile_tcp_child.lua >> %s 2>&1'):format(
+			tostring(timeout_s), table.concat(env_parts, ' '), hostile_shquote(log_path))
+		local code = hostile_shell_exit_status(os.execute(cmd))
+		hostile_append_file(log_path, ('[parent %.6f] attempt:%03d exit=%s\n'):format(os.clock(), attempt, tostring(code)))
+		if code ~= 0 then
+			local tail = hostile_tail_lines(hostile_read_file(log_path), tail_n)
 			error(('hostile TCP child failed or timed out: attempt=%d/%d exit=%s timeout_s=%s log=%s\n%s'):format(
-				attempt, attempts, tostring(exit), tostring(timeout_s), log_path, tail), 0)
+				attempt, attempts, tostring(code), tostring(timeout_s), log_path, tail), 0)
 		end
 	end
-end
-
-function M.http_hostile_tcp_child_payload()
-	if os.getenv('HTTP_METRICS_TIMEOUT_HOSTILE_CHILD') ~= '1' then return end
-	require('integration.devhost.support.http_hostile_tcp_child').run()
-	io.stdout:flush()
-	io.stderr:flush()
-	os.exit(0)
 end
 
 return M

--- a/tests/unit/http/test_client.lua
+++ b/tests/unit/http/test_client.lua
@@ -241,9 +241,10 @@ function M.test_open_exchange_active_abort_terminates_active_request_not_driver(
 				go = function (self)
 					go_active = true
 					while not req_closed do runtime.yield() end
-					return nil, 'closed'
+					return nil, 'cancelled'
 				end,
-				shutdown = function () req_closed = true; return true end,
+				cancel = function (_, reason) req_closed = reason or true; return true end,
+				shutdown = function () error('active open_exchange abort must not use graceful request shutdown', 0) end,
 			}
 		end,
 	}
@@ -271,16 +272,27 @@ function M.test_exchange_read_active_abort_terminates_exchange_not_driver()
 	local ctl = fake_controller()
 	local drv = assert(driver_mod.new { controller = ctl })
 	local read_active = false
-	local stream = {
+	local stream
+	stream = {
 		terminated = false,
+		connection = {
+			take_socket = function (conn)
+				return {
+					close = function ()
+						stream.terminated = true
+						conn.taken = true
+						return true
+					end,
+				}
+			end,
+		},
 		get_next_chunk = function (self)
 			read_active = true
 			while not self.terminated do runtime.yield() end
 			return nil
 		end,
-		shutdown = function (self)
-			self.terminated = true
-			return true
+		shutdown = function ()
+			error('active exchange abort must not use graceful stream shutdown', 0)
 		end,
 	}
 	local ex = client.HttpExchange and client.HttpExchange.make

--- a/tests/unit/http/test_client.lua
+++ b/tests/unit/http/test_client.lua
@@ -1,4 +1,5 @@
 local fibers = require 'fibers'
+local sleep  = require 'fibers.sleep'
 local runtime = require 'fibers.runtime'
 local driver_mod = require 'services.http.transport.cqueues_driver'
 local client = require 'services.http.client'
@@ -21,6 +22,36 @@ local function yield_until(pred, msg)
 		yield_once()
 	end
 	error(msg or 'condition was not reached', 2)
+end
+
+local function join_child_with_timeout(child, timeout_s)
+	local which = fibers.perform(fibers.named_choice {
+		joined = child:join_op(),
+		timeout = sleep.sleep_op(timeout_s or 1),
+	})
+	return which == 'joined'
+end
+
+local function shell_quote(s)
+	s = tostring(s or '')
+	return "'" .. s:gsub("'", "'\\''") .. "'"
+end
+
+local function shell_exit_status(a, b, c)
+	if type(a) == 'number' then
+		if a >= 256 then return math.floor(a / 256) end
+		return a
+	end
+	if a == true then return 0 end
+	if b == 'exit' and type(c) == 'number' then return c end
+	if type(c) == 'number' then return c end
+	return 1
+end
+
+local function run_filtered_child(filter, timeout_s)
+	local cmd = ('timeout %s env TEST_FILTER=%s luajit run.lua'):format(
+		tostring(timeout_s or 2), shell_quote(filter))
+	return shell_exit_status(os.execute(cmd))
 end
 
 local function fake_controller()
@@ -225,11 +256,12 @@ function M.test_request_body_source_without_read_op_rejects_before_request_const
 	end)
 end
 
-function M.test_open_exchange_active_abort_terminates_active_request_not_driver()
+function M.test_open_exchange_active_abort_detaches_then_cleans_request_in_cqueues_job()
 	local ctl = fake_controller()
 	local drv = assert(driver_mod.new { controller = ctl })
 	local go_active = false
-	local req_closed = false
+	local release_go = false
+	local req_cancelled = false
 	local request_mod = {
 		new_from_uri = function (uri)
 			return {
@@ -238,13 +270,12 @@ function M.test_open_exchange_active_abort_terminates_active_request_not_driver(
 					upsert = function () end,
 					append = function () end,
 				},
-				go = function (self)
+				go = function ()
 					go_active = true
-					while not req_closed do runtime.yield() end
-					return nil, 'cancelled'
+					while not release_go do runtime.yield() end
+					return nil, 'closed'
 				end,
-				cancel = function (_, reason) req_closed = reason or true; return true end,
-				shutdown = function () error('active open_exchange abort must not use graceful request shutdown', 0) end,
+				cancel = function (_, reason) req_cancelled = reason or true; return true end,
 			}
 		end,
 	}
@@ -252,8 +283,9 @@ function M.test_open_exchange_active_abort_terminates_active_request_not_driver(
 	fibers.run(function (scope)
 		assert(drv:start(scope))
 		local waiter = assert(scope:child())
+		local result, err
 		assert(waiter:spawn(function ()
-			fibers.perform(client.open_exchange_op(drv, {
+			result, err = fibers.perform(client.open_exchange_op(drv, {
 				uri = 'http://example.test/',
 				method = 'GET',
 			}, { request_module = request_mod }))
@@ -261,57 +293,85 @@ function M.test_open_exchange_active_abort_terminates_active_request_not_driver(
 
 		yield_until(function () return go_active end, 'request go should become active')
 		waiter:cancel('stop_waiting')
-		fibers.perform(waiter:join_op())
-		ok(req_closed, 'active open_exchange abort should terminate the request')
-		ok(not drv:is_closed(), 'request termination is the narrow owner; driver should survive')
+		if not join_child_with_timeout(waiter, 0.25) then
+			release_go = true
+			drv:terminate('open exchange detach test bounded failure')
+			join_child_with_timeout(waiter, 0.25)
+			error('open_exchange caller did not return after abort; request cleanup must be detached to cqueues job', 2)
+		end
+		eq(result, nil)
+		eq(err, nil)
+		eq(req_cancelled, false, 'request must not be cancelled from the Fibers abort path')
+		ok(not drv:is_closed(), 'detached request must not close the driver')
+		release_go = true
+		yield_until(function () return req_cancelled == 'aborted' end, 'detached request cleanup should run after cqueues job returns')
+		ok(not drv:is_closed(), 'request cleanup is owned by cqueues job; driver should survive')
 		drv:terminate('done')
 	end)
 end
 
-function M.test_exchange_read_active_abort_terminates_exchange_not_driver()
+function M.test_exchange_read_active_abort_detaches_then_cleans_stream_in_cqueues_job()
 	local ctl = fake_controller()
 	local drv = assert(driver_mod.new { controller = ctl })
 	local read_active = false
-	local stream
-	stream = {
+	local release_read = false
+	local stream = {
 		terminated = false,
-		connection = {
-			take_socket = function (conn)
-				return {
-					close = function ()
-						stream.terminated = true
-						conn.taken = true
-						return true
-					end,
-				}
-			end,
-		},
-		get_next_chunk = function (self)
+		get_next_chunk = function (self, timeout)
+			self.timeout = timeout
 			read_active = true
-			while not self.terminated do runtime.yield() end
+			while not release_read do runtime.yield() end
 			return nil
 		end,
-		shutdown = function ()
-			error('active exchange abort must not use graceful stream shutdown', 0)
+		close = function (self)
+			self.terminated = true
+			return true
 		end,
 	}
-	local ex = client.HttpExchange and client.HttpExchange.make
-	-- The public client module exposes the class for type checks; construct via
-	-- the ordinary open path shape by requiring the handle module directly here.
-	ex = require('services.http.exchange').make(drv, fake_headers(200), stream, {})
+	local ex = require('services.http.exchange').make(drv, fake_headers(200), stream, { intra_stream_timeout = 0.125 })
 
 	fibers.run(function (scope)
 		assert(drv:start(scope))
 		local waiter = assert(scope:child())
-		assert(waiter:spawn(function () fibers.perform(ex:read_chunk_op()) end))
+		local result, err
+		assert(waiter:spawn(function () result, err = fibers.perform(ex:read_chunk_op()) end))
 		yield_until(function () return read_active end, 'exchange read should become active')
+		eq(stream.timeout, 0.125, 'exchange read should pass intra_stream_timeout to lua-http stream')
 		waiter:cancel('stop_waiting')
-		fibers.perform(waiter:join_op())
-		ok(stream.terminated, 'active exchange read abort should terminate stream')
-		ok(ex:is_closed(), 'exchange handle should be marked closed')
-		ok(not drv:is_closed(), 'exchange is the narrow owner; driver should survive')
+		if not join_child_with_timeout(waiter, 0.25) then
+			release_read = true
+			drv:terminate('exchange read detach test bounded failure')
+			join_child_with_timeout(waiter, 0.25)
+			error('exchange read caller did not return after abort; stream cleanup must be detached to cqueues job', 2)
+		end
+		eq(result, nil)
+		eq(err, nil)
+		ok(not stream.terminated, 'stream must not be terminated from the Fibers abort path')
+		ok(ex:is_closed(), 'exchange handle should be marked closed immediately')
+		ok(not drv:is_closed(), 'detached exchange read must not close driver')
+		release_read = true
+		yield_until(function () return stream.terminated end, 'detached stream cleanup should run after cqueues read returns')
+		ok(not drv:is_closed(), 'exchange cleanup is owned by cqueues job; driver should survive')
 		drv:terminate('done')
 	end)
+end
+
+-- The hostile OpenWrt regression is partly an ownership-boundary bug, not just
+-- a black-box socket behaviour.  Keep these wrappers under the same regression filter
+-- substring as the devhost hostile test so a single focused run exercises the
+-- unit-level contract that the old hard-close-only fix violated.  The payloads
+-- run in subprocesses so scheduler wedges are bounded failures rather than
+-- stalled test-suite runs.
+function M.test_metrics_style_exchange_timeout_regression_abort_detaches_open_exchange_request_cleanup_to_cqueues_job()
+	local code = run_filtered_child('test_open_exchange_active_abort_detaches_then_cleans_request_in_cqueues_job',
+		tonumber(os.getenv('HTTP_METRICS_TIMEOUT_UNIT_CHILD_TIMEOUT_S') or '') or 2)
+	eq(code, 0, 'open_exchange ownership payload should pass in a bounded child process')
+end
+
+function M.test_metrics_style_exchange_timeout_regression_abort_detaches_response_stream_cleanup_to_cqueues_job()
+	local code = run_filtered_child('test_exchange_read_active_abort_detaches_then_cleans_stream_in_cqueues_job',
+		tonumber(os.getenv('HTTP_METRICS_TIMEOUT_UNIT_CHILD_TIMEOUT_S') or '') or 2)
+	eq(code, 0, 'exchange read ownership payload should pass in a bounded child process')
 end
 
 return M

--- a/tests/unit/http/test_service.lua
+++ b/tests/unit/http/test_service.lua
@@ -432,28 +432,15 @@ end
 
 
 local function fake_stream_for_context()
-	local stream
-	stream = {
+	return {
 		terminated = false,
 		calls = {},
-		connection = {
-			take_socket = function (conn)
-				return {
-					close = function ()
-						stream.terminated = true
-						conn.taken = true
-						return true
-					end,
-				}
-			end,
-		},
-		shutdown = function () error('context termination must not use graceful stream shutdown', 0) end,
+		shutdown = function (self) self.terminated = true; return true end,
 		get_headers = function () return { ':method', 'GET' } end,
 		get_next_chunk = function () return nil end,
 		write_headers = function () return true end,
 		write_chunk = function () return true end,
 	}
-	return stream
 end
 
 local function event_seen(events, kind, pred)
@@ -992,12 +979,13 @@ function M.test_public_open_exchange_handle_read_cancellation_keeps_service_back
 					if tostring(self.uri):match('slow') then
 						first_stream = {
 							terminated = false,
+							release_read = false,
 							get_next_chunk = function (stream)
 								first_read_active = true
-								while not stream.terminated do runtime.yield() end
+								while not stream.release_read do runtime.yield() end
 								return nil, 'closed'
 							end,
-							terminate = function (stream) stream.terminated = true; return true end,
+							shutdown = function (stream) stream.terminated = true; return true end,
 						}
 						return headers, first_stream
 					end
@@ -1032,16 +1020,22 @@ function M.test_public_open_exchange_handle_read_cancellation_keeps_service_back
 		local waiter = ok(scope:child())
 		ok(waiter:spawn(function () fibers.perform(ex:read_chunk_op(1024)) end))
 		yield_until(function () return first_read_active end, 'slow exchange read should be active')
-		-- The driver pump runs the active read job.  Once the caller loses interest,
-		-- the public exchange handle should terminate that stream, not the backend.
-		waiter:cancel('caller_cancelled')
-		fibers.perform(waiter:join_op())
-		yield_until(function () return svc:stats().active_exchanges == 0 end,
+			-- The driver pump runs the active read job.  Once the caller loses interest,
+			-- the public exchange handle should detach and close for the caller, but the
+			-- lua-http/cqueues-owned stream cleanup must wait until the cqueues job
+			-- returns.  The fake read is therefore released explicitly after caller
+			-- cancellation, modelling a cqueues-side timeout/error return.
+			waiter:cancel('caller_cancelled')
+			fibers.perform(waiter:join_op())
+			yield_until(function () return svc:stats().active_exchanges == 0 end,
 			'exchange termination should deregister the service record')
 
-		ok(first_stream.terminated, 'public exchange read cancellation should terminate the exchange stream')
-		ok(ex:is_closed(), 'public exchange handle should be closed after active read abort')
-		ok(not drv:is_closed(), 'the exchange is the narrow owner; the HTTP backend should stay usable')
+			ok(not first_stream.terminated, 'caller cancellation must not synchronously terminate cqueues-owned stream state')
+			ok(ex:is_closed(), 'public exchange handle should be closed after active read abort')
+			first_stream.release_read = true
+			yield_until(function () return first_stream.terminated end,
+			'detached read cleanup should terminate the stream after the cqueues job returns')
+			ok(not drv:is_closed(), 'the exchange is the narrow owner; the HTTP backend should stay usable')
 
 		local second = ok(fibers.perform(ref:exchange_op({ uri = 'http://example.test/fast', method = 'GET' })))
 		eq(second.result.status, '200')

--- a/tests/unit/http/test_service.lua
+++ b/tests/unit/http/test_service.lua
@@ -432,15 +432,28 @@ end
 
 
 local function fake_stream_for_context()
-	return {
+	local stream
+	stream = {
 		terminated = false,
 		calls = {},
-		shutdown = function (self) self.terminated = true; return true end,
+		connection = {
+			take_socket = function (conn)
+				return {
+					close = function ()
+						stream.terminated = true
+						conn.taken = true
+						return true
+					end,
+				}
+			end,
+		},
+		shutdown = function () error('context termination must not use graceful stream shutdown', 0) end,
 		get_headers = function () return { ':method', 'GET' } end,
 		get_next_chunk = function () return nil end,
 		write_headers = function () return true end,
 		write_chunk = function () return true end,
 	}
+	return stream
 end
 
 local function event_seen(events, kind, pred)
@@ -984,7 +997,7 @@ function M.test_public_open_exchange_handle_read_cancellation_keeps_service_back
 								while not stream.terminated do runtime.yield() end
 								return nil, 'closed'
 							end,
-							shutdown = function (stream) stream.terminated = true; return true end,
+							terminate = function (stream) stream.terminated = true; return true end,
 						}
 						return headers, first_stream
 					end

--- a/tests/unit/http/transport/test_cqueues_driver.lua
+++ b/tests/unit/http/transport/test_cqueues_driver.lua
@@ -21,12 +21,42 @@ local function yield_many(n)
 	for _ = 1, n do yield_once() end
 end
 
+local function join_child_with_timeout(child, timeout_s)
+	local which = fibers.perform(fibers.named_choice {
+		joined = child:join_op(),
+		timeout = sleep.sleep_op(timeout_s or 1),
+	})
+	return which == 'joined'
+end
+
 local function yield_until(pred, msg)
 	for _ = 1, 50 do
 		if pred() then return true end
 		yield_once()
 	end
 	error(msg or 'condition was not reached', 2)
+end
+
+local function shell_quote(s)
+	s = tostring(s or '')
+	return "'" .. s:gsub("'", "'\\''") .. "'"
+end
+
+local function shell_exit_status(a, b, c)
+	if type(a) == 'number' then
+		if a >= 256 then return math.floor(a / 256) end
+		return a
+	end
+	if a == true then return 0 end
+	if b == 'exit' and type(c) == 'number' then return c end
+	if type(c) == 'number' then return c end
+	return 1
+end
+
+local function run_filtered_child(filter, timeout_s)
+	local cmd = ('timeout %s env TEST_FILTER=%s luajit run.lua'):format(
+		tostring(timeout_s or 2), shell_quote(filter))
+	return shell_exit_status(os.execute(cmd))
 end
 
 local function fake_controller()
@@ -220,6 +250,56 @@ function M.test_losing_active_run_op_calls_active_abort_without_closing_driver()
 	end)
 end
 
+
+function M.test_losing_active_run_op_can_detach_and_cleanup_after_cqueues_completion()
+	local ctl = fake_controller()
+	local drv = assert(driver_mod.new { controller = ctl })
+	local active = false
+	local release = false
+	local detach_reason
+	local cleanup_reason
+	local cleanup_result
+
+	fibers.run(function (scope)
+		assert(drv:start(scope))
+
+		local waiter = assert(scope:child())
+		local result, err
+		assert(waiter:spawn(function ()
+			result, err = fibers.perform(drv:run_op('unit.active_detached', function ()
+				active = true
+				while not release do runtime.yield() end
+				return 'late_result'
+			end, {
+				detach_on_abort = true,
+				on_detach = function (reason) detach_reason = reason end,
+				on_detached_complete = function (reason, ok, packed)
+					cleanup_reason = reason
+					if ok and packed then cleanup_result = packed[1] end
+				end,
+			}))
+		end))
+
+		yield_until(function () return active end, 'job should become active')
+		waiter:cancel('stop_waiting')
+		if not join_child_with_timeout(waiter, 0.25) then
+			release = true
+			drv:terminate('detached test bounded failure')
+			join_child_with_timeout(waiter, 0.25)
+			error('detached run_op caller did not return after abort; active cqueues jobs must detach caller cleanup', 2)
+		end
+		eq(result, nil)
+		eq(err, nil)
+		eq(detach_reason, 'aborted')
+		ok(not drv:is_closed(), 'detached active abort must not close driver')
+		release = true
+		yield_until(function () return cleanup_reason == 'aborted' end, 'detached cleanup should run after cqueues job returns')
+		eq(cleanup_result, 'late_result')
+		ok(not drv:is_closed(), 'detached cleanup must not close driver')
+		drv:terminate('done')
+	end)
+end
+
 function M.test_losing_active_run_op_without_owner_terminates_driver()
 	local ctl = fake_controller()
 	local drv = assert(driver_mod.new { controller = ctl })
@@ -357,6 +437,18 @@ function M.test_driver_start_can_target_started_parent_scope_from_child_scope()
 		eq(start_err, nil)
 		drv:terminate('done')
 	end)
+end
+
+
+-- Keep this ownership-boundary regression under the same focused regression filter as the
+-- hostile real-HTTP test.  Run the raw payload in a subprocess: the old
+-- hard-close-only implementation can wedge the Fibers scheduler so an
+-- in-process watchdog cannot fire reliably.  The subprocess timeout turns that
+-- into a bounded, clear test failure.
+function M.test_metrics_style_exchange_timeout_regression_cqueues_driver_detaches_active_job_cleanup_to_cqueues_job()
+	local code = run_filtered_child('test_losing_active_run_op_can_detach_and_cleanup_after_cqueues_completion',
+		tonumber(os.getenv('HTTP_METRICS_TIMEOUT_UNIT_CHILD_TIMEOUT_S') or '') or 2)
+	eq(code, 0, 'detached cqueues-driver ownership payload should pass in a bounded child process')
 end
 
 return M

--- a/tests/unit/http/transport/test_lua_http.lua
+++ b/tests/unit/http/transport/test_lua_http.lua
@@ -89,6 +89,7 @@ local function listener_with(opts)
 		max_accept_queue = opts.max_accept_queue,
 		condition_factory = function () return fake_condition() end,
 		context_terminator = opts.context_terminator,
+		intra_stream_timeout = opts.intra_stream_timeout,
 		on_context = opts.on_context,
 	})
 end
@@ -176,6 +177,23 @@ function M.test_http_context_read_helpers_preserve_http_semantics()
 		eq(body, 'body')
 		eq(stream.calls[1][1], 'body')
 		eq(stream.calls[1][2], nil)
+		ctx:terminate('done')
+		listener:terminate('done')
+	end)
+end
+
+function M.test_http_context_stream_ops_pass_intra_stream_timeout()
+	local listener = listener_with { intra_stream_timeout = 0.25 }
+	local stream = fake_stream()
+	local ctx = lua_http._new_context_for_test(listener, listener:_raw_server_for_test(), stream)
+
+	fibers.run(function (scope)
+		assert(scope:spawn(function () fibers.perform(ctx:read_chunk_op()) end))
+		yield_many(3)
+		ok(ctx:_drain_one_for_test())
+		yield_many(3)
+		eq(stream.calls[1][1], 'chunk')
+		eq(stream.calls[1][2], 0.25, 'server context should pass intra_stream_timeout to lua-http stream read')
 		ctx:terminate('done')
 		listener:terminate('done')
 	end)

--- a/tests/unit/http/transport/test_terminate.lua
+++ b/tests/unit/http/transport/test_terminate.lua
@@ -7,18 +7,7 @@ local function eq(a, b, msg)
 end
 local function ok(v, msg) if not v then error(msg or 'assertion failed', 2) end return v end
 
-function M.test_terminate_stream_uses_terminate_when_available()
-	local reason
-	local stream = {
-		terminate = function (_, why) reason = why; return true end,
-		close = function () error('close must not be used by terminate_stream', 0) end,
-		shutdown = function () error('shutdown must not be used by terminate_stream', 0) end,
-	}
-	ok(terminate.terminate_stream(stream, 'done'))
-	eq(reason, 'done')
-end
-
-function M.test_terminate_stream_takes_and_closes_underlying_socket()
+function M.test_terminate_stream_takes_and_closes_underlying_socket_before_graceful_methods()
 	local socket_closed = false
 	local stream_close_called = false
 	local stream_shutdown_called = false
@@ -37,36 +26,36 @@ function M.test_terminate_stream_takes_and_closes_underlying_socket()
 	eq(stream_shutdown_called, false)
 end
 
-function M.test_terminate_stream_does_not_use_graceful_fallbacks_when_socket_is_unavailable()
-	local stream_close_called = false
-	local stream_shutdown_called = false
+function M.test_terminate_stream_prefers_terminate_then_close_over_shutdown_when_socket_take_unavailable()
+	local calls = {}
 	local stream = {
-		connection = {},
-		close = function () stream_close_called = true; return true end,
-		shutdown = function () stream_shutdown_called = true; return true end,
+		terminate = function (_, reason) calls[#calls + 1] = 'terminate:' .. tostring(reason); return true end,
+		close = function () calls[#calls + 1] = 'close'; return true end,
+		shutdown = function () calls[#calls + 1] = 'shutdown'; return true end,
 	}
-	ok(terminate.terminate_stream(stream, 'drop'))
-	eq(stream_close_called, false)
-	eq(stream_shutdown_called, false)
+	ok(terminate.terminate_stream(stream, 'done'))
+	eq(calls[1], 'terminate:done')
+	eq(calls[2], nil)
 end
 
-function M.test_terminate_server_uses_immediate_termination_or_listener_close()
-	local reason
-	ok(terminate.terminate_server({ terminate = function (_, why) reason = why; return true end }, 'down'))
-	eq(reason, 'down')
+function M.test_terminate_stream_falls_back_to_close_before_shutdown()
+	local calls = {}
+	local stream = {
+		close = function () calls[#calls + 1] = 'close'; return true end,
+		shutdown = function () calls[#calls + 1] = 'shutdown'; return true end,
+	}
+	ok(terminate.terminate_stream(stream, 'done'))
+	eq(calls[1], 'close')
+	eq(calls[2], nil)
+end
 
+function M.test_terminate_server_uses_immediate_termination()
 	local closed
 	ok(terminate.terminate_server({ close = function () closed = true; return true end }, 'down'))
 	eq(closed, true)
 end
 
-function M.test_terminate_websocket_uses_terminate_when_available()
-	local reason
-	ok(terminate.terminate_websocket({ terminate = function (_, why) reason = why; return true end }, 'drop'))
-	eq(reason, 'drop')
-end
-
-function M.test_terminate_websocket_uses_abnormal_zero_timeout_as_last_resort()
+function M.test_terminate_websocket_uses_abnormal_immediate_termination()
 	local code, reason, timeout
 	ok(terminate.terminate_websocket({ close = function (_, c, r, t) code, reason, timeout = c, r, t; return true end }, 'drop'))
 	eq(code, 1006)
@@ -74,40 +63,39 @@ function M.test_terminate_websocket_uses_abnormal_zero_timeout_as_last_resort()
 	eq(timeout, 0)
 end
 
-function M.test_terminate_request_prefers_request_terminate()
-	local reason
-	ok(terminate.terminate_request({ terminate = function (_, why) reason = why; return true end }, 'drop'))
-	eq(reason, 'drop')
-end
-
-function M.test_terminate_request_takes_and_closes_connection_socket_when_available()
+function M.test_terminate_request_takes_and_closes_underlying_socket_when_present()
 	local socket_closed = false
-	local cancel_called = false
-	local req = {
+	local request = {
 		connection = {
-			take_socket = function ()
-				return { close = function () socket_closed = true; return true end }
-			end,
+			take_socket = function () return { close = function () socket_closed = true; return true end } end,
 		},
-		cancel = function () cancel_called = true; return true end,
+		cancel = function () error('cancel must not be used when socket take succeeds', 0) end,
+		close = function () error('close must not be used when socket take succeeds', 0) end,
+		shutdown = function () error('shutdown must not be used when socket take succeeds', 0) end,
 	}
-	ok(terminate.terminate_request(req, 'drop'))
+	ok(terminate.terminate_request(request, 'drop'))
 	eq(socket_closed, true)
-	eq(cancel_called, false)
 end
 
-function M.test_terminate_request_uses_cancel_when_no_socket_exists_yet()
-	local cancel_reason
-	local close_called = false
-	local shutdown_called = false
+function M.test_terminate_request_prefers_terminate_when_available()
+	local calls = {}
 	ok(terminate.terminate_request({
-		cancel = function (_, reason) cancel_reason = reason; return true end,
-		close = function () close_called = true; return true end,
-		shutdown = function () shutdown_called = true; return true end,
+		terminate = function (_, reason) calls[#calls + 1] = 'terminate:' .. tostring(reason); return true end,
+		cancel = function () calls[#calls + 1] = 'cancel'; return true end,
 	}, 'drop'))
-	eq(cancel_reason, 'drop')
-	eq(close_called, false)
-	eq(shutdown_called, false)
+	eq(calls[1], 'terminate:drop')
+	eq(calls[2], nil)
+end
+
+function M.test_terminate_request_falls_back_to_cancel_before_graceful_methods()
+	local calls = {}
+	ok(terminate.terminate_request({
+		cancel = function (_, reason) calls[#calls + 1] = 'cancel:' .. tostring(reason); return true end,
+		close = function () calls[#calls + 1] = 'close'; return true end,
+		shutdown = function () calls[#calls + 1] = 'shutdown'; return true end,
+	}, 'drop'))
+	eq(calls[1], 'cancel:drop')
+	eq(calls[2], nil)
 end
 
 return M

--- a/tests/unit/http/transport/test_terminate.lua
+++ b/tests/unit/http/transport/test_terminate.lua
@@ -7,24 +7,66 @@ local function eq(a, b, msg)
 end
 local function ok(v, msg) if not v then error(msg or 'assertion failed', 2) end return v end
 
-function M.test_terminate_stream_prefers_shutdown_and_is_idempotent_shape()
-	local calls = {}
+function M.test_terminate_stream_uses_terminate_when_available()
+	local reason
 	local stream = {
-		shutdown = function () calls[#calls + 1] = 'shutdown'; return true end,
-		close = function () calls[#calls + 1] = 'close'; return true end,
+		terminate = function (_, why) reason = why; return true end,
+		close = function () error('close must not be used by terminate_stream', 0) end,
+		shutdown = function () error('shutdown must not be used by terminate_stream', 0) end,
 	}
 	ok(terminate.terminate_stream(stream, 'done'))
-	eq(calls[1], 'shutdown')
-	eq(calls[2], nil)
+	eq(reason, 'done')
 end
 
-function M.test_terminate_server_uses_immediate_termination()
+function M.test_terminate_stream_takes_and_closes_underlying_socket()
+	local socket_closed = false
+	local stream_close_called = false
+	local stream_shutdown_called = false
+	local stream = {
+		connection = {
+			take_socket = function ()
+				return { close = function () socket_closed = true; return true end }
+			end,
+		},
+		close = function () stream_close_called = true; return true end,
+		shutdown = function () stream_shutdown_called = true; return true end,
+	}
+	ok(terminate.terminate_stream(stream, 'drop'))
+	eq(socket_closed, true)
+	eq(stream_close_called, false)
+	eq(stream_shutdown_called, false)
+end
+
+function M.test_terminate_stream_does_not_use_graceful_fallbacks_when_socket_is_unavailable()
+	local stream_close_called = false
+	local stream_shutdown_called = false
+	local stream = {
+		connection = {},
+		close = function () stream_close_called = true; return true end,
+		shutdown = function () stream_shutdown_called = true; return true end,
+	}
+	ok(terminate.terminate_stream(stream, 'drop'))
+	eq(stream_close_called, false)
+	eq(stream_shutdown_called, false)
+end
+
+function M.test_terminate_server_uses_immediate_termination_or_listener_close()
+	local reason
+	ok(terminate.terminate_server({ terminate = function (_, why) reason = why; return true end }, 'down'))
+	eq(reason, 'down')
+
 	local closed
 	ok(terminate.terminate_server({ close = function () closed = true; return true end }, 'down'))
 	eq(closed, true)
 end
 
-function M.test_terminate_websocket_uses_abnormal_immediate_termination()
+function M.test_terminate_websocket_uses_terminate_when_available()
+	local reason
+	ok(terminate.terminate_websocket({ terminate = function (_, why) reason = why; return true end }, 'drop'))
+	eq(reason, 'drop')
+end
+
+function M.test_terminate_websocket_uses_abnormal_zero_timeout_as_last_resort()
 	local code, reason, timeout
 	ok(terminate.terminate_websocket({ close = function (_, c, r, t) code, reason, timeout = c, r, t; return true end }, 'drop'))
 	eq(code, 1006)
@@ -32,22 +74,40 @@ function M.test_terminate_websocket_uses_abnormal_immediate_termination()
 	eq(timeout, 0)
 end
 
-function M.test_terminate_request_prefers_immediate_shutdown()
-	local calls = {}
-	ok(terminate.terminate_request({
-		shutdown = function () calls[#calls + 1] = 'shutdown'; return true end,
-		close = function () calls[#calls + 1] = 'close'; return true end,
-	}, 'drop'))
-	eq(calls[1], 'shutdown')
-	eq(calls[2], nil)
+function M.test_terminate_request_prefers_request_terminate()
+	local reason
+	ok(terminate.terminate_request({ terminate = function (_, why) reason = why; return true end }, 'drop'))
+	eq(reason, 'drop')
 end
 
-function M.test_terminate_request_falls_back_to_cancel_with_reason()
+function M.test_terminate_request_takes_and_closes_connection_socket_when_available()
+	local socket_closed = false
+	local cancel_called = false
+	local req = {
+		connection = {
+			take_socket = function ()
+				return { close = function () socket_closed = true; return true end }
+			end,
+		},
+		cancel = function () cancel_called = true; return true end,
+	}
+	ok(terminate.terminate_request(req, 'drop'))
+	eq(socket_closed, true)
+	eq(cancel_called, false)
+end
+
+function M.test_terminate_request_uses_cancel_when_no_socket_exists_yet()
 	local cancel_reason
+	local close_called = false
+	local shutdown_called = false
 	ok(terminate.terminate_request({
 		cancel = function (_, reason) cancel_reason = reason; return true end,
+		close = function () close_called = true; return true end,
+		shutdown = function () shutdown_called = true; return true end,
 	}, 'drop'))
 	eq(cancel_reason, 'drop')
+	eq(close_called, false)
+	eq(shutdown_called, false)
 end
 
 return M


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

* [x] 🐛 Bug Fix
* [x] ✅ Test

## Description

Fixes HTTP client abort handling for hostile, incomplete, or stalled upstream responses.

Previously, when a Fibers caller timed out while HTTP client work was active inside lua-http/cqueues, the abort/finaliser path could attempt to clean up lua-http request, stream, connection, or socket state synchronously from outside the owning cqueues coroutine. Depending on timing and peer behaviour, that could either:

* wedge the scheduler so a later caller-side timeout did not regain control; or
* corrupt cqueues descriptor state and later surface as `EBADF`, causing the shared HTTP backend to fail and taking down the UI listener.

The root issue is descriptor ownership: once cqueues/lua-http owns an active HTTP operation, cleanup of request/stream/connection/socket state must happen from the cqueues coroutine after it returns, not directly from the outer Fibers cancellation path.

This change updates the cancellation model so caller aborts detach from active cqueues jobs instead of synchronously tearing down cqueues-owned transport state:

* Active cqueues jobs can now detach the caller on abort.
* The caller observes the abort immediately.
* The cqueues coroutine remains the owner of lua-http/cqueues resources until it returns.
* Deferred cleanup runs after the cqueues job completes.
* HTTP open-exchange and response-stream reads now use this detached cleanup path.
* lua-http stream read/write helpers receive the configured intra-stream timeout.
* Transport teardown still prefers immediate cleanup where appropriate, but it is now performed from the correct ownership boundary.

This is a cleaner fix than isolating outbound HTTP into a separate driver: it corrects the cqueues ownership contract rather than simply containing the blast radius.

## Regression coverage

Adds and improves tests for the ownership-boundary behaviour:

* cqueues driver regression:

  * active cqueues job abort detaches the caller;
  * cleanup runs only after the cqueues job completes.
* HTTP client open-exchange regression:

  * caller abort does not synchronously close/cancel lua-http request state;
  * request cleanup is deferred to the cqueues job.
* HTTP response-stream regression:

  * caller abort closes the public exchange handle for the caller;
  * lua-http stream cleanup is deferred until the cqueues read job completes.
* lua-http transport tests:

  * intra-stream timeout is passed through to stream read/write operations.
* devhost hostile HTTP regression:

  * partial response body;
  * caller-side timeout;
  * subsequent stalled response;
  * UI-like listener probe;
  * final outbound retry;
  * HTTP backend remains ready and does not report an EBADF-shaped failure.

The focused regression filter now selects both unit-level ownership tests and the hostile devhost integration test. It distinguishes the previous hard-close-only implementation from the detached-cleanup implementation.

## Manual test

* [x] 👍 yes

## Manual test description

Confirmed the focused regression filter fails against the old source in bounded time and passes against the new source.

Focused regression command:

```sh
HTTP_METRICS_TIMEOUT_UNIT_CHILD_TIMEOUT_S=2 \
HTTP_METRICS_TIMEOUT_HOSTILE_CHILD_ATTEMPTS=20 \
HTTP_METRICS_TIMEOUT_HOSTILE_TAIL_LINES=160 \
TEST_FILTER=metrics_style_exchange_timeout_regression \
luajit run.lua
```

Old source result:

* cqueues-driver ownership regression failed;
* HTTP client ownership regressions failed;
* hostile integration path was not sufficient on its own to distinguish the bug.

New source result:

```text
4 tests, 0 failed
```

Also verified the broader real HTTP devhost integration set:

```sh
TEST_FILTER=http_service_real luajit run.lua
```

Result:

```text
7 tests, 0 failed
```

## Added tests?

* [x] 👍 yes

## Added to documentation?

* [x] 🙅 no documentation needed
