### PR TITLE
fixes speedtest, new model

### DIFF
--- a/src/configs/bigbox-v1-cm-2.json
+++ b/src/configs/bigbox-v1-cm-2.json
@@ -550,7 +550,9 @@
           "policy": "balanced",
           "speedtests": {
             "enabled": true,
-            "interval_s": 300
+            "interval_s": 21600,
+            "retry_after_s": 10,
+            "retry_max_s": 3600
           }
         },
         "rules": {

--- a/src/services/hal/backends/network/providers/openwrt/speedtest.lua
+++ b/src/services/hal/backends/network/providers/openwrt/speedtest.lua
@@ -10,6 +10,10 @@ local perform = fibers.perform
 local M = {}
 
 local DEFAULT_URL = 'https://proof.ovh.net/files/100Mb.dat'
+local HARD_MAX_DURATION_S = 1
+local DEFAULT_SAMPLE_INTERVAL_S = 0.06
+local DEFAULT_NO_IMPROVEMENT_SAMPLES = 2
+
 
 local function owned_process_flags()
 	local flags = { process_group = true }
@@ -34,6 +38,26 @@ local function monotonic()
 	return fibers.now and fibers.now() or os.clock()
 end
 
+local function record_sample(state, mbps)
+	if mbps <= 0 then return false end
+	state.samples = state.samples + 1
+	if mbps > state.highest then
+		state.second_highest = state.highest
+		state.highest = mbps
+		state.consecutive_no_improvement = 0
+		return true
+	end
+	if mbps > state.second_highest then state.second_highest = mbps end
+	state.consecutive_no_improvement = state.consecutive_no_improvement + 1
+	return false
+end
+
+local function averaged_top_two(state)
+	if state.samples <= 0 then return 0 end
+	if state.samples == 1 or state.second_highest <= 0 then return state.highest end
+	return (state.highest + state.second_highest) / 2
+end
+
 function M.run_op(req, opts)
 	return fibers.run_scope_op(function(scope)
 		req = req or {}
@@ -43,8 +67,12 @@ function M.run_op(req, opts)
 		if type(iface) ~= 'string' or iface == '' then return { ok = false, err = 'speedtest interface required', backend = 'openwrt' } end
 		if type(dev) ~= 'string' or dev == '' then dev = iface end
 		local url = req.url or opts.url or DEFAULT_URL
-		local duration = tonumber(req.max_duration_s or opts.max_duration_s) or 8
-		local sample_s = tonumber(req.sample_interval_s or opts.sample_interval_s) or 0.1
+		local duration = tonumber(req.max_duration_s or opts.max_duration_s) or HARD_MAX_DURATION_S
+		if duration <= 0 or duration > HARD_MAX_DURATION_S then duration = HARD_MAX_DURATION_S end
+		local sample_s = tonumber(req.sample_interval_s or opts.sample_interval_s) or DEFAULT_SAMPLE_INTERVAL_S
+		if sample_s <= 0 then sample_s = DEFAULT_SAMPLE_INTERVAL_S end
+		local no_improvement_limit = tonumber(req.no_improvement_samples or opts.no_improvement_samples) or DEFAULT_NO_IMPROVEMENT_SAMPLES
+		no_improvement_limit = math.max(1, math.floor(no_improvement_limit))
 		local argv = { 'mwan3', 'use', iface, 'wget', '-O', '/dev/null', tostring(url) }
 		local run_cmd = opts.run_cmd or req.run_cmd
 		if type(run_cmd) == 'function' then
@@ -82,9 +110,16 @@ function M.run_op(req, opts)
 		end
 		local t0 = monotonic()
 		local prev_t, prev_b = t0, start_b
-		local peak = 0
+		local samples = {
+			highest = 0,
+			second_highest = 0,
+			samples = 0,
+			consecutive_no_improvement = 0,
+		}
 		while (monotonic() - t0) < duration do
-			perform(sleep.sleep_op(sample_s))
+			local remaining = duration - (monotonic() - t0)
+			if remaining <= 0 then break end
+			perform(sleep.sleep_op(math.min(sample_s, remaining)))
 			local t = monotonic()
 			local b = read_counter(counter)
 			if not b then break end
@@ -92,15 +127,30 @@ function M.run_op(req, opts)
 			local db = b - prev_b
 			if dt > 0 and db >= 0 then
 				local mbps = (db * 8) / (dt * 1000 * 1000)
-				if mbps > peak then peak = mbps end
+				record_sample(samples, mbps)
 			end
 			prev_t, prev_b = t, b
+			if samples.highest > 0 and samples.consecutive_no_improvement >= no_improvement_limit then break end
 		end
 		perform(cmd:shutdown_op(0.2))
-		if peak <= 0 and (prev_b - start_b) <= 0 then
+		local mbps = averaged_top_two(samples)
+		if mbps <= 0 and (prev_b - start_b) <= 0 then
 			return { ok = false, code = 'insufficient_data', backend = 'openwrt', interface = iface, device = dev, data_mib = 0, duration_s = prev_t - t0 }
 		end
-		return { ok = true, backend = 'openwrt', interface = iface, device = dev, mbps = peak, peak_mbps = peak, data_mib = (prev_b - start_b) / (1024 * 1024), bytes = (prev_b - start_b), duration_s = prev_t - t0 }
+		return {
+			ok = true,
+			backend = 'openwrt',
+			interface = iface,
+			device = dev,
+			mbps = mbps,
+			peak_mbps = mbps,
+			raw_peak_mbps = samples.highest,
+			second_peak_mbps = samples.second_highest > 0 and samples.second_highest or nil,
+			sample_count = samples.samples,
+			data_mib = (prev_b - start_b) / (1024 * 1024),
+			bytes = (prev_b - start_b),
+			duration_s = prev_t - t0,
+		}
 	end):wrap(function(status, _report, result)
 		if status ~= 'ok' then return { ok = false, code = 'worker_failed', err = tostring(result or status), backend = 'openwrt' } end
 		return result

--- a/src/services/net/backhaul_model.lua
+++ b/src/services/net/backhaul_model.lua
@@ -30,6 +30,54 @@ local function status_by_interface(snapshot, iface)
 	return nil
 end
 
+local function observed_live(snapshot)
+	local observed = snapshot and snapshot.observed or nil
+	local live = observed and observed.snapshot and observed.snapshot.live or nil
+	if not is_table(live) then live = observed and observed.live or nil end
+	return is_table(live) and live or nil
+end
+
+local function live_interface(snapshot, iface, ifname)
+	local live = observed_live(snapshot)
+	local interfaces = live and live.interfaces or nil
+	if not is_table(interfaces) then return nil end
+	if type(iface) == 'string' and iface ~= '' and is_table(interfaces[iface]) then return interfaces[iface] end
+	if type(ifname) == 'string' and ifname ~= '' and is_table(interfaces[ifname]) then return interfaces[ifname] end
+	return nil
+end
+
+local function valid_address(addr)
+	if type(addr) ~= 'string' or addr == '' then return nil end
+	if addr == '0.0.0.0' or addr == '::' then return nil end
+	return addr
+end
+
+local function first_address(list)
+	if not is_table(list) then return nil end
+	for i = 1, #list do
+		local rec = list[i]
+		local addr = is_table(rec) and valid_address(rec.address or rec.ip or rec.addr) or valid_address(rec)
+		if addr then return addr end
+	end
+	return nil
+end
+
+local function select_path_address(st, source)
+	if not is_table(st) then return nil end
+	local ipv4 = first_address(st.ipv4 or st.addresses_ipv4 or st.address)
+		or valid_address(st.ipv4_address or st.ipaddr or st.ip or st.address)
+	if ipv4 then return { family = 'ipv4', address = ipv4, source = source } end
+	local ipv6 = first_address(st.ipv6 or st.addresses_ipv6 or st['ipv6-address'] or st.ipv6_address)
+		or valid_address(st.ipv6addr or st.ip6addr)
+	if ipv6 then return { family = 'ipv6', address = ipv6, source = source } end
+	return nil
+end
+
+local function path_address(snapshot, iface, ifname, st)
+	return select_path_address(live_interface(snapshot, iface, ifname), 'hal-network-live')
+		or select_path_address(st, 'multiwan-status')
+end
+
 local function semantic_state_from_host(st)
 	if not is_table(st) then return 'unknown', false end
 	local state = tostring(st.state or st.status or ''):lower()
@@ -42,6 +90,11 @@ local function semantic_state_from_host(st)
 	if state == 'up' or state == 'connected' then state = 'online'; usable = true end
 	if state ~= 'online' then usable = false end
 	return state, usable
+end
+
+local function interface_endpoint(snapshot, iface)
+	local rec = snapshot and snapshot.interfaces and snapshot.interfaces[iface] or nil
+	return is_table(rec) and is_table(rec.endpoint) and rec.endpoint or {}
 end
 
 local function member_interface(member, uplink_id)
@@ -75,14 +128,18 @@ local function reduce_gsm(snapshot, uplink_id, member, opts)
 		usable = gsm.connected == true and state == 'online'
 	end
 	local linux = is_table(gsm and gsm.linux) and gsm.linux or {}
+	local iface = member_interface(member, uplink_id)
+	local endpoint = interface_endpoint(snapshot, iface)
+	local ifname = linux.ifname or member.device or member.ifname or endpoint.ifname or endpoint.device or endpoint.name
 	return {
 		id = tostring(uplink_id),
 		role = member.role or uplink_id,
-		interface = member_interface(member, uplink_id),
-		ifname = linux.ifname or member.device or member.ifname,
+		interface = iface,
+		ifname = ifname,
 		state = state,
 		usable = usable,
 		metric = member_metric(member),
+		path_address = path_address(snapshot, iface, ifname, nil),
 		source = { kind = 'gsm-uplink', id = gsm_source(member) },
 		observed_at = is_table(gsm) and (gsm.updated_at or gsm.observed_at) or (opts and opts.now),
 	}
@@ -93,15 +150,18 @@ local function reduce_host(snapshot, uplink_id, member, opts)
 	local st = status_by_interface(snapshot, iface)
 	local mw = observed_multiwan(snapshot) or {}
 	local state, usable = semantic_state_from_host(st)
+	local endpoint = interface_endpoint(snapshot, iface)
+	local ifname = st and st.ifname or member.device or member.ifname or endpoint.ifname or endpoint.device or endpoint.name
 	return {
 		id = tostring(uplink_id),
 		role = member.role or uplink_id,
 		interface = iface,
-		ifname = st and st.ifname or member.device or member.ifname,
+		ifname = ifname,
 		state = state,
 		usable = usable,
 		observed = st ~= nil,
 		metric = member_metric(member),
+		path_address = path_address(snapshot, iface, ifname, st),
 		uptime_s = st and (tonumber(st.uptime_s) or tonumber(st.uptime)) or nil,
 		age_s = st and (tonumber(st.age_s) or tonumber(st.age)) or nil,
 		source = {
@@ -148,6 +208,7 @@ end
 M._test = {
 	observed_multiwan = observed_multiwan,
 	status_by_interface = status_by_interface,
+	select_path_address = select_path_address,
 }
 
 return M

--- a/src/services/net/service.lua
+++ b/src/services/net/service.lua
@@ -6,10 +6,12 @@
 -- admitted through scoped components.
 
 local fibers = require 'fibers'
+local sleep = require 'fibers.sleep'
 local mailbox = require 'fibers.mailbox'
 
 local service_base = require 'devicecode.service_base'
 local config_watch = require 'devicecode.support.config_watch'
+local queue = require 'devicecode.support.queue'
 
 local model_mod = require 'services.net.model'
 local config_mod = require 'services.net.config'
@@ -66,6 +68,10 @@ end
 
 local function mark_domain_dirty(state, name)
 	publisher.mark_domain(state.dirty, name)
+end
+
+local function mark_interface_dirty(state, id)
+	if id ~= nil then publisher.mark_interface(state.dirty, tostring(id)) end
 end
 
 local function mark_apply_dirty(state)
@@ -228,6 +234,83 @@ local function cancel_active_generation(state, reason)
 	return true, nil
 end
 
+
+local function backhaul_for_interface(backhaul, uplink_id, iface_id)
+	local uplinks = backhaul and backhaul.uplinks or nil
+	if type(uplinks) ~= 'table' then return nil end
+	local direct = uplinks[tostring(uplink_id)]
+	if type(direct) == 'table' then return direct end
+	for id, rec in pairs(uplinks) do
+		if type(rec) == 'table' and (rec.interface == iface_id or rec.id == iface_id or id == iface_id) then
+			return rec
+		end
+	end
+	return nil
+end
+
+local function apply_backhaul_to_interfaces(s)
+	local members = s and s.wan and s.wan.members or {}
+	local interfaces = s and s.interfaces or nil
+	if type(interfaces) ~= 'table' then return s end
+	for uplink_id, member in pairs(members or {}) do
+		if type(member) == 'table' and member.enabled ~= false and member.disabled ~= true then
+			local iface_id = member.interface or uplink_id
+			local iface = interfaces[iface_id]
+			local bh = backhaul_for_interface(s.backhaul, uplink_id, iface_id)
+			if type(iface) == 'table' and type(bh) == 'table' then
+				-- mwan3/backhaul is the semantic authority for WAN reachability.
+				-- Interface config and speedtests enrich this record; they must not
+				-- make an mwan3-online uplink appear offline to consumers.
+				iface.state = bh.state
+				iface.status = bh.state
+				iface.online = bh.state == 'online' and bh.usable == true
+				iface.usable = bh.usable == true
+				iface.backhaul = {
+					state = bh.state,
+					usable = bh.usable == true,
+					ifname = bh.ifname,
+					path_address = model_mod.deep_copy(bh.path_address),
+					source = model_mod.deep_copy(bh.source),
+					observed_at = bh.observed_at,
+				}
+			end
+		end
+	end
+	return s
+end
+
+local function mark_wan_member_interfaces_dirty(state)
+	local snap = state and state.model and state.model:snapshot() or nil
+	local members = snap and snap.wan and snap.wan.members or {}
+	for uplink_id, member in pairs(members or {}) do
+		if type(member) == 'table' and member.enabled ~= false and member.disabled ~= true then
+			mark_interface_dirty(state, member.interface or uplink_id)
+		end
+	end
+end
+
+local function carry_forward_wan_runtime(previous, intent, generation)
+	local out = { generation = generation, uplinks = {}, speedtests = {}, live_weights = { state = 'idle', generation = generation } }
+	if type(previous) ~= 'table' then return out end
+	local members = intent and intent.wan and intent.wan.members or {}
+	for uplink_id, member in pairs(members or {}) do
+		if type(member) == 'table' and member.enabled ~= false and member.disabled ~= true then
+			local rec = previous.speedtests and previous.speedtests[tostring(uplink_id)] or nil
+			if type(rec) == 'table' then
+				local kept = model_mod.deep_copy(rec)
+				if kept.state == 'running' then
+					kept.state = kept.last_success and 'ok' or 'skipped'
+					kept.ok = kept.last_success ~= nil
+					kept.last_skip_reason = kept.last_skip_reason or 'generation_replaced'
+				end
+				out.speedtests[tostring(uplink_id)] = kept
+			end
+		end
+	end
+	out.last_weight_apply = model_mod.deep_copy(previous.last_weight_apply)
+	return out
+end
+
 local function copy_intent_to_model(s, intent)
 	local generation = intent.generation
 	s.generation = generation
@@ -246,7 +329,8 @@ local function copy_intent_to_model(s, intent)
 	s.wan = intent.wan or {}
 	s.sources = s.sources or { gsm_uplinks = {} }
 	s.backhaul = backhaul_model.reduce(s, { now = now() })
-	s.wan_runtime = { generation = generation, uplinks = {}, speedtests = {}, live_weights = { state = 'idle', generation = generation } }
+	apply_backhaul_to_interfaces(s)
+	s.wan_runtime = carry_forward_wan_runtime(s.wan_runtime, intent, generation)
 	s.vpn = intent.vpn or {}
 	s.diagnostics = intent.diagnostics or {}
 	return s
@@ -571,6 +655,7 @@ local function merge_observation(state, s, observed_event)
 	s.stats.observations = (s.stats.observations or 0) + 1
 	s.drift = drift.calculate(s, { now = now })
 	s.backhaul = backhaul_model.reduce(s, { now = now() })
+	apply_backhaul_to_interfaces(s)
 	return project_dependencies(state, s)
 end
 
@@ -580,6 +665,7 @@ local function handle_observed_state(state, ev)
 	state.model:update(function (s) return merge_observation(state, s, observed_event) end)
 	mark_domain_dirty(state, 'observed')
 	mark_domain_dirty(state, 'backhaul')
+	mark_wan_member_interfaces_dirty(state)
 	mark_domain_dirty(state, 'drift')
 	obs_event(state.svc, 'network_observed', { subject = observed_event.subject, source = observed_event.source, kind = observed_event.kind })
 	local ok, err = reconcile_speedtests_if_ready(state, 'observed_state')
@@ -607,11 +693,13 @@ local function handle_gsm_uplink_changed(state, ev)
 		s.sources.gsm_uplinks = s.sources.gsm_uplinks or {}
 		s.sources.gsm_uplinks[role] = payload
 		s.backhaul = backhaul_model.reduce(s, { now = now() })
+		apply_backhaul_to_interfaces(s)
 		s.stats.gsm_uplink_updates = (s.stats.gsm_uplink_updates or 0) + 1
 		return project_dependencies(state, s)
 	end)
 	mark_domain_dirty(state, 'sources')
 	mark_domain_dirty(state, 'backhaul')
+	mark_wan_member_interfaces_dirty(state)
 	mark_summary_dirty(state)
 	local ifname = payload.linux and payload.linux.ifname or payload.interface
 	obs_event(state.svc, 'gsm_uplink_changed', {
@@ -749,6 +837,64 @@ local function handle_dependency_status(state, ev)
 	return publish_snapshot(state)
 end
 
+
+local function schedule_speedtest_retry(state, uplink_id, generation, delay_s, reason)
+	if not state or not state.scope or not state.done_tx then return true, nil end
+	if type(uplink_id) ~= 'string' or uplink_id == '' then return true, nil end
+	delay_s = tonumber(delay_s) or 10
+	if delay_s < 1 then delay_s = 1 end
+	state.speedtest_retries = state.speedtest_retries or {}
+	local existing = state.speedtest_retries[uplink_id]
+	local tnow = now()
+	if type(existing) == 'table' and (existing.due_at or 0) > tnow then return true, nil end
+	local retry_id = state.next_speedtest_retry_id or 1
+	state.next_speedtest_retry_id = retry_id + 1
+	state.speedtest_retries[uplink_id] = {
+		retry_id = retry_id,
+		uplink_id = uplink_id,
+		generation = generation,
+		due_at = tnow + delay_s,
+		reason = reason or 'speedtest_retry',
+	}
+	local ok, err = state.scope:spawn(function ()
+		sleep.sleep(delay_s)
+		queue.assert_admit_required(state.done_tx, {
+			kind = 'speedtest_retry_due',
+			uplink_id = uplink_id,
+			generation = generation,
+			retry_id = retry_id,
+			reason = reason or 'speedtest_retry',
+		}, 'net_speedtest_retry_report_failed')
+	end)
+	if ok ~= true then
+		state.speedtest_retries[uplink_id] = nil
+		return nil, err or 'speedtest_retry_spawn_failed'
+	end
+	obs_log(state.svc, 'debug', {
+		what = 'speedtest_retry_scheduled',
+		uplink_id = uplink_id,
+		generation = generation,
+		retry_id = retry_id,
+		delay_s = delay_s,
+		reason = reason,
+	})
+	return true, nil
+end
+
+local function handle_speedtest_retry_due(state, ev)
+	local pending = state.speedtest_retries and state.speedtest_retries[ev.uplink_id] or nil
+	if type(pending) ~= 'table' or pending.retry_id ~= ev.retry_id then return true, nil end
+	state.speedtest_retries[ev.uplink_id] = nil
+	obs_log(state.svc, 'debug', {
+		what = 'speedtest_retry_due',
+		uplink_id = ev.uplink_id,
+		generation = ev.generation,
+		retry_id = ev.retry_id,
+		reason = ev.reason,
+	})
+	return reconcile_speedtests_if_ready(state, 'speedtest_retry_due')
+end
+
 local function handle_speedtest_done(state, ev)
 	local ok, err = wan_manager.handle_speedtest_done(state, ev)
 	if ok == true and err ~= 'stale' then
@@ -767,6 +913,9 @@ local function handle_speedtest_done(state, ev)
 				ok = rec.ok == true,
 				err = rec.err,
 				peak_mbps = mbps,
+				retry_delay_s = rec.retry_delay_s,
+				retry_after = rec.retry_after,
+				failure_count = rec.failure_count,
 			})
 		end
 		if rec and rec.ok == true and rec.peak_mbps ~= nil and state.svc and type(state.svc.obs_metric) == 'function' then
@@ -774,6 +923,11 @@ local function handle_speedtest_done(state, ev)
 				value = rec.peak_mbps,
 				namespace = { 'net', rec.interface or ev.uplink_id, 'speedtest' },
 			})
+		end
+		if rec and rec.ok ~= true and rec.retry_after then
+			local delay_s = math.max(1, (tonumber(rec.retry_after) or (now() + (tonumber(rec.retry_delay_s) or 10))) - now())
+			local rok, rerr = schedule_speedtest_retry(state, tostring(ev.uplink_id or ''), ev.generation, delay_s, rec.err or 'speedtest_failed')
+			if rok ~= true then return nil, rerr end
 		end
 	end
 	mark_domain_dirty(state, 'wan_runtime')
@@ -864,6 +1018,8 @@ local function handle_event(state, ev)
 		return true, nil
 	elseif ev.kind == 'net_speedtest_done' then
 		return handle_speedtest_done(state, ev)
+	elseif ev.kind == 'speedtest_retry_due' then
+		return handle_speedtest_retry_due(state, ev)
 	elseif ev.kind == 'net_live_weights_done' then
 		return handle_live_weights_done(state, ev)
 	elseif ev.kind == 'net_observation_started' then
@@ -965,8 +1121,10 @@ function M.run(scope, params)
 		next_generation = 1,
 		next_apply_id = 1,
 		next_speedtest_id = 1,
+		next_speedtest_retry_id = 1,
 		next_weight_apply_id = 1,
 		active_speedtests = {},
+		speedtest_retries = {},
 		active_weight_apply = nil,
 		counter_poll_enabled = params.counter_metrics ~= false and params.counter_poll ~= false,
 		counter_poll_interval_s = params.counter_poll_interval_s or params.counter_metrics_interval_s or 60,

--- a/src/services/net/wan_manager.lua
+++ b/src/services/net/wan_manager.lua
@@ -63,12 +63,23 @@ local function speedtest_skip_payload(reason, trigger, uplink, generation)
 	}
 end
 
