### PR TITLE
device: publish MCU metrics

### DIFF
--- a/src/services/device/mcu_metrics.lua
+++ b/src/services/device/mcu_metrics.lua
@@ -1,0 +1,168 @@
+-- services/device/mcu_metrics.lua
+--
+-- Small bridge from the composed MCU component view to the transitional metrics
+-- bus contract.
+
+local projection = require 'services.device.projection'
+
+local M = {}
+
+local function table_or_empty(v)
+	return type(v) == 'table' and v or {}
+end
+
+local function first_number(...)
+	for i = 1, select('#', ...) do
+		local n = tonumber(select(i, ...))
+		if n ~= nil then return n end
+	end
+	return nil
+end
+
+local function first_boolean(t, names)
+	if type(t) ~= 'table' then return nil end
+	for i = 1, #names do
+		local v = t[names[i]]
+		if type(v) == 'boolean' then return v end
+	end
+	return nil
+end
+
+local function emit(out, name, value, namespace)
+	if value == nil then return end
+	out[#out + 1] = {
+		name = name,
+		value = value,
+		namespace = namespace,
+	}
+end
+
+local function emit_boolean_group(out, group, specs, namespace_prefix)
+	for i = 1, #specs do
+		local spec = specs[i]
+		local value = first_boolean(group, spec.keys)
+		emit(out, spec.metric, value, {
+			namespace_prefix[1],
+			namespace_prefix[2],
+			namespace_prefix[3],
+			namespace_prefix[4],
+			namespace_prefix[5],
+			spec.metric,
+		})
+	end
+end
+
+local system_flags = {
+	{ metric = 'charger_enabled', keys = { 'charger_enabled' } },
+	{ metric = 'mppt_en_pin', keys = { 'mppt_en_pin' } },
+	{ metric = 'equalize_req', keys = { 'equalize_req' } },
+	{ metric = 'drvcc_good', keys = { 'drvcc_good' } },
+	{ metric = 'cell_count_error', keys = { 'cell_count_error' } },
+	{ metric = 'ok_to_charge', keys = { 'ok_to_charge' } },
+	{ metric = 'no_rt', keys = { 'no_rt' } },
+	{ metric = 'thermal_shutdown', keys = { 'thermal_shutdown' } },
+	{ metric = 'vin_ovlo', keys = { 'vin_ovlo' } },
+	{ metric = 'vin_gt_vbat', keys = { 'vin_gt_vbat' } },
+	{ metric = 'intvcc_gt_4p3v', keys = { 'intvcc_gt_4p3v' } },
+	{ metric = 'intvcc_gt_2p8v', keys = { 'intvcc_gt_2p8v' } },
+}
+
+local status_flags = {
+	{ metric = 'iin_limited', keys = { 'iin_limited', 'iin_limit_active' } },
+	{ metric = 'uvcl_active', keys = { 'uvcl_active', 'vin_uvcl_active' } },
+	{ metric = 'cc_phase', keys = { 'cc_phase', 'const_current' } },
+	{ metric = 'cv_phase', keys = { 'cv_phase', 'const_voltage' } },
+}
+
+local state_flags = {
+	{ metric = 'bat_short', keys = { 'bat_short', 'bat_short_fault' } },
+	{ metric = 'bat_missing', keys = { 'bat_missing', 'bat_missing_fault' } },
+	{ metric = 'max_charge_time_fault', keys = { 'max_charge_time_fault' } },
+	{ metric = 'c_over_x_term', keys = { 'c_over_x_term' } },
+	{ metric = 'timer_term', keys = { 'timer_term' } },
+	{ metric = 'ntc_pause', keys = { 'ntc_pause' } },
+	{ metric = 'precharge', keys = { 'precharge' } },
+	{ metric = 'cccv', keys = { 'cccv', 'cccv_charge' } },
+	{ metric = 'absorb', keys = { 'absorb', 'absorb_charge' } },
+	{ metric = 'equalize', keys = { 'equalize', 'equalize_charge' } },
+	{ metric = 'suspended', keys = { 'suspended', 'charger_suspended' } },
+}
+
+local function has_group(raw_charger, bits_name)
+	return raw_charger[bits_name] ~= nil
+end
+
+function M.collect_component(rec)
+	if type(rec) ~= 'table' then return {} end
+
+	local view = projection.component_view('mcu', rec)
+	local raw_facts = table_or_empty(rec.raw_facts)
+	local out = {}
+
+	local runtime = table_or_empty(view.runtime)
+	local memory = table_or_empty(runtime.memory)
+	emit(out, 'alloc', first_number(memory.alloc_bytes, memory.alloc), { 'mcu', 'sys', 'mem', 'alloc' })
+
+	local environment = table_or_empty(view.environment)
+	local temperature = table_or_empty(environment.temperature)
+	local humidity = table_or_empty(environment.humidity)
+	local deci_c = first_number(temperature.deci_c)
+	if deci_c ~= nil then
+		emit(out, 'core', deci_c / 10, { 'mcu', 'env', 'temperature', 'core' })
+	end
+	local rh_x100 = first_number(humidity.rh_x100)
+	if rh_x100 ~= nil then
+		emit(out, 'core', rh_x100 / 100, { 'mcu', 'env', 'humidity', 'core' })
+	end
+
+	local power = table_or_empty(view.power)
+	local battery = table_or_empty(power.battery)
+	local temp_mc = first_number(battery.temp_mC)
+	if temp_mc ~= nil then
+		emit(out, 'internal', temp_mc / 1000, { 'mcu', 'power', 'temperature', 'internal' })
+	end
+	emit(out, 'vbat',
+		first_number(battery.pack_mV, battery.vbat_mV, battery.vbat),
+		{ 'mcu', 'power', 'battery', 'internal', 'vbat' })
+	emit(out, 'ibat',
+		first_number(battery.ibat_mA, battery.ibat),
+		{ 'mcu', 'power', 'battery', 'internal', 'ibat' })
+
+	local charger = table_or_empty(power.charger)
+	emit(out, 'vin', first_number(charger.vin_mV, charger.vin), { 'mcu', 'power', 'charger', 'internal', 'vin' })
+	emit(out, 'vsys', first_number(charger.vsys_mV, charger.vsys), { 'mcu', 'power', 'charger', 'internal', 'vsys' })
+	emit(out, 'iin', first_number(charger.iin_mA, charger.iin), { 'mcu', 'power', 'charger', 'internal', 'iin' })
+
+	local raw_charger = table_or_empty(raw_facts.power_charger)
+	if has_group(raw_charger, 'system_bits') then
+		emit_boolean_group(out, table_or_empty(charger.system), system_flags,
+			{ 'mcu', 'power', 'charger', 'internal', 'system' })
+	end
+	if has_group(raw_charger, 'status_bits') then
+		emit_boolean_group(out, table_or_empty(charger.status), status_flags,
+			{ 'mcu', 'power', 'charger', 'internal', 'status' })
+	end
+	if has_group(raw_charger, 'state_bits') then
+		emit_boolean_group(out, table_or_empty(charger.state), state_flags,
+			{ 'mcu', 'power', 'charger', 'internal', 'state' })
+	end
+
+	return out
+end
+
+function M.publish_component(svc, rec)
+	if type(svc) ~= 'table' or type(svc.obs_metric) ~= 'function' then return true, nil, 0 end
+
+	local metrics = M.collect_component(rec)
+	for i = 1, #metrics do
+		local metric = metrics[i]
+		svc:obs_metric(metric.name, {
+			value = metric.value,
+			namespace = metric.namespace,
+		})
+	end
+
+	return true, nil, #metrics
+end
+
+return M

