### PR TITLE
hal: moves to pump, generations

### DIFF
--- a/src/services/hal.lua
+++ b/src/services/hal.lua
@@ -597,8 +597,13 @@ function HalService.start(conn, opts)
 		and opts.manager_shutdown_timeout_s
 		or DEFAULT_MANAGER_SHUTDOWN_TIMEOUT_S
 
-	local cap_emit_ch = channel.new(DEFAULT_Q_LEN)
-	local dev_ev_ch   = channel.new(DEFAULT_Q_LEN)
+	local cap_emit_ch      = channel.new(DEFAULT_Q_LEN)
+	local dev_ev_ch        = channel.new(DEFAULT_Q_LEN)
+	local config_result_ch = channel.new(DEFAULT_Q_LEN)
+
+	local config_generation = 0
+	local active_config_generation = nil
+	local pending_config = nil
 
 	local managers = {}
 	local registry = {
@@ -1103,6 +1108,48 @@ function HalService.start(conn, opts)
 		})
 	end
 
+	local function drain_lifecycle_internal_event(label, source, payload)
+		if source == 'cap_emit' then
+			on_cap_emit(payload)
+			return true
+		end
+
+		if source == 'device_event' then
+			on_device_event(payload)
+			return true
+		end
+
+		log('warn', 'hal_lifecycle_pump_unknown_source', {
+			label = tostring(label),
+			source = tostring(source),
+		})
+		return false
+	end
+
+	local function perform_manager_lifecycle_op_with_hal_pump(label, result_op)
+		local result_ch = channel.new(1)
+		local spawned, spawn_err = fibers.spawn(function()
+			local results = pack(perform(result_op))
+			perform(result_ch:put_op(results))
+		end)
+		if spawned ~= true then return nil, tostring(spawn_err or 'lifecycle worker spawn failed') end
+
+		while true do
+			local source, a = perform(op.named_choice({
+				result       = result_ch:get_op(),
+				cap_emit     = cap_emit_ch:get_op(),
+				device_event = dev_ev_ch:get_op(),
+			}))
+
+			if source == 'result' then
+				return unpack(a, 1, a.n)
+			end
+
+			drain_lifecycle_internal_event(label, source, a)
+		end
+	end
+
+
 	local dependency_resolver, dependency_resolver_err = dependencies.resolver(conn)
 	if not dependency_resolver then
 		error('HAL dependency resolver failed: ' .. tostring(dependency_resolver_err), 0)
@@ -1120,23 +1167,36 @@ function HalService.start(conn, opts)
 			manager   = name,
 		})
 
-		return perform(manager_call_with_timeout_op(
-			name,
-			manager,
-			'start',
-			manager_start_timeout_s,
-			manager_logger,
-			dev_ev_ch,
-			cap_emit_ch,
-			dependencies.manager_options(name, dependency_resolver, { service_name = svc.name })
-		))
+		return perform_manager_lifecycle_op_with_hal_pump(
+			'manager_start:' .. tostring(name),
+			manager_call_with_timeout_op(
+				name,
+				manager,
+				'start',
+				manager_start_timeout_s,
+				manager_logger,
+				dev_ev_ch,
+				cap_emit_ch,
+				dependencies.manager_options(name, dependency_resolver, { service_name = svc.name })
+			)
+		)
 	end
 
-	local function apply_manager_config(name, manager, manager_config)
+	local function apply_manager_config_with_wait(name, manager, manager_config, opts)
+		opts = opts or {}
+		local wait = opts.wait
+		local function wait_for(label, wait_op)
+			if type(wait) == 'function' then return wait(label, wait_op) end
+			return perform(wait_op)
+		end
+
 		local timeout_s = manager_apply_timeout_for(name)
 		local has_op_method = type(manager.apply_config_op) == 'function'
 		if not has_op_method or type(timeout_s) ~= 'number' or timeout_s < 0 then
-			local ok, err = perform(manager_call_op(name, manager, 'apply_config', manager_config))
+			local ok, err = wait_for(
+				'manager_apply:' .. tostring(name),
+				manager_call_op(name, manager, 'apply_config', manager_config)
+			)
 			if ok == true then return 'applied', nil end
 			return 'failed', err
 		end