+local function enrich_measurement(payload, state, uplink)
+	local snap = state and state.model and state.model:snapshot() or nil
+	local measurement = snap and wan_policy.measurement(snap, uplink) or nil
+	if type(measurement) == 'table' then
+		payload.measurement_key = measurement.key
+		payload.address = measurement.address
+		payload.address_family = measurement.address_family
+	end
+	return payload
+end
+
 local function report_speedtest_skip(state, reason, trigger, uplink, generation)
-	local payload = enrich_backhaul_status(speedtest_skip_payload(reason, trigger, uplink, generation), state, uplink)
+	local payload = enrich_measurement(enrich_backhaul_status(speedtest_skip_payload(reason, trigger, uplink, generation), state, uplink), state, uplink)
 	payload.what = 'speedtest_skipped'
 	obs_log(state, 'debug', payload)
 	obs_event(state, 'speedtest_skipped',
-		enrich_backhaul_status(speedtest_skip_payload(reason, trigger, uplink, generation), state, uplink))
+		enrich_measurement(enrich_backhaul_status(speedtest_skip_payload(reason, trigger, uplink, generation), state, uplink), state, uplink))
 end
 
 local function mark_speedtest_skipped(state, uplink, generation, reason)
@@ -77,12 +88,27 @@ local function mark_speedtest_skipped(state, uplink, generation, reason)
 		s.wan_runtime.speedtests = s.wan_runtime.speedtests or {}
 		local id = uplink.uplink_id
 		local rec = s.wan_runtime.speedtests[id] or { uplink_id = id }
