### PR TITLE
gsm, hal, ui: apn editor fix

### DIFF
--- a/src/services/gsm.lua
+++ b/src/services/gsm.lua
@@ -613,6 +613,19 @@ local function log_gsm_summary(svc, modems, reason)
 	svc:info('gsm_summary', { summary = summary, reason = reason })
 end
 
+local function debug_ranked_apn_list(ranked_apns, rankings, rank_cutoff)
+	local out = {}
+	for _, ranking in ipairs(rankings or {}) do
+		local rec = apn_model.redact_record((ranked_apns or {})[ranking.name] or {})
+		local rank = tonumber(ranking.rank) or math.huge
+		rec._name = ranking.name
+		rec._rank = ranking.rank
+		rec._eligible = rank <= tonumber(rank_cutoff or 0)
+		out[#out + 1] = rec
+	end
+	return out
+end
+
 local GsmModem = {}
 GsmModem.__index = GsmModem
 
@@ -987,6 +1000,16 @@ function GsmModem:_apn_connect()
 	-- Get ranked APNs
 	local rank_cutoff = tonumber(self.cfg.apn_rank_cutoff) or 4
 	local ranked_apns, rankings = apns.get_ranked_apns(mcc, mnc, imsi, nil, gid1, self.svc and self.svc.custom_apns)
+	self.svc:obs_log('info', {
+		what = 'apns_loaded_for_sim',
+		temporary_debug = true,
+		modem = self.name,
+		mcc = tostring(mcc or ''),
+		mnc = tostring(mnc or ''),
+		rank_cutoff = rank_cutoff,
+		count = #rankings,
+		apns = debug_ranked_apn_list(ranked_apns, rankings, rank_cutoff),
+	})
 
 	-- Iterate through ranked APNs
 	for _, ranking in ipairs(rankings) do
@@ -1287,6 +1310,8 @@ function GsmService.start(conn, opts)
 	local config_ready = false
 	local custom_apns = {}
 	local apn_store = nil
+	local apn_store_loaded = false
+	local apn_store_retry_delay_s = 1.0
 
 	-- Transitional APN bridge. GSM is still on its pre-modern service
 	-- architecture; keep this surface deliberately small until GSM is migrated.
@@ -1351,9 +1376,11 @@ function GsmService.start(conn, opts)
 	end
 
 	local function open_apn_store_for_config(cfg)
+		apn_store_retry_delay_s = 1.0
 		local store_opts, err = apn_store_opts_from_config(cfg)
 		if not store_opts then
 			apn_store = nil
+			apn_store_loaded = false
 			custom_apns = {}
 			svc.custom_apns = custom_apns
 			publish_apn_state({ state = 'unavailable', ready = false, reason = err })
@@ -1362,11 +1389,12 @@ function GsmService.start(conn, opts)
 		apn_store = apn_store_control.new(conn, store_opts)
 		local records, lerr = perform(apn_store:load_op())
 		if not records then
-			custom_apns = {}
-			svc.custom_apns = custom_apns
+			apn_store_loaded = false
+			apn_store_retry_delay_s = 0
 			publish_apn_state({ state = 'degraded', ready = false, reason = lerr or 'apn_store_load_failed' })
 			return nil, lerr or 'apn_store_load_failed'
 		end
+		apn_store_loaded = true
 		custom_apns = records
 		svc.custom_apns = custom_apns
 		publish_apn_state({ state = 'ready', ready = true })
@@ -1379,8 +1407,42 @@ function GsmService.start(conn, opts)
 		end
 	end
 
+	local function apn_store_retry_op()
+		return fibers.run_scope_op(function ()
+			if apn_store_retry_delay_s > 0 then
+				perform(sleep.sleep_op(apn_store_retry_delay_s))
+			end
+			if not apn_store then return nil, 'apn_store_unavailable' end
+			return perform(apn_store:load_op())
+		end):wrap(function (st, rep, records, lerr)
+			if st ~= 'ok' then return nil, tostring(records or lerr or rep or 'apn_store_load_failed') end
+			return records, lerr
+		end)
+	end
+
+	local function handle_apn_store_load_result(records, lerr)
+		if records then
+			apn_store_loaded = true
+			custom_apns = records
+			svc.custom_apns = custom_apns
+			publish_apn_state({ state = 'ready', ready = true })
+			svc:obs_log('info', { what = 'apn_store_loaded', count = #custom_apns })
+			apn_store_retry_delay_s = 1.0
+			signal_all_modems()
+			return true, nil
+		end
+		publish_apn_state({ state = 'degraded', ready = false, reason = lerr or 'apn_store_load_failed' })
+		if apn_store_retry_delay_s <= 0 then
+			apn_store_retry_delay_s = 1.0
+		else
+			apn_store_retry_delay_s = math.min(apn_store_retry_delay_s * 2, 10.0)
+		end
+		return nil, lerr or 'apn_store_load_failed'
+	end
+
 	local function replace_custom_apns(records)
 		if not apn_store then return nil, 'apn_store_unavailable' end
+		if not apn_store_loaded then return nil, 'apn_store_not_ready' end
 		local list, lerr = apn_model.normalise_list(records)
 		if not list then return nil, lerr end
 		local saved, serr = perform(apn_store:save_op(list))
@@ -1397,6 +1459,7 @@ function GsmService.start(conn, opts)
 
 	local function handle_apn_request(method, payload)
 		if method == 'list-custom-apns' then
+			if not apn_store_loaded then return false, 'apn_store_not_ready' end
 			return true, copy(custom_apns)
 		elseif method == 'replace-custom-apns' then
 			local records, perr = apn_model.list_from_payload(payload or {})
@@ -1553,6 +1616,9 @@ function GsmService.start(conn, opts)
 			cap = modem_cap_sub:recv_op(),
 			cfg = cfg_sub:recv_op(),
 		}
+		if apn_store and not apn_store_loaded then
+			choices.apn_store_retry = apn_store_retry_op()
+		end
 
 		local modem_fault_ops = {}
 		for id, modem in pairs(modems) do
@@ -1567,7 +1633,7 @@ function GsmService.start(conn, opts)
 
 		local which, msg, err = perform(op.named_choice(choices))
 
-		if not msg then
+		if not msg and which ~= 'apn_store_retry' then
 			svc:obs_log('debug', { what = 'subscription_closed', err = tostring(err) })
 			return
 		end
@@ -1588,6 +1654,11 @@ function GsmService.start(conn, opts)
 				svc:obs_log('debug',
 					{ what = 'modem_scope_faulted', modem = tostring(msg.id), err = tostring(msg.primary) })
 				modem:stop()
+			end
+		elseif which == 'apn_store_retry' then
+			local _, retry_err = handle_apn_store_load_result(msg, err)
+			if retry_err then
+				svc:obs_log('debug', { what = 'apn_store_retry_failed', err = tostring(retry_err) })
 			end
 		elseif which == 'cfg' then
 			local cfg_data = msg.payload and msg.payload.data

--- a/src/services/gsm.lua
+++ b/src/services/gsm.lua
@@ -613,19 +613,6 @@ local function log_gsm_summary(svc, modems, reason)
 	svc:info('gsm_summary', { summary = summary, reason = reason })
 end
 
-local function debug_ranked_apn_list(ranked_apns, rankings, rank_cutoff)
-	local out = {}
-	for _, ranking in ipairs(rankings or {}) do
-		local rec = apn_model.redact_record((ranked_apns or {})[ranking.name] or {})
-		local rank = tonumber(ranking.rank) or math.huge
-		rec._name = ranking.name
-		rec._rank = ranking.rank
-		rec._eligible = rank <= tonumber(rank_cutoff or 0)
-		out[#out + 1] = rec
-	end
-	return out
-end
-
 local GsmModem = {}
 GsmModem.__index = GsmModem
 
@@ -1000,16 +987,6 @@ function GsmModem:_apn_connect()
 	-- Get ranked APNs
 	local rank_cutoff = tonumber(self.cfg.apn_rank_cutoff) or 4
 	local ranked_apns, rankings = apns.get_ranked_apns(mcc, mnc, imsi, nil, gid1, self.svc and self.svc.custom_apns)
-	self.svc:obs_log('info', {
-		what = 'apns_loaded_for_sim',
-		temporary_debug = true,
-		modem = self.name,
-		mcc = tostring(mcc or ''),
-		mnc = tostring(mnc or ''),
-		rank_cutoff = rank_cutoff,
-		count = #rankings,
-		apns = debug_ranked_apn_list(ranked_apns, rankings, rank_cutoff),
-	})
 
 	-- Iterate through ranked APNs
 	for _, ranking in ipairs(rankings) do

--- a/src/services/hal/drivers/control_store.lua
+++ b/src/services/hal/drivers/control_store.lua
@@ -147,24 +147,36 @@ function Driver:start_op(owner_scope)
 			return op.always(false, 'missing emit channel')
 		end
 
-		local shell_scope, serr = owner_scope:child()
-		if not shell_scope then
-			return op.always(false, tostring(serr))
-		end
+		return fibers.run_scope_op(function ()
+			local pok, perr = fibers.perform(self.provider:prepare_op())
+			if not pok then
+				return false, tostring(perr or 'control_store provider prepare failed')
+			end
 
-		self.scope = shell_scope
+			local shell_scope, serr = owner_scope:child()
+			if not shell_scope then
+				return false, tostring(serr)
+			end
 
-		local ok, err = shell_scope:spawn(function ()
-			return shell_main(self)
+			self.scope = shell_scope
+
+			local ok, err = shell_scope:spawn(function ()
+				return shell_main(self)
+			end)
+			if not ok then
+				self.scope = nil
+				shell_scope:cancel(tostring(err or 'shell spawn failed'))
+				return false, tostring(err)
+			end
+
+			self.started = true
+			return true, nil
+		end):wrap(function (status, reason, ok, err)
+			if status ~= 'ok' then
+				return false, tostring(reason or err or 'control_store driver start failed')
+			end
+			return ok, err
 		end)
-		if not ok then
-			self.scope = nil
-			shell_scope:cancel(tostring(err or 'shell spawn failed'))
-			return op.always(false, tostring(err))
-		end
-
-		self.started = true
-		return op.always(true, nil)
 	end)
 end
 

--- a/src/services/hal/drivers/control_store_provider.lua
+++ b/src/services/hal/drivers/control_store_provider.lua
@@ -137,9 +137,9 @@ local function write_index_op(root, keys)
 	return write_file_op(index_path(root), join_lines(sort_unique(keys)))
 end
 
-local function ensure_root_op(root)
+function Provider:prepare_op()
 	return op.guard(function ()
-		local ok, err = file.mkdir_p(root)
+		local ok, err = file.mkdir_p(self.root)
 		if ok then return op.always(true, nil) end
 		return op.always(false, tostring(err or 'control_store_root_create_failed'))
 	end)
@@ -195,11 +195,6 @@ function Provider:put_op(opts)
 		end
 
 		return fibers.run_scope_op(function ()
-			local ok_root, root_err = fibers.perform(ensure_root_op(self.root))
-			if not ok_root then
-				return false, root_err
-			end
-
 			local okw, werr = fibers.perform(write_file_op(path_for(self.root, opts.key), opts.data))
 			if not okw then
 				return false, werr

--- a/src/services/hal/drivers/control_store_provider.lua
+++ b/src/services/hal/drivers/control_store_provider.lua
@@ -137,6 +137,14 @@ local function write_index_op(root, keys)
 	return write_file_op(index_path(root), join_lines(sort_unique(keys)))
 end
 
+local function ensure_root_op(root)
+	return op.guard(function ()
+		local ok, err = file.mkdir_p(root)
+		if ok then return op.always(true, nil) end
+		return op.always(false, tostring(err or 'control_store_root_create_failed'))
+	end)
+end
+
 function Provider:status_op()
 	return op.always(true, {
 		root = self.root,
@@ -187,6 +195,11 @@ function Provider:put_op(opts)
 		end
 
 		return fibers.run_scope_op(function ()
+			local ok_root, root_err = fibers.perform(ensure_root_op(self.root))
+			if not ok_root then
+				return false, root_err
+			end
+
 			local okw, werr = fibers.perform(write_file_op(path_for(self.root, opts.key), opts.data))
 			if not okw then
 				return false, werr

--- a/src/services/ui/http/request.lua
+++ b/src/services/ui/http/request.lua
@@ -226,7 +226,12 @@ local function handle_gsm_apns_put(scope, owner, ctx, deps)
 		deps.apn_timeout or 5.0
 	))
 	if st ~= 'ok' then
-		perform_response(owner:reply_error_op(400, result_or_primary or 'gsm_apns_update_failed'))
+		local detail = tostring(result_or_primary or 'gsm_apns_update_failed')
+		perform_response(owner:reply_json_op(400, {
+			error = detail,
+			code = 'gsm_apns_update_failed',
+			detail = detail,
+		}))
 		return { status = 'failed', err = result_or_primary }
 	end
 	perform_response(owner:reply_json_op(200, { ok = true, apns = result_or_primary.value or {} }))

--- a/tests/integration/devhost/local_ui_http_spec.lua
+++ b/tests/integration/devhost/local_ui_http_spec.lua
@@ -57,38 +57,38 @@ function T.devhost_local_ui_apns_round_trip_through_gsm_and_fake_control_store()
 		harness.wait_http_ready(inst.base_url, { timeout = 5 })
 
 		local apns = {
-			records = {
-				{
-					carrier = 'Demo Carrier',
-					mcc = '234',
-					mnc = '10',
-					apn = 'demo.internet',
-					user = 'clinic',
-					password = 'prototype-secret',
-				},
+			{
+				carrier = 'Demo Carrier',
+				mcc = '234',
+				mnc = '10',
+				apn = 'custom-apn',
+				authtype = 'none',
+				user = 'demo-user',
+				password = 'demo-password',
 			},
 		}
 
 		local status, body = harness.curl_json('PUT', inst.base_url .. '/api/gsm/apns/custom', apns)
 		assert_eq(status, '200')
 		assert_true(body.ok, 'APN PUT should succeed')
-		assert_eq(body.apns[1].apn, 'demo.internet')
+		assert_eq(body.apns[1].apn, 'custom-apn')
+		assert_eq(body.apns[1].authtype, 'none')
 
 		status, body = harness.curl_json('GET', inst.base_url .. '/api/gsm/apns/custom')
 		assert_eq(status, '200')
 		assert_eq(body[1].carrier, 'Demo Carrier')
-		assert_eq(body[1].password, 'prototype-secret')
+		assert_eq(body[1].password, 'demo-password')
 
 		local stored = assert_not_nil(inst.control_store:get('custom-apns-v1'),
 			'APN list should be persisted in fake control-store')
-		assert_true(stored:find('demo.internet', 1, true) ~= nil, 'persisted APN JSON should contain the APN')
+		assert_true(stored:find('custom-apn', 1, true) ~= nil, 'persisted APN JSON should contain the APN')
 
 		status, body = harness.curl_json('GET', inst.base_url .. '/api/local-ui/bootstrap')
 		assert_eq(status, '200')
 		local apn_state = assert_not_nil(body.items['state/gsm/apns/custom'],
 			'bootstrap should include GSM APN retained state after PUT')
 		assert_eq(apn_state.payload.count, 1)
-		assert_eq(apn_state.payload.records[1].apn, 'demo.internet')
+		assert_eq(apn_state.payload.records[1].apn, 'custom-apn')
 		assert_eq(apn_state.payload.records[1].password, nil)
 		assert_eq(apn_state.payload.records[1].user, nil)
 		assert_eq(apn_state.payload.records[1].has_password, true)

--- a/tests/unit/gsm/test_apn_model.lua
+++ b/tests/unit/gsm/test_apn_model.lua
@@ -14,6 +14,26 @@ function tests.test_normalise_record_requires_core_fields()
 	if bad then fail('invalid MCC accepted') end
 end
 
+function tests.test_normalise_record_accepts_apn_editor_payload()
+	local rec, err = model.normalise_record({
+		carrier = 'Demo Carrier',
+		mcc = '234',
+		mnc = '10',
+		apn = 'custom-apn',
+		authtype = 'none',
+		user = 'demo-user',
+		password = 'demo-password',
+	})
+	ok(rec, err)
+	eq(rec.carrier, 'Demo Carrier')
+	eq(rec.mcc, '234')
+	eq(rec.mnc, '10')
+	eq(rec.apn, 'custom-apn')
+	eq(rec.authtype, 'none')
+	eq(rec.user, 'demo-user')
+	eq(rec.password, 'demo-password')
+end
+
 function tests.test_normalise_list_rejects_duplicates()
 	local list, err = model.normalise_list({
 		{ carrier='A', mcc='234', mnc='10', apn='internet' },

--- a/tests/unit/hal/control_store_manager_spec.lua
+++ b/tests/unit/hal/control_store_manager_spec.lua
@@ -57,6 +57,40 @@ function T.start_apply_config_and_stop_round_trip()
   rm_rf(root)
 end
 
+function T.apply_config_creates_missing_control_store_root()
+  local base = mk_tmpdir('csm-create-root')
+  local root = base .. '/nested/control-store'
+  local M = fresh_manager()
+
+  runfibers.run(function()
+    local dev_ev_ch = channel.new(8)
+    local cap_emit_ch = channel.new(8)
+
+    local ok_start, err_start = fibers.perform(M.start_op(nil, dev_ev_ch, cap_emit_ch))
+    assert(ok_start == true, tostring(err_start))
+
+    local ok_cfg, err_cfg = fibers.perform(M.apply_config_op({
+      { name = 'main', root = root },
+    }))
+    assert(ok_cfg == true, tostring(err_cfg))
+
+    local ev = recv_or_fail(dev_ev_ch)
+    assert(ev.event_type == 'added')
+    assert(ev.class == 'control-store')
+    assert(ev.id == 'main')
+
+    local probe, perr = io.open(root .. '/.probe', 'wb')
+    assert(probe ~= nil, tostring(perr))
+    probe:write('ok')
+    probe:close()
+
+    local ok_stop, err_stop = fibers.perform(M.shutdown_op())
+    assert(ok_stop == true, tostring(err_stop))
+  end)
+
+  rm_rf(base)
+end
+
 function T.apply_config_fails_when_not_started()
   local root = mk_tmpdir('csm-not-started')
   local M = fresh_manager()


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description
The apn editor had a few issues that are now resolved


1. Custom APN save failed with No such file or directory - fixed by making the control-store driver create/prepare its root directory during startup, before it is advertised as available.
 2. UI showed internal_error instead of the useful backend error - fixed by returning the APN update failure detail from the backend and making the UI prefer detailed error fields.
 3. GSM could start before the APN control store was available - fixed by tracking APN store readiness and retrying the APN store load from the GSM main loop.
 4. Existing APNs could disappear after restart - fixed by refusing custom APN list/update operations until the APN store has successfully loaded, so the UI cannot overwrite persisted APNs from an empty in-memory state.
 5. APN store failure could have blocked modem management - avoided by keeping modem management running even when the custom APN store is not ready; built-in/default APNs can still be used.

## Manual test
<!-- Have you manually tested this code and confirmed it is working? -->
- [x] 👍 yes
- [ ] 🙅 no

## Manual test description
Run the code and add an apn, check the contents of  /data/devicecode/control/gsm/custom-apns-v1 to see the apn. Stop the code and rerun, the apn editor should show the previous apn. The apn editor my take a sec to load, wait up to 10 seconds.

## Added tests?
- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?
- [ ] 📜 README.md
- [x] 🙅 no documentation needed