@@ -1148,10 +1208,13 @@ function HalService.start(conn, opts)
 		end)
 		if spawned ~= true then return 'failed', tostring(spawn_err or 'manager apply worker spawn failed') end
 
-		local which, result = perform(op.named_choice({
-			result = result_ch:get_op(),
-			timeout = sleep.sleep_op(timeout_s),
-		}))
+		local which, result = wait_for(
+			'manager_apply_wait:' .. tostring(name),
+			op.named_choice({
+				result = result_ch:get_op(),
+				timeout = sleep.sleep_op(timeout_s),
+			})
+		)
 		if which == 'result' then
 			if result and result.ok == true then return 'applied', nil end
 			return 'failed', result and result.err or 'manager apply failed'
@@ -1169,62 +1232,131 @@ function HalService.start(conn, opts)
 		return 'pending_after_timeout', 'timeout'
 	end
 
-	local function on_config(config)
-		svc:obs_event('config_begin', {})
+	local function apply_manager_config(name, manager, manager_config)
+		return apply_manager_config_with_wait(name, manager, manager_config, {
+			wait = perform_manager_lifecycle_op_with_hal_pump,
+		})
+	end
 
-		local valid, valid_err = validate_config(config)
-		if not valid then
-			log('warn', 'config_invalid', { err = valid_err })
-			svc:obs_event('config_end', { ok = false, err = valid_err })
-			return
-		end
+	local function copy_list(list)
+		local out = {}
+		for i, v in ipairs(list or {}) do out[i] = v end
+		return out
+	end
 
-		local pending_managers = {}
-		local failed_managers = {}
+	local function copy_map(map)
+		local out = {}
+		for k, v in pairs(map or {}) do out[k] = v end
+		return out
+	end
+
+	local function build_config_generation_plan(config)
+		local plan = { entries = {}, removals = {}, failed_managers = {}, start_errors = {} }
 
 		for name, manager_config in pairs(config) do
 			if name ~= 'schema' then
-				if not managers[name] then
+				local entry = {
+					name = name,
+					manager_config = manager_config,
+					manager = managers[name],
+				}
+				if not entry.manager then
 					local ok, manager = pcall(require, "services.hal.managers." .. name)
 					if not ok then