-		rec.state = 'skipped'
-		rec.ok = false
+		local measurement = wan_policy.measurement(s, uplink)
+		if (reason == 'fresh_same_path' or reason == 'fresh_weak_path') and rec.last_success then
+			rec.state = 'ok'
+			rec.ok = true
+			if reason == 'fresh_weak_path' and type(measurement) == 'table' then
+				rec.last_success.measurement_key = measurement.key
+				rec.last_success.measurement = model_mod.deep_copy(measurement)
+				rec.last_success_key = measurement.key
+			end
+		else
+			rec.state = 'skipped'
+			rec.ok = false
+		end
 		rec.last_skip_generation = generation
 		rec.last_skip_reason = reason
 		rec.interface = uplink.request and uplink.request.interface or rec.interface
 		rec.device = uplink.request and uplink.request.device or rec.device
+		if type(measurement) == 'table' then
+			rec.current_measurement_key = measurement.key
+			rec.current_measurement = model_mod.deep_copy(measurement)
+		end
 		rec.updated_at = now(state)
 		s.wan_runtime.speedtests[id] = rec
 		return s
@@ -111,6 +137,8 @@ local function start_speedtest_for_uplink(state, uplink)
 	local uplink_id = uplink.uplink_id
 	local prev = snap.wan_runtime and snap.wan_runtime.speedtests and snap.wan_runtime.speedtests[uplink_id]
 	if prev and prev.state == 'running' and prev.generation == generation then return true, nil end
