### PR TITLE
gsm: correct signal retrieval to handle multi-technology signals

### DIFF
--- a/src/services/gsm.lua
+++ b/src/services/gsm.lua
@@ -65,6 +65,15 @@ local ACCESS_TECH_MAP = {
 	{ tokens = { 'cdma1x' },      tech = 'cdma1x' },
 }
 
+local SIGNAL_TECH_BY_ACCESS = {
+	cdma1x = 'cdma1x',
+	evdo = 'evdo',
+	gsm = 'gsm',
+	umts = 'umts',
+	lte = 'lte',
+	['5g'] = '5g',
+}
+
 local STATE_CONNECTED = 'connected'
 
 -- Topic helpers (centralized so we can remap if needed)
@@ -160,19 +169,29 @@ local function is_plain_table(value)
 end
 
 ---@param access_techs any
----@return string
-local function derive_access_tech(access_techs)
+---@return table<string, boolean>
+local function access_tech_set(access_techs)
 	local techs = {}
 	if type(access_techs) == 'string' then
 		for token in string.gmatch(access_techs, "([^,]+)") do
+			token = token:match('^%s*(.-)%s*$')
 			techs[token] = true
 		end
 	elseif is_plain_table(access_techs) then
 		for _, token in ipairs(access_techs) do
-			techs[token] = true
+			if type(token) == 'string' then
+				techs[token] = true
+			end
 		end
 	end
 
+	return techs
+end
+
+---@param access_techs any
+---@return string
+local function derive_access_tech(access_techs)
+	local techs = access_tech_set(access_techs)
 	for _, rule in ipairs(ACCESS_TECH_MAP) do
 		local all_match = true
 		for _, required_token in ipairs(rule.tokens) do
@@ -187,6 +206,40 @@ local function derive_access_tech(access_techs)
 	end
 
 	return ""
+end
+
+---@param signals any
+---@param tech string
+---@return table?
+local function signal_values_for_tech(signals, tech)
+	if not is_plain_table(signals) then return nil end
+	local values = signals[tech]
+	if not is_plain_table(values) or next(values) == nil then return nil end
+	return values
+end
+
+---@param access_techs any
+---@param signals any
+---@return table?
+---@return string
+local function select_canonical_signal(access_techs, signals)
+	local access_tech = derive_access_tech(access_techs)
+	local signal_tech = SIGNAL_TECH_BY_ACCESS[access_tech]
+	if not signal_tech then return nil, "" end
+
+	local signal = signal_values_for_tech(signals, signal_tech)
+	if signal then return signal, signal_tech end
+
+	-- 5G NSA can expose either signal set. Prefer 5G when both are valid, but
+	-- only fall back to LTE when LTE is part of the current access technology.
+	local techs = access_tech_set(access_techs)
+	local is_5g_nsa = techs.lte and (techs['5gnr'] or techs['5g'])
+	if is_5g_nsa then
+		signal = signal_values_for_tech(signals, 'lte')
+		if signal then return signal, 'lte' end
+	end
+
+	return nil, ""
 end
 
 ---@param access_tech string
