### PR TITLE
policy-driven bundled MCU firmware updates

### DIFF
--- a/src/configs/bigbox-v1-cm-2.json
+++ b/src/configs/bigbox-v1-cm-2.json
@@ -1496,8 +1496,14 @@
               "path": "/artifacts/mcu.dcmcu",
               "policy": "transient_only"
             },
-            "auto_create": false,
-            "auto_start": false
+            "job": {
+              "job_id": "bundled-mcu",
+              "create_if": "image_differs",
+              "start": "auto",
+              "commit": "auto",
+              "reconcile": "required",
+              "supersede": "same_job_if_image_changed"
+            }
           }
         }
       },

--- a/src/configs/bigbox-v1-cm-2.json
+++ b/src/configs/bigbox-v1-cm-2.json
@@ -1488,6 +1488,7 @@
       },
       "bundled": {
         "enabled": true,
+        "max_attempts": 30,
         "components": {
           "mcu": {
             "component": "mcu",

--- a/src/services/update/active_runtime.lua
+++ b/src/services/update/active_runtime.lua
@@ -540,6 +540,40 @@ function Component:_start_apply(ev)
 	return handle, nil
 end
 
+local function job_policy(job)
+	return type(job) == 'table' and type(job.policy) == 'table' and job.policy or {}
+end
+
+local function policy_auto_commit(job)
+	return job_policy(job).commit == 'auto'
+end
+
+function Component:_start_policy_commit(job)
+	if not (job and job.job_id) then return nil, 'not_ready' end
+	if job.state ~= 'awaiting_commit' then return false, 'not_awaiting_commit' end
+	if not policy_auto_commit(job) then return false, 'manual_commit' end
+	if not (self._jobs and type(self._jobs.admit_transition) == 'function') then return nil, 'job_runtime_unavailable' end
+	local handle, admit_err = self._jobs:admit_transition {
+		kind = 'start_job',
+		generation = job.generation or self._current_generation,
+		job_id = job.job_id,
+		phase = 'commit',
+		reason = 'policy_auto_commit',
+	}
+	if not handle then return nil, admit_err or 'policy_auto_commit_admission_failed' end
+	local result, jerr = fibers.perform(handle:outcome_op())
+	if not result or result.status ~= 'persisted' then
+		return nil, jerr or (result and result.reason) or 'policy_auto_commit_persist_failed'
+	end
+	local ok_report, report_err = self:_report_changed('policy_auto_commit_started', {
+		job_id = job.job_id,
+		phase = 'commit',
+		token = result.token,
+	})
+	if ok_report ~= true then return nil, report_err end
+	return true, nil
+end
+
 function Component:_start_reconcile(job)
 	if not (job and job.job_id) then return nil, 'not_ready' end
 	if self._state.active ~= nil then return nil, 'slot_busy' end
@@ -803,6 +837,12 @@ function Component:_handle_apply_done(ev)
 	if ok_change ~= true then return nil, cerr end
 
 	local job = result.job
+	if job and job.state == 'awaiting_commit' then
+		local ok_commit, commit_err = self:_start_policy_commit(job)
+		if ok_commit == nil and commit_err ~= 'manual_commit' then
+			return nil, commit_err or 'policy_auto_commit_failed'
+		end
+	end
 	if job and job.state == 'awaiting_return' then
 		local ok_rec, rerr = self:_start_reconcile(job)
 		if ok_rec == nil and rerr ~= 'slot_busy' and rerr ~= 'reconcile_backend_unavailable' then

--- a/src/services/update/bundled.lua
+++ b/src/services/update/bundled.lua
@@ -35,6 +35,47 @@ local function component_order(cfg)
 	return out
 end
 
+local function job_policy(item)
+	item = item or {}
+	local job = copy(item.job or {})
+	if job.create_if == nil then
+		if item.auto_create ~= nil then
+			job.create_if = item.auto_create == true and 'always' or 'never'
+		else
+			job.create_if = 'image_differs'
+		end
+	end
+	if job.start == nil then job.start = item.auto_start == true and 'auto' or 'manual' end
+	if job.commit == nil then job.commit = 'manual' end
+	return job
+end
+
+local function component_state(snapshot, component)
+	if type(snapshot) ~= 'table' then return nil end
+	local by_id = snapshot.by_id or snapshot.components
+	local rec = type(by_id) == 'table' and by_id[component] or nil
+	if type(rec) == 'table' and type(rec.state) == 'table' then return rec.state end
+	if type(rec) == 'table' then return rec end
+	if snapshot.component == component then return snapshot.state or snapshot end
+	return nil
+end
+
+local function current_image_id(snapshot, component)
+	local state = component_state(snapshot, component)
+	local software = type(state) == 'table' and (state.software or (type(state.raw_facts) == 'table' and state.raw_facts.software)) or nil
+	local image_id = type(software) == 'table' and software.image_id or nil
+	if type(image_id) == 'string' and image_id ~= '' then return image_id end
+	return nil
+end
+
+local function expected_image_id(desired)
+	if type(desired) ~= 'table' then return nil end
+	local artifact = desired.artifact or desired.desired or desired
+	local image_id = desired.expected_image_id or (type(artifact) == 'table' and artifact.expected_image_id)
+	if type(image_id) == 'string' and image_id ~= '' then return image_id end
+	return nil
+end
+
 function M.new(params)
 	params = params or {}
 	return setmetatable({
@@ -128,14 +169,36 @@ function Coordinator:handle_probe_done(ev)
 	return true, nil
 end
 
-function Coordinator:needs_apply(component)
+function Coordinator:needs_apply(component, opts)
+	opts = opts or {}
 	if not self:enabled() then return false end
 	local item = self:spec(component)
-	return type(item) == 'table'
-		and item.auto_create == true
-		and self.desired[component] ~= nil
-		and self.applies[component] == nil
-		and self.last_apply[component] == nil
+	local policy = job_policy(item)
+	local desired = self.desired[component]
+	if type(item) ~= 'table' or desired == nil or self.applies[component] ~= nil or self.last_apply[component] ~= nil then
+		return false
+	end
+	if policy.create_if == 'never' then
+		self.state[component] = 'create_disabled'
+		return false
+	end
+	if policy.create_if == 'image_differs' then
+		local expected = expected_image_id(desired)
+		local current = current_image_id(opts.current or opts.components or opts.observer_snapshot, component)
+		if expected == nil then
+			self.state[component] = 'pending_expected_image'
+			return false
+		end
+		if current == nil then
+			self.state[component] = 'pending_current_image'
+			return false
+		end
+		if current == expected then
+			self.state[component] = 'already_current'
+			return false
+		end
+	end
+	return true
 end
 
 function Coordinator:start_apply(spec)
@@ -170,7 +233,7 @@ function Coordinator:start_ready_applies(spec)
 	local started = {}
 	if not self:enabled() then return started, nil end
 	for _, component in ipairs(self:components()) do
-		if self:needs_apply(component) then
+		if self:needs_apply(component, spec) then
 			local handle, err = self:start_apply {
 				lifetime_scope = spec.lifetime_scope,
 				reaper_scope = spec.reaper_scope,

--- a/src/services/update/bundled_apply.lua
+++ b/src/services/update/bundled_apply.lua
@@ -26,6 +26,26 @@ local function artifact_ref_of(artifact)
 	return artifact.artifact_ref or artifact.ref or artifact.id
 end
 
+local TERMINAL = { succeeded = true, failed = true, cancelled = true, timed_out = true, superseded = true, discarded = true }
+
+local function job_policy(spec)
+	spec = spec or {}
+	local job = copy(spec.job or {})
+	if job.job_id == nil then job.job_id = spec.job_id or (spec.source and spec.source.job_id) end
+	if job.create_if == nil then
+		if spec.auto_create ~= nil then
+			job.create_if = spec.auto_create == true and 'always' or 'never'
+		else
+			job.create_if = 'image_differs'
+		end
+	end
+	if job.start == nil then job.start = spec.auto_start == true and 'auto' or 'manual' end
+	if job.commit == nil then job.commit = 'manual' end
+	if job.reconcile == nil then job.reconcile = 'required' end
+	if job.supersede == nil then job.supersede = 'same_job_if_image_changed' end
+	return job
+end
+
 local function transition(jobs, cmd)
 	if type(jobs) ~= 'table' or type(jobs.admit_transition) ~= 'function' then
 		return nil, 'job_runtime_unavailable'
@@ -40,7 +60,8 @@ local function create_payload(spec, desired)
 	local artifact = copy(desired.artifact or desired.desired or desired)
 	local component = assert(spec.component, 'bundled_apply component required')
 	local source = spec.source or {}
-	local job_id = spec.job_id or source.job_id or ('bundled-' .. component)
+	local policy = job_policy(spec)
+	local job_id = policy.job_id or spec.job_id or source.job_id or ('bundled-' .. component)
 	local metadata = merge({
 		source = 'bundled',
 		bundled = true,
@@ -58,20 +79,24 @@ local function create_payload(spec, desired)
 		artifact = artifact,
 		artifact_ref = desired.artifact_ref or artifact_ref_of(artifact),
 		metadata = metadata,
-		auto_start = spec.auto_start == true,
+		policy = policy,
+		auto_start = policy.start == 'auto',
 	}
 end
 
-local function create_or_reuse_job(params, payload)
-	local existing = params.jobs:get(payload.job_id)
-	if existing ~= nil then
-		return {
-			status = 'existing',
-			job_id = payload.job_id,
-			job = existing,
-		}, nil
-	end
+local function discard_existing_job(params, job_id)
+	local result, err = transition(params.jobs, {
+		kind = 'discard_job',
+		generation = params.generation,
+		job_id = job_id,
+		reason = 'bundled_supersede_changed_image',
+	})
+	if not result then return nil, err or 'bundled_supersede_discard_failed' end
+	if result.status ~= 'persisted' then return nil, result.reason or 'bundled_supersede_discard_rejected' end
+	return result, nil
+end
 
+local function create_job(params, payload)
 	local result, err = transition(params.jobs, {
 		kind = 'create_job',
 		generation = params.generation,
@@ -90,6 +115,30 @@ local function create_or_reuse_job(params, payload)
 	end
 
 	return nil, result.reason or err or 'bundled_create_job_failed'
+end
+
+local function create_or_reuse_job(params, payload)
+	local existing = params.jobs:get(payload.job_id)
+	if existing ~= nil then
+		if existing.expected_image_id == payload.expected_image_id then
+			return {
+				status = 'existing',
+				job_id = payload.job_id,
+				job = existing,
+			}, nil
+		end
+		local supersede = type(payload.policy) == 'table' and payload.policy.supersede or nil
+		if TERMINAL[existing.state] == true and supersede == 'same_job_if_image_changed' then
+			local discarded, derr = discard_existing_job(params, payload.job_id)
+			if not discarded then return nil, derr end
+			local created, cerr = create_job(params, payload)
+			if created then created.superseded = discarded end
+			return created, cerr
+		end
+		return nil, 'bundled_existing_job_image_mismatch'
+	end
+
+	return create_job(params, payload)
 end
 
 local function maybe_start_job(params, job, auto_start)

--- a/src/services/update/bundled_apply.lua
+++ b/src/services/update/bundled_apply.lua
@@ -28,6 +28,51 @@ end
 
 local TERMINAL = { succeeded = true, failed = true, cancelled = true, timed_out = true, superseded = true, discarded = true }
 
+local function optional_number(v)
+	if type(v) == 'number' then return v end
+	if type(v) == 'string' then return tonumber(v) end
+	return nil
+end
+
+local function max_attempts(policy)
+	local n = optional_number(policy and policy.max_attempts)
+	if type(n) ~= 'number' or n <= 0 or n ~= math.floor(n) then return nil end
+	return n
+end
+
+local function max_number(...)
+	local n = 0
+	for i = 1, select('#', ...) do
+		local candidate = optional_number(select(i, ...))
+		if type(candidate) == 'number' and candidate > n then n = candidate end
+	end
+	return n
+end
+
+local function job_attempt(job)
+	if type(job) ~= 'table' then return 0 end
+	local metadata = type(job.metadata) == 'table' and job.metadata or {}
+	local policy = type(job.policy) == 'table' and job.policy or {}
+	local result = type(job.result) == 'table' and job.result or {}
+	return max_number(
+		job.attempt,
+		job.bundled_attempt,
+		metadata.attempt,
+		metadata.bundled_attempt,
+		policy.attempt,
+		result.attempt,
+		result.bundled_attempt
+	)
+end
+
+local function set_payload_attempt(payload, attempt)
+	attempt = optional_number(attempt) or 1
+	payload.attempt = attempt
+	payload.metadata = merge(payload.metadata or {}, { bundled_attempt = attempt })
+	payload.policy = merge(payload.policy or {}, { attempt = attempt })
+	return payload
+end
+
 local function job_policy(spec)
 	spec = spec or {}
 	local job = copy(spec.job or {})
@@ -96,7 +141,8 @@ local function discard_existing_job(params, job_id)
 	return result, nil
 end
 
-local function create_job(params, payload)
+local function create_job(params, payload, attempt)
+	set_payload_attempt(payload, attempt)
 	local result, err = transition(params.jobs, {
 		kind = 'create_job',
 		generation = params.generation,
@@ -120,25 +166,40 @@ end
 local function create_or_reuse_job(params, payload)
 	local existing = params.jobs:get(payload.job_id)
 	if existing ~= nil then
+		local policy = type(payload.policy) == 'table' and payload.policy or {}
+		local supersede = policy.supersede
 		if existing.expected_image_id == payload.expected_image_id then
+			if TERMINAL[existing.state] == true and supersede == 'same_job_if_image_changed' then
+				local previous_attempt = job_attempt(existing)
+				local next_attempt = previous_attempt + 1
+				local limit = max_attempts(policy)
+				if limit == nil then return nil, 'bundled_max_attempts_required' end
+				if next_attempt > limit then
+					return nil, 'bundled_retry_exhausted:' .. tostring(previous_attempt) .. '/' .. tostring(limit)
+				end
+				local discarded, derr = discard_existing_job(params, payload.job_id)
+				if not discarded then return nil, derr end
+				local created, cerr = create_job(params, payload, next_attempt)
+				if created then created.superseded = discarded end
+				return created, cerr
+			end
 			return {
 				status = 'existing',
 				job_id = payload.job_id,
 				job = existing,
 			}, nil
 		end
-		local supersede = type(payload.policy) == 'table' and payload.policy.supersede or nil
 		if TERMINAL[existing.state] == true and supersede == 'same_job_if_image_changed' then
 			local discarded, derr = discard_existing_job(params, payload.job_id)
 			if not discarded then return nil, derr end
-			local created, cerr = create_job(params, payload)
+			local created, cerr = create_job(params, payload, 1)
 			if created then created.superseded = discarded end
 			return created, cerr
 		end
 		return nil, 'bundled_existing_job_image_mismatch'
 	end
 
-	return create_job(params, payload)
+	return create_job(params, payload, 1)
 end
 
 local function maybe_start_job(params, job, auto_start)

--- a/src/services/update/bundled_apply.lua
+++ b/src/services/update/bundled_apply.lua
@@ -170,12 +170,22 @@ local function create_or_reuse_job(params, payload)
 		local supersede = policy.supersede
 		if existing.expected_image_id == payload.expected_image_id then
 			if TERMINAL[existing.state] == true and supersede == 'same_job_if_image_changed' then
-				local previous_attempt = job_attempt(existing)
-				local next_attempt = previous_attempt + 1
+				-- A previous successful convergence for this image must not consume
+				-- retry budget if the MCU later runs a different image again
+				-- (for example after a downgrade/rollback).  Treat that as a
+				-- fresh convergence episode.  Failed/timed-out terminal jobs remain
+				-- bounded by the retry budget to avoid loops on a bad bundle.
+				local next_attempt
 				local limit = max_attempts(policy)
 				if limit == nil then return nil, 'bundled_max_attempts_required' end
-				if next_attempt > limit then
-					return nil, 'bundled_retry_exhausted:' .. tostring(previous_attempt) .. '/' .. tostring(limit)
+				if existing.state == 'succeeded' then
+					next_attempt = 1
+				else
+					local previous_attempt = job_attempt(existing)
+					next_attempt = previous_attempt + 1
+					if next_attempt > limit then
+						return nil, 'bundled_retry_exhausted:' .. tostring(previous_attempt) .. '/' .. tostring(limit)
+					end
 				end
 				local discarded, derr = discard_existing_job(params, payload.job_id)
 				if not discarded then return nil, derr end

--- a/src/services/update/config.lua
+++ b/src/services/update/config.lua
@@ -135,6 +135,73 @@ local function normalise_components(raw)
 	return out, nil
 end
 
+
+local CREATE_IF = { always = true, image_differs = true, never = true }
+local JOB_START = { auto = true, manual = true }
+local JOB_COMMIT = { auto = true, manual = true }
+local JOB_RECONCILE = { required = true, manual = true }
+local JOB_SUPERSEDE = { same_job_if_image_changed = true, never = true }
+
+local function normalise_enum(t, key, allowed, default, where)
+	if t[key] == nil then t[key] = default end
+	if allowed[t[key]] ~= true then
+		return nil, where .. '.' .. key .. ' invalid: ' .. tostring(t[key])
+	end
+	return t, nil
+end
+
+local function normalise_bundled_job(raw, component, legacy, where)
+	local job, jerr = table_or_empty(raw)
+	if not job then return nil, where .. ': ' .. tostring(jerr) end
+	legacy = legacy or {}
+	if job.job_id == nil then job.job_id = legacy.job_id or ('bundled-' .. component) end
+	if type(job.job_id) ~= 'string' or job.job_id == '' then return nil, where .. '.job_id must be a non-empty string' end
+	if job.create_if == nil and legacy.auto_create ~= nil then job.create_if = legacy.auto_create == true and 'always' or 'never' end
+	if job.start == nil and legacy.auto_start ~= nil then job.start = legacy.auto_start == true and 'auto' or 'manual' end
+	local ok, err = normalise_enum(job, 'create_if', CREATE_IF, 'image_differs', where)
+	if not ok then return nil, err end
+	ok, err = normalise_enum(job, 'start', JOB_START, 'manual', where)
+	if not ok then return nil, err end
+	ok, err = normalise_enum(job, 'commit', JOB_COMMIT, 'manual', where)
+	if not ok then return nil, err end
+	ok, err = normalise_enum(job, 'reconcile', JOB_RECONCILE, 'required', where)
+	if not ok then return nil, err end
+	ok, err = normalise_enum(job, 'supersede', JOB_SUPERSEDE, 'same_job_if_image_changed', where)
+	if not ok then return nil, err end
+	return job, nil
+end
+
+local function normalise_bundled_component(id, item, where)
+	if type(item) ~= 'table' then return nil, where .. ' must be a table' end
+	local c = copy(item)
+	if c.component == nil then c.component = id end
+	if c.component ~= id then return nil, where .. '.component must match component map key' end
+	if c.source ~= nil and type(c.source) ~= 'table' then return nil, where .. '.source must be a table' end
+	local job, jerr = normalise_bundled_job(c.job, id, c, where .. '.job')
+	if not job then return nil, jerr end
+	c.job = job
+	c.auto_create = nil
+	c.auto_start = nil
+	return c, nil
+end
+
+local function normalise_bundled(raw)
+	local bundled, berr = table_or_empty(raw)
+	if not bundled then return nil, berr end
+	if bundled.enabled == nil then bundled.enabled = false end
+	if bundled.enabled ~= true and bundled.enabled ~= false then return nil, 'bundled.enabled must be boolean' end
+	local comps, cerr = table_or_empty(bundled.components or bundled.by_component)
+	if not comps then return nil, 'bundled.components: ' .. tostring(cerr) end
+	local out = { enabled = bundled.enabled, components = {} }
+	for component, item in pairs(comps) do
+		if type(component) ~= 'string' or component == '' then return nil, 'bundled.components keys must be non-empty strings' end
+		local normal, nerr = normalise_bundled_component(component, item, 'bundled.components.' .. component)
+		if not normal then return nil, nerr end
+		out.components[component] = normal
+	end
+	return out, nil
+end
+
 local function summarise(cfg)
 	return {
 		rev             = cfg.rev,
@@ -170,7 +237,7 @@ function M.normalise(raw, opts)
 		return nil, cerr
 	end
 
-	local bundled, berr = table_or_empty(raw.bundled)
+	local bundled, berr = normalise_bundled(raw.bundled)
 	if not bundled then return nil, 'bundled: ' .. tostring(berr) end
 
 	local publish, perr = table_or_empty(raw.publish)

--- a/src/services/update/config.lua
+++ b/src/services/update/config.lua
@@ -150,7 +150,7 @@ local function normalise_enum(t, key, allowed, default, where)
 	return t, nil
 end
 
-local function normalise_bundled_job(raw, component, legacy, where)
+local function normalise_bundled_job(raw, component, legacy, inherited_max_attempts, where)
 	local job, jerr = table_or_empty(raw)
 	if not job then return nil, where .. ': ' .. tostring(jerr) end
 	legacy = legacy or {}
@@ -168,16 +168,19 @@ local function normalise_bundled_job(raw, component, legacy, where)
 	if not ok then return nil, err end
 	ok, err = normalise_enum(job, 'supersede', JOB_SUPERSEDE, 'same_job_if_image_changed', where)
 	if not ok then return nil, err end
+	ok, err = normalise_optional_positive_integer(job, 'max_attempts', where)
+	if not ok then return nil, err end
+	if job.max_attempts == nil then job.max_attempts = inherited_max_attempts end
 	return job, nil
 end
 
-local function normalise_bundled_component(id, item, where)
+local function normalise_bundled_component(id, item, inherited_max_attempts, where)
 	if type(item) ~= 'table' then return nil, where .. ' must be a table' end
 	local c = copy(item)
 	if c.component == nil then c.component = id end
 	if c.component ~= id then return nil, where .. '.component must match component map key' end
 	if c.source ~= nil and type(c.source) ~= 'table' then return nil, where .. '.source must be a table' end
-	local job, jerr = normalise_bundled_job(c.job, id, c, where .. '.job')
+	local job, jerr = normalise_bundled_job(c.job, id, c, inherited_max_attempts, where .. '.job')
 	if not job then return nil, jerr end
 	c.job = job
 	c.auto_create = nil
@@ -192,10 +195,15 @@ local function normalise_bundled(raw)
 	if bundled.enabled ~= true and bundled.enabled ~= false then return nil, 'bundled.enabled must be boolean' end
 	local comps, cerr = table_or_empty(bundled.components or bundled.by_component)
 	if not comps then return nil, 'bundled.components: ' .. tostring(cerr) end
-	local out = { enabled = bundled.enabled, components = {} }
+	local ok, err = normalise_optional_positive_integer(bundled, 'max_attempts', 'bundled')
+	if not ok then return nil, err end
+	if bundled.enabled == true and bundled.max_attempts == nil then
+		return nil, 'bundled.max_attempts must be a positive integer when bundled is enabled'
+	end
+	local out = { enabled = bundled.enabled, max_attempts = bundled.max_attempts, components = {} }
 	for component, item in pairs(comps) do
 		if type(component) ~= 'string' or component == '' then return nil, 'bundled.components keys must be non-empty strings' end
-		local normal, nerr = normalise_bundled_component(component, item, 'bundled.components.' .. component)
+		local normal, nerr = normalise_bundled_component(component, item, bundled.max_attempts, 'bundled.components.' .. component)
 		if not normal then return nil, nerr end
 		out.components[component] = normal
 	end

--- a/src/services/update/generation.lua
+++ b/src/services/update/generation.lua
@@ -141,6 +141,7 @@ local function start_bundled_applies(self)
 		reaper_scope = self._scope,
 		report_scope = self._scope,
 		jobs = self._jobs,
+		observer_snapshot = self._observer and self._observer:snapshot() or nil,
 		done_tx = self._done_tx,
 	}
 	if not started then return nil, err or 'bundled_apply_start_failed' end
@@ -176,6 +177,18 @@ local function reduce_event(self, ev)
 	if ev.kind == 'service_active_snapshot' then
 		handle_service_active_snapshot(self, ev)
 		return
+	end
+
+	if ev.kind == 'component_observer_changed' then
+		self._observer_seen = ev.version or (self._observer and self._observer:version())
+		local aok, aerr = start_bundled_applies(self)
+		if aok ~= true then error(aerr or 'bundled_apply_start_failed', 0) end
+		assert_update_generation_model(self)
+		return
+	end
+
+	if ev.kind == 'component_observer_closed' then
+		error(ev.reason or 'component_observer_closed', 0)
 	end
 
 	if ev.kind == 'manager_request' then
@@ -235,13 +248,15 @@ function M.run(scope, params)
 		m:terminate(primary or status or 'generation_closed')
 	end)
 
-	local observer = observe_mod.new({
+	local observer = params.observer or observe_mod.new({
 		service_id = params.service_id or 'update',
 		components = (params.config and params.config.components) or {},
 	})
-	scope:finally(function (_, status, primary)
-		observer:terminate(primary or status or 'generation_closed')
-	end)
+	if params.observer == nil then
+		scope:finally(function (_, status, primary)
+			observer:terminate(primary or status or 'generation_closed')
+		end)
+	end
 
 	local jobs = params.jobs
 	if not jobs then
@@ -300,6 +315,7 @@ function M.run(scope, params)
 		pending = {},
 		_done_tx = done_tx,
 		_done_rx = done_rx,
+		_observer_seen = observer and observer:version() or nil,
 		_manager_work = {},
 		_active_snapshot = copy(params.active_snapshot),
 		_events = parent_events,

--- a/src/services/update/generation_events.lua
+++ b/src/services/update/generation_events.lua
@@ -39,6 +39,21 @@ function M.next_op(state)
 		pending = state.pending,
 		sources = {
 			{
+				name = 'observer',
+				enabled = function () return state._observer ~= nil end,
+				try_now = function ()
+					local v = state._observer:version()
+					if v == nil or v == state._observer_seen then return nil end
+					return { kind = 'component_observer_changed', version = v, snapshot = state._observer:snapshot() }
+				end,
+				recv_op = function ()
+					return state._observer:changed_op(state._observer_seen):wrap(function (version, snapshot, reason)
+						if version == nil then return { kind = 'component_observer_closed', reason = reason } end
+						return { kind = 'component_observer_changed', version = version, snapshot = snapshot, reason = reason }
+					end)
+				end,
+			},
+			{
 				name = 'done',
 				try_now = function () return try_recv_now(state.done_rx, M.map_done) end,
 				recv_op = function () return state.done_rx:recv_op():wrap(M.map_done) end,

--- a/src/services/update/job_repository.lua
+++ b/src/services/update/job_repository.lua
@@ -135,6 +135,7 @@ function M.new_job(spec, opts)
 		artifact = copy(spec.artifact or spec.artifact_ref),
 		artifact_ref = spec.artifact_ref,
 		metadata = copy(spec.metadata or {}),
+		policy = copy(spec.policy or spec.job_policy or {}),
 		created_seq = seq,
 		updated_seq = seq,
 		history = {{ seq = seq, state = 'created', reason = opts.reason or 'create_job' }},

--- a/src/services/update/job_repository.lua
+++ b/src/services/update/job_repository.lua
@@ -134,6 +134,7 @@ function M.new_job(spec, opts)
 		generation = opts.generation,
 		artifact = copy(spec.artifact or spec.artifact_ref),
 		artifact_ref = spec.artifact_ref,
+		attempt = spec.attempt,
 		metadata = copy(spec.metadata or {}),
 		policy = copy(spec.policy or spec.job_policy or {}),
 		created_seq = seq,

--- a/src/services/update/service.lua
+++ b/src/services/update/service.lua
@@ -245,6 +245,7 @@ local function start_generation(self, cfg, reason)
 				manager_rx = manager_rx,
 				service_rx = service_rx,
 				active_snapshot = active_snapshot(self),
+				observer = self._component_observer,
 				artifact_store = self._artifact_store,
 				events_tx = self._done_tx,
 				done_queue_len = self._generation_done_queue_len,

--- a/tests/unit/update/test_active_runtime.lua
+++ b/tests/unit/update/test_active_runtime.lua
@@ -185,4 +185,49 @@ function tests.test_component_apply_failure_after_start_keeps_completion_and_rep
   end)
 end
 
+function tests.test_component_auto_commit_policy_admits_commit_after_stage_apply()
+  fibers.run(function (scope)
+    local service_tx, service_rx = mailbox.new(16, { full = 'reject_newest' })
+    local seen = {}
+    local fake_jobs = {
+      admit_transition = function (_, cmd)
+        seen[#seen + 1] = cmd
+        if cmd.kind == 'apply_active_result' then
+          return transition_handle({
+            status = 'persisted',
+            job = { job_id = 'j1', component = 'cm5', generation = 1, state = 'awaiting_commit', policy = { commit = 'auto' } },
+          }), nil
+        elseif cmd.kind == 'start_job' then
+          return transition_handle({ status = 'persisted', job_id = cmd.job_id, phase = cmd.phase, token = 'commit-token', job = { job_id = cmd.job_id, component = 'cm5', state = 'committing' } }), nil
+        end
+        return transition_handle({ status = 'rejected', reason = 'unexpected' }), nil
+      end,
+      list = function () return {} end,
+    }
+    local component = assert(active.start_component(scope, {
+      service_id = 'update',
+      done_tx = service_tx,
+      work_scope = scope,
+      jobs = fake_jobs,
+    }))
+    local lease = assert(component:claim({ job_id = 'j1', generation = 1, phase = 'stage' }))
+    assert(component:start_work({
+      lease = lease,
+      job = { job_id='j1', component='cm5', generation = 1, policy = { commit = 'auto' } },
+      backend = stage_backend({ ok=true }),
+    }))
+    local completed = fibers.perform(service_rx:recv_op())
+    assert_eq(completed.reason, 'active_job_completed')
+    local applied = fibers.perform(service_rx:recv_op())
+    assert_eq(applied.reason, 'active_job_applied')
+    local auto = fibers.perform(service_rx:recv_op())
+    assert_eq(auto.reason, 'policy_auto_commit_started')
+    assert_eq(seen[1].kind, 'apply_active_result')
+    assert_eq(seen[2].kind, 'start_job')
+    assert_eq(seen[2].phase, 'commit')
+    assert_eq(seen[2].reason, 'policy_auto_commit')
+    component:cancel('test complete')
+  end)
+end
+
 return tests

--- a/tests/unit/update/test_bundled_probe.lua
+++ b/tests/unit/update/test_bundled_probe.lua
@@ -47,6 +47,7 @@ local function fake_jobs()
 					expected_image_id = payload.expected_image_id,
 					artifact_ref = payload.artifact_ref,
 					artifact = payload.artifact,
+					attempt = payload.attempt,
 					metadata = payload.metadata,
 					policy = payload.policy,
 					state = 'created',
@@ -170,6 +171,8 @@ function tests.test_bundled_apply_creates_and_optionally_starts_normal_job()
 		assert_eq(jobs.jobs['bundled-mcu'].artifact_ref, 'mcu-artifact')
 		assert_eq(jobs.jobs['bundled-mcu'].expected_image_id, 'mcu-image-new')
 		assert_eq(jobs.jobs['bundled-mcu'].policy.commit, 'auto')
+		assert_eq(jobs.jobs['bundled-mcu'].attempt, 1)
+		assert_eq(jobs.jobs['bundled-mcu'].metadata.bundled_attempt, 1)
 		assert_eq(jobs.jobs['bundled-mcu'].state, 'staging')
 		assert_eq(#jobs.transitions, 2)
 	end)
@@ -188,7 +191,7 @@ function tests.test_bundled_coordinator_probe_then_apply_policy()
 					mcu = {
 						component = 'mcu',
 						source = { kind = 'file', path = 'mcu.dcmcu' },
-						job = { create_if = 'image_differs', start = 'auto', commit = 'auto' },
+						job = { create_if = 'image_differs', start = 'auto', commit = 'auto', max_attempts = 3 },
 					},
 				},
 			},
@@ -225,7 +228,7 @@ function tests.test_bundled_apply_skips_when_running_image_matches_artifact()
 		local co = bundled.new({ service_id = 'update', generation = 11, config = { enabled = true, components = { mcu = {
 			component = 'mcu',
 			source = { kind = 'file', path = '/artifacts/mcu.dcmcu', policy = 'transient_only' },
-			job = { create_if = 'image_differs', start = 'auto', commit = 'auto' },
+			job = { create_if = 'image_differs', start = 'auto', commit = 'auto', max_attempts = 3 },
 		} } } })
 		assert_true(co:handle_probe_done({
 			kind = 'bundled_probe_done', generation = 11, component = 'mcu', status = 'ok',
@@ -251,7 +254,7 @@ function tests.test_bundled_apply_waits_for_current_image_before_creating_job()
 		local co = bundled.new({ service_id = 'update', generation = 12, config = { enabled = true, components = { mcu = {
 			component = 'mcu',
 			source = { kind = 'file', path = '/artifacts/mcu.dcmcu', policy = 'transient_only' },
-			job = { create_if = 'image_differs', start = 'auto', commit = 'auto' },
+			job = { create_if = 'image_differs', start = 'auto', commit = 'auto', max_attempts = 3 },
 		} } } })
 		assert_true(co:handle_probe_done({
 			kind = 'bundled_probe_done', generation = 12, component = 'mcu', status = 'ok',
@@ -298,6 +301,68 @@ function tests.test_bundled_apply_supersedes_terminal_changed_image_job()
 		assert_eq(jobs.transitions[2].kind, 'create_job')
 		assert_eq(jobs.jobs['bundled-mcu'].expected_image_id, 'mcu-image-new')
 		assert_eq(jobs.jobs['bundled-mcu'].state, 'created')
+	end)
+end
+
+
+function tests.test_bundled_apply_retries_terminal_same_image_until_attempt_limit()
+	fibers.run(function (scope)
+		local tx, rx = mailbox.new(4, { full = 'reject_newest' })
+		local jobs = fake_jobs()
+		jobs.jobs['bundled-mcu'] = {
+			job_id = 'bundled-mcu', component = 'mcu', expected_image_id = 'mcu-image-new',
+			state = 'failed', attempt = 1, metadata = { bundled_attempt = 1 },
+		}
+		assert(bundled_apply.start({
+			lifetime_scope = scope,
+			report_scope = scope,
+			service_id = 'update',
+			generation = 14,
+			component = 'mcu',
+			jobs = jobs,
+			spec = { component = 'mcu', source = { metadata = { format = 'dcmcu-v1' } }, job = { job_id = 'bundled-mcu', start = 'auto', commit = 'auto', max_attempts = 3, supersede = 'same_job_if_image_changed' } },
+			desired = { artifact_ref = 'mcu-artifact', expected_image_id = 'mcu-image-new', artifact = { artifact_ref = 'mcu-artifact', expected_image_id = 'mcu-image-new' } },
+			done_tx = tx,
+		}))
+		local ev = fibers.perform(rx:recv_op())
+		assert_eq(ev.kind, 'bundled_apply_done')
+		assert_eq(ev.status, 'ok')
+		assert_eq(jobs.transitions[1].kind, 'discard_job')
+		assert_eq(jobs.transitions[2].kind, 'create_job')
+		assert_eq(jobs.transitions[3].kind, 'start_job')
+		assert_eq(jobs.jobs['bundled-mcu'].expected_image_id, 'mcu-image-new')
+		assert_eq(jobs.jobs['bundled-mcu'].attempt, 2)
+		assert_eq(jobs.jobs['bundled-mcu'].metadata.bundled_attempt, 2)
+		assert_eq(jobs.jobs['bundled-mcu'].policy.attempt, 2)
+		assert_eq(jobs.jobs['bundled-mcu'].state, 'staging')
+	end)
+end
+
+function tests.test_bundled_apply_stops_terminal_same_image_after_attempt_limit()
+	fibers.run(function (scope)
+		local tx, rx = mailbox.new(4, { full = 'reject_newest' })
+		local jobs = fake_jobs()
+		jobs.jobs['bundled-mcu'] = {
+			job_id = 'bundled-mcu', component = 'mcu', expected_image_id = 'mcu-image-new',
+			state = 'failed', attempt = 3, metadata = { bundled_attempt = 3 },
+		}
+		assert(bundled_apply.start({
+			lifetime_scope = scope,
+			report_scope = scope,
+			service_id = 'update',
+			generation = 15,
+			component = 'mcu',
+			jobs = jobs,
+			spec = { component = 'mcu', source = { metadata = { format = 'dcmcu-v1' } }, job = { job_id = 'bundled-mcu', start = 'auto', commit = 'auto', max_attempts = 3, supersede = 'same_job_if_image_changed' } },
+			desired = { artifact_ref = 'mcu-artifact', expected_image_id = 'mcu-image-new', artifact = { artifact_ref = 'mcu-artifact', expected_image_id = 'mcu-image-new' } },
+			done_tx = tx,
+		}))
+		local ev = fibers.perform(rx:recv_op())
+		assert_eq(ev.kind, 'bundled_apply_done')
+		assert_eq(ev.status, 'failed')
+		assert_eq(ev.primary, 'bundled_retry_exhausted:3/3')
+		assert_eq(#jobs.transitions, 0)
+		assert_eq(jobs.jobs['bundled-mcu'].state, 'failed')
 	end)
 end
 

--- a/tests/unit/update/test_bundled_probe.lua
+++ b/tests/unit/update/test_bundled_probe.lua
@@ -338,6 +338,40 @@ function tests.test_bundled_apply_retries_terminal_same_image_until_attempt_limi
 	end)
 end
 
+
+function tests.test_bundled_apply_resets_attempts_after_previous_success_for_same_image()
+	fibers.run(function (scope)
+		local tx, rx = mailbox.new(4, { full = 'reject_newest' })
+		local jobs = fake_jobs()
+		jobs.jobs['bundled-mcu'] = {
+			job_id = 'bundled-mcu', component = 'mcu', expected_image_id = 'mcu-image-new',
+			state = 'succeeded', attempt = 30, metadata = { bundled_attempt = 30 },
+		}
+		assert(bundled_apply.start({
+			lifetime_scope = scope,
+			report_scope = scope,
+			service_id = 'update',
+			generation = 16,
+			component = 'mcu',
+			jobs = jobs,
+			spec = { component = 'mcu', source = { metadata = { format = 'dcmcu-v1' } }, job = { job_id = 'bundled-mcu', start = 'auto', commit = 'auto', max_attempts = 30, supersede = 'same_job_if_image_changed' } },
+			desired = { artifact_ref = 'mcu-artifact', expected_image_id = 'mcu-image-new', artifact = { artifact_ref = 'mcu-artifact', expected_image_id = 'mcu-image-new' } },
+			done_tx = tx,
+		}))
+		local ev = fibers.perform(rx:recv_op())
+		assert_eq(ev.kind, 'bundled_apply_done')
+		assert_eq(ev.status, 'ok')
+		assert_eq(jobs.transitions[1].kind, 'discard_job')
+		assert_eq(jobs.transitions[2].kind, 'create_job')
+		assert_eq(jobs.transitions[3].kind, 'start_job')
+		assert_eq(jobs.jobs['bundled-mcu'].expected_image_id, 'mcu-image-new')
+		assert_eq(jobs.jobs['bundled-mcu'].attempt, 1)
+		assert_eq(jobs.jobs['bundled-mcu'].metadata.bundled_attempt, 1)
+		assert_eq(jobs.jobs['bundled-mcu'].policy.attempt, 1)
+		assert_eq(jobs.jobs['bundled-mcu'].state, 'staging')
+	end)
+end
+
 function tests.test_bundled_apply_stops_terminal_same_image_after_attempt_limit()
 	fibers.run(function (scope)
 		local tx, rx = mailbox.new(4, { full = 'reject_newest' })

--- a/tests/unit/update/test_bundled_probe.lua
+++ b/tests/unit/update/test_bundled_probe.lua
@@ -48,6 +48,7 @@ local function fake_jobs()
 					artifact_ref = payload.artifact_ref,
 					artifact = payload.artifact,
 					metadata = payload.metadata,
+					policy = payload.policy,
 					state = 'created',
 					next_step = 'start',
 				}
@@ -56,9 +57,14 @@ local function fake_jobs()
 			end
 		elseif cmd.kind == 'start_job' then
 			local job = assert(self.jobs[cmd.job_id], 'start missing job')
-			job.state = 'staging'
-			job.active_intent = { phase = cmd.phase or 'stage', state = 'pending' }
-			result = { status = 'persisted', job_id = job.job_id, phase = cmd.phase or 'stage', job = job }
+			local phase = cmd.phase or 'stage'
+			job.state = phase == 'commit' and 'committing' or 'staging'
+			job.active_intent = { phase = phase, state = 'pending' }
+			result = { status = 'persisted', job_id = job.job_id, phase = phase, job = job }
+		elseif cmd.kind == 'discard_job' then
+			local job = assert(self.jobs[cmd.job_id], 'discard missing job')
+			self.jobs[cmd.job_id] = nil
+			result = { status = 'persisted', job_id = cmd.job_id, job = job }
 		else
 			result = { status = 'rejected', reason = 'unsupported' }
 		end
@@ -153,7 +159,7 @@ function tests.test_bundled_apply_creates_and_optionally_starts_normal_job()
 			generation = 9,
 			component = 'mcu',
 			jobs = jobs,
-			spec = { component = 'mcu', auto_start = true, source = { metadata = { format = 'dcmcu-v1' } } },
+			spec = { component = 'mcu', source = { metadata = { format = 'dcmcu-v1' } }, job = { start = 'auto', commit = 'auto' } },
 			desired = { artifact_ref = 'mcu-artifact', expected_image_id = 'mcu-image-new', artifact = { artifact_ref = 'mcu-artifact', expected_image_id = 'mcu-image-new' } },
 			done_tx = tx,
 		}))
@@ -163,6 +169,7 @@ function tests.test_bundled_apply_creates_and_optionally_starts_normal_job()
 		assert_eq(ev.result.job_id, 'bundled-mcu')
 		assert_eq(jobs.jobs['bundled-mcu'].artifact_ref, 'mcu-artifact')
 		assert_eq(jobs.jobs['bundled-mcu'].expected_image_id, 'mcu-image-new')
+		assert_eq(jobs.jobs['bundled-mcu'].policy.commit, 'auto')
 		assert_eq(jobs.jobs['bundled-mcu'].state, 'staging')
 		assert_eq(#jobs.transitions, 2)
 	end)
@@ -181,8 +188,7 @@ function tests.test_bundled_coordinator_probe_then_apply_policy()
 					mcu = {
 						component = 'mcu',
 						source = { kind = 'file', path = 'mcu.dcmcu' },
-						auto_create = true,
-						auto_start = true,
+						job = { create_if = 'image_differs', start = 'auto', commit = 'auto' },
 					},
 				},
 			},
@@ -199,6 +205,7 @@ function tests.test_bundled_coordinator_probe_then_apply_policy()
 			lifetime_scope = scope,
 			report_scope = scope,
 			jobs = jobs,
+			observer_snapshot = { by_id = { mcu = { state = { software = { image_id = 'mcu-image-old' } } } } },
 			done_tx = tx,
 		}))
 		local apply_ev = fibers.perform(rx:recv_op())
@@ -207,6 +214,90 @@ function tests.test_bundled_coordinator_probe_then_apply_policy()
 		assert_eq(snap.state.mcu, 'applied')
 		assert_eq(jobs.jobs['bundled-mcu'].state, 'staging')
 		assert_eq(jobs.jobs['bundled-mcu'].expected_image_id, 'mcu-image-new')
+	end)
+end
+
+
+function tests.test_bundled_apply_skips_when_running_image_matches_artifact()
+	fibers.run(function (scope)
+		local tx = mailbox.new(4, { full = 'reject_newest' })
+		local jobs = fake_jobs()
+		local co = bundled.new({ service_id = 'update', generation = 11, config = { enabled = true, components = { mcu = {
+			component = 'mcu',
+			source = { kind = 'file', path = '/artifacts/mcu.dcmcu', policy = 'transient_only' },
+			job = { create_if = 'image_differs', start = 'auto', commit = 'auto' },
+		} } } })
+		assert_true(co:handle_probe_done({
+			kind = 'bundled_probe_done', generation = 11, component = 'mcu', status = 'ok',
+			result = { desired = { artifact_ref = 'mcu-artifact', expected_image_id = 'mcu-image-new' } },
+		}))
+		local started = assert(co:start_ready_applies({
+			lifetime_scope = scope,
+			report_scope = scope,
+			jobs = jobs,
+			observer_snapshot = { by_id = { mcu = { state = { software = { image_id = 'mcu-image-new' } } } } },
+			done_tx = tx,
+		}))
+		assert_eq(#started, 0)
+		assert_eq(co:snapshot().state.mcu, 'already_current')
+		assert_eq(#jobs.transitions, 0)
+	end)
+end
+
+function tests.test_bundled_apply_waits_for_current_image_before_creating_job()
+	fibers.run(function (scope)
+		local tx, rx = mailbox.new(4, { full = 'reject_newest' })
+		local jobs = fake_jobs()
+		local co = bundled.new({ service_id = 'update', generation = 12, config = { enabled = true, components = { mcu = {
+			component = 'mcu',
+			source = { kind = 'file', path = '/artifacts/mcu.dcmcu', policy = 'transient_only' },
+			job = { create_if = 'image_differs', start = 'auto', commit = 'auto' },
+		} } } })
+		assert_true(co:handle_probe_done({
+			kind = 'bundled_probe_done', generation = 12, component = 'mcu', status = 'ok',
+			result = { desired = { artifact_ref = 'mcu-artifact', expected_image_id = 'mcu-image-new' } },
+		}))
+		local none = assert(co:start_ready_applies({ lifetime_scope = scope, report_scope = scope, jobs = jobs, observer_snapshot = {}, done_tx = tx }))
+		assert_eq(#none, 0)
+		assert_eq(co:snapshot().state.mcu, 'pending_current_image')
+		local started = assert(co:start_ready_applies({
+			lifetime_scope = scope,
+			report_scope = scope,
+			jobs = jobs,
+			observer_snapshot = { by_id = { mcu = { state = { software = { image_id = 'mcu-image-old' } } } } },
+			done_tx = tx,
+		}))
+		assert_eq(#started, 1)
+		local ev = fibers.perform(rx:recv_op())
+		assert_true(co:handle_apply_done(ev))
+		assert_eq(jobs.jobs['bundled-mcu'].state, 'staging')
+	end)
+end
+
+
+function tests.test_bundled_apply_supersedes_terminal_changed_image_job()
+	fibers.run(function (scope)
+		local tx, rx = mailbox.new(4, { full = 'reject_newest' })
+		local jobs = fake_jobs()
+		jobs.jobs['bundled-mcu'] = { job_id = 'bundled-mcu', component = 'mcu', expected_image_id = 'mcu-image-old', state = 'failed' }
+		assert(bundled_apply.start({
+			lifetime_scope = scope,
+			report_scope = scope,
+			service_id = 'update',
+			generation = 13,
+			component = 'mcu',
+			jobs = jobs,
+			spec = { component = 'mcu', source = { metadata = { format = 'dcmcu-v1' } }, job = { job_id = 'bundled-mcu', start = 'manual', supersede = 'same_job_if_image_changed' } },
+			desired = { artifact_ref = 'mcu-artifact', expected_image_id = 'mcu-image-new', artifact = { artifact_ref = 'mcu-artifact', expected_image_id = 'mcu-image-new' } },
+			done_tx = tx,
+		}))
+		local ev = fibers.perform(rx:recv_op())
+		assert_eq(ev.kind, 'bundled_apply_done')
+		assert_eq(ev.status, 'ok')
+		assert_eq(jobs.transitions[1].kind, 'discard_job')
+		assert_eq(jobs.transitions[2].kind, 'create_job')
+		assert_eq(jobs.jobs['bundled-mcu'].expected_image_id, 'mcu-image-new')
+		assert_eq(jobs.jobs['bundled-mcu'].state, 'created')
 	end)
 end
 

--- a/tests/unit/update/test_config.lua
+++ b/tests/unit/update/test_config.lua
@@ -8,6 +8,7 @@ local function fail(msg) error(msg or 'assertion failed', 2) end
 local function assert_eq(a, b, msg) if a ~= b then fail(msg or ('expected ' .. tostring(b) .. ', got ' .. tostring(a))) end end
 local function assert_true(v, msg) if v ~= true then fail(msg or ('expected true, got ' .. tostring(v))) end end
 local function assert_not_nil(v, msg) if v == nil then fail(msg or 'expected non-nil value') end end
+local function assert_nil(v, msg) if v ~= nil then fail(msg or ('expected nil, got ' .. tostring(v))) end end
 
 function tests.test_default_config_normalises()
 	local cfg, err = config.normalise({})
@@ -79,6 +80,63 @@ function tests.test_retention_policy_normalises()
 	assert_true(cfg.retention.prune_on_startup)
 	assert_eq(cfg.retention.terminal_max_count, 50)
 	assert_eq(cfg.retention.terminal_max_age_s, 604800)
+end
+
+
+function tests.test_bundled_job_policy_normalises()
+	local cfg, err = config.normalise({
+		bundled = {
+			enabled = true,
+			components = {
+				mcu = {
+					component = 'mcu',
+					source = { kind = 'file', path = '/artifacts/mcu.dcmcu', policy = 'transient_only' },
+					job = {
+						job_id = 'bundled-mcu',
+						create_if = 'image_differs',
+						start = 'auto',
+						commit = 'auto',
+						reconcile = 'required',
+						supersede = 'same_job_if_image_changed',
+					},
+				},
+			},
+		},
+	})
+	assert_not_nil(cfg, err)
+	local mcu = cfg.bundled.components.mcu
+	assert_eq(mcu.job.job_id, 'bundled-mcu')
+	assert_eq(mcu.job.create_if, 'image_differs')
+	assert_eq(mcu.job.start, 'auto')
+	assert_eq(mcu.job.commit, 'auto')
+	assert_eq(mcu.job.reconcile, 'required')
+	assert_eq(mcu.job.supersede, 'same_job_if_image_changed')
+	assert_nil(mcu.auto_create)
+	assert_nil(mcu.auto_start)
+end
+
+function tests.test_bundled_legacy_auto_flags_map_to_job_policy()
+	local cfg, err = config.normalise({
+		bundled = {
+			enabled = true,
+			components = {
+				mcu = {
+					component = 'mcu',
+					source = { kind = 'file', path = '/artifacts/mcu.dcmcu' },
+					auto_create = true,
+					auto_start = true,
+				},
+			},
+		},
+	})
+	assert_not_nil(cfg, err)
+	local mcu = cfg.bundled.components.mcu
+	assert_eq(mcu.job.job_id, 'bundled-mcu')
+	assert_eq(mcu.job.create_if, 'always')
+	assert_eq(mcu.job.start, 'auto')
+	assert_eq(mcu.job.commit, 'manual')
+	assert_nil(mcu.auto_create)
+	assert_nil(mcu.auto_start)
 end
 
 return tests

--- a/tests/unit/update/test_config.lua
+++ b/tests/unit/update/test_config.lua
@@ -9,6 +9,11 @@ local function assert_eq(a, b, msg) if a ~= b then fail(msg or ('expected ' .. t
 local function assert_true(v, msg) if v ~= true then fail(msg or ('expected true, got ' .. tostring(v))) end end
 local function assert_not_nil(v, msg) if v == nil then fail(msg or 'expected non-nil value') end end
 local function assert_nil(v, msg) if v ~= nil then fail(msg or ('expected nil, got ' .. tostring(v))) end end
+local function assert_contains(s, needle, msg)
+	if tostring(s or ''):find(tostring(needle), 1, true) == nil then
+		fail(msg or ('expected ' .. tostring(s) .. ' to contain ' .. tostring(needle)))
+	end
+end
 
 function tests.test_default_config_normalises()
 	local cfg, err = config.normalise({})
@@ -87,6 +92,7 @@ function tests.test_bundled_job_policy_normalises()
 	local cfg, err = config.normalise({
 		bundled = {
 			enabled = true,
+			max_attempts = 7,
 			components = {
 				mcu = {
 					component = 'mcu',
@@ -98,12 +104,14 @@ function tests.test_bundled_job_policy_normalises()
 						commit = 'auto',
 						reconcile = 'required',
 						supersede = 'same_job_if_image_changed',
+						max_attempts = 5,
 					},
 				},
 			},
 		},
 	})
 	assert_not_nil(cfg, err)
+	assert_eq(cfg.bundled.max_attempts, 7)
 	local mcu = cfg.bundled.components.mcu
 	assert_eq(mcu.job.job_id, 'bundled-mcu')
 	assert_eq(mcu.job.create_if, 'image_differs')
@@ -111,6 +119,7 @@ function tests.test_bundled_job_policy_normalises()
 	assert_eq(mcu.job.commit, 'auto')
 	assert_eq(mcu.job.reconcile, 'required')
 	assert_eq(mcu.job.supersede, 'same_job_if_image_changed')
+	assert_eq(mcu.job.max_attempts, 5)
 	assert_nil(mcu.auto_create)
 	assert_nil(mcu.auto_start)
 end
@@ -119,6 +128,7 @@ function tests.test_bundled_legacy_auto_flags_map_to_job_policy()
 	local cfg, err = config.normalise({
 		bundled = {
 			enabled = true,
+			max_attempts = 9,
 			components = {
 				mcu = {
 					component = 'mcu',
@@ -135,8 +145,20 @@ function tests.test_bundled_legacy_auto_flags_map_to_job_policy()
 	assert_eq(mcu.job.create_if, 'always')
 	assert_eq(mcu.job.start, 'auto')
 	assert_eq(mcu.job.commit, 'manual')
+	assert_eq(mcu.job.max_attempts, 9)
 	assert_nil(mcu.auto_create)
 	assert_nil(mcu.auto_start)
+end
+
+function tests.test_bundled_enabled_requires_attempt_budget()
+	local cfg, err = config.normalise({
+		bundled = {
+			enabled = true,
+			components = {},
+		},
+	})
+	assert_nil(cfg)
+	assert_contains(err, 'bundled.max_attempts')
 end
 
 return tests


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

* [x] 🍕 Feature
* [x] 🐛 Bug Fix
* [x] 🧑💻 Code Refactor
* [x] ✅ Test

## Description

Adds policy-driven bundled MCU firmware convergence.

Bundled firmware is now treated as an unattended update policy rather than a special case based on artefact origin. The bundled path only creates an update job when the bundled artefact image differs from the MCU’s currently running image, then automatically stages and commits that job according to its policy.

Changes include:

* Replaces bundled `auto_create` / `auto_start` behaviour with an explicit job policy:

  * `create_if = "image_differs"`
  * `start = "auto"`
  * `commit = "auto"`
  * `reconcile = "required"`
  * `supersede = "same_job_if_image_changed"`
* Adds an explicit bundled retry budget:

  * `bundled.max_attempts`
  * optional per-job override via `job.max_attempts`
* Sets the current bundled MCU config to `max_attempts = 30`.
* Keeps HTTP upload/update behaviour separate through job policy rather than origin checks.
* Defers bundled job creation until the running MCU image is known.
* Skips job creation when the bundled artefact image already matches the running MCU image.
* Creates, stages and commits a bundled job automatically when the bundled artefact image differs.
* Preserves a stable `bundled-mcu` job ID.
* Allows terminal bundled jobs to be superseded when the bundled image changes.
* Retries failed terminal bundled jobs for the same image up to the configured attempt budget.
* Treats a previous successful bundled job as a completed convergence episode, so a later downgrade or re-convergence to that same image starts again at attempt 1.
* Prevents active bundled jobs from being overwritten by a newer bundled artefact.
* Removes hidden source-level retry defaults; enabled bundled configs must declare an explicit attempt budget.
* Adds unit coverage for bundled policy normalisation, legacy bundled config mapping, image-difference gating, retry budgeting, supersession, convergence episode reset, and auto-commit behaviour.

## Manual test

* [x] 🙅 no

## Manual test description

To be manually tested on hardware. The change is covered by focused Lua unit tests. The generated bundle was structurally validated.

## Added tests?

* [x] 👍 yes

All 1,004 tests pass under LuaJIT.

## Added to documentation?

* [x] 🙅 no documentation needed

## Post-deployment tasks

Check that deployed configs use the new bundled job policy shape and declare `bundled.max_attempts`. Existing `auto_create` / `auto_start` bundled config is still mapped for compatibility, but should be migrated to the explicit `job` policy form.