+	local measurement, merr = wan_policy.measurement(snap, uplink)
+	if not measurement then return nil, merr or 'speedtest_measurement_key_unavailable' end
 
 	local id = state.next_speedtest_id
 	state.next_speedtest_id = id + 1
@@ -124,6 +152,9 @@ local function start_speedtest_for_uplink(state, uplink)
 			metric = uplink.request.metric,
 			updated_at = now(state),
 		}
+		local previous = s.wan_runtime.speedtests[uplink_id]
+		local same_path_failure = type(previous) == 'table'
+			and (previous.measurement_key == measurement.key or previous.current_measurement_key == measurement.key)
 		s.wan_runtime.speedtests[uplink_id] = {
 			state = 'running',
 			generation = generation,
@@ -132,6 +163,13 @@ local function start_speedtest_for_uplink(state, uplink)
 			interface = uplink.request.interface,
 			device = uplink.request.device,
 			metric = uplink.request.metric,
+			measurement_key = measurement.key,
+			measurement = model_mod.deep_copy(measurement),
+			failure_count = same_path_failure and (tonumber(previous.failure_count) or 0) or 0,
+			last_failure = same_path_failure and model_mod.deep_copy(previous.last_failure) or nil,
+			last_success = previous and model_mod.deep_copy(previous.last_success) or nil,
+			last_success_mbps = previous and previous.last_success_mbps or nil,
+			last_success_at = previous and previous.last_success_at or nil,
 			started_at = now(state),
 		}
 		s.stats.speedtests_started = (s.stats.speedtests_started or 0) + 1
@@ -330,25 +368,41 @@ function M.handle_speedtest_done(state, ev)
 		local mbps = tonumber(result.mbps or result.peak_mbps)
 		if result.ok == true and mbps ~= nil then
 			rec.state = 'ok'
+			rec.failure_count = 0
+			rec.retry_after = nil
+			rec.retry_delay_s = nil
+			rec.last_failure = nil
 			rec.peak_mbps = mbps -- compatibility
 			rec.last_success_mbps = mbps -- compatibility
 			rec.last_success_at = completed_at
+			rec.last_success_key = rec.measurement_key
 			rec.last_success = {
 				mbps = mbps,
 				bytes = result.bytes,
 				data_mib = result.data_mib,
 				duration_s = result.duration_s,
 				completed_at = completed_at,
+				measurement_key = rec.measurement_key,
+				measurement = model_mod.deep_copy(rec.measurement),
 			}
+
 		else
+			local reason = result.code or result.err or 'speedtest_failed'
 			rec.state = 'failed'
 			rec.ok = false
