### PR TITLE
wifi: configure user salt

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ SWITCH_USERNAME=
 SWITCH_PASSWORD=
 UNIFI_ADDRESS=
 CLOUD_URL=
+USER_SALT=
 ```
 
 `.env.secret` is listed in `.gitignore` and must never be committed. If the file is absent, `make build-all` will print a warning and leave placeholders unreplaced.

--- a/docs/specs/wifi.md
+++ b/docs/specs/wifi.md
@@ -45,6 +45,7 @@ Received via retained bus message on `{'cfg', 'wifi'}`. The message uses the sta
   rev  = <number>,   -- config revision; service skips messages with rev <= last applied rev
   data = {
     schema        = "devicecode.config/wifi/1",
+    user_salt     = <string>,       -- required: target-specific salt used to generate client IDs
     report_period = <number>,       -- required: stats publish interval in seconds
     radios = {                      -- required: array of per-radio configs
       {
@@ -116,6 +117,9 @@ Received via retained bus message on `{'cfg', 'wifi'}`. The message uses the sta
   },
 }
 ```
+
+`user_salt` is required and must not be empty. Changing it changes every generated
+client ID, so it should be treated as immutable configuration and must not be logged.
 
 > **Underflow note:** JSON decoding may silently convert negative numbers to large positive integers due to integer underflow. The service must check decoded numeric fields that are expected to be non-negative and, if the value exceeds a sanity threshold (e.g. > 2^31), treat it as if the original value were negative by subtracting 2^32.
 

--- a/src/configs/bigbox-v1-cm-2.json
+++ b/src/configs/bigbox-v1-cm-2.json
@@ -1126,6 +1126,7 @@
     "rev": 1,
     "data": {
       "schema": "devicecode.config/wifi/1",
+      "user_salt": "$USER_SALT",
       "report_period": 10,
       "radios": [
         {

--- a/src/services/wifi.lua
+++ b/src/services/wifi.lua
@@ -53,6 +53,7 @@ local utils    = require 'services.wifi.utils'
 
 ---@class WifiServiceData
 ---@field schema string
+---@field user_salt string
 ---@field report_period? number
 ---@field radios WifiRadioConfig[]
 ---@field ssids WifiSsidConfig[]
@@ -73,6 +74,7 @@ local function map_mode(mode)
 end
 
 local function is_table(v) return type(v) == 'table' end
+local function valid_user_salt(v) return type(v) == 'string' and v ~= '' end
 
 local function count_array(t)
     return is_table(t) and #t or 0
@@ -523,8 +525,9 @@ end
 ---@param conn Connection
 ---@param id string
 ---@param radio_cfg WifiRadioConfig?
+---@param user_salt string
 ---@param svc ServiceBase
-local function radio_stats_loop(conn, id, radio_cfg, svc)
+local function radio_stats_loop(conn, id, radio_cfg, user_salt, svc)
     local band        = ((radio_cfg and radio_cfg.band) or ''):sub(1, 1)
     local hw_platform = '1'
     local sessions    = {}
@@ -548,7 +551,7 @@ local function radio_stats_loop(conn, id, radio_cfg, svc)
 
         prefix, stat = key:match('^(client)_(.+)$')
         if prefix then
-            local uid = gen.userid(p.mac)
+            local uid = gen.userid(p.mac, user_salt)
             local sid = sessions[p.mac]
             if sid then
                 conn:retain(t_obs_metric(stat), {
@@ -570,7 +573,7 @@ local function radio_stats_loop(conn, id, radio_cfg, svc)
         local iface      = p.interface
         local connected  = p.connected
         local timestamp  = p.timestamp or os.time()
-        local uid        = gen.userid(mac)
+        local uid        = gen.userid(mac, user_salt)
         local change     = connected and 1 or -1
 
         iface_sta[iface] = math.max(0, (iface_sta[iface] or 0) + change)
@@ -692,8 +695,11 @@ local function configure_radio(ctx, id)
 end
 
 local function radio_fiber_body(ctx, id)
+    local user_salt = is_table(ctx.data) and ctx.data.user_salt or nil
+    if not valid_user_salt(user_salt) then return end
+
     configure_radio(ctx, id)
-    radio_stats_loop(ctx.conn, id, get_radio_cfg(ctx, id), ctx.svc)
+    radio_stats_loop(ctx.conn, id, get_radio_cfg(ctx, id), user_salt, ctx.svc)
 end
 
 local function spawn_radio_scope(ctx, id)
@@ -745,6 +751,8 @@ local function on_cfg(ctx, msg)
         ctx.svc:obs_log('debug', { what = 'stale_config', rev = rev, last_rev = ctx.last_rev })
     elseif not is_table(data) then
         ctx.svc:obs_log('warn', { what = 'config_data_not_table' })
+    elseif not valid_user_salt(data.user_salt) then
+        ctx.svc:obs_log('warn', { what = 'invalid_config_user_salt' })
     else
         ctx.last_rev = rev or ctx.last_rev
         ctx.data     = data

--- a/src/services/wifi/gen.lua
+++ b/src/services/wifi/gen.lua
@@ -13,11 +13,10 @@ if digest.digest == nil then
     end
 end
 
-local USER_SALT = "$USER_SALT"
 local USER_ID_LEN = 6
 
-local function userid(mac)
-    local hash = digest.digest("sha256", USER_SALT..mac)
+local function userid(mac, user_salt)
+    local hash = digest.digest("sha256", user_salt..mac)
     return string.sub(hash, 1, USER_ID_LEN)
 end
 

--- a/tests/run.lua
+++ b/tests/run.lua
@@ -171,6 +171,7 @@ local files = {
 	"unit.net.test_hal_client",
 	"unit.net.test_service_behaviour",
 	"unit.net.test_wan_runtime",
+	"unit.wifi.gen_spec",
 	"unit.wired.test_config",
 	"unit.wired.test_dependencies",
 	"unit.wired.test_publisher",

--- a/tests/unit/wifi/gen_spec.lua
+++ b/tests/unit/wifi/gen_spec.lua
@@ -1,0 +1,19 @@
+local gen = require 'services.wifi.gen'
+
+local T = {}
+
+function T.userid_is_deterministic_for_a_salt()
+	local mac = '00:11:22:33:44:55'
+	local salt = 'target-salt'
+
+	assert(gen.userid(mac, salt) == '760205')
+	assert(gen.userid(mac, salt) == gen.userid(mac, salt))
+end
+
+function T.userid_changes_with_the_salt()
+	local mac = '00:11:22:33:44:55'
+
+	assert(gen.userid(mac, 'first-salt') ~= gen.userid(mac, 'second-salt'))
+end
+
+return T


### PR DESCRIPTION
## Description

Moves `USER_SALT` into the target Wi-Fi configuration so it follows the existing `.env.secret` JSON substitution path.

- Adds required `wifi.data.user_salt` configuration.
- Passes the configured salt explicitly into client ID generation.
- Rejects missing or empty salts without logging their value.
- Documents that changing the salt changes all generated client IDs.
- Adds focused ID-generation coverage.

The builder change will write the target-specific Vault value into `.env.secret` and pin Lua targets to the forthcoming `v0.11.1` release.

## Validation

- Full devicecode-lua test suite: 1101 tests, 0 failed
- Focused `.env.secret` build substitution check
- `luacheck --no-max-line-length src/services/wifi.lua src/services/wifi/gen.lua tests/unit/wifi/gen_spec.lua`
- JSON and whitespace validation