-						log('error', 'manager_require_failed', { manager = name, err = tostring(manager) })
-						failed_managers[#failed_managers + 1] = name
+						local err = tostring(manager)
+						plan.failed_managers[#plan.failed_managers + 1] = name
+						plan.start_errors[name] = err
 					else
+						local valid, valid_err = validate_strict_manager(name, manager)
+						if not valid then error(valid_err, 0) end
 						local start_ok, start_err = start_manager(name, manager)
 						if start_ok ~= true then
-							log('error', 'manager_start_failed', { manager = name, err = tostring(start_err) })
-							failed_managers[#failed_managers + 1] = name
+							plan.failed_managers[#plan.failed_managers + 1] = name
+							plan.start_errors[name] = tostring(start_err)
 						else
+							entry.manager = manager
 							managers[name] = manager
 							svc:obs_event('manager_started', { manager = name })
 						end
 					end
+				else
+					local valid, valid_err = validate_strict_manager(name, entry.manager)
+					if not valid then error(valid_err, 0) end
 				end
-
-				local manager = managers[name]
-				if manager then
-					local status, apply_err = apply_manager_config(name, manager, manager_config)
-					if status == 'pending_after_timeout' then
-						pending_managers[#pending_managers + 1] = name
-					elseif status ~= 'applied' then
-						failed_managers[#failed_managers + 1] = name
-						log('error', 'manager_apply_failed', { manager = name, err = tostring(apply_err) })
-					end
-				end
+				if entry.manager then plan.entries[#plan.entries + 1] = entry end
 			end
 		end
 
 		for name, manager in pairs(managers) do
 			if not config[name] then
-				managers[name] = nil
-				svc:obs_event('manager_stopping', { manager = name, reason = 'removed_from_config' })
-				shutdown_manager_async(name, manager, 'removed_from_config')
+				plan.removals[#plan.removals + 1] = { name = name, manager = manager }
 			end
 		end
 
+		return plan
+	end
+
+	local function run_config_generation(generation, plan)
+		local result = {
+			generation = generation,
+			pending_managers = {},
+			failed_managers = copy_list(plan.failed_managers),
+			start_errors = copy_map(plan.start_errors),
+			apply_errors = {},
+			removals = plan.removals or {},
+		}
+
+		for _, entry in ipairs(plan.entries or {}) do
+			local name = entry.name
+			local manager = entry.manager
+			if manager then
+				local ok, status, apply_err = pcall(apply_manager_config_with_wait, name, manager, entry.manager_config)
+				if not ok then
+					result.failed_managers[#result.failed_managers + 1] = name
+					result.apply_errors[name] = tostring(status)
+				elseif status == 'pending_after_timeout' then
+					result.pending_managers[#result.pending_managers + 1] = name
+				elseif status ~= 'applied' then
+					result.failed_managers[#result.failed_managers + 1] = name
+					result.apply_errors[name] = tostring(apply_err)
+				end
+			end
+		end
+
+		return result
+	end
+
+	local start_config_generation
+
+	local function finish_config_result(result)
+		if type(result) ~= 'table' then return end
+		local generation = result.generation
+		if generation ~= active_config_generation then
+			log('debug', 'hal_config_generation_stale', { generation = generation, active_generation = active_config_generation })
+			return
+		end
+
+		for name, err in pairs(result.start_errors or {}) do
+			log('error', 'manager_start_failed', { manager = name, err = tostring(err), generation = generation })
+		end
+		for name, err in pairs(result.apply_errors or {}) do
+			log('error', 'manager_apply_failed', { manager = name, err = tostring(err), generation = generation })
+		end
+
+		for _, rec in ipairs(result.removals or {}) do
+			if managers[rec.name] == rec.manager then
+				managers[rec.name] = nil
+				svc:obs_event('manager_stopping', { manager = rec.name, reason = 'removed_from_config', generation = generation })
+				shutdown_manager_async(rec.name, rec.manager, 'removed_from_config')
+			end
+		end
+
+		local pending_managers = result.pending_managers or {}
+		local failed_managers = result.failed_managers or {}
 		local config_ok = #failed_managers == 0
 		local config_degraded = (#pending_managers > 0 or #failed_managers > 0) or nil
 		svc:obs_event('config_end', {
+			generation = generation,
 			ok = config_ok,
 			degraded = config_degraded,
 			pending_managers = (#pending_managers > 0) and pending_managers or nil,
@@ -1241,12 +1373,56 @@ function HalService.start(conn, opts)
 		end
 		log(config_ok and (config_degraded and 'warn' or 'info') or 'error', hal_what, {
 			summary = hal_summary,
+			generation = generation,
 			ok = config_ok,
 			degraded = config_degraded,
 			pending_managers = (#pending_managers > 0) and pending_managers or nil,
 			failed_managers = (#failed_managers > 0) and failed_managers or nil,
 		})
+
+		active_config_generation = nil
+		if pending_config then
+			local next_config = pending_config
+			pending_config = nil
+			start_config_generation(next_config)
+		end
 	end
+
+	function start_config_generation(config)
+		svc:obs_event('config_begin', {})
+		local valid, valid_err = validate_config(config)
+		if not valid then
+			log('warn', 'config_invalid', { err = valid_err })
+			svc:obs_event('config_end', { ok = false, err = valid_err })
+			return
+		end
+
+		config_generation = config_generation + 1
+		local generation = config_generation
+		active_config_generation = generation
+		svc:obs_event('config_generation_started', { generation = generation })
+		local plan = build_config_generation_plan(config)
+		local spawned, spawn_err = fibers.spawn(function()
+			local ok, result = pcall(run_config_generation, generation, plan)
+			if ok ~= true then
+				result = {
+					generation = generation,
+					pending_managers = {},
+					failed_managers = { '_config_generation' },
+					start_errors = {},
+					apply_errors = { _config_generation = tostring(result) },
+					removals = {},
+				}
+			end
+			perform(config_result_ch:put_op(result))
+		end)
+		if spawned ~= true then
+			active_config_generation = nil
+			log('error', 'hal_config_worker_spawn_failed', { generation = generation, err = tostring(spawn_err) })
+			svc:obs_event('config_end', { generation = generation, ok = false, err = tostring(spawn_err) })
+		end
+	end
+
 
 	local function bootstrap()
 		svc:obs_event('bootstrap_begin', {})
@@ -1300,11 +1476,16 @@ function HalService.start(conn, opts)
 
 	local function on_config_message(msg)
 		local cfg_data = msg and msg.payload and msg.payload.data
-		if type(cfg_data) == 'table' then
-			on_config(cfg_data)
-		else
+		if type(cfg_data) ~= 'table' then
 			log('warn', 'config_bad_shape', { payload = msg and msg.payload })
+			return
 		end
+		if active_config_generation then
+			pending_config = cfg_data
+			log('debug', 'hal_config_deferred', { active_generation = active_config_generation })
+			return
+		end
+		start_config_generation(cfg_data)
 	end
 
 	local config_sub
@@ -1351,12 +1532,14 @@ function HalService.start(conn, opts)
 	svc:obs_log('debug', { what = 'subscribed', topic = 'cfg/' .. svc.name })
 
 	while true do
+		local fault_op = active_config_generation and op.never() or op.choice(manager_fault_ops())
 		local source, a, b = perform(op.named_choice({
 			rpc           = op.choice(registry:rpc_ops()),
-			manager_fault = op.choice(manager_fault_ops()),
+			manager_fault = fault_op,
 			cap_emit      = cap_emit_ch:get_op(),
 			device_event  = dev_ev_ch:get_op(),
 			config        = config_sub:recv_op(),
+			config_result = config_result_ch:get_op(),
 		}))
 
 		if source == 'rpc' then
@@ -1367,6 +1550,8 @@ function HalService.start(conn, opts)
 			on_device_event(a)
 		elseif source == 'config' then
 			on_config_message(a)
+		elseif source == 'config_result' then
+			finish_config_result(a)
 		elseif source == 'manager_fault' then
 			on_manager_fault(a)
 		else

--- a/src/services/hal/backends/network/providers/openwrt/observer.lua
+++ b/src/services/hal/backends/network/providers/openwrt/observer.lua
@@ -409,10 +409,11 @@ function Observer:handle_socket_stream(st)
 		local rec = cjson.decode(line)
 		local trig = normalise_hotplug_record(rec)
 		if trig then
+			local trigger_log_level = is_transient_mwan_action(trig) and 'debug' or 'info'
 			if trig.source == 'mwan3' or trig.kind == 'mwan3' then
-				log(self, 'info', { what = 'network_observer_mwan3_trigger', summary = trigger_summary(trig), trigger = trig })
+				log(self, trigger_log_level, { what = 'network_observer_mwan3_trigger', summary = trigger_summary(trig), trigger = trig })
 			elseif trig.directory == 'iface' or trig.directory == 'net' then
-				log(self, 'info', { what = 'network_observer_hotplug_trigger', summary = trigger_summary(trig), trigger = trig })
+				log(self, trigger_log_level, { what = 'network_observer_hotplug_trigger', summary = trigger_summary(trig), trigger = trig })
 			end
 			self:ingest(trig)
 		end

--- a/src/services/hal/managers/network.lua
+++ b/src/services/hal/managers/network.lua
@@ -20,6 +20,9 @@ local state = {
 	cap_emit_ch = nil,
 	driver = nil,
 	controls = {},
+	caps = nil,
+	device_added = false,
+	controls_started = false,
 }
 
 local function log(level, payload)
@@ -89,6 +92,16 @@ local function control_loop_for(kind, ch, methods)
 	control_loop.run_request_loop(ch, methods, state.logger, 'network_' .. tostring(kind))
 end
 
+local function start_control_loops()
+	if state.controls_started == true then return true, nil end
+	if not state.scope then return nil, 'network manager scope not started' end
+	state.scope:spawn(function () control_loop_for('config', state.controls.config, CONFIG_METHODS) end)
+	state.scope:spawn(function () control_loop_for('state', state.controls.state, STATE_METHODS) end)
+	state.scope:spawn(function () control_loop_for('diagnostics', state.controls.diagnostics, DIAGNOSTICS_METHODS) end)
+	state.controls_started = true
+	return true, nil
+end
+
 local function make_capabilities()
 	local cfg_ch = channel.new(16)
 	local state_ch = channel.new(16)
@@ -112,6 +125,10 @@ local function emit_added(dev_ev_ch, caps)
 	return dev_ev_ch:put_op(ev)
 end
 
+-- Network capabilities are published during start so consumers can discover
+-- passive handles early.  The request loops are deliberately not started here:
+-- apply_config_op() must first create the provider driver, otherwise callers
+-- can observe "network driver not configured" during HAL config generation.
 function M.start_op(logger, dev_ev_ch, cap_emit_ch)
 	return op.guard(function ()
 		if state.started then return op.always(true, nil) end
@@ -124,28 +141,28 @@ function M.start_op(logger, dev_ev_ch, cap_emit_ch)
 		state.dev_ev_ch = dev_ev_ch
 		state.cap_emit_ch = cap_emit_ch
 		state.controls = {}
-		local caps = make_capabilities()
+		state.caps = make_capabilities()
+		state.device_added = false
+		state.controls_started = false
 
 		child:finally(function (_, status, primary)
 			M.terminate(primary or status or 'network manager closed')
 		end)
 
-		child:spawn(function () control_loop_for('config', state.controls.config, CONFIG_METHODS) end)
-		child:spawn(function () control_loop_for('state', state.controls.state, STATE_METHODS) end)
-		child:spawn(function () control_loop_for('diagnostics', state.controls.diagnostics, DIAGNOSTICS_METHODS) end)
-
-		return emit_added(dev_ev_ch, caps):wrap(function (ok, err)
-			if ok == false then
-				child:cancel('device_event_failed')
-				return false, err or 'network device event failed'
-			end
-			state.started = true
-			log('debug', { what = 'network_manager_started' })
+		state.started = true
+		log('debug', { what = 'network_manager_started' })
+		return emit_added(dev_ev_ch, state.caps):wrap(function (ok, emit_err)
+			if ok == false then return false, emit_err or 'network device event failed' end
+			state.device_added = true
 			return true, nil
 		end)
 	end)
 end
 
+-- Configuring the driver is the point at which the passive handles become
+-- serviceable.  Start the control loops only after state.driver is ready so
+-- queued requests wait rather than receiving a premature driver-not-configured
+-- failure.
 function M.apply_config_op(config)
 	return op.guard(function ()
 		if not state.started then return op.always(false, 'network manager not started') end
@@ -160,6 +177,8 @@ function M.apply_config_op(config)
 		end
 		state.driver = driver
 		log('debug', { what = 'network_driver_configured', provider = (config and (config.provider or config.backend)) or 'fake' })
+		local loops_ok, loops_err = start_control_loops()
+		if loops_ok ~= true then return op.always(false, loops_err or 'network control loops failed to start') end
 		return op.always(true, nil)
 	end)
 end
@@ -176,6 +195,9 @@ function M.terminate(reason)
 		state.driver:terminate(reason or 'terminated')
 	end
 	state.driver = nil
+	state.caps = nil
+	state.device_added = false
+	state.controls_started = false
 	for _, ch in pairs(state.controls or {}) do
 		if ch and type(ch.close) == 'function' then ch:close(reason or 'terminated') end
 	end

--- a/tests/unit/hal/hal_compat_spec.lua
+++ b/tests/unit/hal/hal_compat_spec.lua
@@ -647,6 +647,85 @@ function T.op_manager_apply_timeout_reports_pending_not_failed()
 	end, { timeout = 2.0 })
 end
 
+
+function T.manager_lifecycle_pump_drains_device_events_during_config_apply()
+	runfibers.run(function(scope)
+		local fs_manager = new_bootstrap_filesystem_manager()
+		local patches = {
+			['services.hal.managers.filesystem'] = fs_manager,
+		}
+		local config = {
+			schema = 'devicecode.config/hal/1',
+		}
+
+		for i = 1, 14 do
+			local name = string.format('burst_mgr_%02d', i)
+			patches['services.hal.managers.' .. name] = new_capability_manager{
+				name = name,
+				cap_class = 'burst_cap',
+				cap_id = string.format('cap_%02d', i),
+				apply_mode = 'op',
+				offerings = { 'echo' },
+			}
+			config[name] = {}
+		end
+
+		with_real_hal(scope, patches, function(bus)
+			local admin = bus:connect()
+			admin:retain({ 'cfg', 'hal' }, { data = config })
+
+			local listener = cap_sdk.new_curated_cap_listener(bus:connect(), 'burst_cap', 'cap_14')
+			local ref, err = fibers.perform(listener:wait_for_cap_op())
+			assert(ref, tostring(err))
+			listener:close()
+		end, {
+			manager_start_timeout_s = 0.1,
+			manager_apply_timeout_s = 0.1,
+		})
+	end, { timeout = 2.0 })
+end
+
+
+function T.hal_config_application_uses_generation_worker_completion_events()
+	local f = assert(io.open('../src/services/hal.lua', 'r'))
+	local src = f:read('*a')
+	f:close()
+
+	assert(src:find('config_result_ch', 1, true), 'expected config result channel')
+	assert(src:find('active_config_generation', 1, true), 'expected active config generation guard')
+	assert(src:find('pending_config', 1, true), 'expected latest pending config coalescing')
+	assert(src:find('run_config_generation', 1, true), 'expected generation worker body')
+	assert(src:find('finish_config_result', 1, true), 'expected coordinator-side completion handler')
+	assert(src:find('hal_config_deferred', 1, true), 'expected config deferral while a generation is active')
+	assert(src:find('config_result = config_result_ch:get_op()', 1, true), 'main coordinator should receive config completion records')
+
+	assert(not src:find('local rpc_op = active_config_generation and op.never()', 1, true), 'main loop should continue serving capability RPC during active config')
+
+	local worker_start = assert(src:find('local function run_config_generation', 1, true), 'expected run_config_generation block')
+	local worker_end = assert(src:find('local start_config_generation', worker_start, true), 'expected run_config_generation terminator')
+	local worker = src:sub(worker_start, worker_end)
+	assert(not worker:find('on_device_event', 1, true), 'worker must not mutate device registry')
+	assert(not worker:find('on_cap_emit', 1, true), 'worker must not mutate capability registry')
+	assert(not worker:find('start_manager', 1, true), 'worker must not start managers from a short-lived config scope')
+
+	local plan_start = assert(src:find('local function build_config_generation_plan', 1, true), 'expected config planning block')
+	local plan_end = assert(src:find('local function run_config_generation', plan_start, true), 'expected config planning terminator')
+	local plan_block = src:sub(plan_start, plan_end)
+	assert(plan_block:find('start_manager%(name, manager%)'), 'coordinator should start missing managers while planning')
+	assert(plan_block:find('managers%[name%] = manager'), 'coordinator should admit started managers before spawning apply worker')
+
+	local start_start = assert(src:find('function start_config_generation', 1, true), 'expected start_config_generation block')
+	local start_end = assert(src:find('local function bootstrap', start_start, true), 'expected start_config_generation terminator')
+	local start_block = src:sub(start_start, start_end)
+	assert(start_block:find('fibers%.spawn%(function%('), 'apply generation should run in a worker')
+
+	local finish_start = assert(src:find('local function finish_config_result', 1, true), 'expected finish_config_result block')
+	local finish_end = assert(src:find('function start_config_generation', finish_start, true), 'expected finish_config_result terminator')
+	local finish = src:sub(finish_start, finish_end)
+	assert(not finish:find('managers%[rec%.name%] = rec%.manager'), 'finish handler should not admit worker-started managers')
+	assert(finish:find('shutdown_manager_async'), 'coordinator should own manager removal')
+end
+
 function T.unsupported_control_verb_returns_no_route()
 	runfibers.run(function(scope)
 		local fs_manager = new_bootstrap_filesystem_manager()
@@ -785,6 +864,23 @@ function T.strict_hal_managers_do_not_use_perform_raw()
 		f:close()
 		assert(not s:find('perform_raw', 1, true), path .. ' uses perform_raw')
 	end
+end
+
+
+function T.network_manager_control_loops_start_after_driver_configured()
+	local f = assert(io.open('../src/services/hal/managers/network.lua', 'r'))
+	local src = f:read('*a')
+	f:close()
+	local start_s = src:find('function M.start_op', 1, true)
+	local apply_s = src:find('function M.apply_config_op', 1, true)
+	local shutdown_s = src:find('function M.shutdown_op', 1, true)
+	assert(start_s and apply_s and shutdown_s, 'expected network manager lifecycle functions')
+	local start_block = src:sub(start_s, apply_s - 1)
+	local apply_block = src:sub(apply_s, shutdown_s - 1)
+	assert(start_block:find('emit_added', 1, true), 'network start should publish passive capability handles for legacy consumers')
+	assert(not start_block:find('start_control_loops', 1, true), 'network start must not serve requests before config')
+	assert(apply_block:find('state.driver = driver', 1, true), 'network apply should configure driver')
+	assert(apply_block:find('start_control_loops', 1, true), 'network apply should start control loops after driver configuration')
 end
 
 return T


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

* [x] 🐛 Bug Fix
* [x] 🧑💻 Code Refactor
* [x] ✅ Test

## Description

Moves HAL manager configuration towards generation-scoped application while keeping manager ownership in the HAL coordinator.

This fixes intermittent startup failures where HAL manager lifecycle work could block while waiting for HAL’s own internal device/capability event queues to be drained. It also prevents NET from calling the network capability before the OpenWrt network driver is configured.

Changes include:

* Adds a HAL lifecycle pump used while waiting for manager start/apply operations.
* Keeps draining HAL’s internal `cap_emit_ch` and `dev_ev_ch` queues during manager lifecycle waits.
* Introduces generation-scoped HAL config application with:

  * `config_result_ch`
  * `config_generation`
  * `active_config_generation`
  * `pending_config`
* Keeps manager start in the HAL coordinator/service scope.
* Runs manager config apply work in a generation-scoped worker.
* Coalesces config updates received while a config generation is active.
* Keeps capability RPCs live while config application is active.
* Defers manager fault handling during active config application.
* Keeps manager admission/removal owned by the HAL coordinator.
* Deduplicates manager apply handling through a shared apply helper.
* Keeps network capabilities discoverable at manager start, but delays network request-loop startup until `apply_config_op()` has configured the provider driver.
* Downgrades transient `mwan3`/hotplug `connecting` and `disconnecting` observer logs to debug, while keeping stable events at info level.

## Manual test

* [x] 👍 yes

## Manual test description

Manually tested on OpenWrt using the production service set with `luajit main.lua`.

Confirmed that:

* HAL reaches `hal_ready` promptly.
* Update reaches `update_ready`.
* NET starts and completes network apply successfully.
* WAN member state reaches online.
* The previous intermittent `manager_start_failed manager=network` failure was not observed.
* The previous `network driver not configured` apply failure was not observed.

## Added tests?

* [x] 👍 yes

Added and updated test coverage for:

* HAL lifecycle pump draining device events during manager config application.
* Generation-scoped HAL config application using completion records.
* Coordinator-owned manager start and manager admission.
* Worker-side config application not mutating device or capability registries.
* Deferred/coalesced config while a generation is active.
* Network manager control loops starting only after the provider driver is configured.
* Network start still publishing passive capability handles for existing consumers.

Full suite passes:

```text
1,099 tests, 0 failed, 0 skipped
```

## Added to documentation?

* [x] 🙅 no documentation needed
