### PR TITLE
ui: updates tests, makes explicit policy required

### DIFF
--- a/src/services/ui/config.lua
+++ b/src/services/ui/config.lua
@@ -24,12 +24,6 @@ local DEFAULTS = {
 		queue_len = 32,
 		replay = true,
 	},
-	updates = {
-		upload = {
-			enabled = true,
-			max_bytes = 64 * 1024 * 1024,
-		},
-	},
 	sessions = {
 		prune_interval = 60,
 	},
@@ -224,7 +218,7 @@ local function normalise_update_upload(raw)
 	local ok
 	ok, err = allowed(raw, UPDATE_UPLOAD_KEYS, 'updates.upload')
 	if not ok then return nil, err end
-	local out = copy_plain(DEFAULTS.updates.upload)
+	local out = {}
 	local v
 	v, err = bool_or_nil(raw.enabled, 'updates.upload.enabled')
 	if err then return nil, err end

--- a/tests/unit/ui/test_config.lua
+++ b/tests/unit/ui/test_config.lua
@@ -37,8 +37,7 @@ function M.test_normalise_supplies_http_static_sse_defaults_and_accepts_explicit
 	eq(cfg.updates.upload.create_job, true)
 	eq(cfg.updates.upload.start_job, true)
 	eq(cfg.updates.commit.require_auth, false)
-	eq(cfg.uploads.enabled, true)
-	eq(cfg.uploads.require_auth, false)
+	eq(config.DEFAULTS.updates, nil)
 	eq(cfg.observability.status_interval_s, 30)
 end
 
@@ -46,18 +45,21 @@ end
 function M.test_observability_status_interval_is_configurable()
 	local cfg = ok(config.normalise({
 		schema = config.SCHEMA,
+		updates = update_policy(),
 		observability = { status_interval_s = 15 },
 	}))
 	eq(cfg.observability.status_interval_s, 15)
 
 	cfg = ok(config.normalise({
 		schema = config.SCHEMA,
+		updates = update_policy(),
 		observability = { status_interval_s = false },
 	}))
 	eq(cfg.observability.status_interval_s, false)
 
 	local bad, err = config.normalise({
 		schema = config.SCHEMA,
+		updates = update_policy(),
 		observability = { every_status = true },
 	})
 	eq(bad, nil)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

* [x] 🐛 Bug Fix
* [x] ✅ Test

## Description

Aligns the UI config tests and defaults with the current explicit update-policy contract.

The UI config normaliser now requires `updates.upload` and `updates.commit` to be provided explicitly, rather than relying on partial defaults or the old root-level `uploads` shape.

Changes:

* Removes the partial `DEFAULTS.updates.upload` block from `services/ui/config.lua`.
* Builds `updates.upload` from explicit input only.
* Updates UI config tests to assert `cfg.updates.upload` / `cfg.updates.commit`, not legacy `cfg.uploads`.
* Adds explicit update policy input to observability config tests.
* Asserts that `config.DEFAULTS.updates` is absent, making the explicit policy requirement clear.

## Manual test

* [x] 👍 yes

## Manual test description

Ran the LuaJIT unit test suite:

```text
994 tests, 0 failed, 0 skipped
```

## Added tests?

* [x] 👍 yes

## Added to documentation?

* [x] 🙅 no documentation needed