--- a/src/services/device/service.lua
+++ b/src/services/device/service.lua
@@ -12,6 +12,7 @@ local model_mod   = require 'services.device.model'
 local topics      = require 'services.device.topics'
 local publisher   = require 'services.device.publisher'
 local projection  = require 'services.device.projection'
+local mcu_metrics = require 'services.device.mcu_metrics'
 local observer_manager = require 'services.device.observer_manager'
 local action_manager   = require 'services.device.action_manager'
 local priority_event   = require 'devicecode.support.priority_event'
@@ -496,6 +497,14 @@ local function flush_publication(state)
 		emit_event = state.emit_events ~= false,
 	})
 	if ok ~= true then return nil, err end
+
+	if state.dirty.components.mcu then
+		local metrics_ok, metrics_err = mcu_metrics.publish_component(
+			state.svc,
+			snapshot.components and snapshot.components.mcu
+		)
+		if metrics_ok ~= true then return nil, metrics_err end
+	end
 
 	for component_id in pairs(state.dirty.components) do
 		state.published_components[component_id] = true

--- a/tests/unit/device/test_service.lua
+++ b/tests/unit/device/test_service.lua
@@ -14,6 +14,9 @@ local function assert_eq(a, b, msg) if a ~= b then fail(msg or ('expected ' .. t
 local function assert_true(v, msg) if v ~= true then fail(msg or ('expected true, got ' .. tostring(v))) end end
 local function assert_nil(v, msg) if v ~= nil then fail(msg or ('expected nil, got ' .. tostring(v))) end end
 local function assert_not_nil(v, msg) if v == nil then fail(msg or 'expected non-nil') end end
+local function assert_close(a, b, msg)
+	if math.abs(a - b) > 0.000001 then fail(msg or ('expected ' .. tostring(b) .. ', got ' .. tostring(a))) end
+end
 
 local function key(topic) return table.concat(topic, '/') end
 local function fake_conn()
@@ -54,6 +57,34 @@ local function fake_conn()
 	return c
 end
 
+local function fake_svc()
+	local svc = { metrics = {} }
+	function svc:obs_metric(name, payload)
+		self.metrics[#self.metrics + 1] = { name = name, payload = payload }
+	end
+	return svc
+end
+
+local function metrics_by_namespace(svc)
+	local out = {}
+	for i = 1, #(svc.metrics or {}) do
+		local rec = svc.metrics[i]
+		out[table.concat(rec.payload.namespace or {}, '.')] = rec
+	end
+	return out
+end
+
+local function assert_metric(map, namespace, name, value)
+	local rec = map[namespace]
+	assert_not_nil(rec, 'missing metric ' .. namespace)
+	assert_eq(rec.name, name, 'metric topic key mismatch for ' .. namespace)
+	if type(value) == 'number' then
+		assert_close(rec.payload.value, value, 'metric value mismatch for ' .. namespace)
+	else
+		assert_eq(rec.payload.value, value, 'metric value mismatch for ' .. namespace)
+	end
+end
+
 local function cfg_one(extra)
 	local c = {
 		schema = config.SCHEMA,
@@ -63,6 +94,24 @@ local function cfg_one(extra)
 	}
 	if extra then for k, v in pairs(extra) do c[k] = v end end
 	return c
+end
+
+local function cfg_mcu_metrics()
+	return {
+		schema = config.SCHEMA,
+		components = {
+			mcu = {
+				subtype = 'mcu',
+				facts = {
+					runtime_memory = topics.raw_member_state('mcu', 'runtime', 'memory'),
+					environment_temperature = topics.raw_member_state('mcu', 'environment', 'temperature'),
+					environment_humidity = topics.raw_member_state('mcu', 'environment', 'humidity'),
+					power_battery = topics.raw_member_state('mcu', 'power', 'battery'),
+					power_charger = topics.raw_member_state('mcu', 'power', 'charger'),
+				},
+			},
+		},
+	}
 end
 
 
@@ -230,6 +279,127 @@ function tests.test_publication_coalesces_repeated_materially_identical_observat
 		assert_true(service.flush_publication(state))
 		assert_eq(conn.retain_calls, retain_after_first)
 		assert_eq(conn.publish_calls, publish_after_first)
+	end)
+end
+
+function tests.test_mcu_dirty_publication_emits_mcu_metrics()
+	fibers.run(function (scope)
+		local conn = fake_conn()
+		local state = service.build_state(scope, {
+			conn = conn,
+			enable_actions = false,
+			enable_observers = false,
+			now = function () return 100 end,
+		})
+
+		assert_true(service.apply_config_payload(state, cfg_mcu_metrics()))
+		local generation = state.active.generation
+		local observations = {
+			{ fact = 'runtime_memory', payload = { alloc_bytes = 32768 } },
+			{ fact = 'environment_temperature', payload = { deci_c = 234 } },
+			{ fact = 'environment_humidity', payload = { rh_x100 = 4512 } },
+			{ fact = 'power_battery', payload = {
+				pack_mV = 12800,
+				ibat_mA = -120,
+				temp_mC = 24500,
+			} },
+			{ fact = 'power_charger', payload = {
+				vin_mV = 24000,
+				vsys_mV = 12800,
+				iin_mA = 500,
+				state_bits = 0x0142,
+				status_bits = 0x000d,
+				system_bits = 0x2045,
+			} },
+		}
+		for i = 1, #observations do
+			local obs = observations[i]
+			assert_true(service.reduce_event(state, {
+				kind = 'component_observation',
+				generation = generation,
+				component = 'mcu',
+				tag = 'fact_retained',
+				fact = obs.fact,
+				payload = obs.payload,
+			}))
+		end
+
+		local svc = fake_svc()
+		state.svc = svc
+		local ok, err = service.flush_publication(state)
+		assert_true(ok, err)
+
+		local metrics = metrics_by_namespace(svc)
+		assert_metric(metrics, 'mcu.sys.mem.alloc', 'alloc', 32768)
+		assert_metric(metrics, 'mcu.env.temperature.core', 'core', 23.4)
+		assert_metric(metrics, 'mcu.env.humidity.core', 'core', 45.12)
+		assert_metric(metrics, 'mcu.power.temperature.internal', 'internal', 24.5)
+		assert_metric(metrics, 'mcu.power.battery.internal.vbat', 'vbat', 12800)
+		assert_metric(metrics, 'mcu.power.battery.internal.ibat', 'ibat', -120)
+		assert_metric(metrics, 'mcu.power.charger.internal.vin', 'vin', 24000)
+		assert_metric(metrics, 'mcu.power.charger.internal.vsys', 'vsys', 12800)
+		assert_metric(metrics, 'mcu.power.charger.internal.iin', 'iin', 500)
+		assert_metric(metrics,
+			'mcu.power.charger.internal.system.charger_enabled', 'charger_enabled', true)
+		assert_metric(metrics, 'mcu.power.charger.internal.system.ok_to_charge', 'ok_to_charge', true)
+		assert_metric(metrics, 'mcu.power.charger.internal.system.vin_gt_vbat', 'vin_gt_vbat', true)
+		assert_metric(metrics, 'mcu.power.charger.internal.status.iin_limited', 'iin_limited', true)
+		assert_metric(metrics, 'mcu.power.charger.internal.status.uvcl_active', 'uvcl_active', true)
+		assert_metric(metrics, 'mcu.power.charger.internal.status.cc_phase', 'cc_phase', false)
+		assert_metric(metrics, 'mcu.power.charger.internal.status.cv_phase', 'cv_phase', true)
+		assert_metric(metrics, 'mcu.power.charger.internal.state.bat_missing', 'bat_missing', true)
+		assert_metric(metrics, 'mcu.power.charger.internal.state.cccv', 'cccv', true)
+		assert_metric(metrics, 'mcu.power.charger.internal.state.suspended', 'suspended', true)
+		assert_metric(metrics, 'mcu.power.charger.internal.state.bat_short', 'bat_short', false)
+	end)
+end
+
+function tests.test_mcu_metrics_skip_empty_component_values()
+	fibers.run(function (scope)
+		local conn = fake_conn()
+		local state = service.build_state(scope, {
+			conn = conn,
+			enable_actions = false,
+			enable_observers = false,
+			now = function () return 100 end,
+		})
+
+		assert_true(service.apply_config_payload(state, cfg_mcu_metrics()))
+		local svc = fake_svc()
+		state.svc = svc
+		local ok, err = service.flush_publication(state)
+		assert_true(ok, err)
+		assert_eq(#svc.metrics, 0)
+	end)
+end
+
+function tests.test_non_mcu_dirty_publication_does_not_emit_mcu_metrics()
+	fibers.run(function (scope)
+		local conn = fake_conn()
+		local state = service.build_state(scope, {
+			conn = conn,
+			enable_actions = false,
+			enable_observers = false,
+			now = function () return 100 end,
+		})
+
+		assert_true(service.apply_config_payload(state, {
+			schema = config.SCHEMA,
+			components = {
+				host = {
+					class = 'host',
+					subtype = 'cm5',
+					facts = {
+						software = topics.raw_host_cap_state('updater', 'updater', 'cm5', 'software'),
+					},
+				},
+			},
+		}))
+		local svc = fake_svc()
+		state.svc = svc
+		local ok, err = service.flush_publication(state)
+		assert_true(ok, err)
+		assert_eq(#svc.metrics, 0)
 	end)
 end
 

--- a/tests/unit/device/test_static.lua
+++ b/tests/unit/device/test_static.lua
@@ -15,6 +15,7 @@ local files = {
 	'../src/services/device/model.lua',
 	'../src/services/device/publisher.lua',
 	'../src/services/device/projection.lua',
+	'../src/services/device/mcu_metrics.lua',
 	'../src/services/device/catalogue.lua',
 	'../src/services/device/component_mcu.lua',
 	'../src/services/device/component_host.lua',


### PR DESCRIPTION
## Summary
- publish MCU component metrics from the device service
- add MCU metric projection helper and focused unit/static coverage

## Tests
- TEST_FILTER="device.test_service" luajit run.lua
- TEST_FILTER="device.test_static" luajit run.lua