-			rec.retry_after = completed_at + 60
-			rec.last_attempt = {
+			rec.err = reason
+			rec.failure_count = (tonumber(rec.failure_count) or 0) + 1
+			rec.retry_delay_s = wan_policy.speedtest_retry_delay_s(s, rec)
+			rec.retry_after = completed_at + rec.retry_delay_s
+			rec.last_failure = {
 				state = 'failed',
-				reason = result.code or result.err or 'speedtest_failed',
+				reason = reason,
 				completed_at = completed_at,
+				failure_count = rec.failure_count,
+				retry_delay_s = rec.retry_delay_s,
+				retry_after = rec.retry_after,
 			}
+			rec.last_attempt = rec.last_failure -- compatibility
 			if rec.last_success_mbps ~= nil then rec.peak_mbps = rec.last_success_mbps end
 		end
 		rec.data_mib = result.data_mib

--- a/src/services/net/wan_policy.lua
+++ b/src/services/net/wan_policy.lua
@@ -5,6 +5,11 @@ local tablex = require 'shared.table'
 
 local M = {}
 
+local DEFAULT_SPEEDTEST_INTERVAL_S = 6 * 60 * 60
+local DEFAULT_SPEEDTEST_RETRY_AFTER_S = 10
+local DEFAULT_SPEEDTEST_RETRY_MAX_S = 60 * 60
+local HARD_MAX_SPEEDTEST_DURATION_S = 1
+
 local function copy(v) return tablex.deep_copy(v) end
 
 local function sorted_keys(t)
@@ -30,6 +35,32 @@ local function runtime_opts(snapshot)
 		or type(rt.speedtest) == 'table' and rt.speedtest
 		or {}
 	return sp
+end
+
+
+local function bounded_number(v, default, minv)
+	local n = tonumber(v)
+	if n == nil then n = default end
+	if minv ~= nil and n < minv then n = minv end
+	return n
+end
+
+function M.speedtest_retry_delay_s(snapshot, rec)
+	local cfg = runtime_opts(snapshot)
+	local base = bounded_number(cfg.retry_after_s or cfg.retry_base_s or cfg.retry_s,
+		DEFAULT_SPEEDTEST_RETRY_AFTER_S, 1)
+	local cap = bounded_number(cfg.retry_max_s or cfg.max_retry_after_s or cfg.retry_cap_s,
+		DEFAULT_SPEEDTEST_RETRY_MAX_S, base)
+	if cap < base then cap = base end
+	local failures = math.floor(tonumber(rec and (rec.failure_count or rec.consecutive_failures)) or 1)
+	if failures < 1 then failures = 1 end
+	local delay = base
+	for _ = 2, failures do
+		delay = delay * 2
+		if delay >= cap then return cap end
+	end
+	if delay > cap then delay = cap end
+	return delay
 end
 
 function M.speedtest_enabled(snapshot)
@@ -60,6 +91,22 @@ local function gsm_source(member)
 	return src.id
 end
 
+local function source_kind(member, status)
+	local src = member and member.source or nil
+	if type(src) == 'table' and type(src.kind) == 'string' and src.kind ~= '' then return src.kind end
+	local st_src = status and status.source or nil
+	if type(st_src) == 'table' and type(st_src.kind) == 'string' and st_src.kind ~= '' then return st_src.kind end
+	return 'host-multiwan'
+end
+
+local function source_id(member, status)
+	local src = member and member.source or nil
+	if type(src) == 'table' and src.id ~= nil then return src.id end
+	local st_src = status and status.source or nil
+	if type(st_src) == 'table' and st_src.id ~= nil then return st_src.id end
+	return nil
+end
+
 function M.gsm_uplink_state(snapshot, member)
 	local id = gsm_source(member)
 	if not id then return nil end
@@ -74,11 +121,13 @@ function M.build_speedtest_request(snapshot, uplink_id, member)
 	local gsm = M.gsm_uplink_state(snapshot, member)
 	local gsm_linux = type(gsm) == 'table' and type(gsm.linux) == 'table' and gsm.linux or {}
 	local metric = tonumber(member.metric) or 1
+	local duration = tonumber(member.speedtest_duration_s) or HARD_MAX_SPEEDTEST_DURATION_S
+	if duration <= 0 or duration > HARD_MAX_SPEEDTEST_DURATION_S then duration = HARD_MAX_SPEEDTEST_DURATION_S end
 	return {
 		interface = iface_id,
 		device = member.device or member.linux_interface or member.ifname or endpoint.ifname or endpoint.device or endpoint.name or (iface and iface.device) or gsm_linux.ifname,
 		url = member.speedtest_url,
-		max_duration_s = member.speedtest_duration_s,
+		max_duration_s = duration,
 		uplink_id = tostring(uplink_id),
 		metric = metric,
 	}
@@ -128,13 +177,59 @@ function M.uplink_online(snapshot, uplink)
 	return status_online(M.uplink_observed_status(snapshot, uplink))
 end
 
+local function normalise_address(addr)
+	if type(addr) ~= 'table' then return nil end
+	local address = addr.address or addr.ip or addr.addr
+	if type(address) ~= 'string' or address == '' then return nil end
+	if address == '0.0.0.0' or address == '::' then return nil end
+	return {
+		family = tostring(addr.family or addr.af or 'ipv4'),
+		address = address,
+		source = addr.source,
+	}
+end
+
+function M.measurement(snapshot, uplink)
+	local status = M.uplink_observed_status(snapshot, uplink)
+	local addr = normalise_address(status and status.path_address)
+	local req = uplink and uplink.request or {}
+	local member = uplink and uplink.member or {}
+	local parts = {
+		schema = 'devicecode.net.speedtest-key/1',
+		uplink_id = tostring(uplink and uplink.uplink_id or ''),
+		interface = tostring(req.interface or ''),
+		device = tostring(req.device or ''),
+		source_kind = tostring(source_kind(member, status) or ''),
+		source_id = tostring(source_id(member, status) or ''),
+		address_family = addr and addr.family or 'unknown',
+		address = addr and addr.address or 'unknown',
+		address_known = addr ~= nil,
+		speedtest_url = tostring(req.url or ''),
+	}
+	local key = table.concat({
+		'v1', parts.uplink_id, parts.interface, parts.device,
+		parts.source_kind, parts.source_id, parts.address_family,
+		parts.address, parts.speedtest_url,
+	}, '|')
+	parts.key = key
+	parts.address_source = addr and addr.source or 'unobserved'
+	return parts, nil
+end
+
+function M.measurement_key(snapshot, uplink)
+	local m, err = M.measurement(snapshot, uplink)
+	return m and m.key or nil, err, m
+end
+
 local function now_from_opts(opts)
 	return opts and opts.now or nil
 end
 
 local function speedtest_ttl(snapshot)
 	local cfg = runtime_opts(snapshot)
-	return tonumber(cfg.interval_s or cfg.refresh_s or cfg.ttl_s or cfg.max_age_s)
+	local ttl = tonumber(cfg.interval_s or cfg.refresh_s or cfg.ttl_s or cfg.max_age_s)
+	if ttl == nil then return DEFAULT_SPEEDTEST_INTERVAL_S end
+	return ttl
 end
 
 local function speedtest_last_success(rec)
@@ -148,6 +243,35 @@ local function speedtest_last_success(rec)
 	return mbps, completed
 end
 
+local function speedtest_last_key(rec)
+	if type(rec) ~= 'table' then return nil end
+	local last = type(rec.last_success) == 'table' and rec.last_success or nil
+	return last and (last.measurement_key or last.path_key) or rec.last_success_key or rec.measurement_key
+end
+
+local function speedtest_last_address(rec)
+	local last = type(rec) == 'table' and type(rec.last_success) == 'table' and rec.last_success or nil
+	local m = last and type(last.measurement) == 'table' and last.measurement or nil
+	return m and m.address or nil
+end
+
+local function address_known(address)
+	return type(address) == 'string' and address ~= '' and address ~= 'unknown'
+end
+
+local function speedtest_last_address_known(rec)
+	return address_known(speedtest_last_address(rec))
+end
+
+local function weak_key_for_measurement(m)
+	if type(m) ~= 'table' then return nil end
+	return table.concat({
+		'v1', tostring(m.uplink_id or ''), tostring(m.interface or ''), tostring(m.device or ''),
+		tostring(m.source_kind or ''), tostring(m.source_id or ''), 'unknown', 'unknown',
+		tostring(m.speedtest_url or ''),
+	}, '|')
+end
+
 local function speedtest_success_fresh(snapshot, rec, now)
 	local mbps, completed = speedtest_last_success(rec)
 	if mbps == nil then return false end
@@ -156,18 +280,50 @@ local function speedtest_success_fresh(snapshot, rec, now)
 	return now ~= nil and completed ~= nil and completed > 0 and now - completed < ttl
 end
 
+local function speedtest_success_valid(snapshot, rec, now, key, measurement)
+	if not speedtest_success_fresh(snapshot, rec, now) then return false end
+	if key == nil then return false end
+	if speedtest_last_key(rec) == key then return true end
+	-- If the original measurement was admitted before an address was observable,
+	-- allow that fresh result to be used while the current path is being
+	-- strengthened with a known address.  The manager will re-key the cached
+	-- success on the skip path so future IP changes still matter.
+	if measurement and measurement.address_known == true and not speedtest_last_address_known(rec)
+		and speedtest_last_key(rec) == weak_key_for_measurement(measurement) then
+		return true
+	end
+	return false
+end
+
 function M.speedtest_due(snapshot, uplink, opts)
 	opts = opts or {}
 	if not M.speedtest_enabled(snapshot) then return false, 'speedtests_disabled' end
 	if not M.uplink_online(snapshot, uplink) then return false, 'not_online' end
+	local key, _, measurement = M.measurement_key(snapshot, uplink)
 	local generation = opts.generation or snapshot.generation
 	local id = uplink.uplink_id
 	local runtime = snapshot.wan_runtime or {}
 	local rec = runtime.speedtests and runtime.speedtests[id]
 	if rec and rec.state == 'running' and rec.generation == generation then return false, 'running' end
 	local now = now_from_opts(opts)
-	if rec and rec.retry_after and now and now < rec.retry_after then return false, 'retry_later' end
-	if speedtest_success_fresh(snapshot, rec, now) then return false, 'fresh' end
+	if rec and rec.retry_after and now and now < rec.retry_after then
+		local retry_key = rec.measurement_key or rec.current_measurement_key or speedtest_last_key(rec)
+		if retry_key == key then return false, 'retry_later' end
+	end
+	if speedtest_success_valid(snapshot, rec, now, key, measurement) then
+		if measurement and measurement.address_known == true and not speedtest_last_address_known(rec) then
+			return false, 'fresh_weak_path'
+		end
+		return false, 'fresh_same_path'
+	end
+	if speedtest_success_fresh(snapshot, rec, now) and speedtest_last_key(rec) ~= nil then
+		local last_addr = speedtest_last_address(rec)
+		if measurement and measurement.address_known == true and address_known(last_addr) and last_addr ~= measurement.address then
+			return true, 'path_changed_ip'
+		end
+		return true, 'path_changed'
+	end
+	if speedtest_success_fresh(snapshot, rec, now) then return true, 'missing_previous_key' end
 	return true, 'due'
 end
 
@@ -202,17 +358,37 @@ function M.compute_weights(snapshot, generation, opts)
 		local rec = tests[id]
 		local mbps = nil
 		if rec then
+			local key, _, measurement = M.measurement_key(snapshot, uplink)
 			local success_mbps = speedtest_last_success(rec)
-			if success_mbps and (rec.generation == generation or speedtest_success_fresh(snapshot, rec, now_from_opts(opts))) then
+			if success_mbps and speedtest_success_valid(snapshot, rec, now_from_opts(opts), key, measurement) then
 				mbps = success_mbps
 			end
 		end
 		if mbps and mbps > 0 then total = total + mbps end
 		measured[id] = mbps
 	end
-	if total <= 0 then return nil, 'no_successful_speedtests' end
-
 	local out = {}
+	if total <= 0 then
+		local online = {}
+		for _, uplink in ipairs(uplinks) do
+			if M.uplink_online(snapshot, uplink) then online[#online + 1] = uplink end
+		end
+		if #online == 0 then return nil, 'no_online_wan_uplinks' end
+		local fallback_weight = math.max(1, math.floor((weight_scale / #online) + 0.5))
+		for _, uplink in ipairs(online) do
+			out[#out + 1] = {
+				id = uplink.uplink_id,
+				interface = uplink.request.interface,
+				metric = math.max(1, math.floor(tonumber(uplink.request.metric) or 1)),
+				weight = fallback_weight,
+				measured_mbps = nil,
+				probe = true,
+				reason = 'no_successful_speedtests',
+			}
+		end
+		return out, nil
+	end
+
 	for _, uplink in ipairs(uplinks) do
 		local id = uplink.uplink_id
 		local mbps = measured[id]

--- a/src/services/net/wan_runtime.lua
+++ b/src/services/net/wan_runtime.lua
@@ -9,6 +9,8 @@ local queue = require 'devicecode.support.queue'
 
 local M = {}
 
+local HARD_MAX_SPEEDTEST_DURATION_S = 1
+
 local function with_timeout(work_op, timeout_s, label)
 	timeout_s = tonumber(timeout_s)
 	if not timeout_s or timeout_s < 0 then return work_op end
@@ -56,7 +58,8 @@ function M.start_speedtest(spec)
 			uplink_id = spec.uplink_id,
 		},
 		run = function ()
-			local timeout_s = request.max_duration_s or spec.timeout_s or 30
+			local timeout_s = tonumber(request.max_duration_s or spec.timeout_s) or HARD_MAX_SPEEDTEST_DURATION_S
+			if timeout_s <= 0 or timeout_s > HARD_MAX_SPEEDTEST_DURATION_S then timeout_s = HARD_MAX_SPEEDTEST_DURATION_S end
 			local result = fibers.perform(with_timeout(
 				hal:speedtest_op(request, { timeout = false }),
 				timeout_s,

--- a/tests/unit/net/test_backhaul_model.lua
+++ b/tests/unit/net/test_backhaul_model.lua
@@ -27,6 +27,11 @@ function tests.test_reduces_hal_multiwan_facts_to_semantic_backhaul()
                         },
                     },
                 },
+                live = {
+                    interfaces = {
+                        wan = { ipv4 = { { address = '203.0.113.10', mask = 24 } } },
+                    },
+                },
             },
         },
     }, { now = 42 })
