### PR TITLE
fix: allow configurable exit grace period for service cancellation to fix timout in main test

### DIFF
--- a/src/devicecode/main.lua
+++ b/src/devicecode/main.lua
@@ -173,6 +173,7 @@ function M.run(scope, params)
     params = params or {}
 
     local env = params.env or (os.getenv('DEVICECODE_ENV') or 'dev')
+    local exit_grace_period = params.exit_grace_period or EXIT_GRACE_PERIOD
 
     local service_names = parse_csv(params.services_csv or require_env('DEVICECODE_SERVICES'))
     if #service_names == 0 then
@@ -288,7 +289,7 @@ function M.run(scope, params)
             primary = tostring(jprimary),
         })
 
-        sleep.sleep(params.exit_grace_period or EXIT_GRACE_PERIOD)
+        sleep.sleep(exit_grace_period)
 
 		scope:cancel(('service_not_ok:%s'):format(tostring(svc)))
     end)

--- a/src/devicecode/main.lua
+++ b/src/devicecode/main.lua
@@ -288,7 +288,7 @@ function M.run(scope, params)
             primary = tostring(jprimary),
         })
 
-        sleep.sleep(EXIT_GRACE_PERIOD)
+        sleep.sleep(params.exit_grace_period or EXIT_GRACE_PERIOD)
 
 		scope:cancel(('service_not_ok:%s'):format(tostring(svc)))
     end)

--- a/tests/integration/devhost/main_failure_spec.lua
+++ b/tests/integration/devhost/main_failure_spec.lua
@@ -97,6 +97,7 @@ local function spawn_main(scope, bus, fake_hal, linger_box, services_csv)
 			services_csv   = services_csv,
 			bus            = bus,
 			service_loader = make_service_loader(fake_hal, linger_box),
+			exit_grace_period = 0.05,
 		})
 	end)
 	assert(ok_spawn, tostring(err))


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description
The grace period introduced in an earlier PR caused the main spec test to fail due to timing out while waiting for the main scope to join. This PR fixes the timeout by making the grace period configurable.

## Related Issues, Tickets & Documents
#272

## Manual test
<!-- Have you manually tested this code and confirmed it is working? -->
- [x] 👍 yes
- [ ] 🙅 no

## Manual test description
run `make test` and all tests should pass

## Added tests?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?
- [ ] 📜 README.md
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?