@@ -342,45 +395,40 @@ local function build_sim_payload(sim_state, sim_lock, sim_lock_retries, modem_st
 	return sim_payload_from_value(sim_state, sim_lock, sim_lock_retries, modem_state)
 end
 
----@param access_techs any
+---@param signal_tech string?
 ---@param rssi any
 ---@param rsrp any
 ---@param rscp any
 ---@return string
 ---@return number
 ---@return string
-local function select_signal_for_bars(access_techs, rssi, rsrp, rscp)
-	if not access_techs then
-		return "", 0, "access tech unavailable"
+local function select_signal_for_bars(signal_tech, rssi, rsrp, rscp)
+	if not signal_tech or signal_tech == "" then
+		return "", 0, "signal tech unavailable"
 	end
 
-	local access_tech = derive_access_tech(access_techs)
-	if access_tech == "" then
-		return "", 0, "access tech unknown"
-	end
-
-	if access_tech == 'umts' and rscp ~= nil then
+	if signal_tech == 'umts' and rscp ~= nil then
 		local rscp_value = tonumber(rscp)
 		if rscp_value then
-			return access_tech, rscp_value, "rscp"
+			return signal_tech, rscp_value, "rscp"
 		end
 	end
 
-	if (access_tech == 'lte' or access_tech == '5g') and rsrp ~= nil then
+	if (signal_tech == 'lte' or signal_tech == '5g') and rsrp ~= nil then
 		local rsrp_value = tonumber(rsrp)
 		if rsrp_value then
-			return access_tech, rsrp_value, "rsrp"
+			return signal_tech, rsrp_value, "rsrp"
 		end
 	end
 
 	if rssi ~= nil then
 		local rssi_value = tonumber(rssi)
 		if rssi_value then
-			return access_tech, rssi_value, "rssi"
+			return signal_tech, rssi_value, "rssi"
 		end
 	end
 
-	return access_tech, 0, ""
+	return signal_tech, 0, ""
 end
 
 ---@param cfg table?
@@ -765,10 +813,15 @@ function GsmModem:_publish_uplink_state(connected, iface)
 			self.domain:unretain({ 'modem', self.name, 'operator' })
 		end
 
-		local signal, signal_err = modem_get_field(self.cap, 'signal', REQUEST_TIMEOUT, 0)
-		if signal_err == '' and type(signal) == 'table' then
-			signal_payload = signal
-			self.domain:retain({ 'modem', self.name, 'signal' }, signal)
+		local signals, signal_err = modem_get_field(self.cap, 'signal', REQUEST_TIMEOUT, 0)
+		local canonical_signal, signal_tech = nil, ""
+		if signal_err == '' then
+			canonical_signal, signal_tech = select_canonical_signal(access_techs, signals)
+		end
+		if canonical_signal then
+			signal_payload = shallow_copy(canonical_signal)
+			access.signal_tech = signal_tech
+			self.domain:retain({ 'modem', self.name, 'signal' }, signal_payload)
 		else
 			self.domain:unretain({ 'modem', self.name, 'signal' })
 		end
@@ -808,7 +861,7 @@ end
 function GsmModem:_emit_metrics_once()
 	-- Derived metrics only; HAL remains the source of truth.
 	local inventory = {}
-	local access_techs, access_err = modem_get_field(self.cap, 'access_techs', REQUEST_TIMEOUT)
+	local access_techs, access_err = modem_get_field(self.cap, 'access_techs', REQUEST_TIMEOUT, 0)
 	if access_err == "" then
 		local access_tech = derive_access_tech(access_techs)
 		if access_tech ~= "" then
@@ -899,9 +952,13 @@ function GsmModem:_emit_metrics_once()
 		self:_emit_metric('tx_bytes', tx_bytes)
 	end
 
-	local signal, signal_err = modem_get_field(self.cap, 'signal', REQUEST_TIMEOUT)
+	local signals, signal_err = modem_get_field(self.cap, 'signal', REQUEST_TIMEOUT, 0)
+	local signal, signal_tech = nil, ""
 	local rssi, rsrp, rsrq, rscp = nil, nil, nil, nil
 	if signal_err == "" then
+		signal, signal_tech = select_canonical_signal(access_techs, signals)
+	end
+	if signal then
 		rssi = signal.rssi
 		rsrp = signal.rsrp
 		rsrq = signal.rsrq
@@ -921,7 +978,7 @@ function GsmModem:_emit_metrics_once()
 	end
 
 	local bars_access_tech, signal_value, signal_type = select_signal_for_bars(
-		access_techs,
+		signal_tech,
 		rssi,
 		rsrp,
 		rscp
@@ -1666,6 +1723,9 @@ end
 
 GsmService._test = {
 	build_sim_payload = build_sim_payload,
+	derive_access_tech = derive_access_tech,
+	select_canonical_signal = select_canonical_signal,
+	select_signal_for_bars = select_signal_for_bars,
 	uplink_state_for_modem = uplink_state_for_modem,
 }
 

--- a/src/services/hal/backends/modem/providers/linux_mm/impl.lua
+++ b/src/services/hal/backends/modem/providers/linux_mm/impl.lua
@@ -62,6 +62,21 @@ local SIGNAL_IGNORE_FIELDS = list_to_map {
     "error-rate"
 }
 
+local SIGNAL_INVALID_VALUES = list_to_map {
+    -32768,
+    -3276.8,
+}
+
+---@param signal number?
+---@return boolean
+local function is_signal_valid(signal)
+    return signal ~= nil
+        and signal == signal
+        and signal ~= math.huge
+        and signal ~= -math.huge
+        and not SIGNAL_INVALID_VALUES[signal]
+end
+
 ---@param nested table
 ---@param key_paths table<string, string[]>
 ---@return table<string, any>
@@ -85,16 +100,6 @@ local function nested_to_flat(nested, key_paths)
         end
     end
     return flat
-end
-
----@param tbl table<string, any>
----@return table<string, any>
-local function shallow_copy(tbl)
-    local copy = {}
-    for key, value in pairs(tbl) do
-        copy[key] = value
-    end
-    return copy
 end
 
 ---@param ports string[]
@@ -275,15 +280,10 @@ local function read_firmware_version(identity)
     return version, ""
 end
 
----@param identity ModemIdentity
+---@param output string
 ---@return ModemSignalInfo?
 ---@return string error
-local function read_signal_info(identity)
-    local output, err = run_command(identity.address, { "mmcli", "-J", "-m", identity.address, "--signal-get" })
-    if not output then
-        return nil, err
-    end
-
+local function parse_signal_info_json(output)
     local data, json_err = json.decode(output)
     if not data then
         return nil, "Failed to decode mmcli output as JSON: " .. tostring(json_err) .. ", output: " .. tostring(output)
@@ -294,27 +294,41 @@ local function read_signal_info(identity)
         return nil, "No signal info found in mmcli output"
     end
 
-    local active_signal = nil
+    local active_signals = {}
     for tech, signals in pairs(signal_techs) do
         if SIGNAL_TECHNOLOGIES[tech] and type(signals) == 'table' then
             local filtered_fields = {}
             for signal_name, signal_value in pairs(signals) do
                 if not SIGNAL_IGNORE_FIELDS[signal_name] and signal_value ~= "--" then
-                    filtered_fields[signal_name] = signal_value
+                    local numeric_value = tonumber(signal_value)
+                    if is_signal_valid(numeric_value) then
+                        filtered_fields[signal_name] = numeric_value
+                    end
                 end
             end
             if next(filtered_fields) ~= nil then
-                active_signal = filtered_fields
-                break
+                active_signals[tech] = filtered_fields
             end
         end
     end
 
-    if not active_signal then
+    if next(active_signals) == nil then
         return nil, "No active signal found"
     end
 
-    return modem_types.new.ModemSignalInfo(shallow_copy(active_signal))
+    return modem_types.new.ModemSignalInfo(active_signals)
+end
+
+---@param identity ModemIdentity
+---@return ModemSignalInfo?
+---@return string error
+local function read_signal_info(identity)
+    local output, err = run_command(identity.address, { "mmcli", "-J", "-m", identity.address, "--signal-get" })
+    if not output then
+        return nil, err
+    end
+
+    return parse_signal_info_json(output)
 end
 
 ---@param sim_path string
@@ -812,5 +826,6 @@ return {
     _test = {
         normalize_unlock_retries = normalize_unlock_retries,
         parse_modem_info_json = parse_modem_info_json,
+        parse_signal_info_json = parse_signal_info_json,
     },
 }

--- a/src/services/hal/types/modem.lua
+++ b/src/services/hal/types/modem.lua
@@ -126,8 +126,10 @@ ModemSimInfo.__index = ModemSimInfo
 local ModemNetworkInfo = {}
 ModemNetworkInfo.__index = ModemNetworkInfo
 
+---@alias ModemSignalValues table<string, table<string, number>>
+
 ---@class ModemSignalInfo
----@field values table<string, string|number>
+---@field values ModemSignalValues
 local ModemSignalInfo = {}
 ModemSignalInfo.__index = ModemSignalInfo
 
@@ -171,16 +173,26 @@ local function is_signal_value_table(value)
 	if type(value) ~= 'table' then
 		return false
 	end
-	for key, entry in pairs(value) do
-		if type(key) ~= 'string' then
+
+	local has_tech = false
+	for tech, signals in pairs(value) do
+		if type(tech) ~= 'string' or type(signals) ~= 'table' then
 			return false
 		end
-		local entry_type = type(entry)
-		if entry_type ~= 'string' and entry_type ~= 'number' then
+
+		local has_signal = false
+		for signal_name, signal_value in pairs(signals) do
+			if type(signal_name) ~= 'string' or type(signal_value) ~= 'number' then
+				return false
+			end
+			has_signal = true
+		end
+		if not has_signal then
 			return false
 		end
+		has_tech = true
 	end
-	return true
+	return has_tech
 end
 
 ---Create a new ModemIdentityInfo.
@@ -379,7 +391,7 @@ function new.ModemNetworkInfo(operator, access_techs, mcc, mnc, active_band_clas
 end
 
 ---Create a new ModemSignalInfo.
----@param values table<string, string|number>
+---@param values ModemSignalValues
 ---@return ModemSignalInfo?
 ---@return string error
 function new.ModemSignalInfo(values)

--- a/tests/run.lua
+++ b/tests/run.lua
@@ -47,6 +47,7 @@ local files = {
 	"unit.hal.uart_manager_spec",
 	"unit.hal.network_manager_spec",
 	"unit.hal.modem_linux_mm_spec",
+	"unit.hal.modem_types_spec",
 	"unit.hal.modem_qmi_spec",
 	"unit.hal.openwrt_network_observer_spec",
 	"unit.hal.openwrt_network_provider_advanced_spec",

--- a/tests/unit/gsm/test_state.lua
+++ b/tests/unit/gsm/test_state.lua
@@ -82,4 +82,55 @@ function tests.test_sim_payload_reports_absent_explicitly()
 	eq(payload.lock, nil)
 end
 
+function tests.test_canonical_signal_matches_current_access_tech()
+	local signals = {
+		lte = { rsrp = -96 },
+		['5g'] = { rsrp = -103 },
+		umts = { rscp = -88 },
+		gsm = { rssi = -78 },
+	}
+
+	local signal, tech = gsm._test.select_canonical_signal({ 'lte' }, signals)
+	eq(tech, 'lte')
+	eq(signal.rsrp, -96)
+
+	signal, tech = gsm._test.select_canonical_signal({ 'umts' }, signals)
+	eq(tech, 'umts')
+	eq(signal.rscp, -88)
+
+	signal, tech = gsm._test.select_canonical_signal({ 'gsm' }, signals)
+	eq(tech, 'gsm')
+	eq(signal.rssi, -78)
+end
+
+function tests.test_5g_nsa_prefers_5g_when_both_signal_sets_are_valid()
+	local signals = {
+		lte = { rsrp = -96 },
+		['5g'] = { rsrp = -103 },
+	}
+	local signal, tech = gsm._test.select_canonical_signal({ 'lte', '5gnr' }, signals)
+	eq(tech, '5g')
+	eq(signal.rsrp, -103)
+end
+
+function tests.test_5g_nsa_falls_back_to_lte_when_5g_signal_is_unavailable()
+	local signals = { lte = { rsrp = -96 } }
+	local signal, tech = gsm._test.select_canonical_signal({ '5gnr', 'lte' }, signals)
+	eq(tech, 'lte')
+	eq(signal.rsrp, -96)
+end
+
+function tests.test_5g_sa_does_not_fall_back_to_an_unrelated_lte_signal()
+	local signal, tech = gsm._test.select_canonical_signal({ '5gnr' }, { lte = { rsrp = -96 } })
+	eq(signal, nil)
+	eq(tech, '')
+end
+
+function tests.test_signal_bars_use_the_selected_signal_tech()
+	local tech, value, field = gsm._test.select_signal_for_bars('lte', nil, -96, nil)
+	eq(tech, 'lte')
+	eq(value, -96)
+	eq(field, 'rsrp')
+end
+
 return tests

--- a/tests/unit/hal/modem_linux_mm_spec.lua
+++ b/tests/unit/hal/modem_linux_mm_spec.lua
@@ -7,6 +7,11 @@ local function eq(a, b, msg)
 	if a ~= b then fail(msg or ('expected ' .. tostring(b) .. ', got ' .. tostring(a))) end
 end
 local function ok(v, msg) if not v then fail(msg or 'expected truthy') end end
+local function contains(value, expected, msg)
+	if not tostring(value):find(expected, 1, true) then
+		fail(msg or ('expected ' .. tostring(value) .. ' to contain ' .. expected))
+	end
+end
 
 function tests.test_linux_mm_parses_sim_lock_fields_from_modem_json()
 	local info, err = linux_mm._test.parse_modem_info_json([[
@@ -70,6 +75,104 @@ function tests.test_linux_mm_normalises_absent_unlock_required()
 	eq(info.sim_lock_retries, nil)
 	eq(info.access_techs[1], 'lte')
 	eq(info.drivers[1], 'qmi_wwan')
+end
+
+function tests.test_linux_mm_signal_parser_returns_all_valid_techs_as_numbers()
+	local info, err = linux_mm._test.parse_signal_info_json([[
+{
+  "modem": {
+    "signal": {
+      "5g": {
+        "rsrp": "-103.5",
+        "snr": 12.25,
+        "error-rate": "99"
+      },
+      "lte": {
+        "rsrp": "-96",
+        "rsrq": "-11.5"
+      },
+      "umts": {
+        "rscp": "--"
+      }
+    }
+  }
+}
+]])
+	ok(info, err)
+	eq(info.values['5g'].rsrp, -103.5)
+	eq(info.values['5g'].snr, 12.25)
+	eq(info.values['5g']['error-rate'], nil)
+	eq(info.values.lte.rsrp, -96)
+	eq(info.values.lte.rsrq, -11.5)
+	eq(info.values.umts, nil)
+end
+
+function tests.test_linux_mm_signal_parser_filters_sentinels_and_invalid_fields()
+	local info, err = linux_mm._test.parse_signal_info_json([[
+{
+  "modem": {
+    "signal": {
+      "5g": {
+        "rsrp": "-32768",
+        "snr": -3276.8,
+        "error-rate": "0"
+      },
+      "lte": {
+        "rsrp": "-97",
+        "rsrq": "not-a-number",
+        "rssi": "--"
+      },
+      "unknown": {
+        "rssi": "-50"
+      }
+    }
+  }
+}
+]])
+	ok(info, err)
+	eq(info.values['5g'], nil)
+	eq(info.values.unknown, nil)
+	eq(info.values.lte.rsrp, -97)
+	eq(info.values.lte.rsrq, nil)
+	eq(info.values.lte.rssi, nil)
+end
+
+function tests.test_linux_mm_signal_parser_preserves_zero()
+	local info, err = linux_mm._test.parse_signal_info_json([[
+{
+  "modem": {
+    "signal": {
+      "lte": {
+        "rsrp": "0",
+        "snr": 0
+      }
+    }
+  }
+}
+]])
+	ok(info, err)
+	eq(info.values.lte.rsrp, 0)
+	eq(info.values.lte.snr, 0)
+end
+
+function tests.test_linux_mm_signal_parser_rejects_payload_without_valid_signals()
+	local info, err = linux_mm._test.parse_signal_info_json([[
+{
+  "modem": {
+    "signal": {
+      "5g": {
+        "rsrp": "-32768",
+        "error-rate": "0"
+      },
+      "lte": {
+        "rsrp": "--"
+      }
+    }
+  }
+}
+]])
+	eq(info, nil)
+	contains(err, 'No active signal found')
 end
 
 return tests

--- a/tests/unit/hal/modem_types_spec.lua
+++ b/tests/unit/hal/modem_types_spec.lua
@@ -1,0 +1,45 @@
+local modem_types = require 'services.hal.types.modem'
+
+local tests = {}
+
+local function fail(msg) error(msg or 'assertion failed', 2) end
+local function eq(a, b, msg)
+	if a ~= b then fail(msg or ('expected ' .. tostring(b) .. ', got ' .. tostring(a))) end
+end
+local function ok(v, msg) if not v then fail(msg or 'expected truthy') end end
+
+function tests.test_modem_signal_info_accepts_technology_keyed_numeric_values()
+	local info, err = modem_types.new.ModemSignalInfo({
+		lte = { rsrp = -97, rsrq = -11.5 },
+		['5g'] = { rsrp = -103, snr = 0 },
+	})
+	ok(info, err)
+	eq(info.values.lte.rsrp, -97)
+	eq(info.values['5g'].snr, 0)
+end
+
+function tests.test_modem_signal_info_rejects_legacy_flat_values()
+	local info, err = modem_types.new.ModemSignalInfo({ rsrp = -97 })
+	eq(info, nil)
+	eq(err, 'invalid signal values')
+end
+
+function tests.test_modem_signal_info_rejects_non_numeric_measurements()
+	local info, err = modem_types.new.ModemSignalInfo({
+		lte = { rsrp = '-97' },
+	})
+	eq(info, nil)
+	eq(err, 'invalid signal values')
+end
+
+function tests.test_modem_signal_info_rejects_empty_signal_sets()
+	local empty_info, empty_err = modem_types.new.ModemSignalInfo({})
+	eq(empty_info, nil)
+	eq(empty_err, 'invalid signal values')
+
+	local empty_tech_info, empty_tech_err = modem_types.new.ModemSignalInfo({ lte = {} })
+	eq(empty_tech_info, nil)
+	eq(empty_tech_err, 'invalid signal values')
+end
+
+return tests


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description

Signals have been retrieved by iterating signal techs and taking the first tech which has signals that are numerical values (rather than the empty "--" placeholder), this resulted in a bug where a modem in 5gnr mode would have seemingly valid 5g signals which were all set to -32768 which is an impossible value, meanwhile the lte signal values were valid and real. 

I have change signal processing in the backend of the modem driver to return all access tech signals which are valid, where valid is considered to be signal tech where all signals are NOT "--" or -32768. This change allows both 5g and lte signals to be reported to GSM where the GSM service can prioritise which signal tech to report to metrics and UI (with 5G being priority).  

## Related Issues, Tickets & Documents
#267 #174 #216

## Manual test
<!-- Have you manually tested this code and confirmed it is working? -->
- [x] 👍 yes
- [ ] 🙅 no

## Manual test description
Run the code on a bigbox v1, check the signal values are not -32k and check the primary modems access tech via mmcli then check the signals via mmcli --signal-get. 

## Added tests?
- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?
- [ ] 📜 README.md
- [x] 🙅 no documentation needed