@@ -37,6 +42,34 @@ function tests.test_reduces_hal_multiwan_facts_to_semantic_backhaul()
     eq(wan.usable, true)
     eq(wan.uptime_s, 123)
     eq(wan.source.kind, 'host-multiwan')
+    eq(wan.source.tool, 'mwan3')
+    eq(wan.path_address.address, '203.0.113.10')
+end
+
+
+function tests.test_backhaul_uses_mwan3_for_status_and_endpoint_for_device_name()
+    local model = backhaul.reduce({
+        interfaces = {
+            wan = { endpoint = { ifname = 'vl-wan' } },
+        },
+        wan = { members = { wan = { interface = 'wan', metric = 10 } } },
+        observed = {
+            snapshot = {
+                multiwan = {
+                    backend = 'openwrt',
+                    source = 'mwan3',
+                    interfaces_by_semantic = {
+                        wan = { interface = 'wan', state = 'online', usable = true },
+                    },
+                },
+            },
+        },
+    }, { now = 42 })
+
+    local wan = ok(model.uplinks.wan, 'wan uplink expected')
+    eq(wan.state, 'online')
+    eq(wan.usable, true)
+    eq(wan.ifname, 'vl-wan')
     eq(wan.source.tool, 'mwan3')
 end
 
@@ -56,6 +89,11 @@ function tests.test_gsm_uplink_is_mapped_without_hal_backend_terms()
                 },
             },
         },
+        observed = {
+            snapshot = {
+                live = { interfaces = { wwan0 = { ipv4 = { { address = '10.1.2.3' } } } } },
+            },
+        },
     }, { now = 42 })
 
     local uplink = ok(model.uplinks.gsm_primary, 'gsm uplink expected')
@@ -63,6 +101,7 @@ function tests.test_gsm_uplink_is_mapped_without_hal_backend_terms()
     eq(uplink.usable, false)
     eq(uplink.source.kind, 'gsm-uplink')
     eq(uplink.ifname, 'wwan0')
+    eq(uplink.path_address.address, '10.1.2.3')
     eq(uplink.gsm, nil)
 end
 

--- a/tests/unit/net/test_service_behaviour.lua
+++ b/tests/unit/net/test_service_behaviour.lua
@@ -740,6 +740,9 @@ function tests.test_wan_speedtests_wait_for_multiwan_observation()
 						wan_a = { interface = 'wan_a', state = 'online', online = true, usable = true },
 					},
 				},
+				live = { interfaces = {
+					wan_a = { ipv4 = { { address = '203.0.113.10' } } },
+				} },
 			},
 		} })
 
@@ -807,6 +810,10 @@ function tests.test_wan_members_trigger_speedtests_and_live_weights()
 						wan_b = { interface = 'wan_b', state = 'online', online = true, usable = true },
 					},
 				},
+				live = { interfaces = {
+					wan_a = { ipv4 = { { address = '203.0.113.10' } } },
+					wan_b = { ipv4 = { { address = '10.1.2.3' } } },
+				} },
 			},
 		} })
 

--- a/tests/unit/net/test_wan_policy_event_led.lua
+++ b/tests/unit/net/test_wan_policy_event_led.lua
@@ -18,13 +18,36 @@ local function snapshot()
 		},
 		backhaul = {
 			uplinks = {
-				wan = { id = 'wan', interface = 'wan', state = 'online', usable = true },
-				modem_primary = { id = 'modem_primary', interface = 'modem_primary', state = 'offline', usable = false },
+				wan = { id = 'wan', interface = 'wan', device = 'eth1', state = 'online', usable = true, path_address = { family = 'ipv4', address = '203.0.113.10' } },
+				modem_primary = { id = 'modem_primary', interface = 'modem_primary', device = 'wwan1', state = 'offline', usable = false, path_address = { family = 'ipv4', address = '10.1.2.3' } },
 			},
 		},
 		wan_runtime = { speedtests = {} },
 		sources = { gsm_uplinks = { primary = { linux = { ifname = 'wwan1' } } } },
 	}
+end
+
+local function uplinks_by_id(s)
+    local out = {}
+    for _, u in ipairs(policy.collect_uplinks(s)) do out[u.uplink_id] = u end
+    return out
+end
+
+local function keyed_success(s, uplink_id, mbps, completed_at)
+    local uplink = uplinks_by_id(s)[uplink_id]
+    local measurement = assert(policy.measurement(s, uplink))
+    return {
+        state = 'ok',
+        generation = s.generation,
+        ok = true,
+        peak_mbps = mbps,
+        last_success_mbps = mbps,
+        completed_at = completed_at,
+        interface = uplink.request.interface,
+        measurement_key = measurement.key,
+        measurement = measurement,
+        last_success = { mbps = mbps, completed_at = completed_at, measurement_key = measurement.key, measurement = measurement },
+    }
 end
 
 function tests.test_only_observed_online_uplink_is_due()
@@ -40,8 +63,8 @@ end
 
 function tests.test_weights_include_probe_members_after_one_measurement()
 	local s = snapshot()
