### PR TITLE
net: stabilises backhaul modelling

### DIFF
--- a/src/services/hal/backends/network/providers/openwrt/hotplug_send.lua
+++ b/src/services/hal/backends/network/providers/openwrt/hotplug_send.lua
@@ -2,6 +2,77 @@
 -- Forward one OpenWrt hotplug/MWAN3 event to the devicecode network observer.
 -- Intended for tiny scripts in /etc/hotplug.d/* and /etc/mwan3.user.
 
+local function dirname(path)
+	path = tostring(path or '')
+	local dir = path:match('^(.*)/[^/]*$')
+	if dir == nil or dir == '' then return '.' end
+	return dir
+end
+
+
+local function prepend_package_paths(paths, cpaths)
+	if #paths > 0 then package.path = table.concat(paths, ';') .. ';' .. package.path end
+	if #cpaths > 0 then package.cpath = table.concat(cpaths, ';') .. ';' .. package.cpath end
+end
+
+local function split_sender_path(path)
+	path = tostring(path or '')
+	local prefix = path:match('^(.*)/src/services/hal/backends/network/providers/openwrt/hotplug_send%.lua$')
+	if prefix then return prefix, prefix .. '/src' end
+	prefix = path:match('^(.*)/services/hal/backends/network/providers/openwrt/hotplug_send%.lua$')
+	if prefix then return prefix, prefix end
+	return nil, nil
+end
+
+local function bootstrap_package_path()
+	local src = arg and arg[0] or debug.getinfo(1, 'S').source or ''
+	if src:sub(1, 1) == '@' then src = src:sub(2) end
+	local project_root, lua_root = split_sender_path(src)
+	if not project_root then
+		local dir = dirname(src)
+		-- Fall back from .../openwrt to the package root if this file was copied
+		-- without its original tree.  This remains harmless when paths do not exist.
+		lua_root = dir .. '/../../../../../../'
+		project_root = lua_root
+	end
+
+	local paths = {
+		-- Installed/check-out deployments flatten third-party modules into lib/.
+		-- This is the layout on production targets, for example lib/fibers.lua
+		-- and lib/fibers/*.lua.  Keep these before vendor paths so the hook
+		-- uses the same module set as the running checkout.
+		project_root .. '/lib/?.lua',
+		project_root .. '/lib/?/init.lua',
+		lua_root .. '/lib/?.lua',
+		lua_root .. '/lib/?/init.lua',
+
+		lua_root .. '/?.lua',
+		lua_root .. '/?/init.lua',
+		project_root .. '/src/?.lua',
+		project_root .. '/src/?/init.lua',
+
+		-- Development and test checkouts may still carry the original vendor tree.
+		project_root .. '/vendor/lua-fibers/src/?.lua',
+		project_root .. '/vendor/lua-fibers/src/?/init.lua',
+		project_root .. '/vendor/lua-bus/src/?.lua',
+		project_root .. '/vendor/lua-bus/src/?/init.lua',
+		project_root .. '/vendor/lua-trie/src/?.lua',
+		project_root .. '/vendor/lua-trie/src/?/init.lua',
+		project_root .. '/vendor/lua-trie/?.lua',
+		project_root .. '/vendor/lua-trie/?/init.lua',
+	}
+	local cpaths = {
+		project_root .. '/lib/?.so',
+		lua_root .. '/lib/?.so',
+		project_root .. '/vendor/?.so',
+		project_root .. '/vendor/?/?.so',
+		project_root .. '/vendor/?/lib/?.so',
+	}
+	prepend_package_paths(paths, cpaths)
+end
+
+bootstrap_package_path()
+
 local fibers = require 'fibers'
 local client = require 'services.hal.backends.network.providers.openwrt.hotplug_client'
 

--- a/src/services/hal/backends/network/providers/openwrt/init.lua
+++ b/src/services/hal/backends/network/providers/openwrt/init.lua
@@ -24,6 +24,11 @@ local Provider = {}
 Provider.__index = Provider
 
 local HOST_NETMASK = '255.255.255.255'
+local DEFAULT_OBSERVER_SOCKET = '/var/run/devicecode-net-observe.sock'
+local DEFAULT_HOTPLUG_SENDER = '/usr/lib/lua/services/hal/backends/network/providers/openwrt/hotplug_send.lua'
+local OBSERVER_HOTPLUG_NAME = '95-devicecode-net-observe'
+local OBSERVER_BLOCK_BEGIN = '# BEGIN devicecode-net-observer'
+local OBSERVER_BLOCK_END = '# END devicecode-net-observer'
 local OWNED_PACKAGES = { 'network', 'dhcp', 'firewall', 'mwan3' }
 local COUNTER_STATS = {
 	'rx_bytes',
@@ -86,6 +91,219 @@ local function run_provider_command(self, argv)
 	local status, code = perform(cmd:run_op())
 	if status == 'exited' and code == 0 then return true, nil end
 	return nil, table.concat(argv, ' ') .. ' exited with status=' .. tostring(status) .. ' code=' .. tostring(code)
+end
+
+local function run_hook_command(self, argv)
+	local cfg = self and self.config or {}
+	local runner = cfg.hook_run_cmd or cfg.run_cmd
+	if type(runner) == 'function' then return runner(argv) end
+	local cmd = exec.command(exec_spec(argv))
+	local status, code = perform(cmd:run_op())
+	if status == 'exited' and code == 0 then return true, nil end
+	return nil, table.concat(argv or {}, ' ') .. ' exited with status=' .. tostring(status) .. ' code=' .. tostring(code)
+end
+
+local function shell_quote(v)
+	v = tostring(v or '')
+	return "'" .. v:gsub("'", "'\\''") .. "'"
+end
+
+local function observer_socket_path(config)
+	config = config or {}
+	return config.observer_socket_path or config.hotplug_socket_path or DEFAULT_OBSERVER_SOCKET
+end
+
+local function path_dirname(path)
+	return tostring(path or ''):match('^(.*)/[^/]+$') or '.'
+end
+
+local function absolute_path(path)
+	if type(path) ~= 'string' or path == '' then return nil end
+	if path:sub(1, 1) == '/' then return path end
+	path = path:gsub('^%./', '')
+	local cwd = os.getenv('PWD')
+	if type(cwd) == 'string' and cwd ~= '' then return cwd:gsub('/+$', '') .. '/' .. path end
+	return path
+end
+
+local function source_tree_hotplug_sender_path()
+	local info = debug and debug.getinfo and debug.getinfo(1, 'S') or nil
+	local source = info and info.source or nil
+	if type(source) ~= 'string' then return nil end
+	if source:sub(1, 1) == '@' then source = source:sub(2) end
+	local dir = path_dirname(absolute_path(source) or source)
+	if dir and dir ~= '' then return dir .. '/hotplug_send.lua' end
+	return nil
+end
+
+local function hotplug_sender_path(config)
+	config = config or {}
+	return config.hotplug_sender_path or source_tree_hotplug_sender_path() or DEFAULT_HOTPLUG_SENDER
+end
+
+local function observer_hook_root(config)
+	config = config or {}
+	local root = config.observer_hook_root or config.observer_hooks_root
+	if type(root) == 'string' and root ~= '' then
+		return root:gsub('/+$', '')
+	end
+	return ''
+end
+
+local function rooted_hook_path(config, path)
+	local root = observer_hook_root(config)
+	if root == '' then return path end
+	return root .. path
+end
+
+local function write_text_file(path, content)
+	local f, err = file.open(path, 'w')
+	if not f then return nil, err end
+	local ok, werr = f:write(content or '')
+	if ok == false or ok == nil then
+		f:close()
+		return nil, werr
+	end
+	if f.flush then
+		local fok, ferr = f:flush()
+		if fok == false or fok == nil then
+			f:close()
+			return nil, ferr
+		end
+	end
+	local cok, cerr = f:close()
+	if cok == false or cok == nil then return nil, cerr end
+	return true, nil
+end
+
+local function read_text_file(path)
+	local f = file.open(path, 'r')
+	if not f then return nil end
+	local data = f:read_all()
+	f:close()
+	return data or ''
+end
+
+local function observer_forward_script(config, source, kind, directory, prelude)
+	local socket_path = observer_socket_path(config)
+	local sender = hotplug_sender_path(config)
+	local lines = {
+		'#!/bin/sh',
+		'# Installed by devicecode.  Keep policy in Lua; this only wakes the observer.',
+		'DEVICECODE_NET_HOTPLUG_SOCKET=${DEVICECODE_NET_HOTPLUG_SOCKET:-' .. shell_quote(socket_path) .. '}',
+		'LUA_BIN=${DEVICECODE_LUA:-}',
+		'if [ -z "$LUA_BIN" ]; then',
+		'  if command -v lua >/dev/null 2>&1; then LUA_BIN=lua; elif command -v luajit >/dev/null 2>&1; then LUA_BIN=luajit; fi',
+		'fi',
+	}
+	if type(prelude) == 'string' and prelude ~= '' then
+		for line in tostring(prelude):gmatch('[^\n]+') do lines[#lines + 1] = line end
+	end
+	lines[#lines + 1] = 'DEVICECODE_NET_HOTPLUG_SENDER=' .. shell_quote(sender)
+	lines[#lines + 1] = 'if [ ! -S "$DEVICECODE_NET_HOTPLUG_SOCKET" ]; then'
+	lines[#lines + 1] = '  logger -t devicecode-net-observe "socket missing: $DEVICECODE_NET_HOTPLUG_SOCKET source=' .. tostring(source) .. ' action=${ACTION:-} interface=${INTERFACE:-}" 2>/dev/null || true'
+	lines[#lines + 1] = 'elif [ ! -r "$DEVICECODE_NET_HOTPLUG_SENDER" ]; then'
+	lines[#lines + 1] = '  logger -t devicecode-net-observe "sender missing: $DEVICECODE_NET_HOTPLUG_SENDER" 2>/dev/null || true'
+	lines[#lines + 1] = 'elif [ -n "$LUA_BIN" ]; then'
+	lines[#lines + 1] = '  "$LUA_BIN" "$DEVICECODE_NET_HOTPLUG_SENDER"'
+		.. ' --source=' .. shell_quote(source)
+		.. ' --kind=' .. shell_quote(kind)
+		.. ' --directory=' .. shell_quote(directory)
+		.. ' --socket="$DEVICECODE_NET_HOTPLUG_SOCKET"'
+		.. ' --ACTION="${ACTION:-}"'
+		.. ' --INTERFACE="${INTERFACE:-}"'
+		.. ' --DEVICE="${DEVICE:-}"'
+		.. ' --DEVICENAME="${DEVICENAME:-}"'
+		.. ' --DEVNAME="${DEVNAME:-}"'
+		.. ' --SUBSYSTEM="${SUBSYSTEM:-}" >/dev/null 2>&1 || {'
+		.. ' logger -t devicecode-net-observe "send failed source=' .. tostring(source) .. ' kind=' .. tostring(kind) .. ' directory=' .. tostring(directory) .. ' action=${ACTION:-} interface=${INTERFACE:-}" 2>/dev/null || true; }'
+	lines[#lines + 1] = 'else'
+	lines[#lines + 1] = '  logger -t devicecode-net-observe "lua interpreter missing" 2>/dev/null || true'
+	lines[#lines + 1] = 'fi'
+	lines[#lines + 1] = 'exit 0'
+	return table.concat(lines, '\n') .. '\n'
+end
+
+local function mwan3_user_block(config)
+	local prelude = table.concat({
+		'case "$1" in',
+		'  ifup|ifdown|online|offline|connected|disconnected|disabled|enabled)',
+		'    [ -n "$ACTION" ] || export ACTION="$1"',
+		'    [ -n "$INTERFACE" ] || export INTERFACE="$2"',
+		'    ;;',
+		'  *)',
+		'    [ -n "$INTERFACE" ] || export INTERFACE="$1"',
+		'    [ -n "$ACTION" ] || export ACTION="$2"',
+		'    ;;',
+		'esac',
+	}, '\n')
+	local body = observer_forward_script(config, 'mwan3', 'mwan3', 'mwan3.user', prelude)
+	body = body:gsub('^#!/bin/sh\n', '')
+	body = body:gsub('exit 0\n$', '')
+	return OBSERVER_BLOCK_BEGIN .. '\n' .. body .. OBSERVER_BLOCK_END .. '\n'
+end
+
+local function strip_observer_block(content)
+	content = tostring(content or '')
+	local pattern = '\n?%# BEGIN devicecode%-net%-observer.-%# END devicecode%-net%-observer\n?'
+	local stripped = content:gsub(pattern, '\n')
+	stripped = stripped:gsub('\n+$', '\n')
+	return stripped
+end
+
+local function install_observer_file(self, path, content)
+	local cfg = self and self.config or {}
+	local dir = path_dirname(path)
+	local ok, err = file.mkdir_p(dir)
+	if ok ~= true then return nil, 'failed to create ' .. dir .. ': ' .. tostring(err) end
+	ok, err = write_text_file(path, content)
+	if ok ~= true then return nil, 'failed to write ' .. path .. ': ' .. tostring(err) end
+	if cfg.observer_hook_chmod ~= false then
+		ok, err = run_hook_command(self, { 'chmod', '+x', path })
+		if ok ~= true then return nil, 'failed to chmod ' .. path .. ': ' .. tostring(err) end
+	end
+	return true, nil
+end
+
+local function install_mwan3_user_hook(self)
+	local cfg = self and self.config or {}
+	local path = rooted_hook_path(cfg, cfg.mwan3_user_path or '/etc/mwan3.user')
+	local old = read_text_file(path)
+	local base = strip_observer_block(old or '')
+	if base == '' then base = '#!/bin/sh\n' end
+	if not base:match('^#!') then base = '#!/bin/sh\n' .. base end
+	if not base:match('\n$') then base = base .. '\n' end
+	local shebang, rest = base:match('^(#![^\n]*\n?)(.*)$')
+	shebang = shebang or '#!/bin/sh\n'
+	rest = rest or base
+	local content = shebang .. '\n' .. mwan3_user_block(cfg) .. '\n' .. rest
+	return install_observer_file(self, path, content)
+end
+
+local function install_hotplug_hook(self, directory)
+	local cfg = self and self.config or {}
+	local path = rooted_hook_path(cfg, '/etc/hotplug.d/' .. tostring(directory) .. '/' .. OBSERVER_HOTPLUG_NAME)
+	local content = observer_forward_script(cfg, 'hotplug', 'hotplug', directory)
+	return install_observer_file(self, path, content)
+end
+
+local function install_observer_hooks(self)
+	local cfg = self and self.config or {}
+	if cfg.install_observer_hooks == false then return true, nil end
+	if cfg.allow_fake_uci == true and cfg.install_observer_hooks ~= true and observer_hook_root(cfg) == '' then
+		return true, nil, { 'skipped:fake_uci' }
+	end
+	local installed = {}
+	local ok, err = install_hotplug_hook(self, 'iface')
+	if ok ~= true then return nil, err end
+	installed[#installed + 1] = 'hotplug:iface'
+	ok, err = install_hotplug_hook(self, 'net')
+	if ok ~= true then return nil, err end
+	installed[#installed + 1] = 'hotplug:net'
+	ok, err = install_mwan3_user_hook(self)
+	if ok ~= true then return nil, err end
+	installed[#installed + 1] = 'mwan3.user'
+	return true, nil, installed
 end
 
 local function wait_for_linux_device(self, dev, opts)
@@ -1200,9 +1418,22 @@ function Provider:_ensure_observer()
 	if self._observer then return self._observer, nil end
 	local scope = self:_owner()
 	if not scope then return nil, 'provider owner scope required' end
+	local hooks_ok, hooks_err, hooks = install_observer_hooks(self)
+	log_provider(self, hooks_ok == true and 'info' or 'warn', {
+		what = 'openwrt_network_observer_hooks_installed',
+		summary = hooks_ok == true
+			and ('network observer hooks installed sender=' .. tostring(hotplug_sender_path(self.config)) .. ' socket=' .. tostring(observer_socket_path(self.config)))
+			or ('network observer hook installation failed: ' .. tostring(hooks_err)),
+		ok = hooks_ok == true,
+		err = hooks_err,
+		hooks = hooks,
+		sender = hotplug_sender_path(self.config),
+		socket = observer_socket_path(self.config),
+	})
+	if hooks_ok ~= true then return nil, hooks_err end
 	local obs, err = observer_mod.new({
 		logger = self.logger,
-		socket_path = self.config.observer_socket_path or self.config.hotplug_socket_path or '/var/run/devicecode-net-observe.sock',
+		socket_path = observer_socket_path(self.config),
 		debounce_s = self.config.observer_debounce_s or self.config.debounce_observation_s or 0.15,
 		enable_socket = self.config.enable_hotplug_socket ~= false,
 		enable_ubus = self.config.enable_ubus_listener == true,
@@ -2214,6 +2445,10 @@ end
 
 M._test = {
 	normalise_mwan3_status = normalise_mwan3_status,
+	observer_forward_script = observer_forward_script,
+	mwan3_user_block = mwan3_user_block,
+	strip_observer_block = strip_observer_block,
+	install_observer_hooks = install_observer_hooks,
 }
 
 return M

--- a/src/services/hal/backends/network/providers/openwrt/init.lua
+++ b/src/services/hal/backends/network/providers/openwrt/init.lua
@@ -27,6 +27,8 @@ local HOST_NETMASK = '255.255.255.255'
 local DEFAULT_OBSERVER_SOCKET = '/var/run/devicecode-net-observe.sock'
 local DEFAULT_HOTPLUG_SENDER = '/usr/lib/lua/services/hal/backends/network/providers/openwrt/hotplug_send.lua'
 local OBSERVER_HOTPLUG_NAME = '95-devicecode-net-observe'
+local DEFAULT_IFACE_HOTPLUG_HOOK = '/etc/hotplug.d/iface/' .. OBSERVER_HOTPLUG_NAME
+local DEFAULT_NET_HOTPLUG_HOOK = '/etc/hotplug.d/net/' .. OBSERVER_HOTPLUG_NAME
 local OBSERVER_BLOCK_BEGIN = '# BEGIN devicecode-net-observer'
 local OBSERVER_BLOCK_END = '# END devicecode-net-observer'
 local OWNED_PACKAGES = { 'network', 'dhcp', 'firewall', 'mwan3' }
@@ -280,9 +282,16 @@ local function install_mwan3_user_hook(self)
 	return install_observer_file(self, path, content)
 end
 
+local function default_hotplug_hook_path(directory)
+	directory = tostring(directory or '')
+	if directory == 'iface' then return DEFAULT_IFACE_HOTPLUG_HOOK end
+	if directory == 'net' then return DEFAULT_NET_HOTPLUG_HOOK end
+	return '/etc/hotplug.d/' .. directory .. '/' .. OBSERVER_HOTPLUG_NAME
+end
+
 local function install_hotplug_hook(self, directory)
 	local cfg = self and self.config or {}
-	local path = rooted_hook_path(cfg, '/etc/hotplug.d/' .. tostring(directory) .. '/' .. OBSERVER_HOTPLUG_NAME)
+	local path = rooted_hook_path(cfg, default_hotplug_hook_path(directory))
 	local content = observer_forward_script(cfg, 'hotplug', 'hotplug', directory)
 	return install_observer_file(self, path, content)
 end

--- a/src/services/hal/backends/network/providers/openwrt/observer.lua
+++ b/src/services/hal/backends/network/providers/openwrt/observer.lua
@@ -144,6 +144,30 @@ local function decode_ubus_line(line)
 	}
 end
 
+local TRANSIENT_MWAN_ACTIONS = {
+	connecting = true,
+	disconnecting = true,
+}
+
+local function trigger_env(trigger)
+	if type(trigger) ~= 'table' then return {} end
+	local env = trigger.env or trigger.payload or trigger
+	if type(env) ~= 'table' then return {} end
+	return env
+end
+
+local function trigger_action(trigger)
+	local env = trigger_env(trigger)
+	local action = env.ACTION or env.action
+	if action == nil and type(trigger) == 'table' then action = trigger.action end
+	if action == nil then return nil end
+	return tostring(action):lower()
+end
+
+local function is_transient_mwan_action(trigger)
+	return TRANSIENT_MWAN_ACTIONS[trigger_action(trigger) or ''] == true
+end
+
 local function normalise_hotplug_record(rec)
 	if type(rec) ~= 'table' then return nil end
 	local env = rec.env or rec
@@ -181,6 +205,14 @@ end
 
 function Observer:ingest(trigger)
 	if self.closed then return false, 'observer closed' end
+	-- mwan3.user emits transitional phases such as connecting/disconnecting.
+	-- Treat these as diagnostics only: they are not stable data-path states and
+	-- must not become retained NET backhaul status.  Terminal events such as
+	-- connected/disconnected still wake the observer and take a fresh snapshot.
+	if is_transient_mwan_action(trigger) then
+		log(self, 'debug', { what = 'network_observer_transient_trigger_ignored', summary = 'transient mwan event ignored action=' .. tostring(trigger_action(trigger) or '?'), trigger = trigger })
+		return true, 'ignored_transient_mwan_action'
+	end
 	return self.tx:send(trigger)
 end
 

--- a/src/services/hal/backends/network/providers/openwrt/observer.lua
+++ b/src/services/hal/backends/network/providers/openwrt/observer.lua
@@ -358,6 +358,17 @@ function Observer:ubus_listener()
 	self:_stop_ubus_listener()
 end
 
+local function trigger_summary(trigger)
+	trigger = trigger or {}
+	local env = trigger.env or trigger.payload or trigger
+	return string.format('%s event action=%s interface=%s device=%s directory=%s',
+		tostring(trigger.source or trigger.kind or 'hotplug'),
+		tostring(env.ACTION or env.action or '?'),
+		tostring(env.INTERFACE or env.interface or '?'),
+		tostring(env.DEVICE or env.DEVICENAME or env.DEVNAME or env.device or '?'),
+		tostring(trigger.directory or env.SUBSYSTEM or '?'))
+end
+
 function Observer:handle_socket_stream(st)
 	self:_track_stream(st)
 	while not self.closed do
@@ -365,7 +376,14 @@ function Observer:handle_socket_stream(st)
 		if line == nil then break end
 		local rec = cjson.decode(line)
 		local trig = normalise_hotplug_record(rec)
-		if trig then self:ingest(trig) end
+		if trig then
+			if trig.source == 'mwan3' or trig.kind == 'mwan3' then
+				log(self, 'info', { what = 'network_observer_mwan3_trigger', summary = trigger_summary(trig), trigger = trig })
+			elseif trig.directory == 'iface' or trig.directory == 'net' then
+				log(self, 'info', { what = 'network_observer_hotplug_trigger', summary = trigger_summary(trig), trigger = trig })
+			end
+			self:ingest(trig)
+		end
 	end
 	self:_untrack_stream(st)
 	close_stream(st)

--- a/src/services/net/backhaul_model.lua
+++ b/src/services/net/backhaul_model.lua
@@ -211,7 +211,7 @@ function M.reduce(snapshot, opts)
 		observed_at = opts.now,
 		uplinks = {},
 	}
-	local members = snapshot and snapshot.wan and snapshot.wan.members or {}
+	local members = snapshot and snapshot.wan and snapshot.wan.configured_members or {}
 	local total, online, known = 0, 0, 0
 	for uplink_id, member in pairs(members or {}) do
 		if is_table(member) and member.enabled ~= false and member.disabled ~= true then

--- a/src/services/net/backhaul_model.lua
+++ b/src/services/net/backhaul_model.lua
@@ -106,6 +106,39 @@ local function member_metric(member)
 	return tonumber(member and member.metric) or 1
 end
 
+local function vlan_id(vlan)
+	if type(vlan) == 'number' then return vlan end
+	if is_table(vlan) then return tonumber(vlan.id) end
+	return nil
+end
+
+local function first_kind(segment, endpoint)
+	local kind = (is_table(segment) and segment.kind) or (is_table(endpoint) and endpoint.kind)
+	if kind == 'wan' or kind == 'wired' then return 'wired' end
+	return kind or 'wired'
+end
+
+local function link_view(snapshot, iface, member, source_kind)
+	local segment = snapshot and snapshot.segments and snapshot.segments[iface] or nil
+	local endpoint = interface_endpoint(snapshot, iface)
+	local vid = vlan_id(member and member.vlan) or vlan_id(segment and segment.vlan) or vlan_id(endpoint and endpoint.vlan)
+	local kind = source_kind == 'gsm-uplink' and 'cellular' or first_kind(segment, endpoint)
+	return {
+		kind = kind,
+		segment = iface,
+		vlan = vid,
+	}
+end
+
+local function status_source(snapshot, st)
+	local mw = observed_multiwan(snapshot) or {}
+	return {
+		kind = 'host-multiwan',
+		backend = st and (st.backend or mw.backend) or mw.backend,
+		tool = st and (st.tool or mw.source) or mw.source,
+	}
+end
+
 local function gsm_source(member)
 	local src = member and member.source or nil
 	if is_table(src) and src.kind == 'gsm-uplink' then return src.id end
@@ -120,17 +153,12 @@ end
 
 local function reduce_gsm(snapshot, uplink_id, member, opts)
 	local gsm = gsm_uplink(snapshot, member)
-	local state = 'unknown'
-	local usable = false
-	if is_table(gsm) then
-		state = tostring(gsm.state or (gsm.connected and 'connected' or 'disconnected'))
-		if state == 'connected' then state = 'online' end
-		usable = gsm.connected == true and state == 'online'
-	end
 	local linux = is_table(gsm and gsm.linux) and gsm.linux or {}
 	local iface = member_interface(member, uplink_id)
+	local st = status_by_interface(snapshot, iface)
+	local state, usable = semantic_state_from_host(st)
 	local endpoint = interface_endpoint(snapshot, iface)
-	local ifname = linux.ifname or member.device or member.ifname or endpoint.ifname or endpoint.device or endpoint.name
+	local ifname = st and st.ifname or linux.ifname or member.device or member.ifname or endpoint.ifname or endpoint.device or endpoint.name
 	return {
 		id = tostring(uplink_id),
 		role = member.role or uplink_id,
@@ -138,17 +166,20 @@ local function reduce_gsm(snapshot, uplink_id, member, opts)
 		ifname = ifname,
 		state = state,
 		usable = usable,
+		observed = st ~= nil,
 		metric = member_metric(member),
-		path_address = path_address(snapshot, iface, ifname, nil),
+		path_address = path_address(snapshot, iface, ifname, st),
 		source = { kind = 'gsm-uplink', id = gsm_source(member) },
-		observed_at = is_table(gsm) and (gsm.updated_at or gsm.observed_at) or (opts and opts.now),
+		status_source = status_source(snapshot, st),
+		link = link_view(snapshot, iface, member, 'gsm-uplink'),
+		observed_at = st and (st.observed_at or ((observed_multiwan(snapshot) or {}).observed_at))
+			or (is_table(gsm) and (gsm.updated_at or gsm.observed_at) or (opts and opts.now)),
 	}
 end
 
 local function reduce_host(snapshot, uplink_id, member, opts)
 	local iface = member_interface(member, uplink_id)
 	local st = status_by_interface(snapshot, iface)
-	local mw = observed_multiwan(snapshot) or {}
 	local state, usable = semantic_state_from_host(st)
 	local endpoint = interface_endpoint(snapshot, iface)
 	local ifname = st and st.ifname or member.device or member.ifname or endpoint.ifname or endpoint.device or endpoint.name
@@ -164,13 +195,11 @@ local function reduce_host(snapshot, uplink_id, member, opts)
 		path_address = path_address(snapshot, iface, ifname, st),
 		uptime_s = st and (tonumber(st.uptime_s) or tonumber(st.uptime)) or nil,
 		age_s = st and (tonumber(st.age_s) or tonumber(st.age)) or nil,
-		source = {
-			kind = 'host-multiwan',
-			backend = st and (st.backend or mw.backend) or nil,
-			tool = st and (st.tool or mw.source) or nil,
-		},
+		source = status_source(snapshot, st),
+		status_source = status_source(snapshot, st),
+		link = link_view(snapshot, iface, member, 'host-multiwan'),
 		probes = st and copy(st.probes) or nil,
-		observed_at = st and (st.observed_at or mw.observed_at) or nil,
+		observed_at = st and (st.observed_at or ((observed_multiwan(snapshot) or {}).observed_at)) or (opts and opts.now),
 	}
 end
 

--- a/src/services/net/drift.lua
+++ b/src/services/net/drift.lua
@@ -80,7 +80,7 @@ local function check_firewall(items, snapshot, observed)
 end
 
 local function check_wan(items, snapshot, observed)
-	local desired = snapshot.wan and snapshot.wan.members or {}
+	local desired = snapshot.wan and (snapshot.wan.realised_members or snapshot.wan.members) or {}
 	local obs = observed and observed.wan and observed.wan.members or nil
 	if type(obs) ~= 'table' then return end
 	for id, member in pairs(desired or {}) do

--- a/src/services/net/drift.lua
+++ b/src/services/net/drift.lua
@@ -80,7 +80,7 @@ local function check_firewall(items, snapshot, observed)
 end
 
 local function check_wan(items, snapshot, observed)
-	local desired = snapshot.wan and (snapshot.wan.realised_members or snapshot.wan.members) or {}
+	local desired = snapshot.wan and snapshot.wan.realised_members or {}
 	local obs = observed and observed.wan and observed.wan.members or nil
 	if type(obs) ~= 'table' then return end
 	for id, member in pairs(desired or {}) do

--- a/src/services/net/metrics.lua
+++ b/src/services/net/metrics.lua
@@ -58,17 +58,11 @@ local function counter_aliases(snapshot)
 		if has_counter_interface(snapshot, rec.interface) then add_counter_alias(out, seen_alias, seen_iface, rec.alias, rec.interface) end
 	end
 
-	if has_counter_interface(snapshot, 'modem_primary') then add_counter_alias(out, seen_alias, seen_iface, 'mdm0', 'modem_primary') end
-	if has_counter_interface(snapshot, 'modem_secondary') then add_counter_alias(out, seen_alias, seen_iface, 'mdm1', 'modem_secondary') end
-
-	local members = snapshot.wan and snapshot.wan.members or {}
+	local members = snapshot.wan and snapshot.wan.configured_members or {}
 	for _, member_id in ipairs(sorted_keys(members)) do
 		local member = members[member_id]
-		local source = type(member) == 'table' and member.source or nil
-		local source_id = type(source) == 'table' and source.id or nil
 		local iface = type(member) == 'table' and (member.interface or member_id) or member_id
-		if source_id == 'primary' then add_counter_alias(out, seen_alias, seen_iface, 'mdm0', iface) end
-		if source_id == 'secondary' then add_counter_alias(out, seen_alias, seen_iface, 'mdm1', iface) end
+		add_counter_alias(out, seen_alias, seen_iface, tostring(member_id), iface)
 	end
 	return out
 end

--- a/src/services/net/model.lua
+++ b/src/services/net/model.lua
@@ -67,7 +67,7 @@ function M.initial(service_id)
 		dhcp = {},
 		firewall = {},
 		routing = {},
-		wan = {},
+		wan = { members = {}, realised_members = {} },
 		backhaul = { schema = 'devicecode.net.backhaul/1', state = 'unknown', uplinks = {} },
 		wan_runtime = { uplinks = {}, speedtests = {}, live_weights = {}, last_weight_apply = nil },
 		sources = { gsm_uplinks = {} },

--- a/src/services/net/model.lua
+++ b/src/services/net/model.lua
@@ -67,7 +67,7 @@ function M.initial(service_id)
 		dhcp = {},
 		firewall = {},
 		routing = {},
-		wan = { members = {}, realised_members = {} },
+		wan = { configured_members = {}, realised_members = {} },
 		backhaul = { schema = 'devicecode.net.backhaul/1', state = 'unknown', uplinks = {} },
 		wan_runtime = { uplinks = {}, speedtests = {}, live_weights = {}, last_weight_apply = nil },
 		sources = { gsm_uplinks = {} },

--- a/src/services/net/projection.lua
+++ b/src/services/net/projection.lua
@@ -38,7 +38,7 @@ function M.summary(snapshot)
 		counts = {
 			segments = count_map(snapshot.segments),
 			interfaces = count_map(snapshot.interfaces),
-			wan_members = count_map(snapshot.wan and snapshot.wan.members),
+			wan_members = count_map(snapshot.wan and snapshot.wan.configured_members),
 			gsm_uplinks = count_map(snapshot.sources and snapshot.sources.gsm_uplinks),
 			vpn_tunnels = count_map(snapshot.vpn and snapshot.vpn.tunnels),
 		},

--- a/src/services/net/service.lua
+++ b/src/services/net/service.lua
@@ -171,6 +171,42 @@ local function log_net_summary(state, reason)
 	obs_log(state.svc, 'info', { what = 'net_summary', summary = summary, reason = reason })
 end
 
+
+local function backhaul_uplinks(backhaul)
+	local uplinks = type(backhaul) == 'table' and backhaul.uplinks or nil
+	return type(uplinks) == 'table' and uplinks or {}
+end
+
+local function log_mwan_backhaul_transitions(state, before, after, trigger)
+	if not state.svc then return end
+	local prev = backhaul_uplinks(before)
+	local next_uplinks = backhaul_uplinks(after)
+	for _, uplink_id in ipairs(sorted_keys(next_uplinks)) do
+		local rec = next_uplinks[uplink_id]
+		if type(rec) == 'table' then
+			local source = type(rec.status_source) == 'table' and rec.status_source or rec.source
+			local tool = type(source) == 'table' and source.tool or nil
+			local prev_rec = prev[uplink_id]
+			local prev_state = type(prev_rec) == 'table' and prev_rec.state or nil
+			local state_now = rec.state
+			if (state_now == 'online' or state_now == 'offline') and state_now ~= prev_state and (tool == nil or tool == 'mwan3') then
+				obs_log(state.svc, 'info', {
+					what = state_now == 'online' and 'mwan_member_online' or 'mwan_member_offline',
+					summary = string.format('mwan member %s %s interface=%s ifname=%s', tostring(uplink_id), tostring(state_now), tostring(rec.interface or '?'), tostring(rec.ifname or '?')),
+					uplink_id = tostring(uplink_id),
+					interface = rec.interface,
+					ifname = rec.ifname,
+					state = state_now,
+					usable = rec.usable == true,
+					previous_state = prev_state,
+					subject = trigger and trigger.subject or nil,
+					source = trigger and trigger.source or nil,
+				})
+			end
+		end
+	end
+end
+
 local function set_model_state(state, service_state, reason)
 	state.model:update(function (s)
 		s.state = service_state
@@ -311,28 +347,47 @@ local function carry_forward_wan_runtime(previous, intent, generation)
 	return out
 end
 
-local function copy_intent_to_model(s, intent)
-	local generation = intent.generation
+local function copy_wan_with_realised_members(configured_wan, realised_wan)
+	local wan = model_mod.deep_copy(configured_wan or {})
+	wan.members = model_mod.deep_copy((configured_wan and configured_wan.members) or {})
+	wan.realised_members = model_mod.deep_copy((realised_wan and realised_wan.members) or {})
+	return wan
+end
+
+local function copy_intent_to_model(s, apply_intent, configured_intent)
+	configured_intent = configured_intent or apply_intent
+	local generation = configured_intent.generation or apply_intent.generation
 	s.generation = generation
-	s.config = { rev = intent.rev, schema = intent.schema, config_schema = intent.config_schema, version = intent.version }
+	s.config = {
+		rev = configured_intent.rev,
+		schema = configured_intent.schema,
+		config_schema = configured_intent.config_schema,
+		version = configured_intent.version,
+	}
 	s.intent = s.intent or {}
 	s.intent.generation = generation
-	s.segments = intent.segments or {}
-	s.vlan_policy = intent.vlan_policy or {}
-	s.policies = intent.policies or {}
-	s.interfaces = intent.interfaces or {}
-	s.addressing = intent.addressing or {}
-	s.dns = intent.dns or {}
-	s.dhcp = intent.dhcp or {}
-	s.firewall = intent.firewall or {}
-	s.routing = intent.routing or {}
-	s.wan = intent.wan or {}
+	s.intent.realised_generation = apply_intent.generation
+	s.segments = apply_intent.segments or {}
+	s.vlan_policy = apply_intent.vlan_policy or {}
+	s.policies = apply_intent.policies or {}
+	s.interfaces = apply_intent.interfaces or {}
+	s.addressing = apply_intent.addressing or {}
+	s.dns = apply_intent.dns or {}
+	s.dhcp = apply_intent.dhcp or {}
+	s.firewall = apply_intent.firewall or {}
+	s.routing = apply_intent.routing or {}
+	-- Keep the product-level WAN member catalogue stable in the public NET
+	-- model.  The OpenWrt/HAL apply intent may legitimately omit GSM-backed
+	-- members until a Linux ifname exists; that volatility must not remove
+	-- state/net/backhaul.uplinks or local-UI cards.  The realised set is kept
+	-- separately for diagnostics and apply/runtime policy that needs it.
+	s.wan = copy_wan_with_realised_members(configured_intent.wan, apply_intent.wan)
 	s.sources = s.sources or { gsm_uplinks = {} }
 	s.backhaul = backhaul_model.reduce(s, { now = now() })
 	apply_backhaul_to_interfaces(s)
-	s.wan_runtime = carry_forward_wan_runtime(s.wan_runtime, intent, generation)
-	s.vpn = intent.vpn or {}
-	s.diagnostics = intent.diagnostics or {}
+	s.wan_runtime = carry_forward_wan_runtime(s.wan_runtime, configured_intent, generation)
+	s.vpn = apply_intent.vpn or {}
+	s.diagnostics = apply_intent.diagnostics or {}
 	return s
 end
 
@@ -366,7 +421,7 @@ local function accept_pending_intent(state, intent, reason)
 	state.last_realised_source_fingerprint = realised_fingerprint(state, intent)
 
 	state.model:update(function (s)
-		copy_intent_to_model(s, apply_intent)
+		copy_intent_to_model(s, apply_intent, intent)
 		s.state = 'waiting_for_hal'
 		s.ready = false
 		s.reason = reason
@@ -408,7 +463,7 @@ local function start_apply_for_intent(state, intent, reason)
 	state.pending_apply_reason = nil
 
 	state.model:update(function (s)
-		copy_intent_to_model(s, apply_intent)
+		copy_intent_to_model(s, apply_intent, intent)
 		s.state = 'applying'
 		s.ready = false
 		s.reason = nil
@@ -532,7 +587,8 @@ end
 local function return_apply_to_pending(state, result, reason)
 	reason = reason or 'network_config_unavailable'
 	local gen = state.current_generation
-	local intent = gen and gen.intent or nil
+	local apply_intent = gen and gen.intent or nil
+	local intent = state.base_intent or apply_intent
 	state.active_apply = nil
 	if not intent then return set_model_state(state, 'waiting_for_hal', reason) end
 
@@ -662,7 +718,10 @@ end
 local function handle_observed_state(state, ev)
 	local observed_event = ev and ev.event or nil
 	if type(observed_event) ~= 'table' then return true, nil end
+	local before = state.model and state.model:snapshot().backhaul or nil
 	state.model:update(function (s) return merge_observation(state, s, observed_event) end)
+	local after = state.model and state.model:snapshot().backhaul or nil
+	log_mwan_backhaul_transitions(state, before, after, observed_event)
 	mark_domain_dirty(state, 'observed')
 	mark_domain_dirty(state, 'backhaul')
 	mark_wan_member_interfaces_dirty(state)
@@ -739,7 +798,7 @@ local function handle_gsm_uplink_changed(state, ev)
 					summary = string.format('network apply %s superseded by generation=%s reason=gsm_uplink_binding_changed', tostring(active_apply.apply_id or '?'), tostring(next_intent.generation)),
 					apply_id = active_apply.apply_id,
 					generation = active_apply.generation,
-				next_generation = next_intent.generation,
+					next_generation = next_intent.generation,
 					reason = 'gsm_uplink_binding_changed',
 				})
 			end

--- a/src/services/net/service.lua
+++ b/src/services/net/service.lua
@@ -156,13 +156,15 @@ local function log_net_summary(state, reason)
 		if #eff > 0 then parts[#parts + 1] = 'effective=' .. table.concat(eff, ',') end
 		if #skipped > 0 then parts[#parts + 1] = 'skipped=' .. table.concat(skipped, ',') end
 	end
-	local gsm = snap.sources and snap.sources.gsm_uplinks or {}
-	local gsm_parts = {}
-	for _, role in ipairs(sorted_keys(gsm)) do
-		local rec = gsm[role]
-		gsm_parts[#gsm_parts + 1] = tostring(role) .. '=' .. tostring((rec and (rec.state or (rec.connected and 'connected' or 'disconnected'))) or 'unknown')
+	local backhaul = snap.backhaul and snap.backhaul.uplinks or {}
+	local backhaul_parts = {}
+	for _, uplink_id in ipairs(sorted_keys(backhaul)) do
+		local rec = backhaul[uplink_id]
+		if type(rec) == 'table' then
+			backhaul_parts[#backhaul_parts + 1] = tostring(uplink_id) .. '=' .. tostring(rec.state or 'unknown')
+		end
 	end
-	if #gsm_parts > 0 then parts[#parts + 1] = 'modems=' .. table.concat(gsm_parts, ',') end
+	if #backhaul_parts > 0 then parts[#parts + 1] = 'backhaul=' .. table.concat(backhaul_parts, ',') end
 	local summary = 'net summary ' .. table.concat(parts, ' ')
 	local tnow = now()
 	if state.operator_net_summary_key == summary and (tnow - (state.operator_net_summary_at or 0)) < 600 then return end
@@ -285,7 +287,7 @@ local function backhaul_for_interface(backhaul, uplink_id, iface_id)
 end
 
 local function apply_backhaul_to_interfaces(s)
-	local members = s and s.wan and s.wan.members or {}
+	local members = s and s.wan and s.wan.configured_members or {}
 	local interfaces = s and s.interfaces or nil
 	if type(interfaces) ~= 'table' then return s end
 	for uplink_id, member in pairs(members or {}) do
@@ -317,7 +319,7 @@ end
 
 local function mark_wan_member_interfaces_dirty(state)
 	local snap = state and state.model and state.model:snapshot() or nil
-	local members = snap and snap.wan and snap.wan.members or {}
+	local members = snap and snap.wan and snap.wan.configured_members or {}
 	for uplink_id, member in pairs(members or {}) do
 		if type(member) == 'table' and member.enabled ~= false and member.disabled ~= true then
 			mark_interface_dirty(state, member.interface or uplink_id)
@@ -347,10 +349,11 @@ local function carry_forward_wan_runtime(previous, intent, generation)
 	return out
 end
 
-local function copy_wan_with_realised_members(configured_wan, realised_wan)
+local function copy_wan_catalogue_and_realisation(configured_wan, realised_wan)
 	local wan = model_mod.deep_copy(configured_wan or {})
-	wan.members = model_mod.deep_copy((configured_wan and configured_wan.members) or {})
+	wan.configured_members = model_mod.deep_copy((configured_wan and configured_wan.members) or {})
 	wan.realised_members = model_mod.deep_copy((realised_wan and realised_wan.members) or {})
+	wan.members = nil
 	return wan
 end
 
@@ -381,7 +384,7 @@ local function copy_intent_to_model(s, apply_intent, configured_intent)
 	-- members until a Linux ifname exists; that volatility must not remove
 	-- state/net/backhaul.uplinks or local-UI cards.  The realised set is kept
 	-- separately for diagnostics and apply/runtime policy that needs it.
-	s.wan = copy_wan_with_realised_members(configured_intent.wan, apply_intent.wan)
+	s.wan = copy_wan_catalogue_and_realisation(configured_intent.wan, apply_intent.wan)
 	s.sources = s.sources or { gsm_uplinks = {} }
 	s.backhaul = backhaul_model.reduce(s, { now = now() })
 	apply_backhaul_to_interfaces(s)

--- a/src/services/net/wan_policy.lua
+++ b/src/services/net/wan_policy.lua
@@ -135,7 +135,7 @@ end
 
 function M.collect_uplinks(snapshot)
 	local out = {}
-	local members = snapshot and snapshot.wan and snapshot.wan.members or {}
+	local members = snapshot and snapshot.wan and snapshot.wan.configured_members or {}
 	local keys = sorted_keys(members)
 	for i = 1, #keys do
 		local uplink_id = keys[i]

--- a/tests/unit/hal/openwrt_network_observer_spec.lua
+++ b/tests/unit/hal/openwrt_network_observer_spec.lua
@@ -69,6 +69,20 @@ local function read_source(relpath)
 	fail('source file not found: ' .. tostring(relpath))
 end
 
+
+function tests.test_provider_installs_default_hotplug_and_mwan3_hooks()
+	local src = read_source('src/services/hal/backends/network/providers/openwrt/init.lua')
+	ok(src:find('install_observer_hooks(self)', 1, true), 'provider should install observer hooks before starting observer')
+	ok(src:find('/etc/hotplug.d/iface', 1, true), 'iface hotplug hook path expected')
+	ok(src:find('/etc/hotplug.d/net', 1, true), 'net hotplug hook path expected')
+	ok(src:find('/etc/mwan3.user', 1, true), 'mwan3.user hook path expected')
+	ok(src:find('cfg.install_observer_hooks == false', 1, true), 'hook installation should remain explicitly disableable')
+	ok(src:find('skipped:fake_uci', 1, true), 'fake UCI tests should not touch host /etc by default')
+	ok(src:find('source_tree_hotplug_sender_path', 1, true), 'hook sender path should be derived from the running source tree by default')
+	ok(src:find('logger %-t devicecode%-net%-observe'), 'generated hooks should leave syslog diagnostics when forwarding fails')
+	ok(src:find("hooks_ok == true and 'info'", 1, true), 'successful hook installation should be visible at info level')
+end
+
 function tests.test_provider_watch_op_does_not_use_private_run_scope()
 	local src = read_source('src/services/hal/backends/network/providers/openwrt/init.lua')
 	local body = src:match('function Provider:watch_op%b()%s*(.-)\nfunction Provider:ingest_observation')
@@ -77,6 +91,35 @@ function tests.test_provider_watch_op_does_not_use_private_run_scope()
 		fail('watch_op must not use run_scope_op; it starts long-lived observer workers in caller scope')
 	end
 	ok(body:find('op.guard', 1, true), 'watch_op should be an immediate guard op')
+end
+
+
+function tests.test_generated_hooks_pass_event_variables_explicitly_to_sender()
+	local provider = require 'services.hal.backends.network.providers.openwrt.init'
+	local src = read_source('src/services/hal/backends/network/providers/openwrt/init.lua')
+	ok(src:find('--ACTION="${ACTION:-}"', 1, true), 'hook should pass ACTION explicitly')
+	ok(src:find('--INTERFACE="${INTERFACE:-}"', 1, true), 'hook should pass INTERFACE explicitly')
+	ok(src:find('socket missing:', 1, true), 'hook should log missing observer socket')
+	ok(src:find('send failed source=', 1, true), 'hook should log sender failure diagnostics')
+	local block = provider._test.mwan3_user_block({ observer_socket_path = '/tmp/devicecode.sock', hotplug_sender_path = '/tmp/hotplug_send.lua' })
+	ok(block:find('connected', 1, true), 'mwan3.user block should include connected events')
+	ok(block:find('disconnected', 1, true), 'mwan3.user block should include disconnected events')
+end
+
+function tests.test_hotplug_sender_bootstraps_source_tree_lib_and_vendor_package_paths()
+	local src = read_source('src/services/hal/backends/network/providers/openwrt/hotplug_send.lua')
+	ok(src:find('bootstrap_package_path', 1, true), 'hotplug sender should bootstrap its Lua package path')
+	ok(src:find("/lib/?.lua", 1, true), 'hotplug sender should add flattened production lib path')
+	ok(src:find("/lib/?/init.lua", 1, true), 'hotplug sender should add flattened production lib init path')
+	ok(src:find('vendor/lua%-fibers/src'), 'hotplug sender should retain development lua-fibers path')
+	ok(src:find('vendor/lua%-trie/src'), 'hotplug sender should retain development lua-trie src path')
+	ok(src:find('split_sender_path', 1, true), 'hotplug sender should derive roots from its own path')
+end
+
+function tests.test_observer_logs_mwan3_trigger_ingress_at_info_level()
+	local src = read_source('src/services/hal/backends/network/providers/openwrt/observer.lua')
+	ok(src:find('network_observer_mwan3_trigger', 1, true), 'mwan3 socket ingress should be visible at info level')
+	ok(src:find('network_observer_hotplug_trigger', 1, true), 'iface/net hotplug socket ingress should be visible at info level')
 end
 
 return tests

--- a/tests/unit/hal/openwrt_network_observer_spec.lua
+++ b/tests/unit/hal/openwrt_network_observer_spec.lua
@@ -50,6 +50,56 @@ function tests.test_observer_coalesces_wakeups_then_snapshots()
 	end)
 end
 
+
+function tests.test_observer_ignores_transient_mwan3_phases()
+	fibers.run(function (scope)
+		local emitted = {}
+		local snapshots = {}
+		local logs = {}
+		local obs = ok(observer_mod.new({
+			debounce_s = 0.01,
+			enable_socket = false,
+			enable_ubus = false,
+			initial_snapshot = false,
+			logger = function (level, payload)
+				logs[#logs + 1] = { level = level, payload = payload }
+			end,
+			snapshot = function (subject, trigger)
+				snapshots[#snapshots + 1] = { subject = subject, trigger = trigger }
+				return {
+					ok = true,
+					backend = 'test',
+					observed = {
+						schema = 'devicecode.net.observed/1',
+						interfaces = {},
+						segments = {},
+					},
+				}
+			end,
+			emit = function (ev)
+				emitted[#emitted + 1] = ev
+				return true
+			end,
+		}))
+		ok(obs:start(scope))
+
+		ok(obs:ingest({ source = 'mwan3', kind = 'mwan3', env = { ACTION = 'disconnecting', INTERFACE = 'wan' } }))
+		ok(obs:ingest({ source = 'hotplug', kind = 'hotplug', directory = 'iface', env = { ACTION = 'connecting', INTERFACE = 'wan' } }))
+		fibers.perform(sleep.sleep_op(0.05))
+		eq(#snapshots, 0, 'transient mwan phases should not trigger snapshots')
+		eq(#emitted, 0, 'transient mwan phases should not emit observed-state events')
+
+		ok(obs:ingest({ source = 'mwan3', kind = 'mwan3', env = { ACTION = 'connected', INTERFACE = 'wan' } }))
+		fibers.perform(sleep.sleep_op(0.05))
+		eq(#snapshots, 1, 'terminal mwan events should still trigger snapshots')
+		eq(#emitted, 1, 'terminal mwan events should emit observed-state events')
+		eq(emitted[1].kind, 'mwan_member_changed')
+		eq(emitted[1].subject, 'mwan:wan')
+
+		obs:terminate('test complete')
+	end)
+end
+
 local function read_source(relpath)
 	local candidates = {
 		relpath,

--- a/tests/unit/net/test_backhaul_model.lua
+++ b/tests/unit/net/test_backhaul_model.lua
@@ -9,6 +9,9 @@ local function ok(v, msg) if not v then fail(msg or 'expected truthy') end retur
 
 function tests.test_reduces_hal_multiwan_facts_to_semantic_backhaul()
     local model = backhaul.reduce({
+        segments = {
+            wan = { kind = 'wan', vlan = { id = 4 } },
+        },
         wan = { members = { wan = { interface = 'wan', metric = 10 } } },
         observed = {
             snapshot = {
@@ -43,6 +46,9 @@ function tests.test_reduces_hal_multiwan_facts_to_semantic_backhaul()
     eq(wan.uptime_s, 123)
     eq(wan.source.kind, 'host-multiwan')
     eq(wan.source.tool, 'mwan3')
+    eq(wan.status_source.tool, 'mwan3')
+    eq(wan.link.kind, 'wired')
+    eq(wan.link.vlan, 4)
     eq(wan.path_address.address, '203.0.113.10')
 end
 
@@ -71,9 +77,10 @@ function tests.test_backhaul_uses_mwan3_for_status_and_endpoint_for_device_name(
     eq(wan.usable, true)
     eq(wan.ifname, 'vl-wan')
     eq(wan.source.tool, 'mwan3')
+    eq(wan.status_source.tool, 'mwan3')
 end
 
-function tests.test_gsm_uplink_is_mapped_without_hal_backend_terms()
+function tests.test_gsm_uplink_uses_mwan3_status_not_gsm_connection_state()
     local model = backhaul.reduce({
         wan = {
             members = {
@@ -91,18 +98,107 @@ function tests.test_gsm_uplink_is_mapped_without_hal_backend_terms()
         },
         observed = {
             snapshot = {
+                multiwan = {
+                    backend = 'openwrt',
+                    source = 'mwan3',
+                    interfaces_by_semantic = {
+                        modem_primary = {
+                            interface = 'modem_primary',
+                            ifname = 'wwan0',
+                            state = 'online',
+                            usable = true,
+                        },
+                    },
+                },
                 live = { interfaces = { wwan0 = { ipv4 = { { address = '10.1.2.3' } } } } },
             },
         },
     }, { now = 42 })
 
     local uplink = ok(model.uplinks.gsm_primary, 'gsm uplink expected')
-    eq(uplink.state, 'sim_absent')
-    eq(uplink.usable, false)
+    eq(uplink.state, 'online')
+    eq(uplink.usable, true)
+    eq(uplink.observed, true)
     eq(uplink.source.kind, 'gsm-uplink')
+    eq(uplink.source.id, 'primary')
+    eq(uplink.status_source.kind, 'host-multiwan')
+    eq(uplink.status_source.tool, 'mwan3')
+    eq(uplink.link.kind, 'cellular')
     eq(uplink.ifname, 'wwan0')
     eq(uplink.path_address.address, '10.1.2.3')
     eq(uplink.gsm, nil)
+end
+
+function tests.test_gsm_uplink_remains_offline_when_mwan3_is_offline_even_if_gsm_connected()
+    local model = backhaul.reduce({
+        wan = {
+            members = {
+                gsm_primary = { interface = 'modem_primary', source = { kind = 'gsm-uplink', id = 'primary' } },
+            },
+        },
+        sources = {
+            gsm_uplinks = {
+                primary = {
+                    state = 'connected',
+                    connected = true,
+                    linux = { ifname = 'wwan0' },
+                },
+            },
+        },
+        observed = {
+            snapshot = {
+                multiwan = {
+                    backend = 'openwrt',
+                    source = 'mwan3',
+                    interfaces_by_semantic = {
+                        modem_primary = {
+                            interface = 'modem_primary',
+                            ifname = 'wwan0',
+                            state = 'offline',
+                            usable = false,
+                        },
+                    },
+                },
+            },
+        },
+    }, { now = 42 })
+
+    local uplink = ok(model.uplinks.gsm_primary, 'gsm uplink expected')
+    eq(uplink.state, 'offline')
+    eq(uplink.usable, false)
+    eq(uplink.ifname, 'wwan0')
+end
+
+function tests.test_gsm_member_stays_present_without_gsm_details()
+    local model = backhaul.reduce({
+        wan = {
+            members = {
+                gsm_primary = { interface = 'modem_primary', source = { kind = 'gsm-uplink', id = 'primary' } },
+            },
+        },
+        observed = {
+            snapshot = {
+                multiwan = {
+                    backend = 'openwrt',
+                    source = 'mwan3',
+                    interfaces_by_semantic = {
+                        modem_primary = {
+                            interface = 'modem_primary',
+                            ifname = 'wwan0',
+                            state = 'offline',
+                            usable = false,
+                        },
+                    },
+                },
+            },
+        },
+    }, { now = 42 })
+
+    local uplink = ok(model.uplinks.gsm_primary, 'gsm uplink expected')
+    eq(uplink.state, 'offline')
+    eq(uplink.usable, false)
+    eq(uplink.source.id, 'primary')
+    eq(uplink.ifname, 'wwan0')
 end
 
 return tests

--- a/tests/unit/net/test_backhaul_model.lua
+++ b/tests/unit/net/test_backhaul_model.lua
@@ -12,7 +12,7 @@ function tests.test_reduces_hal_multiwan_facts_to_semantic_backhaul()
         segments = {
             wan = { kind = 'wan', vlan = { id = 4 } },
         },
-        wan = { members = { wan = { interface = 'wan', metric = 10 } } },
+        wan = { configured_members = { wan = { interface = 'wan', metric = 10 } } },
         observed = {
             snapshot = {
                 multiwan = {
@@ -58,7 +58,7 @@ function tests.test_backhaul_uses_mwan3_for_status_and_endpoint_for_device_name(
         interfaces = {
             wan = { endpoint = { ifname = 'vl-wan' } },
         },
-        wan = { members = { wan = { interface = 'wan', metric = 10 } } },
+        wan = { configured_members = { wan = { interface = 'wan', metric = 10 } } },
         observed = {
             snapshot = {
                 multiwan = {
@@ -83,7 +83,7 @@ end
 function tests.test_gsm_uplink_uses_mwan3_status_not_gsm_connection_state()
     local model = backhaul.reduce({
         wan = {
-            members = {
+            configured_members = {
                 gsm_primary = { interface = 'modem_primary', source = { kind = 'gsm-uplink', id = 'primary' } },
             },
         },
@@ -132,7 +132,7 @@ end
 function tests.test_gsm_uplink_remains_offline_when_mwan3_is_offline_even_if_gsm_connected()
     local model = backhaul.reduce({
         wan = {
-            members = {
+            configured_members = {
                 gsm_primary = { interface = 'modem_primary', source = { kind = 'gsm-uplink', id = 'primary' } },
             },
         },
@@ -172,7 +172,7 @@ end
 function tests.test_gsm_member_stays_present_without_gsm_details()
     local model = backhaul.reduce({
         wan = {
-            members = {
+            configured_members = {
                 gsm_primary = { interface = 'modem_primary', source = { kind = 'gsm-uplink', id = 'primary' } },
             },
         },

--- a/tests/unit/net/test_service_behaviour.lua
+++ b/tests/unit/net/test_service_behaviour.lua
@@ -219,6 +219,13 @@ function tests.test_backhaul_publishes_configured_gsm_members_even_when_unrealis
 			end,
 			{ timeout = 0.5 })
 
+		local wan_domain = probe.wait_retained_payload(reader, topics.domain('wan'), { timeout = 0.2 })
+		ok(wan_domain.configured_members and wan_domain.configured_members.wan, 'configured WAN catalogue expected')
+		ok(wan_domain.configured_members.modem_primary, 'configured primary modem member expected in NET model')
+		ok(wan_domain.realised_members and wan_domain.realised_members.wan, 'realised wired WAN member expected')
+		eq(wan_domain.realised_members.modem_primary, nil)
+		eq(wan_domain.members, nil)
+
 		local backhaul = probe.wait_retained_payload(reader, topics.domain('backhaul'), { timeout = 0.2 })
 		ok(backhaul.uplinks.wan, 'wired WAN member expected')
 		ok(backhaul.uplinks.modem_primary, 'configured primary modem WAN member expected')
@@ -238,7 +245,7 @@ function tests.test_backhaul_publishes_configured_gsm_members_even_when_unrealis
 	end)
 end
 
-function tests.test_counter_metrics_publish_generic_topics_with_legacy_namespaces()
+function tests.test_counter_metrics_publish_generic_topics_with_member_namespaces()
 	fibers.run(function (scope)
 		local b = busmod.new()
 		local conn = b:connect()
@@ -299,8 +306,8 @@ function tests.test_counter_metrics_publish_generic_topics_with_legacy_namespace
 			['net.adm.rx_bytes'] = 1001,
 			['net.jan.tx_errors'] = 2008,
 			['net.wan.rx_packets'] = 3002,
-			['net.mdm0.rx_dropped'] = 4003,
-			['net.mdm1.tx_packets'] = 5006,
+			['net.modem_primary.rx_dropped'] = 4003,
+			['net.modem_secondary.tx_packets'] = 5006,
 		}
 		local seen = {}
 		local deadline = fibers.now() + 2.0

--- a/tests/unit/net/test_service_behaviour.lua
+++ b/tests/unit/net/test_service_behaviour.lua
@@ -182,6 +182,62 @@ function tests.test_initial_config_starts_apply_and_publishes_running_state()
 end
 
 
+
+function tests.test_backhaul_publishes_configured_gsm_members_even_when_unrealised()
+	fibers.run(function (scope)
+		local b = busmod.new()
+		local conn = b:connect()
+		local reader = b:connect()
+		local calls = {}
+
+		local c = cfg()
+		c.segments.wan = { kind = 'wan', vlan = { id = 4 }, firewall = { zone = 'wan' }, addressing = { ipv4 = { mode = 'dhcp' } } }
+		c.wan = {
+			members = {
+				wan = { interface = 'wan', weight = 1 },
+				modem_primary = { interface = 'modem_primary', source = { kind = 'gsm-uplink', id = 'primary' }, weight = 1 },
+				modem_secondary = { interface = 'modem_secondary', source = { kind = 'gsm-uplink', id = 'secondary' }, weight = 1 },
+			},
+		}
+
+		retain_network_config_status(conn, 'available')
+		local child = start_service(scope, conn, {
+			conn = conn,
+			config = c,
+			rev = 32,
+			hal = success_hal(calls),
+			observe = false,
+		})
+
+		local summary_view = reader:retained_view(topics.summary())
+		probe.wait_versioned_until('net running summary with configured gsm wan members',
+			function () return summary_view:version() end,
+			function (seen) return summary_view:changed_op(seen) end,
+			function ()
+				local msg = summary_view:get(topics.summary())
+				return msg and msg.payload and msg.payload.state == 'running' and msg.payload or nil
+			end,
+			{ timeout = 0.5 })
+
+		local backhaul = probe.wait_retained_payload(reader, topics.domain('backhaul'), { timeout = 0.2 })
+		ok(backhaul.uplinks.wan, 'wired WAN member expected')
+		ok(backhaul.uplinks.modem_primary, 'configured primary modem WAN member expected')
+		ok(backhaul.uplinks.modem_secondary, 'configured secondary modem WAN member expected')
+		eq(backhaul.uplinks.modem_primary.state, 'unknown')
+		eq(backhaul.uplinks.modem_primary.observed, false)
+		eq(backhaul.uplinks.modem_primary.source.kind, 'gsm-uplink')
+		eq(backhaul.uplinks.modem_primary.source.id, 'primary')
+		-- HAL apply still receives only the realised member set: without GSM ifnames,
+		-- modem interfaces are not written to OpenWrt.
+		eq(calls[1].intent.wan.members.modem_primary, nil)
+		eq(calls[1].intent.wan.members.modem_secondary, nil)
+
+		summary_view:close()
+		child:cancel('test complete')
+		fibers.perform(child:join_op())
+	end)
+end
+
 function tests.test_counter_metrics_publish_generic_topics_with_legacy_namespaces()
 	fibers.run(function (scope)
 		local b = busmod.new()

--- a/tests/unit/net/test_wan_policy_event_led.lua
+++ b/tests/unit/net/test_wan_policy_event_led.lua
@@ -10,7 +10,7 @@ local function snapshot()
 	return {
 		generation = 1,
 		wan = {
-			members = {
+			configured_members = {
 				wan = { interface = 'wan', metric = 1 },
 				modem_primary = { interface = 'modem_primary', metric = 1, source = { kind = 'gsm-uplink', id = 'primary' } },
 			},
@@ -159,13 +159,13 @@ end
 
 function tests.test_speedtest_request_duration_is_capped_at_one_second()
 	local s = snapshot()
-	s.wan.members.wan.speedtest_duration_s = 8
+	s.wan.configured_members.wan.speedtest_duration_s = 8
 	local uplinks = policy.collect_uplinks(s)
 	local by_uplink = {}
 	for _, u in ipairs(uplinks) do by_uplink[u.uplink_id] = u end
 	eq(by_uplink.wan.request.max_duration_s, 1)
 
-	s.wan.members.wan.speedtest_duration_s = 0.5
+	s.wan.configured_members.wan.speedtest_duration_s = 0.5
 	uplinks = policy.collect_uplinks(s)
 	by_uplink = {}
 	for _, u in ipairs(uplinks) do by_uplink[u.uplink_id] = u end

--- a/tests/unit/net/test_wan_runtime.lua
+++ b/tests/unit/net/test_wan_runtime.lua
@@ -61,7 +61,7 @@ function tests.test_reconcile_applies_live_weights_when_speedtests_are_fresh()
 			s.generation = 2
 			s.wan = {
 				load_balancing = { speedtests = true, policy = 'balanced' },
-				members = {
+				configured_members = {
 					wan = { interface = 'wan', metric = 1 },
 					modem = { interface = 'modem', metric = 1 },
 				},


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

* [x] 🐛 Bug Fix
* [x] 🧑💻 Code Refactor
* [x] ✅ Test

## Description

Stabilises NET backhaul modelling around configured WAN members and fixes OpenWrt `mwan3` event ingress so WAN member state changes are observed reliably.

This change makes `state/net/backhaul` a stable view of configured WAN members, while keeping realised OpenWrt/HAL members separate for apply and drift checks. It also installs observer hooks for OpenWrt hotplug and `mwan3.user` by default, ensures the standalone hotplug sender can resolve modules from the flattened runtime `lib/` layout, and logs `mwan3` ingress and WAN member online/offline transitions at info level.

Changes include:

* Adds default installation of network observer hooks for:

  * `/etc/hotplug.d/iface`
  * `/etc/hotplug.d/net`
  * `/etc/mwan3.user`
* Adds a managed `mwan3.user` observer block with explicit forwarding of `ACTION`, `INTERFACE`, `DEVICE`, `DEVICENAME`, `DEVNAME`, and `SUBSYSTEM`.
* Adds syslog diagnostics when the observer socket, sender, or Lua interpreter is unavailable.
* Makes the hotplug sender bootstrap Lua package paths from both the flattened runtime `lib/` layout and development `vendor/` layout.
* Logs observer ingress for `mwan3` and hotplug triggers at info level.
* Builds `state/net/backhaul` from `wan.configured_members` rather than the realised apply intent.
* Keeps `wan.realised_members` for OpenWrt/HAL apply and drift checks.
* Uses `mwan3`/host multi-WAN status as the canonical online/offline source for both wired and GSM-backed WAN members.
* Adds `status_source`, `link`, VLAN, and observed-state metadata to backhaul uplinks.
* Logs `mwan_member_online` and `mwan_member_offline` transitions at info level.
* Removes legacy `mdm0`/`mdm1` NET metric aliases in favour of WAN member ids such as `modem_primary` and `modem_secondary`.
* Updates NET summary logging to report backhaul member states.

## Manual test

* [x] 👍 yes

## Manual test description

Manually tested on OpenWrt using the production service set with `luajit main.lua`.

Confirmed that:

* OpenWrt observer hooks are installed and logged at info level.
* `mwan3.user` events reach the HAL network observer.
* WAN cable pull produces `network_observer_mwan3_trigger` ingress logs.
* WAN cable pull produces `mwan_member_offline` at NET level.
* WAN cable reconnect produces `mwan_member_online` at NET level.
* The local UI shows stable WAN-member cards.
* The wired WAN member moves between online and offline in response to `mwan3` state.
* GSM-backed WAN member cards remain present when SIMs are absent and are shown as disabled rather than disappearing.

## Added tests?

* [x] 👍 yes

Lua test suite passes with `luajit`:

```text
1,090 tests, 0 failed, 0 skipped
```

Added and updated unit coverage for:

* Default OpenWrt hotplug and `mwan3.user` hook installation.
* Explicit forwarding of hotplug and `mwan3` environment variables.
* Hotplug sender package-path bootstrapping for flattened runtime `lib/` and development `vendor/` layouts.
* Info-level logging of `mwan3` and hotplug observer ingress.
* `state/net/backhaul` being built from configured WAN members.
* GSM-backed WAN members using `mwan3` status rather than GSM connection state for online/offline behaviour.
* GSM-backed WAN members remaining present when GSM details are unavailable.
* NET model separation between configured WAN members and realised apply members.
* WAN policy and runtime tests using `configured_members`.
* NET metrics using WAN member ids rather than legacy `mdm0`/`mdm1` aliases.

## Added to documentation?

* [x] 🙅 no documentation needed