-	s.wan_runtime.speedtests.wan = { state = 'done', generation = 1, ok = true, peak_mbps = 80, interface = 'wan' }
-	local weights = assert(policy.compute_weights(s, 1))
+	s.wan_runtime.speedtests.wan = keyed_success(s, 'wan', 80, 10)
+	local weights = assert(policy.compute_weights(s, 1, { now = 20 }))
 	eq(#weights, 2)
 	local by_id = {}
 	for _, m in ipairs(weights) do by_id[m.id] = m end
@@ -51,82 +74,187 @@ function tests.test_weights_include_probe_members_after_one_measurement()
 end
 
 function tests.test_fresh_previous_generation_success_is_used_for_weights()
-	local s = snapshot()
-	s.generation = 2
-	s.wan.load_balancing.speedtests.interval_s = 100
-	s.backhaul.uplinks.modem_primary.state = 'online'
-	s.backhaul.uplinks.modem_primary.usable = true
-	s.wan_runtime.speedtests.wan = {
-		state = 'done',
-		generation = 1,
-		ok = true,
-		peak_mbps = 80,
-		last_success_mbps = 80,
-		completed_at = 10,
-		interface = 'wan',
-	}
-	s.wan_runtime.speedtests.modem_primary = {
-		state = 'done',
-		generation = 2,
-		ok = true,
-		peak_mbps = 20,
-		last_success_mbps = 20,
-		completed_at = 20,
-		interface = 'modem_primary',
-	}
-	local uplinks = policy.collect_uplinks(s)
-	local by_uplink = {}
-	for _, u in ipairs(uplinks) do by_uplink[u.uplink_id] = u end
-	local due, reason = policy.speedtest_due(s, by_uplink.wan, { generation = 2, now = 30 })
-	eq(due, false)
-	eq(reason, 'fresh')
+    local s = snapshot()
+    s.generation = 2
+    s.wan.load_balancing.speedtests.interval_s = 100
+    s.backhaul.uplinks.modem_primary.state = 'online'
+    s.backhaul.uplinks.modem_primary.usable = true
+    s.wan_runtime.speedtests.wan = keyed_success(s, 'wan', 80, 10)
+    s.wan_runtime.speedtests.wan.generation = 1
+    s.wan_runtime.speedtests.modem_primary = keyed_success(s, 'modem_primary', 20, 20)
+    s.wan_runtime.speedtests.modem_primary.generation = 2
+    local uplinks = policy.collect_uplinks(s)
+    local by_uplink = {}
+    for _, u in ipairs(uplinks) do by_uplink[u.uplink_id] = u end
+    local due, reason = policy.speedtest_due(s, by_uplink.wan, { generation = 2, now = 30 })
+    eq(due, false)
+    eq(reason, 'fresh_same_path')
 
-	local weights = assert(policy.compute_weights(s, 2, { now = 30 }))
-	local by_id = {}
-	for _, m in ipairs(weights) do by_id[m.id] = m end
-	eq(by_id.wan.weight, 80)
-	eq(by_id.wan.probe, false)
-	eq(by_id.modem_primary.weight, 20)
+    local weights = assert(policy.compute_weights(s, 2, { now = 30 }))
+    local by_id = {}
+    for _, m in ipairs(weights) do by_id[m.id] = m end
+    eq(by_id.wan.weight, 80)
+    eq(by_id.wan.probe, false)
+    eq(by_id.modem_primary.weight, 20)
 
-	local expired_weights = assert(policy.compute_weights(s, 2, { now = 130 }))
-	local expired_by_id = {}
-	for _, m in ipairs(expired_weights) do expired_by_id[m.id] = m end
-	eq(expired_by_id.wan.weight, 1)
-	eq(expired_by_id.wan.probe, true)
-	eq(expired_by_id.modem_primary.weight, 100)
+    local expired_weights = assert(policy.compute_weights(s, 2, { now = 119 }))
+    local expired_by_id = {}
+    for _, m in ipairs(expired_weights) do expired_by_id[m.id] = m end
+    eq(expired_by_id.wan.weight, 1)
+    eq(expired_by_id.wan.probe, true)
+    eq(expired_by_id.modem_primary.weight, 100)
 end
 
 
 function tests.test_failed_latest_speedtest_keeps_fresh_last_success_for_weights()
+    local s = snapshot()
+    s.generation = 2
+    s.wan.load_balancing.speedtests.interval_s = 100
+    s.backhaul.uplinks.modem_primary.state = 'online'
+    s.backhaul.uplinks.modem_primary.usable = true
+    s.wan_runtime.speedtests.wan = keyed_success(s, 'wan', 80, 10)
+    s.wan_runtime.speedtests.wan.state = 'failed'
+    s.wan_runtime.speedtests.wan.ok = false
+    s.wan_runtime.speedtests.wan.last_attempt = { state = 'failed', reason = 'counter_unavailable', completed_at = 30 }
+    s.wan_runtime.speedtests.modem_primary = keyed_success(s, 'modem_primary', 20, 20)
+
+    local weights = assert(policy.compute_weights(s, 2, { now = 30 }))
+    local by_id = {}
+    for _, m in ipairs(weights) do by_id[m.id] = m end
+    eq(by_id.wan.weight, 80)
+    eq(by_id.wan.probe, false)
+    eq(by_id.modem_primary.weight, 20)
+end
+
+
+
+function tests.test_weights_fall_back_to_mwan3_online_members_without_speedtest_success()
+    local s = snapshot()
+    local weights = assert(policy.compute_weights(s, 1, { now = 30 }))
+    eq(#weights, 1)
+    eq(weights[1].id, 'wan')
+    eq(weights[1].weight, 100)
+    eq(weights[1].probe, true)
+    eq(weights[1].reason, 'no_successful_speedtests')
+end
+
+function tests.test_default_speedtest_interval_is_six_hours()
 	local s = snapshot()
 	s.generation = 2
-	s.wan.load_balancing.speedtests.interval_s = 100
-	s.backhaul.uplinks.modem_primary.state = 'online'
-	s.backhaul.uplinks.modem_primary.usable = true
-	s.wan_runtime.speedtests.wan = {
-		state = 'failed',
-		generation = 2,
-		ok = false,
-		last_attempt = { state = 'failed', reason = 'counter_unavailable', completed_at = 30 },
-		last_success = { mbps = 80, completed_at = 10 },
-		last_success_mbps = 80,
-		last_success_at = 10,
-		interface = 'wan',
-	}
-	s.wan_runtime.speedtests.modem_primary = {
-		state = 'ok',
-		generation = 2,
-		ok = true,
-		last_success = { mbps = 20, completed_at = 20 },
-		interface = 'modem_primary',
-	}
+	s.wan_runtime.speedtests.wan = keyed_success(s, 'wan', 80, 10)
+	s.wan_runtime.speedtests.wan.generation = 1
+	local uplinks = policy.collect_uplinks(s)
+	local by_uplink = {}
+	for _, u in ipairs(uplinks) do by_uplink[u.uplink_id] = u end
 
-	local weights = assert(policy.compute_weights(s, 2, { now = 30 }))
-	local by_id = {}
-	for _, m in ipairs(weights) do by_id[m.id] = m end
-	eq(by_id.wan.weight, 80)
-	eq(by_id.wan.probe, false)
-	eq(by_id.modem_primary.weight, 20)
+	local due, reason = policy.speedtest_due(s, by_uplink.wan, { generation = 2, now = 10 + (6 * 60 * 60) - 1 })
+	eq(due, false)
+	eq(reason, 'fresh_same_path')
+
+	due, reason = policy.speedtest_due(s, by_uplink.wan, { generation = 2, now = 10 + (6 * 60 * 60) + 1 })
+	eq(due, true)
+	eq(reason, 'due')
+end
+
+
+function tests.test_speedtest_request_duration_is_capped_at_one_second()
+	local s = snapshot()
+	s.wan.members.wan.speedtest_duration_s = 8
+	local uplinks = policy.collect_uplinks(s)
+	local by_uplink = {}
+	for _, u in ipairs(uplinks) do by_uplink[u.uplink_id] = u end
+	eq(by_uplink.wan.request.max_duration_s, 1)
+
+	s.wan.members.wan.speedtest_duration_s = 0.5
+	uplinks = policy.collect_uplinks(s)
+	by_uplink = {}
+	for _, u in ipairs(uplinks) do by_uplink[u.uplink_id] = u end
+	eq(by_uplink.wan.request.max_duration_s, 0.5)
+end
+
+
+function tests.test_ip_change_invalidates_fresh_measurement()
+    local s = snapshot()
+    s.wan.load_balancing.speedtests.interval_s = 100
+    s.wan_runtime.speedtests.wan = keyed_success(s, 'wan', 80, 10)
+    s.backhaul.uplinks.wan.path_address.address = '198.51.100.42'
+    local by_uplink = uplinks_by_id(s)
+    local due, reason = policy.speedtest_due(s, by_uplink.wan, { generation = 2, now = 30 })
+    eq(due, true)
+    eq(reason, 'path_changed_ip')
+end
+
+
+function tests.test_modem_ip_change_invalidates_fresh_measurement()
+    local s = snapshot()
+    s.wan.load_balancing.speedtests.interval_s = 100
+    s.backhaul.uplinks.modem_primary.state = 'online'
+    s.backhaul.uplinks.modem_primary.usable = true
+    s.wan_runtime.speedtests.modem_primary = keyed_success(s, 'modem_primary', 20, 10)
+    s.backhaul.uplinks.modem_primary.path_address.address = '10.9.8.7'
+    local by_uplink = uplinks_by_id(s)
+    local due, reason = policy.speedtest_due(s, by_uplink.modem_primary, { generation = 2, now = 30 })
+    eq(due, true)
+    eq(reason, 'path_changed_ip')
+end
+
+function tests.test_online_uplink_without_ip_still_runs_first_measurement()
+    local s = snapshot()
+    s.backhaul.uplinks.wan.path_address = nil
+    local by_uplink = uplinks_by_id(s)
+    local due, reason = policy.speedtest_due(s, by_uplink.wan, { generation = 1, now = 10 })
+    eq(due, true)
+    eq(reason, 'due')
+    local measurement = assert(policy.measurement(s, by_uplink.wan))
+    eq(measurement.address_family, 'unknown')
+    eq(measurement.address, 'unknown')
+end
+
+function tests.test_fresh_weak_measurement_is_reused_when_ip_later_appears()
+    local s = snapshot()
+    s.wan.load_balancing.speedtests.interval_s = 100
+    s.backhaul.uplinks.wan.path_address = nil
+    s.wan_runtime.speedtests.wan = keyed_success(s, 'wan', 80, 10)
+    s.backhaul.uplinks.wan.path_address = { family = 'ipv4', address = '203.0.113.10' }
+    local by_uplink = uplinks_by_id(s)
+    local due, reason = policy.speedtest_due(s, by_uplink.wan, { generation = 2, now = 30 })
+    eq(due, false)
+    eq(reason, 'fresh_weak_path')
+end
+
+function tests.test_speedtest_retry_delay_uses_configured_exponential_backoff()
+    local s = snapshot()
+    s.wan.load_balancing.speedtests.retry_after_s = 10
+    s.wan.load_balancing.speedtests.retry_max_s = 60
+    eq(policy.speedtest_retry_delay_s(s, { failure_count = 1 }), 10)
+    eq(policy.speedtest_retry_delay_s(s, { failure_count = 2 }), 20)
+    eq(policy.speedtest_retry_delay_s(s, { failure_count = 3 }), 40)
+    eq(policy.speedtest_retry_delay_s(s, { failure_count = 4 }), 60)
+end
+
+function tests.test_speedtest_retry_delay_defaults_to_ten_seconds()
+    local s = snapshot()
+    eq(policy.speedtest_retry_delay_s(s, { failure_count = 1 }), 10)
+end
+
+
+function tests.test_retry_backoff_only_suppresses_same_path()
+    local s = snapshot()
+    local by_uplink = uplinks_by_id(s)
+    local measurement = assert(policy.measurement(s, by_uplink.wan))
+    s.wan_runtime.speedtests.wan = {
+        state = 'failed', ok = false, measurement_key = measurement.key,
+        failure_count = 1, retry_after = 40,
+    }
+    local due, reason = policy.speedtest_due(s, by_uplink.wan, { generation = 1, now = 20 })
+    eq(due, false)
+    eq(reason, 'retry_later')
+
+    s.backhaul.uplinks.wan.path_address.address = '198.51.100.42'
+    by_uplink = uplinks_by_id(s)
+    due, reason = policy.speedtest_due(s, by_uplink.wan, { generation = 1, now = 20 })
+    eq(due, true)
+    eq(reason, 'due')
 end
 
 return tests

--- a/tests/unit/net/test_wan_runtime.lua
+++ b/tests/unit/net/test_wan_runtime.lua
@@ -74,11 +74,21 @@ function tests.test_reconcile_applies_live_weights_when_speedtests_are_fresh()
 					},
 				},
 			}
+			s.backhaul = {
+				uplinks = {
+					wan = { id = 'wan', interface = 'wan', state = 'online', usable = true, path_address = { family = 'ipv4', address = '203.0.113.10' } },
+					modem = { id = 'modem', interface = 'modem', state = 'online', usable = true, path_address = { family = 'ipv4', address = '10.1.2.3' } },
+				},
+			}
 			s.wan_runtime = {
 				uplinks = {},
 				speedtests = {
-					wan = { state = 'done', generation = 1, ok = true, peak_mbps = 80, last_success_mbps = 80, completed_at = 10 },
-					modem = { state = 'done', generation = 2, ok = true, peak_mbps = 20, last_success_mbps = 20, completed_at = 20 },
+					wan = { state = 'done', generation = 1, ok = true, peak_mbps = 80, last_success_mbps = 80, completed_at = 10,
+						measurement_key = 'v1|wan|wan||host-multiwan||ipv4|203.0.113.10|',
+						last_success = { mbps = 80, completed_at = 10, measurement_key = 'v1|wan|wan||host-multiwan||ipv4|203.0.113.10|' } },
+					modem = { state = 'done', generation = 2, ok = true, peak_mbps = 20, last_success_mbps = 20, completed_at = 20,
+						measurement_key = 'v1|modem|modem||host-multiwan||ipv4|10.1.2.3|',
+						last_success = { mbps = 20, completed_at = 20, measurement_key = 'v1|modem|modem||host-multiwan||ipv4|10.1.2.3|' } },
 				},
 				live_weights = {},
 				last_weight_apply = { generation = 2, members = {


### PR DESCRIPTION
## What type of PR is this?

* [x] Feature
* [x] Bug Fix
* [x] Performance Improvements
* [x] Test

## Description

Updates WAN speedtest behaviour to reduce unnecessary customer data use while preserving accurate multi-WAN weighting.

The speedtest is now treated as a capacity measurement only. WAN online/offline status remains driven by `mwan3`, with speedtest failures handled separately from reachability.

Changes include:

* Limits automatic speedtests to a one-second download window.
* Uses aggressive peak detection and reports the average of the two highest samples.
* Changes the Big Box default speedtest interval to once every six hours.
* Adds path-keyed speedtest caching so unchanged WAN paths are not retested across NET generations.
* Includes the local WAN IP address in the speedtest path key for wired and modem WANs.
* Preserves successful speedtest results across NET generation changes.
* Prevents GSM-only binding changes from causing a wired WAN speedtest when the wired WAN path has not changed.
* Ensures speedtest failures do not mark an uplink offline.
* Treats `mwan3` as canonical for WAN online/offline state.
* Adds configurable speedtest retry settings in `configs/*.json`.
* Adds per-uplink exponential retry backoff starting at 10 seconds and capped by config.
* Keeps live weights usable when no successful speedtest is available by falling back to canonical online WAN state.
* Adds unit coverage for speedtest policy, path-key reuse, IP-change invalidation, retry backoff, and `mwan3`-canonical backhaul state.

## Manual test

* [x] Yes

## Manual test description

Manually confirmed on Big Box hardware after the final exponential retry backoff change.

Suggested manual checks:

1. Boot with wired WAN online and modems absent.
2. Confirm `mwan3 status` reports `wan` online.
3. Confirm the UI shows wired WAN online even if speedtest fails.
4. Confirm a failed speedtest schedules retry using exponential backoff.
5. Confirm GSM binding changes do not trigger another wired WAN speedtest when the WAN IP is unchanged.
6. Confirm changing the WAN IP causes a new speedtest.

## Added tests?

* [x] Yes

Unit tests were added or updated for:

* aggressive one-second speedtest behaviour;
* six-hour speedtest interval defaults;
* path-keyed speedtest reuse;
* WAN IP change invalidation;
* modem IP change invalidation;
* preserving speedtest cache across NET generations;
* retry backoff calculation;
* `mwan3`-canonical WAN online state;
* fallback live weights when no speedtest result is available.

All 1077 tests pass using LuaJIT

## Added to documentation?

* [x] No documentation needed
